### PR TITLE
Follow up for `winit` backend and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
               cross: false,
               command: "test",
               args: "--all --tests",
+              setup: ""
             }
           - {
               target: x86_64-apple-darwin,
@@ -96,6 +97,7 @@ jobs:
               cross: false,
               command: "test",
               args: "--all --tests",
+              setup: ""
             }
           - {
               target: x86_64-unknown-linux-gnu,
@@ -103,6 +105,13 @@ jobs:
               cross: false,
               command: "test",
               args: "--all --tests",
+              setup: "sudo apt-get update; sudo apt-get install --no-install-recommends \
+                libasound2-dev \
+                libatk1.0-dev \
+                libgtk-3-dev \
+                libudev-dev \
+                libpango1.0-dev \
+                libxdo-dev"
             }
 
     steps:
@@ -131,6 +140,9 @@ jobs:
           key: "${{ matrix.platform.target }}"
           cache-all-crates: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Setup
+        run: ${{ matrix.platform.setup }} 
 
       - name: test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
           - {
               target: x86_64-pc-windows-msvc,
               os: windows-latest,
-              toolchain: "1.75.0",
               cross: false,
               command: "test",
               args: "--all --tests",
@@ -94,7 +93,6 @@ jobs:
           - {
               target: x86_64-apple-darwin,
               os: macos-latest,
-              toolchain: "1.75.0",
               cross: false,
               command: "test",
               args: "--all --tests",
@@ -102,26 +100,9 @@ jobs:
           - {
               target: x86_64-unknown-linux-gnu,
               os: ubuntu-latest,
-              toolchain: "1.75.0",
               cross: false,
               command: "test",
               args: "--all --tests",
-            }
-          - {
-              target: aarch64-apple-ios,
-              os: macos-latest,
-              toolchain: "1.75.0",
-              cross: false,
-              command: "build",
-              args: "--package dioxus-mobile",
-            }
-          - {
-              target: aarch64-linux-android,
-              os: ubuntu-latest,
-              toolchain: "1.75.0",
-              cross: true,
-              command: "build",
-              args: "--package dioxus-mobile",
             }
 
     steps:
@@ -129,7 +110,7 @@ jobs:
       - name: install stable
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.platform.toolchain }}
+          toolchain: "1.31.0"
           targets: ${{ matrix.platform.target }}
           components: rustfmt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - name: install stable
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.31.0"
+          toolchain: stable
           targets: ${{ matrix.platform.target }}
           components: rustfmt
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 .DS_Store
 experiments
+/.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "rust-analyzer.check.features": "all",
-    "rust-analyzer.cargo.features": "all",
-    "rust-analyzer.check.allTargets": true,
-    "rust-analyzer.cargo.allTargets": true
-}

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,42 @@
+# Contributing to Blitz
+
+Welcome to the Dioxus community!
+Blitz is a "native" HTML/CSS renderer built to support the "Dioxus Native" project. It is effectively a lightweight webview except that the JavaScript engine is replaced with a native Rust API which allows Rust reactivity / state management libraries like Dioxus to interface with it directly.
+
+Talk to us in: the #native channel in the [Dioxus Discord](https://discord.gg/BWTrn6d3)
+
+## Development
+
+### Windows
+Building Blitz requires Python, which can be installed from the Windows app store.
+
+### Linux
+Requirements:
+ * asound2
+ * atk1.0
+ * gtk-3
+ * udev
+ * pango1.0
+ * xdo
+
+For example on Ubuntu you can install these by running:
+```sh
+sudo apt-get update
+sudo apt-get install \
+    libasound2-dev \
+    libatk1.0-dev \
+    libgtk-3-dev \
+    libudev-dev \
+    libpango1.0-dev \
+    libxdo-dev
+```
+
+### VSCode
+```json
+{
+    "rust-analyzer.check.features": "all",
+    "rust-analyzer.cargo.features": "all",
+    "rust-analyzer.check.allTargets": true,
+    "rust-analyzer.cargo.allTargets": true
+}
+```

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -32,6 +32,7 @@ sudo apt-get install \
 ```
 
 ### VSCode
+You can add the following JSON to your `.vscode/settings.json` to automically build Blitz on all supported targets.
 ```json
 {
     "rust-analyzer.check.features": "all",

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -293,7 +293,6 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
                 }))
                 .unwrap();
 
-            
             self.menu = Some(init_menu(&window));
 
             let size: winit::dpi::PhysicalSize<u32> = window.inner_size();
@@ -335,7 +334,6 @@ pub fn init_menu(window: &Window) -> Menu {
 
     menu.append(&about).unwrap();
 
-
     #[cfg(target_os = "windows")]
     {
         use winit::raw_window_handle::*;
@@ -360,4 +358,3 @@ pub fn init_menu(window: &Window) -> Menu {
 
     menu
 }
-

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -21,8 +21,6 @@ use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
     target_os = "openbsd"
 ))]
 use winit::platform::unix::WindowExtUnix;
-#[cfg(target_os = "windows")]
-use winit::platform::windows::WindowExtWindows;
 use winit::{event::WindowEvent, keyboard::KeyCode, keyboard::ModifiersState, window::Window};
 
 use muda::{AboutMetadata, Menu, MenuId, MenuItem, PredefinedMenuItem, Submenu};
@@ -326,12 +324,9 @@ impl<'a, Doc: DocumentLike> View<'a, Doc> {
 pub fn init_menu_bar(menu: &Menu, window: &Window) {
     #[cfg(target_os = "windows")]
     {
-        use winit::platform::windows::WindowExtWindows;
-        use winit::raw_window_handle;
-        let id = window.window_handle_any_thread().unwrap();
-        if let raw_window_handle::RawWindowHandle::Win32(rwh) = rwh {
-            let hwnd = id.hwnd;
-            _ = menu.init_for_hwnd(hwnd as _);
+        use winit::raw_window_handle::*;
+        if let RawWindowHandle::Win32(handle) = window.window_handle().unwrap().as_raw() {
+            menu.init_for_hwnd(handle.hwnd.get()).unwrap();
         }
     }
 

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -24,7 +24,6 @@ pub(crate) struct View<'s, Doc: DocumentLike> {
     keyboard_modifiers: ModifiersState,
 
     /// Main menu bar of this view's window.
-    ///
     menu: Option<Menu>,
 }
 


### PR DESCRIPTION
### Menu bar
* Fixes menu bar on Windows
* Refactor menu bar initialization and add it to `View`
* Remove GTK menu for now
  - This is the biggest change I've noticed so far from `tao`. I'd love to dig deeper into this but I'm not sure how we can access a potential `gtk::Window` from the `winit::Window` yet.

### CI
* Set default Rust toolchain to latest stable
* Remove mobile CI for now
* Install required Ubuntu dependencies