### PR TITLE
Basic `vello_svg` based SVG support

### DIFF
--- a/packages/blitz/Cargo.toml
+++ b/packages/blitz/Cargo.toml
@@ -17,3 +17,4 @@ vello = { workspace = true }
 wgpu = { workspace = true }
 raw-window-handle = "0.6.0"
 image = "0.25"
+vello_svg = { git = "https://github.com/DioxusLabs/vello_svg", rev = "6a8bf4abd1ad053431253964d1b62ad4427f4311" }

--- a/packages/dom/Cargo.toml
+++ b/packages/dom/Cargo.toml
@@ -30,6 +30,7 @@ data-url = "0.3.1"
 ureq = "2.9"
 image = "0.25.2"
 winit = { version = "0.30.4", default-features = false }
+usvg = "0.42.0"
 
 
 # on wasm use the js feature on getrandom

--- a/packages/dom/src/htmlsink.rs
+++ b/packages/dom/src/htmlsink.rs
@@ -109,18 +109,34 @@ impl<'a> DocumentHtmlParser<'a> {
             if !raw_src.is_empty() {
                 let src = self.doc.resolve_url(raw_src);
 
-                // FIXME: Image fetching should not be a synchronous network request during parsing
-                let image_result = crate::util::fetch_image(src.as_str());
-                match image_result {
-                    Ok(image) => {
-                        self.node_mut(target_id)
-                            .element_data_mut()
-                            .unwrap()
-                            .node_specific_data =
-                            NodeSpecificData::Image(ImageData::new(Arc::new(image)));
+                if src.path().ends_with(".svg") {
+                    // FIXME: Image fetching should not be a synchronous network request during parsing
+                    let svg_results = crate::util::fetch_svg(src.as_str());
+                    match svg_results {
+                        Ok(svg) => {
+                            self.node_mut(target_id)
+                                .element_data_mut()
+                                .unwrap()
+                                .node_specific_data = NodeSpecificData::Svg(svg);
+                        }
+                        Err(_) => {
+                            eprintln!("Error fetching image {}", src);
+                        }
                     }
-                    Err(_) => {
-                        eprintln!("Error fetching image {}", src);
+                } else {
+                    // FIXME: Image fetching should not be a synchronous network request during parsing
+                    let image_result = crate::util::fetch_image(src.as_str());
+                    match image_result {
+                        Ok(image) => {
+                            self.node_mut(target_id)
+                                .element_data_mut()
+                                .unwrap()
+                                .node_specific_data =
+                                NodeSpecificData::Image(ImageData::new(Arc::new(image)));
+                        }
+                        Err(_) => {
+                            eprintln!("Error fetching image {}", src);
+                        }
                     }
                 }
             }

--- a/packages/dom/src/layout/mod.rs
+++ b/packages/dom/src/layout/mod.rs
@@ -168,15 +168,24 @@ impl LayoutPartialTree for Document {
                         };
 
                         // Get image's native size
-                        let inherent_size = match element_data.image_data_mut() {
-                            Some(data) => taffy::Size {
+                        let inherent_size = match &element_data.node_specific_data {
+                            NodeSpecificData::Image(data) => taffy::Size {
                                 width: data.image.width() as f32,
                                 height: data.image.height() as f32,
                             },
-                            None => taffy::Size {
+                            NodeSpecificData::Svg(svg) => {
+                                let size = svg.size();
+                                taffy::Size {
+                                    width: size.width(),
+                                    height: size.height(),
+                                }
+                            }
+                            NodeSpecificData::None => taffy::Size {
                                 width: 0.0,
                                 height: 0.0,
                             },
+
+                            _ => unreachable!(),
                         };
 
                         let image_context = ImageContext {

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -352,6 +352,20 @@ impl ElementNodeData {
         }
     }
 
+    pub fn svg_data(&self) -> Option<&usvg::Tree> {
+        match self.node_specific_data {
+            NodeSpecificData::Svg(ref data) => Some(data),
+            _ => None,
+        }
+    }
+
+    pub fn svg_data_mut(&mut self) -> Option<&mut usvg::Tree> {
+        match self.node_specific_data {
+            NodeSpecificData::Svg(ref mut data) => Some(data),
+            _ => None,
+        }
+    }
+
     pub fn text_input_data(&self) -> Option<&TextInputData> {
         match self.node_specific_data {
             NodeSpecificData::TextInput(ref data) => Some(data),
@@ -470,6 +484,8 @@ impl TextInputData {
 pub enum NodeSpecificData {
     /// The element's image content (\<img\> element's only)
     Image(ImageData),
+    /// The element's image content (\<img\> element's only)
+    Svg(usvg::Tree),
     /// Parley text layout (elements with inline inner display mode only)
     InlineRoot(Box<TextLayout>),
     /// Parley text editor (text inputs)
@@ -482,6 +498,7 @@ impl std::fmt::Debug for NodeSpecificData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             NodeSpecificData::Image(_) => f.write_str("NodeSpecificData::Image"),
+            NodeSpecificData::Svg(_) => f.write_str("NodeSpecificData::Svg"),
             NodeSpecificData::InlineRoot(_) => f.write_str("NodeSpecificData::InlineRoot"),
             NodeSpecificData::TextInput(_) => f.write_str("NodeSpecificData::TextInput"),
             NodeSpecificData::None => f.write_str("NodeSpecificData::None"),


### PR DESCRIPTION
Fixes #99 

Pretty naive (and adds ~3mb to binary size), but this gives us basic support for SVGs included as `<img>` tags