### PR TITLE
Invalidation

### DIFF
--- a/blitz-core/Cargo.toml
+++ b/blitz-core/Cargo.toml
@@ -18,7 +18,7 @@ taffy = "0.2.2"
 tokio = { version = "1.25.0", features = ["full"] }
 lightningcss = "1.0.0-alpha.39"
 cssparser = "0.29.6"
-vello = { git = "https://github.com/linebender/vello", rev = "b8e1bcfac319ddf2d12cadc1df0c95acc9158897" }
+vello = { git = "https://github.com/linebender/vello", rev = "3d83bd7fa070a7737e4356bad764009f833720c7" }
 wgpu = "0.15.0"
 tao = { version = "0.17.0", features = ["serde"] }
 raw-window-handle = "0.5.0"

--- a/blitz-core/src/lib.rs
+++ b/blitz-core/src/lib.rs
@@ -48,7 +48,7 @@ pub async fn render<R: Driver>(
     let window = WindowBuilder::new().build(&event_loop).unwrap();
     let mut appliction =
         ApplicationState::new(spawn_renderer, &window, event_loop.create_proxy()).await;
-    appliction.render();
+    appliction.render(application::DirtyNodes::All);
 
     event_loop.run(move |event, _, control_flow| {
         // ControlFlow::Wait pauses the event loop if no events are available to process.
@@ -80,8 +80,9 @@ pub async fn render<R: Driver>(
                 // this event rather than in MainEventsCleared, since rendering in here allows
                 // the program to gracefully handle redraws requested by the OS.
 
-                if !appliction.clean().is_empty() {
-                    appliction.render();
+                let dirty_nodes = appliction.clean();
+                if !dirty_nodes.is_empty() {
+                    appliction.render(dirty_nodes);
                 }
             }
             Event::UserEvent(_redraw) => {

--- a/blitz-core/src/style.rs
+++ b/blitz-core/src/style.rs
@@ -307,7 +307,7 @@ impl State for FontSize {
     ) -> bool {
         let new = if let Some(size_attr) = node_view.attributes().into_iter().flatten().next() {
             let parent_size = if let Some(parent_size) = parent {
-                parent_size.0 .0.clone()
+                parent_size.0 .0
             } else {
                 DEFAULT_FONT_SIZE
             };
@@ -319,7 +319,7 @@ impl State for FontSize {
                 DEFAULT_FONT_SIZE
             }
         } else if let Some(parent_size) = parent {
-            parent_size.0 .0.clone()
+            parent_size.0 .0
         } else {
             return false;
         };
@@ -361,7 +361,7 @@ fn parse_font_size_from_attr(
                     DimensionPercentage::Dimension(l) => match l {
                         LengthValue::Rem(v) => Some(v * root_font_size),
                         LengthValue::Em(v) => Some(v * parent_font_size),
-                        _ => l.to_px().map(|v| v as f32),
+                        _ => l.to_px(),
                     },
                     // same with em.
                     DimensionPercentage::Percentage(p) => Some(p.0 * parent_font_size),


### PR DESCRIPTION
Browsers generally keep track of what regions of the screen have been invalidated and re-render only those regions of the screen. This PR changes Blitz to use nodes that have been invalidated and rerender only those parts of the screen (along with any layers touching those regions)

![Untitled-2023-04-18-1053](https://user-images.githubusercontent.com/66571940/234037456-9f31fb22-7b32-496d-a8e5-5cead23f862b.png)
