### PR TITLE
fixes build for newest versions of dependencies

### DIFF
--- a/blitz-core/src/text/mod.rs
+++ b/blitz-core/src/text/mod.rs
@@ -207,6 +207,7 @@ fn parse_font_size_from_attr(
                         AbsoluteFontSize::Large => 1.25,
                         AbsoluteFontSize::XLarge => 1.5,
                         AbsoluteFontSize::XXLarge => 2.0,
+                        AbsoluteFontSize::XXXLarge => todo!(),
                     };
                     Some(factor * root_font_size)
                 }

--- a/blitz-core/src/util.rs
+++ b/blitz-core/src/util.rs
@@ -23,7 +23,7 @@ pub(crate) enum Axis {
 }
 
 pub(crate) fn translate_color(color: &CssColor) -> Color {
-    let rgb = color.to_rgb();
+    let rgb = color.to_rgb().unwrap();
     if let CssColor::RGBA(rgba) = rgb {
         Color::rgba(
             rgba.red as f64 / 255.0,


### PR DESCRIPTION
- Vello now returns `color.to_rgb()` as a Result(CssColor, ())
- Fill all match branches of FontSizeProperty abs_val