### PR TITLE
List item improvements

### DIFF
--- a/packages/blitz/src/renderer/render.rs
+++ b/packages/blitz/src/renderer/render.rs
@@ -7,7 +7,8 @@ use crate::{
     util::{GradientSlice, StyloGradient, ToVelloColor},
 };
 use blitz_dom::node::{
-    ListItemLayout, ListItemLayoutPosition, NodeData, TextBrush, TextInputData, TextNodeData,
+    ListItemLayout, ListItemLayoutPosition, Marker, NodeData, TextBrush, TextInputData,
+    TextNodeData,
 };
 use blitz_dom::{local_name, Document, Node};
 
@@ -46,8 +47,7 @@ use style::values::generics::image::{
 };
 use style::values::specified::percentage::ToPercentage;
 use taffy::prelude::Layout;
-use vello::glyph::skrifa::prelude::{NormalizedCoord, Size};
-use vello::glyph::skrifa::{FontRef, GlyphId};
+use vello::glyph::skrifa::prelude::NormalizedCoord;
 use vello::kurbo::{BezPath, Cap, Join};
 use vello::peniko::Gradient;
 use vello::skrifa::MetadataProvider;
@@ -410,58 +410,20 @@ impl<'dom> VelloSceneGenerator<'dom> {
                 );
             }
         } else if let Some(ListItemLayout {
-            marker: _,
-            position,
+            marker,
+            position: ListItemLayoutPosition::Outside(layout),
         }) = cx.list_item
         {
-            match position {
-                ListItemLayoutPosition::OutsideGlyph {
-                    font,
-                    glyph_id,
-                    font_size_px,
-                    line_height_px,
-                    color,
-                } => {
-                    let font_ref = FontRef::from_index(font.data.data(), font.index).unwrap();
-                    let variations: &[(&str, f32)] = &[];
-                    let location = font_ref.axes().location(variations);
-                    let glyph_metrics = font_ref.glyph_metrics(Size::new(*font_size_px), &location);
-                    let glyph_width = glyph_metrics
-                        .advance_width(GlyphId::new(*glyph_id))
-                        .unwrap();
-                    let metrics = font_ref.metrics(Size::new(*font_size_px), &location);
-                    let coords = location.coords();
-                    let pos = Point {
-                        // Right align the glyph, and add some gap between the glyph and the following list item text
-                        x: pos.x - glyph_width as f64 - 8.0,
-                        // Center the glyph on the line
-                        y: pos.y
-                            + (*line_height_px as f64 + metrics.ascent as f64
-                                - metrics.descent as f64)
-                                / 2.0,
-                    };
-                    cx.stroke_glyph(
-                        scene,
-                        Glyph {
-                            glyph_id: *glyph_id,
-                            font,
-                            font_size: *font_size_px,
-                            coords,
-                            brush: &Brush::Solid(*color),
-                        },
-                        pos,
-                    );
-                }
-                ListItemLayoutPosition::OutsideString { layout } => {
-                    //Right align and pad the bullet when rendering outside
-                    let pos = Point {
-                        x: pos.x - (layout.full_width() / layout.scale()) as f64,
-                        y: pos.y,
-                    };
-                    cx.stroke_text(scene, layout, pos);
-                }
-                ListItemLayoutPosition::Inside => {}
-            }
+            let x_margin = match marker {
+                Marker::Char(_) => 8.0,
+                Marker::String(_) => 0.0,
+            };
+            //Right align and pad the bullet when rendering outside
+            let pos = Point {
+                x: pos.x - (layout.full_width() / layout.scale() + x_margin) as f64,
+                y: pos.y,
+            };
+            cx.stroke_text(scene, layout, pos);
         }
 
         if element.is_inline_root {
@@ -566,16 +528,6 @@ impl<'dom> VelloSceneGenerator<'dom> {
     }
 }
 
-/// A glyph to be rendered by an ELementCx
-#[derive(Debug)]
-struct Glyph<'a> {
-    glyph_id: u16,
-    font: &'a parley::Font,
-    font_size: f32,
-    coords: &'a [NormalizedCoord],
-    brush: &'a Brush,
-}
-
 /// A context of loaded and hot data to draw the element from
 struct ElementCx<'a> {
     frame: ElementFrame,
@@ -592,24 +544,6 @@ struct ElementCx<'a> {
 }
 
 impl ElementCx<'_> {
-    fn stroke_glyph(&self, scene: &mut Scene, glyph: Glyph, pos: Point) {
-        let transform = Affine::translate((pos.x * self.scale, pos.y * self.scale));
-        scene
-            .draw_glyphs(glyph.font)
-            .font_size(glyph.font_size * self.scale as f32)
-            .normalized_coords(glyph.coords)
-            .brush(glyph.brush)
-            .transform(transform)
-            .draw(
-                Fill::NonZero,
-                std::iter::once(vello::glyph::Glyph {
-                    id: glyph.glyph_id as u32,
-                    x: 0.0,
-                    y: 0.0,
-                }),
-            )
-    }
-
     fn stroke_text(&self, scene: &mut Scene, text_layout: &parley::Layout<TextBrush>, pos: Point) {
         let transform = Affine::translate((pos.x * self.scale, pos.y * self.scale));
 

--- a/packages/dom/src/document.rs
+++ b/packages/dom/src/document.rs
@@ -3,7 +3,6 @@ use crate::node::{NodeSpecificData, TextBrush};
 use crate::{ElementNodeData, Node, NodeData, TextNodeData, Viewport};
 use app_units::Au;
 use html5ever::local_name;
-use parley::fontique::FamilyId;
 use peniko::kurbo;
 // use quadtree_rs::Quadtree;
 use parley::editor::{PointerButton, TextEvent};
@@ -104,8 +103,6 @@ pub struct Document {
 
     /// A Parley font context
     pub(crate) font_ctx: parley::FontContext,
-
-    pub(crate) bullet_font_id: FamilyId,
 
     /// A Parley layout context
     pub(crate) layout_ctx: parley::LayoutContext<TextBrush>,
@@ -223,7 +220,7 @@ impl Document {
         style_config::set_bool("layout.legacy_layout", true);
         style_config::set_bool("layout.columns.enabled", true);
 
-        let (font_ctx, bullet_font_id) = Self::create_font_context();
+        let font_ctx = Self::create_font_context();
 
         let mut doc = Self {
             guard,
@@ -237,7 +234,6 @@ impl Document {
             // quadtree: Quadtree::new(20),
             stylesheets: HashMap::new(),
             font_ctx,
-            bullet_font_id,
             layout_ctx: parley::LayoutContext::new(),
 
             hover_node_id: None,
@@ -251,12 +247,11 @@ impl Document {
         doc
     }
 
-    fn create_font_context() -> (parley::FontContext, FamilyId) {
+    fn create_font_context() -> parley::FontContext {
         let mut ctx = parley::FontContext::default();
-        let names = ctx
-            .collection
+        ctx.collection
             .register_fonts(include_bytes!("moz-bullet-font.otf").to_vec());
-        (ctx, names[0].0)
+        ctx
     }
 
     /// Set base url for resolving linked resources (stylesheets, images, fonts, etc)

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -557,16 +557,7 @@ pub enum Marker {
 #[derive(Clone)]
 pub enum ListItemLayoutPosition {
     Inside,
-    OutsideGlyph {
-        font: Font,
-        glyph_id: parley::swash::GlyphId,
-        font_size_px: f32,
-        line_height_px: f32,
-        color: peniko::Color,
-    },
-    OutsideString {
-        layout: Box<parley::Layout<TextBrush>>,
-    },
+    Outside(Box<parley::Layout<TextBrush>>),
 }
 
 impl std::fmt::Debug for ListItemLayout {

--- a/packages/dom/src/node.rs
+++ b/packages/dom/src/node.rs
@@ -1,7 +1,7 @@
 use atomic_refcell::{AtomicRef, AtomicRefCell};
 use html5ever::{local_name, LocalName, QualName};
 use image::DynamicImage;
-use peniko::{kurbo, Font};
+use peniko::kurbo;
 use selectors::matching::QuirksMode;
 use slab::Slab;
 use std::cell::RefCell;


### PR DESCRIPTION
- Revert back to using parley layout regardless if rendering a single glyph or string
- Align the marker layout with baseline of first line of text in the list item