### PR TITLE
Skip setting default window size on mobile

### DIFF
--- a/packages/dioxus-blitz/src/lib.rs
+++ b/packages/dioxus-blitz/src/lib.rs
@@ -24,7 +24,11 @@ mod accessibility;
 use blitz_dom::{DocumentLike, HtmlDocument};
 use dioxus::prelude::{ComponentFunction, Element, VirtualDom};
 use url::Url;
-use winit::event_loop::{ControlFlow, EventLoop};
+use winit::{
+    dpi::LogicalSize,
+    event_loop::{ControlFlow, EventLoop},
+    window::Window,
+};
 
 use crate::application::Application;
 use crate::window::View;
@@ -62,9 +66,8 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
     // We're going to need to hit it with a special waker
     let vdom = VirtualDom::new_with_props(root, props);
     let document = DioxusDocument::new(vdom);
-    let window = WindowConfig::new(document, 800.0, 600.0);
 
-    launch_with_window(window)
+    launch_with_document(document)
 }
 
 pub fn launch_url(url: &str) {
@@ -97,7 +100,22 @@ pub fn launch_static_html(html: &str) {
 
 pub fn launch_static_html_cfg(html: &str, cfg: Config) {
     let document = HtmlDocument::from_html(html, cfg.base_url, cfg.stylesheets);
-    let window = WindowConfig::new(document, 800.0, 600.0);
+    launch_with_document(document)
+}
+
+fn launch_with_document(doc: impl DocumentLike) {
+    let mut window_attrs = Window::default_attributes();
+    if !cfg!(all(target_os = "android", target_os = "ios")) {
+        window_attrs.inner_size = Some(
+            LogicalSize {
+                width: 800.,
+                height: 800.,
+            }
+            .into(),
+        );
+    }
+    let window = WindowConfig::new(doc);
+
     launch_with_window(window)
 }
 

--- a/packages/dioxus-blitz/src/lib.rs
+++ b/packages/dioxus-blitz/src/lib.rs
@@ -109,7 +109,7 @@ fn launch_with_document(doc: impl DocumentLike) {
         window_attrs.inner_size = Some(
             LogicalSize {
                 width: 800.,
-                height: 800.,
+                height: 600.,
             }
             .into(),
         );

--- a/packages/dioxus-blitz/src/window.rs
+++ b/packages/dioxus-blitz/src/window.rs
@@ -11,7 +11,6 @@ use wgpu::rwh::HasWindowHandle;
 
 use std::sync::Arc;
 use std::task::Waker;
-use winit::dpi::LogicalSize;
 use winit::event::{ElementState, MouseButton};
 use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
 use winit::window::{WindowAttributes, WindowId};
@@ -26,10 +25,10 @@ pub struct WindowConfig<Doc: DocumentLike> {
 }
 
 impl<Doc: DocumentLike> WindowConfig<Doc> {
-    pub fn new(doc: Doc, width: f32, height: f32) -> Self {
+    pub fn new(doc: Doc) -> Self {
         WindowConfig {
             doc,
-            attributes: Window::default_attributes().with_inner_size(LogicalSize { width, height }),
+            attributes: Window::default_attributes(),
         }
     }
 


### PR DESCRIPTION
Skips setting the default window size to 800x600 when compiling for mobile

Fixes #124