### PR TITLE
Run CI when blitz core changes

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - master
     paths:
-      - packages/**
+      - blitz_core/src/**
+      - blitz_core/examples/**
+      - blitz_core/Cargo.toml
       - examples/**
       - src/**
       - .github/**
-      - lib.rs
       - Cargo.toml
 
   pull_request:
@@ -17,6 +18,9 @@ on:
     branches:
       - master
     paths:
+      - blitz_core/src/**
+      - blitz_core/examples/**
+      - blitz_core/Cargo.toml
       - examples/**
       - src/**
       - .github/**

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,13 @@ on:
     branches:
       - master
     paths:
-      - packages/**
+      - blitz_core/src/**
+      - blitz_core/examples/**
+      - blitz_core/Cargo.toml
       - examples/**
       - docs/guide/**
       - src/**
       - .github/**
-      - lib.rs
       - Cargo.toml
 
   pull_request:
@@ -18,7 +19,11 @@ on:
     branches:
       - master
     paths:
+      - blitz_core/src/**
+      - blitz_core/examples/**
+      - blitz_core/Cargo.toml
       - examples/**
+      - docs/guide/**
       - src/**
       - .github/**
       - Cargo.toml

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - master
     paths:
-      - packages/**
+      - blitz_core/src/**
+      - blitz_core/examples/**
+      - blitz_core/Cargo.toml
       - examples/**
       - src/**
       - .github/**
-      - lib.rs
       - Cargo.toml
 
   pull_request:
@@ -17,6 +18,9 @@ on:
     branches:
       - master
     paths:
+      - blitz_core/src/**
+      - blitz_core/examples/**
+      - blitz_core/Cargo.toml
       - examples/**
       - src/**
       - .github/**


### PR DESCRIPTION
in #43 and #41, CI did not run because the blitz-core path was ignored. This adds blitz-core to the files CI listens to so that it will run when future PRs change Blitz core