### PR TITLE
fix: scroll clamping

### DIFF
--- a/packages/blitz/src/render.rs
+++ b/packages/blitz/src/render.rs
@@ -263,8 +263,8 @@ where
             .to_f64_px();
         self.scroll_offset = self
             .scroll_offset
-            .min(0.0)
-            .max(-(content_height - viewport_height));
+            .max(-(content_height - viewport_height))
+            .min(0.0);
     }
 
     pub fn click(&mut self, button: &str) {


### PR DESCRIPTION
Fix #80.
When the viewport_height is greater than the content_height, the scroll_offset becomes positive.