### PR TITLE
Replace tao with winit

### DIFF
--- a/packages/dioxus-blitz/Cargo.toml
+++ b/packages/dioxus-blitz/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tao = { version = "0.26.1", features = ["serde"] }
+winit = "0.30.2"
 muda = { version = "0.11.5", features = ["serde"] }
 tokio = { workspace = true, features = ["full"] }
 dioxus = { workspace = true }

--- a/packages/dioxus-blitz/src/lib.rs
+++ b/packages/dioxus-blitz/src/lib.rs
@@ -11,13 +11,13 @@ use dioxus::prelude::*;
 use documents::DioxusDocument;
 use muda::{MenuEvent, MenuId};
 use std::collections::HashMap;
-use tao::event_loop::EventLoopBuilder;
-use tao::window::WindowId;
-use tao::{
+use url::Url;
+use winit::event_loop::{EventLoop, EventLoopBuilder};
+use winit::window::WindowId;
+use winit::{
     event::{Event, WindowEvent},
     event_loop::ControlFlow,
 };
-use url::Url;
 
 #[derive(Default)]
 pub struct Config {
@@ -93,7 +93,9 @@ fn launch_with_window<Doc: DocumentLike + 'static>(window: View<'static, Doc>) {
     let _guard = rt.enter();
 
     // Build an event loop for the application
-    let event_loop = EventLoopBuilder::<UserWindowEvent>::with_user_event().build();
+    let event_loop = EventLoop::<UserWindowEvent>::with_user_event()
+        .build()
+        .unwrap();
     let proxy = event_loop.create_proxy();
 
     // Multiwindow ftw
@@ -106,94 +108,96 @@ fn launch_with_window<Doc: DocumentLike + 'static>(window: View<'static, Doc>) {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     let mut initial = true;
 
-    event_loop.run(move |event, event_loop, control_flow| {
-        *control_flow = ControlFlow::Wait;
+    event_loop
+        .run(move |event, event_loop| {
+            event_loop.set_control_flow(ControlFlow::Wait);
 
-        let mut on_resume = || {
-            for (_, view) in windows.iter_mut() {
-                view.resume(event_loop, &proxy, &rt);
+            let mut on_resume = || {
+                for (_, view) in windows.iter_mut() {
+                    view.resume(event_loop, &proxy, &rt);
+                }
+
+                for view in pending_windows.iter_mut() {
+                    view.resume(event_loop, &proxy, &rt);
+                }
+
+                for window in pending_windows.drain(..) {
+                    let RenderState::Active(state) = &window.renderer.render_state else {
+                        continue;
+                    };
+                    windows.insert(state.window.id(), window);
+                }
+            };
+
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
+            if initial {
+                on_resume();
+                initial = false;
             }
 
-            for view in pending_windows.iter_mut() {
-                view.resume(event_loop, &proxy, &rt);
+            match event {
+                // Exit the app when close is request
+                // Not always necessary
+                Event::WindowEvent {
+                    event: WindowEvent::CloseRequested,
+                    ..
+                } => event_loop.exit(),
+
+                Event::WindowEvent {
+                    window_id,
+                    event: winit::event::WindowEvent::RedrawRequested,
+                } => {
+                    if let Some(window) = windows.get_mut(&window_id) {
+                        window.renderer.dom.as_mut().resolve();
+                        window.renderer.render(&mut window.scene);
+                    };
+                }
+
+                Event::UserEvent(UserWindowEvent(EventData::Poll, id)) => {
+                    if let Some(view) = windows.get_mut(&id) {
+                        if view.poll() {
+                            view.request_redraw();
+                        }
+                    };
+                }
+                // Event::UserEvent(_redraw) => {
+                //     for (_, view) in windows.iter() {
+                //         view.request_redraw();
+                //     }
+                // }
+                Event::NewEvents(_) => {
+                    for id in windows.keys() {
+                        _ = proxy.send_event(UserWindowEvent(EventData::Poll, *id));
+                    }
+                }
+
+                Event::Suspended => {
+                    for (_, view) in windows.iter_mut() {
+                        view.suspend();
+                    }
+                }
+
+                Event::Resumed => on_resume(),
+
+                Event::WindowEvent {
+                    window_id, event, ..
+                } => {
+                    if let Some(window) = windows.get_mut(&window_id) {
+                        window.handle_window_event(event);
+                    };
+                }
+
+                _ => (),
             }
 
-            for window in pending_windows.drain(..) {
-                let RenderState::Active(state) = &window.renderer.render_state else {
-                    continue;
-                };
-                windows.insert(state.window.id(), window);
-            }
-        };
-
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        if initial {
-            on_resume();
-            initial = false;
-        }
-
-        match event {
-            // Exit the app when close is request
-            // Not always necessary
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => *control_flow = ControlFlow::Exit,
-
-            // Nothing else to do, try redrawing?
-            Event::MainEventsCleared => {}
-
-            Event::UserEvent(UserWindowEvent(EventData::Poll, id)) => {
-                if let Some(view) = windows.get_mut(&id) {
-                    if view.poll() {
+            if let Ok(event) = menu_channel.try_recv() {
+                if event.id == MenuId::new("dev.show_layout") {
+                    for (_, view) in windows.iter_mut() {
+                        view.renderer.devtools.show_layout = !view.renderer.devtools.show_layout;
                         view.request_redraw();
                     }
-                };
-            }
-            // Event::UserEvent(_redraw) => {
-            //     for (_, view) in windows.iter() {
-            //         view.request_redraw();
-            //     }
-            // }
-            Event::NewEvents(_) => {
-                for id in windows.keys() {
-                    _ = proxy.send_event(UserWindowEvent(EventData::Poll, *id));
                 }
             }
-
-            Event::RedrawRequested(window_id) => {
-                if let Some(window) = windows.get_mut(&window_id) {
-                    window.renderer.dom.as_mut().resolve();
-                    window.renderer.render(&mut window.scene);
-                };
-            }
-
-            Event::Suspended => {
-                for (_, view) in windows.iter_mut() {
-                    view.suspend();
-                }
-            }
-
-            Event::Resumed => on_resume(),
-
-            Event::WindowEvent {
-                window_id, event, ..
-            } => {
-                if let Some(window) = windows.get_mut(&window_id) {
-                    window.handle_window_event(event);
-                };
-            }
-
-            _ => (),
-        }
-
-        if let Ok(event) = menu_channel.try_recv() {
-            if event.id == MenuId::new("dev.show_layout") {
-                for (_, view) in windows.iter_mut() {
-                    view.renderer.devtools.show_layout = !view.renderer.devtools.show_layout;
-                    view.request_redraw();
-                }
-            }
-        }
-    });
+        })
+        .unwrap();
 }

--- a/packages/dioxus-blitz/src/waker.rs
+++ b/packages/dioxus-blitz/src/waker.rs
@@ -1,6 +1,6 @@
 use futures_util::task::ArcWake;
 use std::sync::Arc;
-use tao::{event_loop::EventLoopProxy, window::WindowId};
+use winit::{event_loop::EventLoopProxy, window::WindowId};
 
 #[derive(Debug, Clone)]
 pub struct UserWindowEvent(pub EventData, pub WindowId);

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -1,12 +1,16 @@
 use crate::waker::UserWindowEvent;
 use blitz::{RenderState, Renderer, Viewport};
 use blitz_dom::DocumentLike;
+use wgpu::rwh::HasWindowHandle;
+use winit::keyboard::PhysicalKey;
+use winit::window::WindowAttributes;
 
 use std::sync::Arc;
 use std::task::Waker;
-use tao::dpi::LogicalSize;
-use tao::event::{ElementState, MouseButton};
-use tao::event_loop::{EventLoopProxy, EventLoopWindowTarget};
+use vello::Scene;
+use winit::dpi::LogicalSize;
+use winit::event::{ElementState, MouseButton};
+use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
 #[cfg(any(
     target_os = "linux",
     target_os = "dragonfly",
@@ -14,16 +18,10 @@ use tao::event_loop::{EventLoopProxy, EventLoopWindowTarget};
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
-use tao::platform::unix::WindowExtUnix;
+use winit::platform::unix::WindowExtUnix;
 #[cfg(target_os = "windows")]
-use tao::platform::windows::WindowExtWindows;
-use tao::{
-    event::WindowEvent,
-    keyboard::KeyCode,
-    keyboard::ModifiersState,
-    window::{Window, WindowBuilder},
-};
-use vello::Scene;
+use winit::platform::windows::WindowExtWindows;
+use winit::{event::WindowEvent, keyboard::KeyCode, keyboard::ModifiersState, window::Window};
 
 #[cfg(not(target_os = "macos"))]
 use muda::{AboutMetadata, Menu, MenuId, MenuItem, PredefinedMenuItem, Submenu};
@@ -91,7 +89,7 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
 
             // Store new keyboard modifier (ctrl, shift, etc) state for later use
             WindowEvent::ModifiersChanged(new_state) => {
-                self.keyboard_modifiers = new_state;
+                self.keyboard_modifiers = new_state.state();
             }
 
             // todo: if there's an active text input, we want to direct input towards it and translate system emi text
@@ -99,54 +97,60 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
                 dbg!(&event);
 
                 match event.physical_key {
-                    KeyCode::Equal => {
-                        if self.keyboard_modifiers.control_key()
-                            || self.keyboard_modifiers.super_key()
-                        {
-                            self.renderer.zoom(0.1);
-                            self.request_redraw();
+                    PhysicalKey::Code(key_code) => {
+                        match key_code {
+                            KeyCode::Equal => {
+                                if self.keyboard_modifiers.control_key()
+                                    || self.keyboard_modifiers.super_key()
+                                {
+                                    self.renderer.zoom(0.1);
+                                    self.request_redraw();
+                                }
+                            }
+                            KeyCode::Minus => {
+                                if self.keyboard_modifiers.control_key()
+                                    || self.keyboard_modifiers.super_key()
+                                {
+                                    self.renderer.zoom(-0.1);
+                                    self.request_redraw();
+                                }
+                            }
+                            KeyCode::Digit0 => {
+                                if self.keyboard_modifiers.control_key()
+                                    || self.keyboard_modifiers.super_key()
+                                {
+                                    self.renderer.reset_zoom();
+                                    self.request_redraw();
+                                }
+                            }
+                            KeyCode::KeyD => {
+                                if event.state == ElementState::Pressed && self.keyboard_modifiers.alt_key()
+                                {
+                                    self.renderer.devtools.show_layout =
+                                        !self.renderer.devtools.show_layout;
+                                    self.request_redraw();
+                                }
+                            }
+                            KeyCode::KeyH => {
+                                if event.state == ElementState::Pressed && self.keyboard_modifiers.alt_key()
+                                {
+                                    self.renderer.devtools.highlight_hover =
+                                        !self.renderer.devtools.highlight_hover;
+                                    self.request_redraw();
+                                }
+                            }
+                            KeyCode::KeyT => {
+                                if event.state == ElementState::Pressed && self.keyboard_modifiers.alt_key()
+                                {
+                                    self.renderer.print_taffy_tree();
+                                }
+                            }
+                            _ => {}
                         }
-                    }
-                    KeyCode::Minus => {
-                        if self.keyboard_modifiers.control_key()
-                            || self.keyboard_modifiers.super_key()
-                        {
-                            self.renderer.zoom(-0.1);
-                            self.request_redraw();
-                        }
-                    }
-                    KeyCode::Digit0 => {
-                        if self.keyboard_modifiers.control_key()
-                            || self.keyboard_modifiers.super_key()
-                        {
-                            self.renderer.reset_zoom();
-                            self.request_redraw();
-                        }
-                    }
-                    KeyCode::KeyD => {
-                        if event.state == ElementState::Pressed && self.keyboard_modifiers.alt_key()
-                        {
-                            self.renderer.devtools.show_layout =
-                                !self.renderer.devtools.show_layout;
-                            self.request_redraw();
-                        }
-                    }
-                    KeyCode::KeyH => {
-                        if event.state == ElementState::Pressed && self.keyboard_modifiers.alt_key()
-                        {
-                            self.renderer.devtools.highlight_hover =
-                                !self.renderer.devtools.highlight_hover;
-                            self.request_redraw();
-                        }
-                    }
-                    KeyCode::KeyT => {
-                        if event.state == ElementState::Pressed && self.keyboard_modifiers.alt_key()
-                        {
-                            self.renderer.print_taffy_tree();
-                        }
-                    }
-                    _ => {}
+                    },
+                    PhysicalKey::Unidentified(_) => {}
                 }
+               
             }
             WindowEvent::Moved(_) => {}
             WindowEvent::CloseRequested => {}
@@ -154,7 +158,6 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
             WindowEvent::DroppedFile(_) => {}
             WindowEvent::HoveredFile(_) => {}
             WindowEvent::HoveredFileCancelled => {}
-            WindowEvent::ReceivedImeText(_) => {}
             WindowEvent::Focused(_) => {}
             WindowEvent::CursorMoved {
                 // device_id,
@@ -163,7 +166,7 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
                 ..
             } => {
                 let changed = if let RenderState::Active(state) = &self.renderer.render_state {
-                    let tao::dpi::LogicalPosition::<f32> { x, y } = position.to_logical(state.window.scale_factor());
+                    let winit::dpi::LogicalPosition::<f32> { x, y } = position.to_logical(state.window.scale_factor());
 
                     self.renderer.mouse_move(x, y)
                 } else {
@@ -175,11 +178,11 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
 
                     if let Some(cursor) = cursor {
                         use style::values::computed::ui::CursorKind;
-                        use tao::window::CursorIcon as TaoCursor;
+                        use winit::window::CursorIcon as TaoCursor;
                         let tao_cursor = match cursor {
                             CursorKind::None => todo!("set the cursor to none"),
                             CursorKind::Default => TaoCursor::Default,
-                            CursorKind::Pointer => TaoCursor::Hand,
+                            CursorKind::Pointer => TaoCursor::Pointer,
                             CursorKind::ContextMenu => TaoCursor::ContextMenu,
                             CursorKind::Help => TaoCursor::Help,
                             CursorKind::Progress => TaoCursor::Progress,
@@ -240,10 +243,10 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
                 ..
             } => {
                 match delta {
-                    tao::event::MouseScrollDelta::LineDelta(_, y) => {
+                    winit::event::MouseScrollDelta::LineDelta(_, y) => {
                         self.renderer.scroll_by(y as f64 * 20.0)
                     }
-                    tao::event::MouseScrollDelta::PixelDelta(offsets) => {
+                    winit::event::MouseScrollDelta::PixelDelta(offsets) => {
                         self.renderer.scroll_by(offsets.y)
                     }
                     _ => {}
@@ -270,29 +273,30 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
                 ..
             } => {}
             WindowEvent::ThemeChanged(_) => {}
-            WindowEvent::DecorationsClick => {}
             _ => {}
         }
     }
 
     pub fn resume(
         &mut self,
-        event_loop: &EventLoopWindowTarget<UserWindowEvent>,
+        event_loop: &ActiveEventLoop,
         proxy: &EventLoopProxy<UserWindowEvent>,
         rt: &tokio::runtime::Runtime,
     ) {
         let window_builder = || {
-            let window = WindowBuilder::new()
-                .with_inner_size(LogicalSize {
+            let window = event_loop
+                .create_window(Window::default_attributes().with_inner_size(LogicalSize {
                     width: 800,
                     height: 600,
-                })
-                .build(event_loop)
+                }))
                 .unwrap();
 
             #[cfg(target_os = "windows")]
             {
-                build_menu().init_for_hwnd(window.hwnd());
+                use winit::raw_window_handle::*;
+                if let RawWindowHandle::Win32(handle) = window.window_handle().unwrap().as_raw() {
+                    build_menu().init_for_hwnd(handle.hwnd.get()).unwrap();
+                }
             }
             #[cfg(target_os = "linux")]
             {
@@ -306,7 +310,7 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
             //     build_menu().set_as_windows_menu_for_nsapp();
             // }
 
-            let size: tao::dpi::PhysicalSize<u32> = window.inner_size();
+            let size: winit::dpi::PhysicalSize<u32> = window.inner_size();
             let mut viewport = Viewport::new((size.width, size.height));
             viewport.set_hidpi_scale(window.scale_factor() as _);
 


### PR DESCRIPTION
Replaces the `tao` backend with `winit` in anticipation of `accesskit` and `masonry` features.

I wanted to make a quick working draft for now to see how this change integrates with the project. So far I haven't noticed any different behavior between the two crates 👍 