### PR TITLE
Pass focus to accesskit and simplify node ids

### DIFF
--- a/packages/dioxus-blitz/src/accessibility.rs
+++ b/packages/dioxus-blitz/src/accessibility.rs
@@ -7,7 +7,7 @@ use winit::{event_loop::EventLoopProxy, window::Window};
 /// State of the accessibility node tree and platform adapter.
 pub struct AccessibilityState {
     /// Adapter to connect to the [`EventLoop`](`winit::event_loop::EventLoop`).
-    adapter: accesskit_winit::Adapter,
+    pub adapter: accesskit_winit::Adapter,
 }
 
 impl AccessibilityState {

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -255,6 +255,12 @@ impl<Doc: DocumentLike> View<Doc> {
     }
 
     pub fn handle_winit_event(&mut self, event: WindowEvent) {
+        // Process an event through AccessKit if enabled.
+        #[cfg(feature = "accessibility")]
+        self.accessibility
+            .adapter
+            .process_event(&self.window, &event);
+
         match event {
             // Window lifecycle events
             WindowEvent::Destroyed => {}

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -67,6 +67,7 @@ pub trait DocumentLike: AsRef<Document> + AsMut<Document> + Into<Document> + 'st
     }
 }
 
+// TODO (Matt): change document IDs to be u64 for accesskit compatibility.
 pub struct Document {
     /// A bump-backed tree
     ///
@@ -576,6 +577,10 @@ impl Document {
 
             node = next;
         }
+    }
+
+    pub fn focus(&self) -> Option<usize> {
+        self.focus_node_id
     }
 
     pub fn focus_next_node(&mut self) -> Option<usize> {


### PR DESCRIPTION
 - Unifies AccessKit IDs with `Document` element IDs
 - Adds the `Document::focus` method and calls it to send the currently focused ID to AccessKit
 - Process window events with AccessKit
 - TODO fix ID errors in interactive examples