### PR TITLE
Checkbox internal state

### DIFF
--- a/examples/form.rs
+++ b/examples/form.rs
@@ -20,11 +20,11 @@ fn app() -> Element {
                         id: "check1",
                         name: "check1",
                         value: "check1",
-                        checked: "{checkbox_checked}",
-                        oninput: move |ev| {
-                            dbg!(ev);
-                            checkbox_checked.set(!checkbox_checked());
-                        },
+                        checked: checkbox_checked(),
+                        // This works too
+                        // checked: "{checkbox_checked}",
+                        oninput: move |ev| checkbox_checked.set(!ev.checked())
+                        ,
                     }
                     label {
                         r#for: "check1",

--- a/packages/blitz/src/renderer/render.rs
+++ b/packages/blitz/src/renderer/render.rs
@@ -1213,7 +1213,13 @@ impl ElementCx<'_> {
         if self.element.local_name() == "input"
             && matches!(self.element.attr(local_name!("type")), Some("checkbox"))
         {
-            let checked = self.element.attr(local_name!("checked")).is_some();
+            let Some(checked) = self
+                .element
+                .element_data()
+                .and_then(|data| data.checkbox_input_checked())
+            else {
+                return;
+            };
             let disabled = self.element.attr(local_name!("disabled")).is_some();
 
             // TODO this should be coming from css accent-color, but I couldn't find how to retrieve it

--- a/packages/dioxus-blitz/src/documents/dioxus_document.rs
+++ b/packages/dioxus-blitz/src/documents/dioxus_document.rs
@@ -188,7 +188,10 @@ impl DioxusDocument {
                 // - if value is not specified, it defaults to 'on'
                 if let Some(name) = form_input.attr(local_name!("name")) {
                     if form_input.attr(local_name!("type")) == Some("checkbox")
-                        && form_input.attr(local_name!("checked")) == Some("true")
+                        && form_input
+                            .element_data()
+                            .and_then(|data| data.checkbox_input_checked())
+                            .unwrap_or(false)
                     {
                         let value = form_input
                             .attr(local_name!("value"))

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -1,8 +1,8 @@
 use crate::events::{EventData, HitResult, RendererEvent};
-use crate::node::{Attribute, NodeSpecificData, TextBrush};
+use crate::node::{NodeSpecificData, TextBrush};
 use crate::{ElementNodeData, Node, NodeData, TextNodeData, Viewport};
 use app_units::Au;
-use html5ever::{local_name, namespace_url, ns, QualName};
+use html5ever::local_name;
 use peniko::kurbo;
 // use quadtree_rs::Quadtree;
 use parley::editor::{PointerButton, TextEvent};
@@ -313,24 +313,10 @@ impl Document {
     }
 
     pub fn toggle_checkbox(el: &mut ElementNodeData) {
-        let is_checked = el
-            .attrs
-            .iter()
-            .any(|attr| attr.name.local == local_name!("checked"));
-
-        if is_checked {
-            el.attrs
-                .retain(|attr| attr.name.local != local_name!("checked"))
-        } else {
-            el.attrs.push(Attribute {
-                name: QualName {
-                    prefix: None,
-                    ns: ns!(html),
-                    local: local_name!("checked"),
-                },
-                value: String::new(),
-            })
-        }
+        let Some(is_checked) = el.checkbox_input_checked_mut() else {
+            return;
+        };
+        *is_checked = !*is_checked;
     }
 
     pub fn root_node(&self) -> &Node {

--- a/packages/dom/src/layout/construct.rs
+++ b/packages/dom/src/layout/construct.rs
@@ -44,6 +44,9 @@ pub(crate) fn collect_layout_children(
         ) {
             create_text_editor(doc, container_node_id, false);
             return;
+        } else if type_attr == Some("checkbox") {
+            create_checkbox_input(doc, container_node_id);
+            return;
         }
     }
 
@@ -300,6 +303,20 @@ fn create_text_editor(doc: &mut Document, input_element_id: usize, is_multiline:
             .set_text_size(parley_style.font_size * doc.viewport.scale());
         text_input_data.editor.set_brush(parley_style.brush);
         element.node_specific_data = NodeSpecificData::TextInput(text_input_data);
+    }
+}
+
+fn create_checkbox_input(doc: &mut Document, input_element_id: usize) {
+    let node = &mut doc.nodes[input_element_id];
+
+    let element = &mut node.raw_dom_data.downcast_element_mut().unwrap();
+    if !matches!(
+        element.node_specific_data,
+        NodeSpecificData::CheckboxInput(_)
+    ) {
+        let checked = element.attr_parsed(local_name!("checked")).unwrap_or(false);
+
+        element.node_specific_data = NodeSpecificData::CheckboxInput(checked);
     }
 }
 

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -391,16 +391,16 @@ impl ElementNodeData {
         }
     }
 
-    pub fn inline_layout_data(&self) -> Option<&TextLayout> {
+    pub fn checkbox_input_checked(&self) -> Option<bool> {
         match self.node_specific_data {
-            NodeSpecificData::InlineRoot(ref data) => Some(data),
+            NodeSpecificData::CheckboxInput(checked) => Some(checked),
             _ => None,
         }
     }
 
-    pub fn inline_layout_data_mut(&mut self) -> Option<&mut TextLayout> {
+    pub fn checkbox_input_checked_mut(&mut self) -> Option<&mut bool> {
         match self.node_specific_data {
-            NodeSpecificData::InlineRoot(ref mut data) => Some(data),
+            NodeSpecificData::CheckboxInput(ref mut checked) => Some(checked),
             _ => None,
         }
     }
@@ -497,12 +497,12 @@ pub enum NodeSpecificData {
     Image(ImageData),
     /// The element's image content (\<img\> element's only)
     Svg(usvg::Tree),
-    /// Parley text layout (elements with inline inner display mode only)
-    InlineRoot(Box<TextLayout>),
     /// Pre-computed table layout data
     TableRoot(Arc<TableContext>),
     /// Parley text editor (text inputs)
     TextInput(TextInputData),
+    /// Checkbox checked state
+    CheckboxInput(bool),
     /// No data (for nodes that don't need any node-specific data)
     None,
 }
@@ -512,9 +512,9 @@ impl std::fmt::Debug for NodeSpecificData {
         match self {
             NodeSpecificData::Image(_) => f.write_str("NodeSpecificData::Image"),
             NodeSpecificData::Svg(_) => f.write_str("NodeSpecificData::Svg"),
-            NodeSpecificData::InlineRoot(_) => f.write_str("NodeSpecificData::InlineRoot"),
             NodeSpecificData::TableRoot(_) => f.write_str("NodeSpecificData::TableRoot"),
             NodeSpecificData::TextInput(_) => f.write_str("NodeSpecificData::TextInput"),
+            NodeSpecificData::CheckboxInput(_) => f.write_str("NodeSpecificData::CheckboxInput"),
             NodeSpecificData::None => f.write_str("NodeSpecificData::None"),
         }
     }

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -405,6 +405,20 @@ impl ElementNodeData {
         }
     }
 
+    pub fn inline_layout_data(&self) -> Option<&TextLayout> {
+        match self.node_specific_data {
+            NodeSpecificData::InlineRoot(ref data) => Some(data),
+            _ => None,
+        }
+    }
+
+    pub fn inline_layout_data_mut(&mut self) -> Option<&mut TextLayout> {
+        match self.node_specific_data {
+            NodeSpecificData::InlineRoot(ref mut data) => Some(data),
+            _ => None,
+        }
+    }
+
     pub fn flush_is_focussable(&mut self) {
         let disabled: bool = self.attr_parsed(local_name!("disabled")).unwrap_or(false);
         let tabindex: Option<i32> = self.attr_parsed(local_name!("tabindex"));
@@ -497,6 +511,8 @@ pub enum NodeSpecificData {
     Image(ImageData),
     /// The element's image content (\<img\> element's only)
     Svg(usvg::Tree),
+    /// Parley text layout (elements with inline inner display mode only)
+    InlineRoot(Box<TextLayout>),
     /// Pre-computed table layout data
     TableRoot(Arc<TableContext>),
     /// Parley text editor (text inputs)
@@ -512,6 +528,7 @@ impl std::fmt::Debug for NodeSpecificData {
         match self {
             NodeSpecificData::Image(_) => f.write_str("NodeSpecificData::Image"),
             NodeSpecificData::Svg(_) => f.write_str("NodeSpecificData::Svg"),
+            NodeSpecificData::InlineRoot(_) => f.write_str("NodeSpecificData::InlineRoot"),
             NodeSpecificData::TableRoot(_) => f.write_str("NodeSpecificData::TableRoot"),
             NodeSpecificData::TextInput(_) => f.write_str("NodeSpecificData::TextInput"),
             NodeSpecificData::CheckboxInput(_) => f.write_str("NodeSpecificData::CheckboxInput"),

--- a/packages/dom/src/stylo.rs
+++ b/packages/dom/src/stylo.rs
@@ -407,7 +407,11 @@ impl<'a> selectors::Element for BlitzNode<'a> {
                         && elem.attr(local_name!("href")).is_some()
                 })
                 .unwrap_or(false),
-            NonTSPseudoClass::Checked => false,
+            NonTSPseudoClass::Checked => self
+                .raw_dom_data
+                .downcast_element()
+                .and_then(|elem| elem.checkbox_input_checked())
+                .unwrap_or(false),
             NonTSPseudoClass::Valid => false,
             NonTSPseudoClass::Invalid => false,
             NonTSPseudoClass::Defined => false,


### PR DESCRIPTION
Keeps checkbox checked value internally in `NodeSpecificData`, instead of setting the `checked` attribute on the node. This  more closely aligns it with the w3c spec. 

In addition, as the checked property in rsx is now interpreted specially instead of being forwarded directly to the attribute, it can now handle boolean values as well as strings, such that `checked: checkbox_checked(),` rsx now works.

Last of all the 'value' property of formevent now reflects the checked state instead of the value attribute of the checked element, aligning it with dioxus web, and ensuring that FormEvent.checked() is correct.