### PR TITLE
Bump Vello Revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ taffy = "0.2.2"
 tokio = { version = "1.17.0", features = ["full"] }
 lightningcss = "1.0.0-alpha.38"
 cssparser = "0.29.2"
-vello = { git = "https://github.com/linebender/vello", rev = "dfde0936e5064ac8bb2765e1c3fdc1d5ac757a83" }
+vello = { git = "https://github.com/linebender/vello", rev = "bf523e8845e7f1b970068712ab1326a7784a5fdc" }
 wgpu = "0.14"
 tao = { version = "0.15.8", features = ["serde"] }
 raw-window-handle = "0.4.2"

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -79,7 +79,7 @@ impl NodeDepState for Focus {
                 if let Some(index) = a
                     .value
                     .as_int()
-                    .or_else(|| a.value.as_text().and_then(|v| v.parse::<i32>().ok()))
+                    .or_else(|| a.value.as_text().and_then(|v| v.parse::<i64>().ok()))
                 {
                     match index.cmp(&0) {
                         Ordering::Less => FocusLevel::Unfocusable,


### PR DESCRIPTION
This bumps the Vello version to make the project compile again. The revision we previously relied on had it's own git [dependencies that were not pinned](https://github.com/linebender/vello/blob/dfde0936e5064ac8bb2765e1c3fdc1d5ac757a83/vello/Cargo.toml#L15). The current revision has pinned git dependencies