### PR TITLE
Refactor and document Viewport

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -151,8 +151,10 @@ impl DocumentLike for Document {
                     if let NodeSpecificData::TextInput(ref mut text_input_data) =
                         el.node_specific_data
                     {
-                        let x = (hit.x - content_box_offset.x) as f64 * self.viewport.scale_f64();
-                        let y = (hit.y - content_box_offset.y) as f64 * self.viewport.scale_f64();
+                        let x =
+                            (hit.x - content_box_offset.x) as f64 * self.viewport.scale() as f64;
+                        let y =
+                            (hit.y - content_box_offset.y) as f64 * self.viewport.scale() as f64;
                         text_input_data.editor.transact(
                             &mut self.font_ctx,
                             &mut self.layout_ctx,
@@ -1132,8 +1134,8 @@ impl Document {
     pub fn scroll_viewport_by(&mut self, x: f64, y: f64) {
         let content_size = self.root_element().final_layout.size;
         let new_scroll = (self.viewport_scroll.x - x, self.viewport_scroll.y - y);
-        let window_width = self.viewport.window_size.0 as f64 / self.viewport.scale() as f64;
-        let window_height = self.viewport.window_size.1 as f64 / self.viewport.scale() as f64;
+        let window_width = self.viewport.window_size.0 as f64 / self.viewport.hidpi_scale as f64;
+        let window_height = self.viewport.window_size.1 as f64 / self.viewport.hidpi_scale as f64;
         self.viewport_scroll.x = f64::max(
             0.0,
             f64::min(new_scroll.0, content_size.width as f64 - window_width),

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -505,7 +505,7 @@ fn create_text_editor(doc: &mut Document, input_element_id: usize, is_multiline:
             &mut doc.layout_ctx,
             [
                 PlainEditorOp::SetText(text),
-                PlainEditorOp::SetScale(doc.viewport.scale_f64() as f32),
+                PlainEditorOp::SetScale(doc.viewport.scale() as f32),
                 PlainEditorOp::SetWidth(10000.0),
                 PlainEditorOp::SetDefaultStyle(styles),
             ],

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -505,7 +505,7 @@ fn create_text_editor(doc: &mut Document, input_element_id: usize, is_multiline:
             &mut doc.layout_ctx,
             [
                 PlainEditorOp::SetText(text),
-                PlainEditorOp::SetScale(doc.viewport.scale() as f32),
+                PlainEditorOp::SetScale(doc.viewport.scale()),
                 PlainEditorOp::SetWidth(10000.0),
                 PlainEditorOp::SetDefaultStyle(styles),
             ],

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -53,7 +53,6 @@ use style::values::computed::text::TextAlign as StyloTextAlign;
 impl crate::document::Document {
     /// Walk the whole tree, converting styles to layout
     pub fn flush_styles_to_layout(&mut self, node_id: usize) {
-
         let display = {
             let node = self.nodes.get_mut(node_id).unwrap();
             let stylo_element_data = node.stylo_element_data.borrow();
@@ -85,7 +84,6 @@ impl crate::document::Document {
         // If the node has children, then take those children and...
         let children = self.nodes[node_id].layout_children.borrow_mut().take();
         if let Some(mut children) = children {
-
             // Recursively call flush_styles_to_layout on each child
             for child in children.iter() {
                 self.flush_styles_to_layout(*child);

--- a/packages/blitz-dom/src/viewport.rs
+++ b/packages/blitz-dom/src/viewport.rs
@@ -4,18 +4,24 @@ use style::{
     properties::{style_structs::Font, ComputedValues},
 };
 
+/// Window viewport.
 #[derive(Default, Debug, Clone)]
 pub struct Viewport {
+    /// Size of the window.
     pub window_size: (u32, u32),
 
-    hidpi_scale: f32,
-
-    zoom: f32,
-
+    /// Font size.
     pub font_size: f32,
+
+    /// Zoom level.
+    pub zoom: f32,
+
+    /// HiDPI (High Dots Per Inch) scaling factor.
+    pub hidpi_scale: f32,
 }
 
 impl Viewport {
+    /// Create a new viewport from a window's physical size and scale factor.
     pub fn new(physical_width: u32, physical_height: u32, scale_factor: f32) -> Self {
         Self {
             window_size: (physical_width, physical_height),
@@ -25,29 +31,9 @@ impl Viewport {
         }
     }
 
-    // Total scaling, the product of the zoom and hdpi scale
+    /// Calculate the total scaling, the product of the zoom and hdpi scale.
     pub fn scale(&self) -> f32 {
         self.hidpi_scale * self.zoom
-    }
-    // Total scaling, the product of the zoom and hdpi scale
-    pub fn scale_f64(&self) -> f64 {
-        self.scale() as f64
-    }
-
-    pub fn set_hidpi_scale(&mut self, scale: f32) {
-        self.hidpi_scale = scale;
-    }
-
-    pub fn zoom(&self) -> f32 {
-        self.zoom
-    }
-
-    pub fn set_zoom(&mut self, zoom: f32) {
-        self.zoom = zoom;
-    }
-
-    pub fn zoom_mut(&mut self) -> &mut f32 {
-        &mut self.zoom
     }
 
     pub(crate) fn make_device(&self) -> Device {

--- a/packages/blitz-renderer-vello/src/renderer.rs
+++ b/packages/blitz-renderer-vello/src/renderer.rs
@@ -200,7 +200,7 @@ pub async fn render_to_buffer(dom: &Document, viewport: Viewport) -> Vec<u8> {
     generate_vello_scene(
         &mut scene,
         dom,
-        viewport.scale_f64(),
+        viewport.scale() as _,
         width,
         height,
         Devtools::default(),

--- a/packages/dioxus-native/src/window.rs
+++ b/packages/dioxus-native/src/window.rs
@@ -132,7 +132,7 @@ impl<Doc: DocumentLike> View<Doc> {
         let (width, height) = self.viewport.window_size;
         self.renderer.render(
             self.dom.as_ref(),
-            self.viewport.scale_f64(),
+            self.viewport.scale() as _,
             width,
             height,
             self.devtools,
@@ -179,7 +179,7 @@ impl<Doc: DocumentLike> View<Doc> {
         let (width, height) = self.viewport.window_size;
         self.renderer.render(
             self.dom.as_ref(),
-            self.viewport.scale_f64(),
+            self.viewport.scale() as _,
             width,
             height,
             self.devtools,
@@ -213,8 +213,8 @@ impl<Doc: DocumentLike> View<Doc> {
 
     pub fn mouse_move(&mut self, x: f32, y: f32) -> bool {
         let viewport_scroll = self.dom.as_ref().viewport_scroll();
-        let dom_x = x + viewport_scroll.x as f32 / self.viewport.zoom();
-        let dom_y = y + viewport_scroll.y as f32 / self.viewport.zoom();
+        let dom_x = x + viewport_scroll.x as f32 / self.viewport.zoom;
+        let dom_y = y + viewport_scroll.y as f32 / self.viewport.zoom;
 
         // println!("Mouse move: ({}, {})", x, y);
         // println!("Unscaled: ({}, {})",);
@@ -338,15 +338,15 @@ impl<Doc: DocumentLike> View<Doc> {
                 if ctrl | meta {
                     match key_code {
                         KeyCode::Equal => {
-                            *self.viewport.zoom_mut() += 0.1;
+                            self.viewport.zoom += 0.1;
                             self.kick_dom_viewport();
                         }
                         KeyCode::Minus => {
-                            *self.viewport.zoom_mut() -= 0.1;
+                            self.viewport.zoom -= 0.1;
                             self.kick_dom_viewport();
                         }
                         KeyCode::Digit0 => {
-                            *self.viewport.zoom_mut() = 1.0;
+                            self.viewport.zoom = 1.0;
                             self.kick_dom_viewport();
                         }
                         _ => {}


### PR DESCRIPTION
* Replaces `Viewport::zoom` and `Viewport::set_zoom` with an exported field
* Removes `Viewport::scale_f64` convenience method
  - My thought here is to keep the codebase minimal while we're still building
* Docs and general refactors
