### PR TITLE
Remove wasm32 target dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,6 @@ blitz-core = { path = "./blitz-core" }
 tokio = { version = "1.26.0", features = ["full"] }
 keyboard-types = "0.6.2"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = "0.1.7"
-console_log = "0.2.0"
-wasm-bindgen-futures = "0.4.33"
-web-sys = "0.3.60"
-
 [features]
 default = ["hot-reload"]
 hot-reload = []

--- a/blitz-core/Cargo.toml
+++ b/blitz-core/Cargo.toml
@@ -33,9 +33,3 @@ once_cell = "1.17.1"
 image = "0.24.5"
 quadtree_rs = "0.1.2"
 smallvec = "1.10.0"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = "0.1.7"
-console_log = "0.2.0"
-wasm-bindgen-futures = "0.4.33"
-web-sys = "0.3.60"


### PR DESCRIPTION
Building for wasm32 doesn't work and it seems like this is intended to be a native target.