### PR TITLE
Fix building and few crashes on Linux

### DIFF
--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -7,6 +7,14 @@ use std::task::Waker;
 use tao::dpi::LogicalSize;
 use tao::event::{ElementState, MouseButton};
 use tao::event_loop::{EventLoopProxy, EventLoopWindowTarget};
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+use tao::platform::unix::WindowExtUnix;
 #[cfg(target_os = "windows")]
 use tao::platform::windows::WindowExtWindows;
 use tao::{


### PR DESCRIPTION
Project could not be compiled on Linux due to missing import. This import was added.

Crashes when resizing were also common so they were solved with an early return.

Lastly, the `get_cursor` function sometimes unwraped a `None` variant on an `Option` so the `unwrap` was replaced with an error propagation syntax.