### PR TITLE
Non-root  scrolling

### DIFF
--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -1,6 +1,6 @@
-// Example: dioxus + css + stylo
-//
-// Create a style context for a dioxus document.
+// Example: scrolling.
+// Creates a scrollable element to demo being able to scroll elements when their content size
+// exceeds their layout size
 use dioxus::prelude::*;
 
 fn root() -> Element {
@@ -47,31 +47,4 @@ fn root() -> Element {
 
 fn main() {
     dioxus_blitz::launch(root);
-
-    // let document = blitz_dom::Document::new();
-
-    // let styled_dom = blitz::style_lazy_nodes(css, nodes);
-
-    // print_styles(&styled_dom);
 }
-
-// fn print_styles(markup: &blitz::RealDom) {
-//     use style::dom::{TElement, TNode};
-
-//     let root = markup.root_node();
-//     for node in 0..markup.nodes.len() {
-//         let Some(el) = root.with(node).as_element() else {
-//             continue;
-//         };
-
-//         let data = el.borrow_data().unwrap();
-//         let primary = data.styles.primary();
-//         let bg_color = &primary.get_background().background_color;
-
-//         println!(
-//             "Styles for node {node_idx}:\n{:#?}",
-//             bg_color,
-//             node_idx = node
-//         );
-//     }
-// }

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -19,6 +19,10 @@ fn root() -> Element {
             align-items: center;
             color: white;
         }
+        
+        .gap:hover {
+            background: red;
+        }
 
         .not-scrollable {
             background-color: yellow;
@@ -35,6 +39,7 @@ fn root() -> Element {
             }
             div {
                 class: "gap",
+                onclick: |_| println!("Gap clicked!"),
                 "gap"
             }
             div {

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -1,0 +1,70 @@
+// Example: dioxus + css + stylo
+//
+// Create a style context for a dioxus document.
+use dioxus::prelude::*;
+
+fn root() -> Element {
+    let css = r#"
+        .scrollable {
+            background-color: green;
+            overflow: scroll;
+            height: 200px;
+        }
+
+        .gap {
+            height: 300px;
+        }
+
+        .not-scrollable {
+            background-color: yellow;
+        "#;
+
+    rsx! {
+        style { {css} }
+        div { class: "not-scrollable", "Not scrollable" }
+        div { class: "scrollable",
+            div {
+                "Scroll me"
+            }
+            div {
+                class: "gap",
+                "gap"
+            }
+            div {
+                "Hello"
+            }
+        }
+        div { class: "not-scrollable", "Not scrollable" }
+    }
+}
+
+fn main() {
+    dioxus_blitz::launch(root);
+
+    // let document = blitz_dom::Document::new();
+
+    // let styled_dom = blitz::style_lazy_nodes(css, nodes);
+
+    // print_styles(&styled_dom);
+}
+
+// fn print_styles(markup: &blitz::RealDom) {
+//     use style::dom::{TElement, TNode};
+
+//     let root = markup.root_node();
+//     for node in 0..markup.nodes.len() {
+//         let Some(el) = root.with(node).as_element() else {
+//             continue;
+//         };
+
+//         let data = el.borrow_data().unwrap();
+//         let primary = data.styles.primary();
+//         let bg_color = &primary.get_background().background_color;
+
+//         println!(
+//             "Styles for node {node_idx}:\n{:#?}",
+//             bg_color,
+//             node_idx = node
+//         );
+//     }
+// }

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -13,10 +13,17 @@ fn root() -> Element {
 
         .gap {
             height: 300px;
+            margin: 8px;
+            background: #11ff11;
+            display: flex;
+            align-items: center;
+            color: white;
         }
 
         .not-scrollable {
             background-color: yellow;
+            padding-top: 16px;
+            padding-bottom: 16px;
         "#;
 
     rsx! {

--- a/packages/blitz/src/renderer/render.rs
+++ b/packages/blitz/src/renderer/render.rs
@@ -115,7 +115,10 @@ impl<'dom> VelloSceneGenerator<'dom> {
         self.render_element(
             scene,
             self.dom.as_ref().root_element().id,
-            Point { x: -viewport_scroll.x, y: -viewport_scroll.y },
+            Point {
+                x: -viewport_scroll.x,
+                y: -viewport_scroll.y,
+            },
         );
 
         // Render debug overlay

--- a/packages/blitz/src/renderer/render.rs
+++ b/packages/blitz/src/renderer/render.rs
@@ -111,10 +111,11 @@ impl<'dom> VelloSceneGenerator<'dom> {
     pub fn generate_vello_scene(&self, scene: &mut Scene) {
         // Simply render the document (the root element (note that this is not the same as the root node)))
         scene.reset();
+        let viewport_scroll = self.dom.as_ref().get_viewport().scroll();
         self.render_element(
             scene,
             self.dom.as_ref().root_element().id,
-            Point { x: 0.0, y: 0.0 },
+            Point { x: -viewport_scroll.0, y: -viewport_scroll.1 },
         );
 
         // Render debug overlay
@@ -356,7 +357,7 @@ impl<'dom> VelloSceneGenerator<'dom> {
         cx.stroke_border(scene);
         cx.stroke_devtools(scene);
 
-        //Now that background has been drawn, offset pos and cx in order to draw our contents scrolled
+        // Now that background has been drawn, offset pos and cx in order to draw our contents scrolled
         let pos = Point {
             x: pos.x - element.scroll_offset.x,
             y: pos.y - element.scroll_offset.y,

--- a/packages/blitz/src/renderer/render.rs
+++ b/packages/blitz/src/renderer/render.rs
@@ -111,11 +111,11 @@ impl<'dom> VelloSceneGenerator<'dom> {
     pub fn generate_vello_scene(&self, scene: &mut Scene) {
         // Simply render the document (the root element (note that this is not the same as the root node)))
         scene.reset();
-        let viewport_scroll = self.dom.as_ref().get_viewport().scroll();
+        let viewport_scroll = self.dom.as_ref().viewport_scroll();
         self.render_element(
             scene,
             self.dom.as_ref().root_element().id,
-            Point { x: -viewport_scroll.0, y: -viewport_scroll.1 },
+            Point { x: -viewport_scroll.x, y: -viewport_scroll.y },
         );
 
         // Render debug overlay

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -391,15 +391,18 @@ impl<Doc: DocumentLike> View<Doc> {
                 }
             }
             WindowEvent::MouseWheel { delta, .. } => {
-                let hover_node = self.dom.as_ref().get_hover_node_id().and_then(|id| self.dom.as_mut().get_node_mut(id));
                 let (scroll_x, scroll_y)= match delta {
                     winit::event::MouseScrollDelta::LineDelta(x, y) => (x as f64 * 20.0, y as f64 * 20.0),
                     winit::event::MouseScrollDelta::PixelDelta(offsets) => (offsets.x, offsets.y)
                 };
-                if let Some(hover_node) = hover_node {
-                    hover_node.scroll_by(scroll_x, scroll_y);
-                    self.request_redraw();
+
+                if let Some(hover_node_id)= self.dom.as_ref().get_hover_node_id() {
+                    self.dom.as_mut().scroll_node_by(hover_node_id, scroll_x, scroll_y);
+                } else {
+                    self.dom.as_mut().scroll_viewport_by(scroll_x, scroll_y);
                 }
+                    
+                self.request_redraw();
             }
 
             // File events
@@ -409,7 +412,7 @@ impl<Doc: DocumentLike> View<Doc> {
             WindowEvent::Focused(_) => {}
 
             // Touch and motion events
-            //Todo implement touch scrolling
+            // Todo implement touch scrolling
             WindowEvent::Touch(_) => {}
             WindowEvent::TouchpadPressure { .. } => {}
             WindowEvent::AxisMotion { .. } => {}

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -409,6 +409,7 @@ impl<Doc: DocumentLike> View<Doc> {
             WindowEvent::Focused(_) => {}
 
             // Touch and motion events
+            //Todo implement touch scrolling
             WindowEvent::Touch(_) => {}
             WindowEvent::TouchpadPressure { .. } => {}
             WindowEvent::AxisMotion { .. } => {}

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -191,7 +191,7 @@ impl<Doc: DocumentLike> View<Doc> {
 
     pub fn mouse_move(&mut self, x: f32, y: f32) -> bool {
         let dom_x = x / self.viewport.zoom();
-        let dom_y = (y - self.dom.as_ref().scroll_offset as f32) / self.viewport.zoom();
+        let dom_y = y / self.viewport.zoom();
 
         // println!("Mouse move: ({}, {})", x, y);
         // println!("Unscaled: ({}, {})",);
@@ -391,15 +391,15 @@ impl<Doc: DocumentLike> View<Doc> {
                 }
             }
             WindowEvent::MouseWheel { delta, .. } => {
-                match delta {
-                    winit::event::MouseScrollDelta::LineDelta(_, y) => {
-                        self.dom.as_mut().scroll_by(y as f64 * 20.0)
-                    }
-                    winit::event::MouseScrollDelta::PixelDelta(offsets) => {
-                        self.dom.as_mut().scroll_by(offsets.y)
-                    }
+                let hover_node = self.dom.as_ref().get_hover_node_id().and_then(|id| self.dom.as_mut().get_node_mut(id));
+                let (scroll_x, scroll_y)= match delta {
+                    winit::event::MouseScrollDelta::LineDelta(x, y) => (x as f64 * 20.0, y as f64 * 20.0),
+                    winit::event::MouseScrollDelta::PixelDelta(offsets) => (offsets.x, offsets.y)
                 };
-                self.request_redraw();
+                if let Some(hover_node) = hover_node {
+                    hover_node.scroll_by(scroll_x, scroll_y);
+                    self.request_redraw();
+                } 
             }
 
             // File events

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -399,7 +399,7 @@ impl<Doc: DocumentLike> View<Doc> {
                 if let Some(hover_node) = hover_node {
                     hover_node.scroll_by(scroll_x, scroll_y);
                     self.request_redraw();
-                } 
+                }
             }
 
             // File events

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -190,8 +190,9 @@ impl<Doc: DocumentLike> View<Doc> {
     }
 
     pub fn mouse_move(&mut self, x: f32, y: f32) -> bool {
-        let dom_x = x / self.viewport.zoom();
-        let dom_y = y / self.viewport.zoom();
+        let viewport_scroll = self.dom.as_ref().viewport_scroll();
+        let dom_x = x + viewport_scroll.x as f32 / self.viewport.zoom();
+        let dom_y = y + viewport_scroll.y as f32 / self.viewport.zoom();
 
         // println!("Mouse move: ({}, {})", x, y);
         // println!("Unscaled: ({}, {})",);

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -401,7 +401,6 @@ impl<Doc: DocumentLike> View<Doc> {
                 } else {
                     self.dom.as_mut().scroll_viewport_by(scroll_x, scroll_y);
                 }
-                    
                 self.request_redraw();
             }
 

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -107,9 +107,6 @@ pub struct Document {
     /// The node which is currently focussed (if any)
     pub(crate) focus_node_id: Option<usize>,
 
-    // TODO: move to nodes
-    pub scroll_offset: f64,
-
     pub changed: HashSet<usize>,
 }
 
@@ -207,7 +204,6 @@ impl Document {
 
             hover_node_id: None,
             focus_node_id: None,
-            scroll_offset: 0.0,
             changed: HashSet::new(),
         };
 
@@ -659,7 +655,6 @@ impl Document {
             self.stylist.set_device(device, &guards)
         };
         self.stylist.force_stylesheet_origins_dirty(origins);
-        self.clamp_scroll();
     }
 
     pub fn stylist_device(&mut self) -> &Device {
@@ -737,31 +732,6 @@ impl Document {
         };
 
         Some(cursor)
-    }
-
-    pub fn scroll_by(&mut self, px: f64) {
-        // Invert scrolling on macos
-        #[cfg(target_os = "macos")]
-        {
-            self.scroll_offset += px;
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            self.scroll_offset -= px;
-        }
-
-        self.clamp_scroll();
-    }
-
-    /// Clamp scroll offset
-    fn clamp_scroll(&mut self) {
-        let content_height = self.root_element().final_layout.size.height as f64;
-        let viewport_height = self.stylist_device().au_viewport_size().height.to_f64_px();
-
-        self.scroll_offset = self
-            .scroll_offset
-            .max(-(content_height - viewport_height))
-            .min(0.0);
     }
 
     pub fn visit<F>(&self, mut visit: F)

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -740,6 +740,7 @@ impl Document {
 
     /// Scroll a node by given x and y
     /// Will bubble scrolling up to parent node once it can no longer scroll further
+    /// If we're already at the root node, bubbles scrolling up to the viewport
     pub fn scroll_node_by(&mut self, node_id: usize, x: f64, y: f64) {
         let Some(node) = self.nodes.get_mut(node_id) else {
             return;
@@ -754,7 +755,7 @@ impl Document {
         let scroll_width = node.final_layout.scroll_width() as f64;
         let scroll_height = node.final_layout.scroll_height() as f64;
 
-        // If we're past our scroll bounds, transfer remainder of scrolling to parent
+        // If we're past our scroll bounds, transfer remainder of scrolling to parent/viewport
         if new_x < 0.0 {
             bubble_x = -new_x;
             node.scroll_offset.x = 0.0;
@@ -784,6 +785,7 @@ impl Document {
         }
     }
 
+    /// Scroll the viewport by the given values
     pub fn scroll_viewport_by(&mut self, x: f64, y: f64) {
         let content_size = self.root_element().final_layout.size;
         let new_scroll = (self.viewport_scroll.x - x, self.viewport_scroll.y - y);

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -791,8 +791,14 @@ impl Document {
         let new_scroll = (self.viewport_scroll.x - x, self.viewport_scroll.y - y);
         let window_width = self.viewport.window_size.0 as f64 / self.viewport.scale() as f64;
         let window_height = self.viewport.window_size.1 as f64 / self.viewport.scale() as f64;
-        self.viewport_scroll.x = f64::max(0.0, f64::min(new_scroll.0, content_size.width as f64 - window_width));
-        self.viewport_scroll.y = f64::max(0.0, f64::min(new_scroll.1, content_size.height as f64 - window_height))
+        self.viewport_scroll.x = f64::max(
+            0.0,
+            f64::min(new_scroll.0, content_size.width as f64 - window_width),
+        );
+        self.viewport_scroll.y = f64::max(
+            0.0,
+            f64::min(new_scroll.1, content_size.height as f64 - window_height),
+        )
     }
 
     pub fn viewport_scroll(&self) -> kurbo::Point {

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -692,12 +692,22 @@ impl Document {
             height: AvailableSpace::Definite(size.height.to_f32_px()),
         };
 
-        let root_node_id = taffy::NodeId::from(self.root_element().id);
+        let root_element_id = taffy::NodeId::from(self.root_element().id);
 
         // println!("\n\nRESOLVE LAYOUT\n===========\n");
 
-        taffy::compute_root_layout(self, root_node_id, available_space);
-        taffy::round_layout(self, root_node_id);
+        taffy::compute_root_layout(self, root_element_id, available_space);
+        taffy::round_layout(self, root_element_id);
+
+        // Root element's size is viewport size
+        let root_element = self.get_node_mut(self.root_element().id).unwrap();
+
+        root_element.final_layout.size = taffy::Size {
+            width: size.width.to_f32_px(),
+            height: size.height.to_f32_px(),
+        };
+
+        root_element.clamp_scroll_offset();
 
         // println!("\n\n");
         // taffy::print_tree(self, root_node_id)

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -1,6 +1,7 @@
 use atomic_refcell::{AtomicRef, AtomicRefCell};
 use html5ever::{local_name, LocalName, QualName};
 use image::DynamicImage;
+use peniko::kurbo;
 use selectors::matching::QuirksMode;
 use slab::Slab;
 use std::cell::RefCell;
@@ -12,7 +13,6 @@ use style::invalidation::element::restyle_hints::RestyleHint;
 use style::values::computed::Display;
 use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style_dom::ElementState;
-use peniko::kurbo;
 // use string_cache::Atom;
 use parley;
 use style::properties::ComputedValues;

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -800,50 +800,6 @@ impl Node {
                 y,
             }))
     }
-
-    /// Scroll this node by given x and y
-    /// Will bubble scrolling up to parent node once it can no longer scroll further
-    pub fn scroll_by(&mut self, x: f64, y: f64) {
-        self.scroll_offset.x += x;
-        self.scroll_offset.y += y;
-
-        //If we're past our scroll bounds, transfer scrolling to parent
-        if self.scroll_offset.x < 0.0
-            || self.scroll_offset.x > self.final_layout.scroll_width() as f64
-            || self.scroll_offset.y < 0.0
-            || self.scroll_offset.y > self.final_layout.scroll_height() as f64
-        {
-            if let Some(parent) = self.parent {
-                unsafe {
-                    self.tree
-                        .as_mut()
-                        .unwrap()
-                        .get_mut(parent)
-                        .unwrap()
-                        .scroll_by(x, y);
-                }
-            }
-        }
-        self.clamp_scroll_offset();
-    }
-
-    /// Ensure this node is not scrolled further than it should be able to
-    pub fn clamp_scroll_offset(&mut self) {
-        self.scroll_offset.x = f64::max(
-            0.0,
-            f64::min(
-                self.scroll_offset.x,
-                self.final_layout.scroll_width() as f64,
-            ),
-        );
-        self.scroll_offset.y = f64::max(
-            0.0,
-            f64::min(
-                self.scroll_offset.y,
-                self.final_layout.scroll_height() as f64,
-            ),
-        );
-    }
 }
 
 /// It might be wrong to expose this since what does *equality* mean outside the dom?

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -801,13 +801,17 @@ impl Node {
             }))
     }
 
+    /// Scroll this node by given x and y
+    /// Will bubble scrolling up to parent node once it can no longer scroll further
     pub fn scroll_by(&mut self, x: f64, y: f64) {
         self.scroll_offset.x += x;
         self.scroll_offset.y += y;
 
         //If we're past our scroll bounds, transfer scrolling to parent
-        if self.scroll_offset.x >= self.final_layout.scroll_width() as f64
-            || self.scroll_offset.y >= self.final_layout.scroll_height() as f64
+        if self.scroll_offset.x < 0.0
+            || self.scroll_offset.x > self.final_layout.scroll_width() as f64
+            || self.scroll_offset.y < 0.0
+            || self.scroll_offset.y > self.final_layout.scroll_height() as f64
         {
             if let Some(parent) = self.parent {
                 unsafe {
@@ -820,7 +824,11 @@ impl Node {
                 }
             }
         }
-        // Now clamp scroll based on layout
+        self.clamp_scroll_offset();
+    }
+
+    /// Ensure this node is not scrolled further than it should be able to
+    pub fn clamp_scroll_offset(&mut self) {
         self.scroll_offset.x = f64::max(
             0.0,
             f64::min(

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -782,11 +782,15 @@ impl Node {
     /// TODO: z-index
     /// (If multiple children are positioned at the position then a random one will be recursed into)
     pub fn hit(&self, x: f32, y: f32) -> Option<HitResult> {
-        let x = x - self.final_layout.location.x;
-        let y = y - self.final_layout.location.y;
+        let x = x - self.final_layout.location.x + self.scroll_offset.x as f32;
+        let y = y - self.final_layout.location.y + self.scroll_offset.y as f32;
 
         let size = self.final_layout.size;
-        if x < 0.0 || x > size.width || y < 0.0 || y > size.height {
+        if x < 0.0
+            || x > size.width + self.scroll_offset.x as f32
+            || y < 0.0
+            || y > size.height + self.scroll_offset.y as f32
+        {
             return None;
         }
 

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -12,7 +12,7 @@ use style::invalidation::element::restyle_hints::RestyleHint;
 use style::values::computed::Display;
 use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style_dom::ElementState;
-use taffy::Point;
+use peniko::kurbo;
 // use string_cache::Atom;
 use parley;
 use style::properties::ComputedValues;
@@ -77,7 +77,7 @@ pub struct Node {
     pub unrounded_layout: Layout,
     pub final_layout: Layout,
     pub listeners: Vec<EventListener>,
-    pub scroll_offset: Point<f64>,
+    pub scroll_offset: kurbo::Point,
 
     // Flags
     pub is_inline_root: bool,
@@ -110,7 +110,7 @@ impl Node {
             unrounded_layout: Layout::new(),
             final_layout: Layout::new(),
             listeners: Default::default(),
-            scroll_offset: Point { x: 0.0, y: 0.0 },
+            scroll_offset: kurbo::Point::ZERO,
             is_inline_root: false,
             is_table_root: false,
         }

--- a/packages/dom/src/viewport.rs
+++ b/packages/dom/src/viewport.rs
@@ -14,7 +14,6 @@ pub struct Viewport {
 
     pub font_size: f32,
 
-    scroll: (f64, f64),
 }
 
 impl Viewport {
@@ -24,7 +23,6 @@ impl Viewport {
             hidpi_scale: scale_factor,
             zoom: 1.0,
             font_size: 16.0,
-            scroll: (0.0, 0.0),
         }
     }
 
@@ -51,29 +49,6 @@ impl Viewport {
 
     pub fn zoom_mut(&mut self) -> &mut f32 {
         &mut self.zoom
-    }
-
-    pub fn scroll_by_with_content_size(&mut self, x: f64, y: f64, content_width: f64, content_height: f64) {
-        let new_scroll: (f64, f64);
-        #[cfg(target_os = "macos")]
-        {
-            new_scroll = (self.scroll.0 + x, self.scroll.1 + y);
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            new_scroll = (self.scroll.0 - x, self.scroll.1 - y);
-        }
-        dbg!(self.window_size.1, content_height);
-        let window_width = self.window_size.0 as f64 / self.scale() as f64;
-        let window_height = self.window_size.1 as f64 / self.scale() as f64;
-        self.scroll = (
-            f64::max(0.0, f64::min(new_scroll.0, content_width - window_width)),
-            f64::max(0.0, f64::min(new_scroll.1, content_height - window_height))
-        );
-    }
-
-    pub fn scroll(&self) -> (f64, f64) {
-        self.scroll
     }
 
     pub(crate) fn make_device(&self) -> Device {

--- a/packages/dom/src/viewport.rs
+++ b/packages/dom/src/viewport.rs
@@ -13,6 +13,8 @@ pub struct Viewport {
     zoom: f32,
 
     pub font_size: f32,
+
+    scroll: (f64, f64),
 }
 
 impl Viewport {
@@ -22,6 +24,7 @@ impl Viewport {
             hidpi_scale: scale_factor,
             zoom: 1.0,
             font_size: 16.0,
+            scroll: (0.0, 0.0),
         }
     }
 
@@ -48,6 +51,29 @@ impl Viewport {
 
     pub fn zoom_mut(&mut self) -> &mut f32 {
         &mut self.zoom
+    }
+
+    pub fn scroll_by_with_content_size(&mut self, x: f64, y: f64, content_width: f64, content_height: f64) {
+        let new_scroll: (f64, f64);
+        #[cfg(target_os = "macos")]
+        {
+            new_scroll = (self.scroll.0 + x, self.scroll.1 + y);
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            new_scroll = (self.scroll.0 - x, self.scroll.1 - y);
+        }
+        dbg!(self.window_size.1, content_height);
+        let window_width = self.window_size.0 as f64 / self.scale() as f64;
+        let window_height = self.window_size.1 as f64 / self.scale() as f64;
+        self.scroll = (
+            f64::max(0.0, f64::min(new_scroll.0, content_width - window_width)),
+            f64::max(0.0, f64::min(new_scroll.1, content_height - window_height))
+        );
+    }
+
+    pub fn scroll(&self) -> (f64, f64) {
+        self.scroll
     }
 
     pub(crate) fn make_device(&self) -> Device {

--- a/packages/dom/src/viewport.rs
+++ b/packages/dom/src/viewport.rs
@@ -13,7 +13,6 @@ pub struct Viewport {
     zoom: f32,
 
     pub font_size: f32,
-
 }
 
 impl Viewport {


### PR DESCRIPTION
Implements scrolling on mouse-wheel events, of any node which is hovered. When a node has hit its scroll boundary, scrolling bubbles up to the node's parent, all the way up to the root element. The root (html) element is sized to the viewport (is this technically the right thing to do?) and therefore will automatically handle root-level scrolling.

Adds an example `scrolling` which demos scrolling in the middle element. Scrolling the root element can be tested by resizing the window smaller than the content and scrolling, otherwise the tailwind example has a large content area and should be scrollable too.

Todo: Touch scrolling, flinging with momentum (even with mouse wheel? chromium does this).