### PR TITLE
Fix incorrect file path in parse_debug example

### DIFF
--- a/examples/parse_debug.rs
+++ b/examples/parse_debug.rs
@@ -1,5 +1,5 @@
 //! Render minimal html5 page
 
 fn main() {
-    dioxus_blitz::launch_static_html(include_str!("./google_bits/google_reduced.html"));
+    dioxus_blitz::launch_static_html(include_str!("./assets/google_reduced.html"));
 }


### PR DESCRIPTION
There is no "google_bits" folder, its renamed to "assets".