### PR TITLE
Cache inline layout created by Parley

### DIFF
--- a/packages/dioxus-blitz/src/documents/dioxus_document.rs
+++ b/packages/dioxus-blitz/src/documents/dioxus_document.rs
@@ -438,8 +438,11 @@ impl WriteMutations for MutationWriter<'_> {
 
         if let Some(parent) = node.parent {
             // if the text is the child of a style element, we want to put the style into the stylesheet cache
-            let parent = self.doc.get_node(parent).unwrap();
-            if let NodeData::Element(ref element) = parent.raw_dom_data {
+            let parent = self.doc.get_node_mut(parent).unwrap();
+            if let NodeData::Element(ref mut element) = parent.raw_dom_data {
+                if changed {
+                    element.inline_layout = None;
+                }
                 // Only set stylsheets if the text content has *changed* - we need to unload
                 if changed && element.name.local.as_ref() == "style" {
                     self.doc.add_stylesheet(value);

--- a/packages/dom/src/layout/construct.rs
+++ b/packages/dom/src/layout/construct.rs
@@ -80,14 +80,25 @@ pub(crate) fn collect_layout_children(
 
             // TODO: fix display:contents
             if all_inline {
-                let (inline_layout, ilayout_children) = build_inline_layout(doc, container_node_id);
-                doc.nodes[container_node_id].is_inline_root = true;
-                doc.nodes[container_node_id]
+                // Caching because calling Parley is expensive
+                if doc.nodes[container_node_id]
                     .raw_dom_data
-                    .downcast_element_mut()
+                    .downcast_element()
                     .unwrap()
-                    .inline_layout = Some(Box::new(inline_layout));
-                return layout_children.extend_from_slice(&ilayout_children);
+                    .inline_layout
+                    .is_none()
+                {
+                    let (inline_layout, ilayout_children) =
+                        build_inline_layout(doc, container_node_id);
+                    doc.nodes[container_node_id].is_inline_root = true;
+                    doc.nodes[container_node_id]
+                        .raw_dom_data
+                        .downcast_element_mut()
+                        .unwrap()
+                        .inline_layout = Some(Box::new(inline_layout));
+                    layout_children.extend_from_slice(&ilayout_children);
+                }
+                return;
             }
 
             // If the children are either all inline or all block then simply return the regular children


### PR DESCRIPTION
Add a logic to the inline layout generation reuse. This speeds up resolving the DOM significantly (takes roughly ~1/3 the time of the previous time spent in resolve).

Note: Many invalidation methods are not handled and it's an early work