### PR TITLE
Use SPDX 2.1 license expression.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Jonathan Kelley <jkelleyrtp@gmail.com>", "Evan Almloff"]
 description = "Native WGPU based renderer for Dioxus"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/DioxusLabs/blitz"
 
 

--- a/blitz-core/Cargo.toml
+++ b/blitz-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Jonathan Kelley <jkelleyrtp@gmail.com>", "Evan Almloff"]
 description = "Native WGPU based renderer for Dioxus"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/DioxusLabs/blitz"
 
 


### PR DESCRIPTION
This improves the usage of automated tooling which consumes the license information.