### PR TITLE
Add patch for naga to fix macOS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,8 @@ console_error_panic_hook = "0.1.7"
 console_log = "0.2"
 wasm-bindgen-futures = "0.4.33"
 web-sys = "0.3.60"
+
+[patch.crates-io]
+# Required for metal support to work on wgpu
+# TODO: remove when wgpu is upgraded to 0.15
+naga = { git = "https://github.com/gfx-rs/naga", rev = "ddcd5d3121150b2b1beee6e54e9125ff31aaa9a2" }

--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ Please contribute! There's a lot of solid foundations here:
 - Dioxus is underpinning state management
 
 Blitz is for *everyone*, so you don't need Dioxus to drive updates to the final render tree.
+
+### MacOs support
+
+There is a known issue with the wgpu on MacOS. If you're on MacOS, you'll need to add the following patch to your `Cargo.toml` to make Blitz run:
+
+```toml
+[patch.crates-io]
+naga = { git = "https://github.com/gfx-rs/naga", rev = "ddcd5d3121150b2b1beee6e54e9125ff31aaa9a2" }
+```


### PR DESCRIPTION
This applies a patch for naga to fix macOS support (https://github.com/gfx-rs/naga/pull/2099).

This should be reverted once wgpu 15 is released.