### PR TITLE
Upgrade to Taffy 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ repository = "https://github.com/DioxusLabs/blitz"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus = { git = "https://github.com/DioxusLabs/dioxus/" }
-dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus/", features = ["dioxus"] }
-dioxus-html = { git = "https://github.com/DioxusLabs/dioxus/" }
-dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus/" }
+dioxus = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
+dioxus-native-core = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474", features = ["dioxus"] }
+dioxus-html = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
+dioxus-hot-reload = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
+
 blitz-core = { path = "./blitz-core" }
 tokio = { version = "1.26.0", features = ["full"] }
 keyboard-types = "0.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ repository = "https://github.com/DioxusLabs/blitz"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
-dioxus-native-core = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474", features = ["dioxus"] }
-dioxus-html = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
-dioxus-hot-reload = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
-
+dioxus = { git = "https://github.com/DioxusLabs/dioxus/" }
+dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus/", features = ["dioxus"] }
+dioxus-html = { git = "https://github.com/DioxusLabs/dioxus/" }
+dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus/" }
 blitz-core = { path = "./blitz-core" }
 tokio = { version = "1.26.0", features = ["full"] }
 keyboard-types = "0.6.2"

--- a/blitz-core/Cargo.toml
+++ b/blitz-core/Cargo.toml
@@ -11,12 +11,9 @@ repository = "https://github.com/DioxusLabs/blitz"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus/" }
-# dioxus-native-core-macro = { git = "https://github.com/DioxusLabs/dioxus/" }
-# dioxus-html = { git = "https://github.com/DioxusLabs/dioxus/" }
-dioxus-native-core = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
-dioxus-native-core-macro = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
-dioxus-html = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
+dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus/" }
+dioxus-native-core-macro = { git = "https://github.com/DioxusLabs/dioxus/" }
+dioxus-html = { git = "https://github.com/DioxusLabs/dioxus/" }
 taffy = "0.3.12"
 tokio = { version = "1.25.0", features = ["full"] }
 lightningcss = "1.0.0-alpha.39"

--- a/blitz-core/Cargo.toml
+++ b/blitz-core/Cargo.toml
@@ -11,10 +11,13 @@ repository = "https://github.com/DioxusLabs/blitz"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus/" }
-dioxus-native-core-macro = { git = "https://github.com/DioxusLabs/dioxus/" }
-dioxus-html = { git = "https://github.com/DioxusLabs/dioxus/" }
-taffy = "0.2.2"
+# dioxus-native-core = { git = "https://github.com/DioxusLabs/dioxus/" }
+# dioxus-native-core-macro = { git = "https://github.com/DioxusLabs/dioxus/" }
+# dioxus-html = { git = "https://github.com/DioxusLabs/dioxus/" }
+dioxus-native-core = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
+dioxus-native-core-macro = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
+dioxus-html = { git = "https://github.com/nicoburns/dioxus/", rev = "8010d9b4e3afce740bcc40a111197400886f8474" }
+taffy = "0.3.12"
 tokio = { version = "1.25.0", features = ["full"] }
 lightningcss = "1.0.0-alpha.39"
 cssparser = "0.29.6"

--- a/blitz-core/src/application.rs
+++ b/blitz-core/src/application.rs
@@ -280,7 +280,7 @@ async fn spawn_dom<R: Driver>(
         let root_node = rdom.get(rdom.root_id()).unwrap();
         let root_taffy_node = root_node.get::<TaffyLayout>().unwrap().node.unwrap();
 
-        let mut style = *locked_taffy.style(root_taffy_node).unwrap();
+        let mut style = locked_taffy.style(root_taffy_node).unwrap().clone();
         style.size = Size {
             width: Dimension::Points(width),
             height: Dimension::Points(height),
@@ -331,7 +331,7 @@ async fn spawn_dom<R: Driver>(
             let root_node = rdom.get(rdom.root_id()).unwrap();
             let root_node_layout = root_node.get::<TaffyLayout>().unwrap();
             let root_taffy_node = root_node_layout.node.unwrap();
-            let mut style = *taffy.style(root_taffy_node).unwrap();
+            let mut style = taffy.style(root_taffy_node).unwrap().clone();
             let new_size = Size {
                 width: Dimension::Points(width),
                 height: Dimension::Points(height),

--- a/blitz-core/src/layout.rs
+++ b/blitz-core/src/layout.rs
@@ -58,7 +58,7 @@ impl State for TaffyLayout {
                 ..Default::default()
             };
 
-            let style_has_changed = &self.style != &style;
+            let style_has_changed = self.style != style;
 
             if let Some(n) = self.node {
                 if style_has_changed {
@@ -104,7 +104,7 @@ impl State for TaffyLayout {
                 child_layout.push(l.node.unwrap());
             }
 
-            let style_has_changed = &self.style != &style;
+            let style_has_changed = self.style != style;
             if let Some(n) = self.node {
                 if taffy.children(n).unwrap() != child_layout {
                     taffy.set_children(n, &child_layout).unwrap();

--- a/blitz-core/src/layout.rs
+++ b/blitz-core/src/layout.rs
@@ -53,23 +53,24 @@ impl State for TaffyLayout {
             let style = Style {
                 size: Size {
                     height: Dimension::Points(height as f32),
-
                     width: Dimension::Points(width as f32),
                 },
                 ..Default::default()
             };
 
+            let style_has_changed = &self.style != &style;
+
             if let Some(n) = self.node {
-                if self.style != style {
-                    taffy.set_style(n, style).unwrap();
+                if style_has_changed {
+                    taffy.set_style(n, style.clone()).unwrap();
                     changed = true;
                 }
             } else {
-                self.node = Some(taffy.new_leaf(style).unwrap());
+                self.node = Some(taffy.new_leaf(style.clone()).unwrap());
                 changed = true;
             }
 
-            if style != self.style {
+            if style_has_changed {
                 self.style = style;
                 changed = true;
             }
@@ -103,21 +104,22 @@ impl State for TaffyLayout {
                 child_layout.push(l.node.unwrap());
             }
 
+            let style_has_changed = &self.style != &style;
             if let Some(n) = self.node {
                 if taffy.children(n).unwrap() != child_layout {
                     taffy.set_children(n, &child_layout).unwrap();
                     changed = true;
                 }
-                if self.style != style {
-                    taffy.set_style(n, style).unwrap();
+                if style_has_changed {
+                    taffy.set_style(n, style.clone()).unwrap();
                     changed = true;
                 }
             } else {
-                self.node = Some(taffy.new_with_children(style, &child_layout).unwrap());
+                self.node = Some(taffy.new_with_children(style.clone(), &child_layout).unwrap());
                 changed = true;
             }
 
-            if style != self.style {
+            if style_has_changed {
                 self.style = style;
                 changed = true;
             }

--- a/blitz-core/src/layout.rs
+++ b/blitz-core/src/layout.rs
@@ -115,7 +115,11 @@ impl State for TaffyLayout {
                     changed = true;
                 }
             } else {
-                self.node = Some(taffy.new_with_children(style.clone(), &child_layout).unwrap());
+                self.node = Some(
+                    taffy
+                        .new_with_children(style.clone(), &child_layout)
+                        .unwrap(),
+                );
                 changed = true;
             }
 

--- a/examples/css_grid_buttons.rs
+++ b/examples/css_grid_buttons.rs
@@ -1,0 +1,108 @@
+use dioxus::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    blitz::launch(app).await;
+}
+
+#[derive(PartialEq, Props)]
+struct ButtonProps {
+    color_offset: u32,
+    layer: u16,
+}
+
+#[allow(non_snake_case)]
+fn Button(cx: Scope<ButtonProps>) -> Element {
+    let toggle = use_state(cx, || false);
+    let hovered = use_state(cx, || false);
+
+    let hue = cx.props.color_offset % 255;
+    let saturation = if *toggle.get() { 50 } else { 25 } + if *hovered.get() { 50 } else { 25 };
+    let brightness = saturation / 2;
+    let color = format!("hsl({hue}, {saturation}%, {brightness}%)");
+
+    cx.render(rsx! {
+        div {
+            border_width: "0px",
+            background_color: "{color}",
+            tabindex: "{cx.props.layer}",
+            onkeydown: |e| {
+                if e.code() == keyboard_types::Code::Space {
+                    toggle.modify(|f| !f);
+                }
+            },
+            onmouseup: |_| {
+                toggle.modify(|f| !f);
+            },
+            onmouseenter: |_| {
+                hovered.set(true);
+            },
+            onmouseleave: |_| {
+                hovered.set(false);
+            },
+            justify_content: "center",
+            align_items: "center",
+            text_align: "center",
+            display: "flex",
+            flex_direction: "column",
+
+            p { "{cx.props.layer}" }
+        }
+    })
+}
+
+fn app(cx: Scope) -> Element {
+    let count = use_state(cx, || 3);
+    let current_count = **count;
+    let tracks = "1fr ".repeat(current_count as usize);
+    cx.render(rsx! {
+        div { display: "flex", flex_direction: "column", width: "100%", height: "100%",
+            div {
+                display: "flex",
+                flex_direction: "row",
+                justify_content: "center",
+                align_items: "center",
+                text_align: "center",
+                width: "100%",
+                height: "10%",
+                background_color: "green",
+                tabindex: "0",
+                onmouseup: |_| {
+                    count.modify(|c| *c + 3);
+                },
+                "grid: {current_count}x{current_count} = {current_count*current_count} tiles - Click to add more"
+            }
+            div {
+                display: "grid",
+                grid_template_columns: "{tracks}",
+                grid_template_rows: "{tracks}",
+                width: "100%",
+                height: "90%",
+                background_color: "red",
+                flex_grow: "1",
+                (0..(current_count*current_count)).map(|x| {
+                    let color = if x % 2 == 0 {
+                      "rgb(255, 255, 255)"
+                    } else {
+                      "rgb(0, 0, 0)"
+                    };
+                    if x % 2 == 0 {
+                        rsx! {
+                            div {
+                                border_width: "0px",
+                                background_color: "{color}"
+                            }
+                        }
+                    } else {
+                        rsx! {
+                            Button {
+                                color_offset: x,
+                                layer: (x % 3) as u16
+                            }
+                        }
+                    }
+                })
+            }
+        }
+    })
+}


### PR DESCRIPTION
Depends on: https://github.com/DioxusLabs/dioxus/pull/1030

# Objective

Support CSS Grid and gain the fixes from Taffy 0.3

## Changes made

- ~Point deps at https://github.com/DioxusLabs/dioxus/pull/1030~ PR has been merged, so this change has now been reverted.
- Upgrade Taffy version
- Add `.clone`s because `Style` is no longer `Copy`
- Add CSS Grid example

## Notes

Waiting on https://github.com/parcel-bundler/lightningcss/pull/490 in order to support `repeat()` syntax, but I don't think that ought to block this being merged.