### PR TITLE
Add a root html element in Dioxus integration

### DIFF
--- a/packages/dioxus-blitz/src/documents/dioxus_document.rs
+++ b/packages/dioxus-blitz/src/documents/dioxus_document.rs
@@ -138,15 +138,15 @@ impl DioxusDocument {
         let viewport = Viewport::new(0, 0, 1.0);
         let mut doc = Document::new(viewport);
 
-        // Create a virtual "dioxus:document" element to act as the root element, as we won't necessarily
+        // Create a virtual "html" element to act as the root element, as we won't necessarily
         // have a single root otherwise, while the rest of blitz requires that we do
-        let document_element_id = doc.create_node(NodeData::Element(ElementNodeData::new(
-            qual_name("document", Some("dioxus")),
+        let html_element_id = doc.create_node(NodeData::Element(ElementNodeData::new(
+            qual_name("html", None),
             Vec::new(),
         )));
         let root_node_id = doc.root_node().id;
-        let document_element = doc.get_node_mut(document_element_id).unwrap();
-        document_element.parent = Some(root_node_id);
+        let html_element = doc.get_node_mut(html_element_id).unwrap();
+        html_element.parent = Some(root_node_id);
         let root_node = doc.get_node_mut(root_node_id).unwrap();
         // Stylo data on the root node container is needed to render the element
         let stylo_element_data = ElementData {
@@ -160,7 +160,7 @@ impl DioxusDocument {
             ..Default::default()
         };
         *root_node.stylo_element_data.borrow_mut() = Some(stylo_element_data);
-        root_node.children.push(document_element_id);
+        root_node.children.push(html_element_id);
 
         // Include default and user-specified stylesheets
         doc.add_stylesheet(DEFAULT_CSS);

--- a/packages/dioxus-blitz/src/documents/dioxus_document.rs
+++ b/packages/dioxus-blitz/src/documents/dioxus_document.rs
@@ -12,7 +12,7 @@ use dioxus::{
         AttributeValue, ElementId, Template, TemplateAttribute, TemplateNode, VirtualDom,
         WriteMutations,
     },
-    prelude::{set_event_converter, Element, PlatformEventData},
+    prelude::{set_event_converter, PlatformEventData},
 };
 use futures_util::{pin_mut, FutureExt};
 use rustc_hash::FxHashMap;
@@ -138,8 +138,8 @@ impl DioxusDocument {
         let viewport = Viewport::new(0, 0, 1.0);
         let mut doc = Document::new(viewport);
 
-        //Create a virtual "dioxus:document" element to act as the root element, as we won't have
-        //a single root otherwise
+        // Create a virtual "dioxus:document" element to act as the root element, as we won't necessarily
+        // have a single root otherwise, while the rest of blitz requires that we do
         let document_element_id = doc.create_node(NodeData::Element(ElementNodeData::new(
             qual_name("document", Some("dioxus")),
             Vec::new(),
@@ -148,6 +148,7 @@ impl DioxusDocument {
         let document_element = doc.get_node_mut(document_element_id).unwrap();
         document_element.parent = Some(root_node_id);
         let root_node = doc.get_node_mut(root_node_id).unwrap();
+        // Stylo data on the root node container is needed to render the element
         let stylo_element_data = ElementData {
             styles: ElementStyles {
                 primary: Some(
@@ -225,7 +226,7 @@ pub struct MutationWriter<'a> {
 impl DioxusState {
     /// Initialize the DioxusState in the RealDom
     pub fn create(doc: &mut Document) -> Self {
-        let root = doc.root_node();
+        let root = doc.root_element();
         let root_id = root.id;
 
         Self {


### PR DESCRIPTION
Fixes #81 - Currently, dioxus apps without a single root element crash when rendered in blitz. This fixes that by creating a virtual `<html>` root element. 

I experimented with a couple of other approaches as well, such as:

- treating Document nodes as an element as well - a bit of an impedance mismatch since stylo makes a distinction between documents and elements
- abolishing the concept of a root element and rendering all child elements of the root node - mismatch since taffy wants to draw a root element.

So this way seemed to be the best way to make it work out. With this fix you should find that the dioxus examples such as `bare_style` and `tailwind` no longer crash, and render correctly as far as they can.