### PR TITLE
Use `ApplicationHandler` trait for winit integration

### DIFF
--- a/packages/dioxus-blitz/src/application.rs
+++ b/packages/dioxus-blitz/src/application.rs
@@ -1,0 +1,133 @@
+use crate::waker::{BlitzEvent, BlitzWindowEvent};
+
+use blitz_dom::DocumentLike;
+use std::collections::HashMap;
+use winit::application::ApplicationHandler;
+use winit::event::WindowEvent;
+use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
+use winit::window::WindowId;
+
+use crate::{View, WindowConfig};
+
+pub struct Application<Doc: DocumentLike> {
+    rt: tokio::runtime::Runtime,
+    windows: HashMap<WindowId, View<Doc>>,
+    pending_windows: Vec<WindowConfig<Doc>>,
+    proxy: EventLoopProxy<BlitzEvent>,
+
+    #[cfg(all(feature = "menu", not(any(target_os = "android", target_os = "ios"))))]
+    menu_channel: muda::MenuEventReceiver,
+}
+
+impl<Doc: DocumentLike> Application<Doc> {
+    pub fn new(rt: tokio::runtime::Runtime, proxy: EventLoopProxy<BlitzEvent>) -> Self {
+        Application {
+            windows: HashMap::new(),
+            pending_windows: Vec::new(),
+            rt,
+            proxy,
+
+            #[cfg(all(feature = "menu", not(any(target_os = "android", target_os = "ios"))))]
+            menu_channel: muda::MenuEvent::receiver().clone(),
+        }
+    }
+
+    pub fn add_window(&mut self, window_config: WindowConfig<Doc>) {
+        self.pending_windows.push(window_config);
+    }
+}
+
+impl<Doc: DocumentLike> ApplicationHandler<BlitzEvent> for Application<Doc> {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        // Resume existing windows
+        for (_, view) in self.windows.iter_mut() {
+            view.resume(&self.rt);
+        }
+
+        // Initialise pending windows
+        for window_config in self.pending_windows.drain(..) {
+            let mut view = View::init(window_config, event_loop, &self.proxy);
+            view.resume(&self.rt);
+            if !view.renderer.is_active() {
+                continue;
+            }
+            self.windows.insert(view.window_id(), view);
+        }
+    }
+
+    fn suspended(&mut self, _event_loop: &ActiveEventLoop) {
+        for (_, view) in self.windows.iter_mut() {
+            view.suspend();
+        }
+    }
+
+    fn new_events(&mut self, _event_loop: &ActiveEventLoop, _cause: winit::event::StartCause) {
+        for window_id in self.windows.keys().copied() {
+            _ = self.proxy.send_event(BlitzEvent::Window {
+                data: BlitzWindowEvent::Poll,
+                window_id,
+            });
+        }
+
+        #[cfg(all(feature = "menu", not(any(target_os = "android", target_os = "ios"))))]
+        if let Ok(event) = self.menu_channel.try_recv() {
+            if event.id == muda::MenuId::new("dev.show_layout") {
+                for (_, view) in self.windows.iter_mut() {
+                    view.devtools.show_layout = !view.devtools.show_layout;
+                    view.request_redraw();
+                }
+            }
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        // Exit the app when window close is requested. TODO: Only exit when last window is closed.
+        if matches!(event, WindowEvent::CloseRequested) {
+            event_loop.exit();
+            return;
+        }
+
+        if let Some(window) = self.windows.get_mut(&window_id) {
+            window.handle_winit_event(event);
+        }
+    }
+
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: BlitzEvent) {
+        match event {
+            BlitzEvent::Window { data, window_id } => {
+                if let Some(view) = self.windows.get_mut(&window_id) {
+                    view.handle_blitz_event(data);
+                };
+            }
+
+            #[cfg(all(
+                feature = "hot-reload",
+                debug_assertions,
+                not(target_os = "android"),
+                not(target_os = "ios")
+            ))]
+            BlitzEvent::HotReloadEvent(msg) => match msg {
+                dioxus_hot_reload::HotReloadMsg::UpdateTemplate(template) => {
+                    for window in self.windows.values_mut() {
+                        use crate::documents::DioxusDocument;
+                        if let Some(dx_doc) =
+                            window.dom.as_any_mut().downcast_mut::<DioxusDocument>()
+                        {
+                            dx_doc.vdom.replace_template(template);
+                            window.handle_blitz_event(BlitzWindowEvent::Poll);
+                        }
+                    }
+                }
+                dioxus_hot_reload::HotReloadMsg::Shutdown => event_loop.exit(),
+                dioxus_hot_reload::HotReloadMsg::UpdateAsset(_asset) => {
+                    // TODO dioxus-desktop seems to handle this by forcing a reload of all stylesheets.
+                }
+            },
+        }
+    }
+}

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -260,7 +260,7 @@ impl<Doc: DocumentLike> View<Doc> {
             WindowEvent::Destroyed => {}
             WindowEvent::ActivationTokenDone { .. } => {},
             WindowEvent::CloseRequested => {
-                // Currently handled at the level above in lib.rs
+                // Currently handled at the level above in application.rs
             }
             WindowEvent::RedrawRequested => {
                 self.redraw();


### PR DESCRIPTION
@jkelleyrtp I'm assuming that we were only previously using the closure because you hadn't gotten around to changing it rather than because there was a specific reason to prefer that API?