### PR TITLE
Webfonts WIP

### DIFF
--- a/examples/assets/servo.html
+++ b/examples/assets/servo.html
@@ -22,6 +22,10 @@
   <meta property="og:logo" content="/img/servo-symbol-color-no-container.png">
   <meta property="og:url" content="/">
 
+  <!-- TODO: support @import -->
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Sans:300,400,600,700|Fira+Mono:300,400,600,700|Fire+Sans:100,200,300,400,500,600,700">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.0/css/all.css">
+
   <link rel="stylesheet" href="/css/style.css">
   <link rel="shortcut icon" href="/img/servo-symbol-color-no-container.png">
   <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet">

--- a/packages/dom/Cargo.toml
+++ b/packages/dom/Cargo.toml
@@ -31,6 +31,7 @@ ureq = "2.9"
 image = "0.25.2"
 winit = { version = "0.30.4", default-features = false }
 usvg = "0.42.0"
+woff = "0.3.3"
 
 
 # on wasm use the js feature on getrandom

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -482,14 +482,14 @@ impl Document {
                             if let Some(hint) = &source.format_hint {
                                 match hint {
                                     FontFaceSourceFormat::String(s) => {
-                                        println!("Skipping unsupported font of custom type {}", s);
-                                        continue;
+                                        // println!("Skipping unsupported font of custom type {}", s);
+                                        // continue;
                                     }
                                     FontFaceSourceFormat::Keyword(keyword) => {
                                         use FontFaceSourceFormatKeyword as KW;
                                         if matches!(
                                             keyword,
-                                            KW::EmbeddedOpentype | KW::Svg | KW::Woff | KW::Woff2
+                                            KW::EmbeddedOpentype | KW::Svg
                                         ) {
                                             println!(
                                                 "Skipping unsupported font of type {:?}",
@@ -510,9 +510,19 @@ impl Document {
                                 continue;
                             };
 
-                            // TODO: Support WOFF
-                            self.font_ctx.collection.register_fonts(font_data);
-                            println!("Registed font {}", url.as_str());
+                            if url.path().ends_with("woff2") || url.path().ends_with("woff") {
+                                if let Some(font_data) = woff::version2::decompress(&font_data) {
+                                    self.font_ctx.collection.register_fonts(font_data);
+                                    println!("Registed font {}", url.as_str());
+                                } else {
+                                    println!("Error decompressing woff2 data");
+                                }
+
+                            } else {
+                                self.font_ctx.collection.register_fonts(font_data);
+                                println!("Registed font {}", url.as_str());
+                            }
+
                         }
                     }
                 }

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -461,6 +461,8 @@ impl Document {
 
         let sheet = DocumentStyleSheet(ServoArc::new(data));
 
+        self.add_webfonts_from_stylesheet(&*sheet.0);
+
         self.stylesheets.insert(css.to_string(), sheet.clone());
 
         self.stylist.append_stylesheet(sheet, &self.guard.read());


### PR DESCRIPTION
This one isn't working yet either:
- Servo.org also requires `@import` support for it's webfonts
- Dioxuslabs.com loads the font but REALLY slowly (due to sync IO I think). We're going to need a proper tokio-based network thread before we land this.
- The fonts still don't actually take affect. We may need to improve support in Fontique for this.