### PR TITLE
Add screenshot example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .DS_Store
 experiments
 /.vscode
+/examples/output/*.png
+/examples/output/*.jpg
+/examples/output/*.jpeg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ opt-level = 2
 blitz = { path = "./packages/blitz" }
 blitz-dom = { path = "./packages/dom" }
 comrak = { version = "0.21.0", default-features = false }
+png = { version = "0.17" }
 dioxus-blitz = { path = "./packages/dioxus-blitz" }
 dioxus = { workspace = true }
 euclid = { version = "0.22", features = ["serde"] }

--- a/examples/output/.gitkeep
+++ b/examples/output/.gitkeep
@@ -1,0 +1,1 @@
+.gitkeep

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,0 +1,70 @@
+//! Load first CLI argument as a url. Fallback to google.com if no CLI argument is provided.
+
+use std::{fs::File, path::Path};
+
+use blitz::render_to_buffer;
+use blitz_dom::Viewport;
+use dioxus_blitz::{Config, HtmlDocument};
+use reqwest::Url;
+
+#[tokio::main]
+async fn main() {
+    let url = std::env::args()
+        .skip(1)
+        .next()
+        .unwrap_or_else(|| "https://www.google.com".into());
+
+    const USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0";
+    println!("{}", url);
+
+    // Assert that url is valid
+    let url = url.to_owned();
+    Url::parse(&url).expect("Invalid url");
+
+    let html = ureq::get(&url)
+        .set("User-Agent", USER_AGENT)
+        .call()
+        .unwrap()
+        .into_string()
+        .unwrap();
+    let config = Config {
+        stylesheets: Vec::new(),
+        base_url: Some(url),
+    };
+
+    let scale = 2;
+    let width = 800 * scale;
+    let height = 600 * scale;
+
+    let viewport = Viewport::new(width, height, scale as f32);
+    let mut document = HtmlDocument::from_html(&html, &config);
+    document.as_mut().set_viewport(viewport.clone());
+    document.as_mut().resolve();
+
+    let buffer = render_to_buffer(document.as_ref(), viewport).await;
+
+    let out_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples/output/screenshot")
+        .with_extension("png");
+
+    write_png(out_path.as_path(), &buffer, width, height);
+
+    println!("Wrote result ({width}x{height}) to {out_path:?}");
+}
+
+fn write_png(out_path: &Path, buffer: &[u8], width: u32, height: u32) {
+    let mut file = File::create(&out_path).unwrap();
+
+    let mut encoder = png::Encoder::new(&mut file, width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    const PPM: u32 = (144.0 * 39.3701) as u32;
+    encoder.set_pixel_dims(Some(png::PixelDimensions {
+        xppu: PPM,
+        yppu: PPM,
+        unit: png::Unit::Meter,
+    }));
+    let mut writer = encoder.write_header().unwrap();
+    writer.write_image_data(&buffer).unwrap();
+    writer.finish().unwrap();
+}

--- a/packages/blitz/Cargo.toml
+++ b/packages/blitz/Cargo.toml
@@ -18,3 +18,4 @@ wgpu = { workspace = true }
 raw-window-handle = "0.6.0"
 image = "0.25"
 vello_svg = { git = "https://github.com/DioxusLabs/vello_svg", rev = "6a8bf4abd1ad053431253964d1b62ad4427f4311" }
+futures-intrusive = "0.5.0"

--- a/packages/dioxus-blitz/src/documents/html_document.rs
+++ b/packages/dioxus-blitz/src/documents/html_document.rs
@@ -30,7 +30,7 @@ impl DocumentLike for HtmlDocument {
 }
 
 impl HtmlDocument {
-    pub(crate) fn from_html(html: &str, cfg: &Config) -> Self {
+    pub fn from_html(html: &str, cfg: &Config) -> Self {
         // Spin up the virtualdom and include the default stylesheet
         let viewport = Viewport::new(0, 0, 1.0);
         let mut dom = Document::new(viewport);

--- a/packages/dioxus-blitz/src/documents/mod.rs
+++ b/packages/dioxus-blitz/src/documents/mod.rs
@@ -2,5 +2,5 @@ mod dioxus_document;
 mod event_handler;
 mod html_document;
 
-pub(crate) use dioxus_document::DioxusDocument;
-pub(crate) use html_document::HtmlDocument;
+pub use dioxus_document::DioxusDocument;
+pub use html_document::HtmlDocument;

--- a/packages/dioxus-blitz/src/lib.rs
+++ b/packages/dioxus-blitz/src/lib.rs
@@ -27,9 +27,9 @@ use url::Url;
 use winit::event_loop::{ControlFlow, EventLoop};
 
 use crate::application::Application;
-use crate::documents::{DioxusDocument, HtmlDocument};
 use crate::window::View;
 
+pub use crate::documents::{DioxusDocument, HtmlDocument};
 pub use crate::waker::BlitzEvent;
 pub use crate::window::WindowConfig;
 

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -644,6 +644,10 @@ impl Document {
         self.set_stylist_device(self.viewport.make_device());
     }
 
+    pub fn get_viewport(&self) -> Viewport {
+        self.viewport.clone()
+    }
+
     /// Update the device and reset the stylist to process the new size
     pub fn set_stylist_device(&mut self, device: Device) {
         let origins = {


### PR DESCRIPTION
The new example renders to an image which it writes to the `examples/output` directory.