### PR TITLE
Simplify net traits

### DIFF
--- a/apps/readme/src/main.rs
+++ b/apps/readme/src/main.rs
@@ -6,7 +6,7 @@ use blitz_traits::net::SharedCallback;
 use markdown::{markdown_to_html, BLITZ_MD_STYLES, GITHUB_MD_STYLES};
 use reqwest::header::HeaderName;
 
-use dioxus_native::{create_default_event_loop, Callback};
+use dioxus_native::{create_default_event_loop, WinitNetCallback};
 use std::env::current_dir;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -42,7 +42,7 @@ fn main() {
 
     // println!("{html}");
 
-    let net_callback = Arc::new(Callback::new(proxy));
+    let net_callback = Arc::new(WinitNetCallback::new(proxy));
     let net_provider = Arc::new(Provider::new(
         Handle::current(),
         Arc::clone(&net_callback) as SharedCallback<Resource>,

--- a/apps/wpt/src/net_provider.rs
+++ b/apps/wpt/src/net_provider.rs
@@ -1,4 +1,4 @@
-use blitz_traits::net::{BoxedHandler, Bytes, Callback, NetProvider, Url};
+use blitz_traits::net::{BoxedHandler, Bytes, NetCallback, NetProvider, Url};
 use data_url::DataUrl;
 use std::{
     path::{Path, PathBuf},
@@ -87,7 +87,7 @@ impl<T> VecCallback<T> {
         }
     }
 }
-impl<T: Send + Sync + 'static> Callback for VecCallback<T> {
+impl<T: Send + Sync + 'static> NetCallback for VecCallback<T> {
     type Data = T;
     fn call(&self, _doc_id: usize, data: Self::Data) {
         self.0

--- a/apps/wpt/src/net_provider.rs
+++ b/apps/wpt/src/net_provider.rs
@@ -23,13 +23,18 @@ impl<D: Send + Sync + 'static> WptNetProvider<D> {
         self.callback.for_each(cb);
     }
 
-    fn fetch_inner(&self, url: Url, handler: BoxedHandler<D>) -> Result<(), WptNetProviderError> {
+    fn fetch_inner(
+        &self,
+        doc_id: usize,
+        url: Url,
+        handler: BoxedHandler<D>,
+    ) -> Result<(), WptNetProviderError> {
         let callback = self.callback.clone();
         match url.scheme() {
             "data" => {
                 let data_url = DataUrl::process(url.as_str())?;
                 let decoded = data_url.decode_to_vec()?;
-                handler.bytes(Bytes::from(decoded.0), callback);
+                handler.bytes(doc_id, Bytes::from(decoded.0), callback);
             }
             _ => {
                 let relative_path = url.path().strip_prefix('/').unwrap();
@@ -37,7 +42,7 @@ impl<D: Send + Sync + 'static> WptNetProvider<D> {
                 let file_content = std::fs::read(&path).inspect_err(|err| {
                     eprintln!("Error loading {}: {}", path.display(), &err);
                 })?;
-                handler.bytes(Bytes::from(file_content), callback);
+                handler.bytes(doc_id, Bytes::from(file_content), callback);
             }
         }
         Ok(())
@@ -45,8 +50,8 @@ impl<D: Send + Sync + 'static> WptNetProvider<D> {
 }
 impl<D: Send + Sync + 'static> NetProvider for WptNetProvider<D> {
     type Data = D;
-    fn fetch(&self, url: Url, handler: BoxedHandler<D>) {
-        let res = self.fetch_inner(url.clone(), handler);
+    fn fetch(&self, doc_id: usize, url: Url, handler: BoxedHandler<D>) {
+        let res = self.fetch_inner(doc_id, url.clone(), handler);
         if let Err(e) = res {
             if !matches!(e, WptNetProviderError::Io(_)) {
                 eprintln!("Error loading {}: {e}", url);
@@ -84,7 +89,7 @@ impl<T> VecCallback<T> {
 }
 impl<T: Send + Sync + 'static> Callback for VecCallback<T> {
     type Data = T;
-    fn call(&self, data: Self::Data) {
+    fn call(&self, _doc_id: usize, data: Self::Data) {
         self.0
             .lock()
             .unwrap_or_else(|err| err.into_inner())

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -82,7 +82,7 @@ async fn main() {
         .set_viewport(Viewport::new(width * scale, height * scale, scale as f32));
 
     while !net.is_empty() {
-        let Some(res) = recv.recv().await else {
+        let Some((_, res)) = recv.recv().await else {
             break;
         };
         document.as_mut().load_resource(res);

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -75,6 +75,10 @@ pub trait DocumentLike: AsRef<Document> + AsMut<Document> + Into<Document> + 'st
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
+
+    fn id(&self) -> usize {
+        self.as_ref().id
+    }
 }
 
 pub struct Document {

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -3,7 +3,7 @@ use crate::node::{ImageData, NodeSpecificData, Status, TextBrush};
 use crate::util::ImageType;
 use crate::{ElementNodeData, Node, NodeData, TextNodeData, Viewport};
 use app_units::Au;
-use blitz_traits::net::{DummyProvider, SharedProvider};
+use blitz_traits::net::{DummyNetProvider, SharedProvider};
 use html5ever::local_name;
 use parley::{FontContext, PlainEditorOp};
 use peniko::kurbo;
@@ -438,7 +438,7 @@ impl Document {
             hover_node_id: None,
             focus_node_id: None,
             changed: HashSet::new(),
-            net_provider: Arc::new(DummyProvider::default()),
+            net_provider: Arc::new(DummyNetProvider::default()),
         };
 
         // Initialise document with root Document node

--- a/packages/blitz-dom/src/htmlsink.rs
+++ b/packages/blitz-dom/src/htmlsink.rs
@@ -388,13 +388,13 @@ impl<'b> TreeSink for DocumentHtmlParser<'b> {
 #[test]
 fn parses_some_html() {
     use crate::Viewport;
-    use blitz_traits::net::{DummyCallback, DummyProvider};
+    use blitz_traits::net::DummyNetProvider;
     use std::sync::Arc;
 
     let html = "<!DOCTYPE html><html><body><h1>hello world</h1></body></html>";
     let viewport = Viewport::new(800, 600, 1.0);
     let mut doc = Document::new(viewport);
-    let sink = DocumentHtmlParser::new(&mut doc, Arc::new(DummyProvider::default()));
+    let sink = DocumentHtmlParser::new(&mut doc, Arc::new(DummyNetProvider::default()));
 
     html5ever::parse_document(sink, Default::default())
         .from_utf8()

--- a/packages/blitz-dom/src/htmlsink.rs
+++ b/packages/blitz-dom/src/htmlsink.rs
@@ -24,6 +24,7 @@ fn html5ever_to_blitz_attr(attr: html5ever::Attribute) -> Attribute {
 }
 
 pub struct DocumentHtmlParser<'a> {
+    doc_id: usize,
     doc: RefCell<&'a mut Document>,
     style_nodes: RefCell<Vec<usize>>,
 
@@ -39,6 +40,7 @@ pub struct DocumentHtmlParser<'a> {
 impl DocumentHtmlParser<'_> {
     pub fn new(doc: &mut Document, net_provider: SharedProvider<Resource>) -> DocumentHtmlParser {
         DocumentHtmlParser {
+            doc_id: doc.id(),
             doc: RefCell::new(doc),
             style_nodes: RefCell::new(Vec::new()),
             errors: RefCell::new(Vec::new()),
@@ -116,6 +118,7 @@ impl DocumentHtmlParser<'_> {
         if let (Some("stylesheet"), Some(href)) = (rel_attr, href_attr) {
             let url = self.doc.borrow().resolve_url(href);
             self.net_provider.fetch(
+                self.doc_id,
                 url.clone(),
                 Box::new(CssHandler {
                     node: target_id,
@@ -133,6 +136,7 @@ impl DocumentHtmlParser<'_> {
             if !raw_src.is_empty() {
                 let src = self.doc.borrow().resolve_url(raw_src);
                 self.net_provider.fetch(
+                    self.doc.borrow().id(),
                     src,
                     Box::new(ImageHandler::new(target_id, ImageType::Image)),
                 );

--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -17,7 +17,7 @@ use style::{
     values::{CssUrl, SourceLocation},
 };
 
-use blitz_traits::net::{Bytes, RequestHandler, SharedCallback, SharedProvider};
+use blitz_traits::net::{Bytes, NetHandler, SharedCallback, SharedProvider};
 
 use url::Url;
 use usvg::Tree;
@@ -89,7 +89,7 @@ impl ServoStylesheetLoader for StylesheetLoader {
             sheet: ServoArc<Stylesheet>,
             provider: SharedProvider<Resource>,
         }
-        impl RequestHandler for StylesheetLoaderInner {
+        impl NetHandler for StylesheetLoaderInner {
             type Data = Resource;
             fn bytes(
                 self: Box<Self>,
@@ -126,7 +126,7 @@ impl ServoStylesheetLoader for StylesheetLoader {
         ServoArc::new(lock.wrap(import))
     }
 }
-impl RequestHandler for CssHandler {
+impl NetHandler for CssHandler {
     type Data = Resource;
     fn bytes(self: Box<Self>, doc_id: usize, bytes: Bytes, callback: SharedCallback<Resource>) {
         let css = std::str::from_utf8(&bytes).expect("Invalid UTF8");
@@ -152,7 +152,7 @@ impl RequestHandler for CssHandler {
     }
 }
 struct FontFaceHandler(FontFaceSourceFormatKeyword);
-impl RequestHandler for FontFaceHandler {
+impl NetHandler for FontFaceHandler {
     type Data = Resource;
     fn bytes(
         mut self: Box<Self>,
@@ -257,7 +257,7 @@ impl ImageHandler {
         Self(node_id, kind)
     }
 }
-impl RequestHandler for ImageHandler {
+impl NetHandler for ImageHandler {
     type Data = Resource;
     fn bytes(self: Box<Self>, doc_id: usize, bytes: Bytes, callback: SharedCallback<Resource>) {
         // Try parse image

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -57,6 +57,8 @@ use style::values::computed::text::TextAlign as StyloTextAlign;
 impl crate::document::Document {
     /// Walk the whole tree, converting styles to layout
     pub fn flush_styles_to_layout(&mut self, node_id: usize) {
+        let doc_id = self.id();
+
         let display = {
             let node = self.nodes.get_mut(node_id).unwrap();
             let stylo_element_data = node.stylo_element_data.borrow();
@@ -98,6 +100,7 @@ impl crate::document::Document {
                             }
 
                             self.net_provider.fetch(
+                                doc_id,
                                 (**new_url).clone(),
                                 Box::new(ImageHandler::new(node_id, ImageType::Background(idx))),
                             );

--- a/packages/blitz-net/src/lib.rs
+++ b/packages/blitz-net/src/lib.rs
@@ -1,4 +1,4 @@
-use blitz_traits::net::{BoxedHandler, Bytes, Callback, NetProvider, SharedCallback, Url};
+use blitz_traits::net::{BoxedHandler, Bytes, NetCallback, NetProvider, SharedCallback, Url};
 use data_url::DataUrl;
 use reqwest::Client;
 use std::sync::Arc;
@@ -91,7 +91,7 @@ impl<T> MpscCallback<T> {
         (recv, Self(send))
     }
 }
-impl<T: Send + Sync + 'static> Callback for MpscCallback<T> {
+impl<T: Send + Sync + 'static> NetCallback for MpscCallback<T> {
     type Data = T;
     fn call(&self, doc_id: usize, data: Self::Data) {
         let _ = self.0.send((doc_id, data));

--- a/packages/blitz-traits/src/net.rs
+++ b/packages/blitz-traits/src/net.rs
@@ -5,15 +5,20 @@ use std::sync::Arc;
 pub use url::Url;
 
 pub type SharedProvider<D> = Arc<dyn NetProvider<Data = D>>;
-pub type BoxedHandler<D> = Box<dyn RequestHandler<Data = D>>;
-pub type SharedCallback<D> = Arc<dyn Callback<Data = D>>;
+pub type BoxedHandler<D> = Box<dyn NetHandler<Data = D>>;
+pub type SharedCallback<D> = Arc<dyn NetCallback<Data = D>>;
 
+/// A type that fetches resources for a Document.
+///
+/// This may be over the network via http(s), via the filesystem, or some other method.
 pub trait NetProvider: Send + Sync + 'static {
     type Data;
     fn fetch(&self, doc_id: usize, url: Url, handler: BoxedHandler<Self::Data>);
 }
 
-pub trait RequestHandler: Send + Sync + 'static {
+/// A type that parses raw bytes from a network request into a Self::Data and then calls
+/// the NetCallack with the result.
+pub trait NetHandler: Send + Sync + 'static {
     type Data;
     fn bytes(self: Box<Self>, doc_id: usize, bytes: Bytes, callback: SharedCallback<Self::Data>);
     fn method(&self) -> Method {
@@ -21,29 +26,33 @@ pub trait RequestHandler: Send + Sync + 'static {
     }
 }
 
-pub trait Callback: Send + Sync + 'static {
+/// A type which accepts the parsed result of a network request and sends it back to the Document
+/// (or does arbitrary things with it)
+pub trait NetCallback: Send + Sync + 'static {
     type Data;
     fn call(&self, doc_id: usize, data: Self::Data);
 }
 
-pub struct DummyProvider<D>(PhantomData<D>);
-impl<D> Default for DummyProvider<D> {
+/// A default noop NetProvider
+pub struct DummyNetProvider<D>(PhantomData<D>);
+impl<D> Default for DummyNetProvider<D> {
     fn default() -> Self {
         Self(PhantomData)
     }
 }
-impl<D: Send + Sync + 'static> NetProvider for DummyProvider<D> {
+impl<D: Send + Sync + 'static> NetProvider for DummyNetProvider<D> {
     type Data = D;
     fn fetch(&self, _doc_id: usize, _url: Url, _handler: BoxedHandler<D>) {}
 }
 
-pub struct DummyCallback<D>(PhantomData<D>);
-impl<D: Send + Sync + 'static> Default for DummyCallback<D> {
+/// A default noop NetCallback
+pub struct DummyNetCallback<D>(PhantomData<D>);
+impl<D: Send + Sync + 'static> Default for DummyNetCallback<D> {
     fn default() -> Self {
         Self(PhantomData)
     }
 }
-impl<D: Send + Sync + 'static> Callback for DummyCallback<D> {
+impl<D: Send + Sync + 'static> NetCallback for DummyNetCallback<D> {
     type Data = D;
     fn call(&self, _doc_id: usize, _data: Self::Data) {}
 }

--- a/packages/blitz-traits/src/net.rs
+++ b/packages/blitz-traits/src/net.rs
@@ -10,12 +10,12 @@ pub type SharedCallback<D> = Arc<dyn Callback<Data = D>>;
 
 pub trait NetProvider: Send + Sync + 'static {
     type Data;
-    fn fetch(&self, url: Url, handler: BoxedHandler<Self::Data>);
+    fn fetch(&self, doc_id: usize, url: Url, handler: BoxedHandler<Self::Data>);
 }
 
 pub trait RequestHandler: Send + Sync + 'static {
     type Data;
-    fn bytes(self: Box<Self>, bytes: Bytes, callback: SharedCallback<Self::Data>);
+    fn bytes(self: Box<Self>, doc_id: usize, bytes: Bytes, callback: SharedCallback<Self::Data>);
     fn method(&self) -> Method {
         Method::GET
     }
@@ -23,7 +23,7 @@ pub trait RequestHandler: Send + Sync + 'static {
 
 pub trait Callback: Send + Sync + 'static {
     type Data;
-    fn call(&self, data: Self::Data);
+    fn call(&self, doc_id: usize, data: Self::Data);
 }
 
 pub struct DummyProvider<D>(PhantomData<D>);
@@ -34,7 +34,7 @@ impl<D> Default for DummyProvider<D> {
 }
 impl<D: Send + Sync + 'static> NetProvider for DummyProvider<D> {
     type Data = D;
-    fn fetch(&self, _url: Url, _handler: BoxedHandler<D>) {}
+    fn fetch(&self, _doc_id: usize, _url: Url, _handler: BoxedHandler<D>) {}
 }
 
 pub struct DummyCallback<D>(PhantomData<D>);
@@ -45,5 +45,5 @@ impl<D: Send + Sync + 'static> Default for DummyCallback<D> {
 }
 impl<D: Send + Sync + 'static> Callback for DummyCallback<D> {
     type Data = D;
-    fn call(&self, _data: Self::Data) {}
+    fn call(&self, _doc_id: usize, _data: Self::Data) {}
 }

--- a/packages/dioxus-native/src/application.rs
+++ b/packages/dioxus-native/src/application.rs
@@ -35,6 +35,10 @@ impl<Doc: DocumentLike> Application<Doc> {
     pub fn add_window(&mut self, window_config: WindowConfig<Doc>) {
         self.pending_windows.push(window_config);
     }
+
+    fn window_mut_by_doc_id(&mut self, doc_id: usize) -> Option<&mut View<Doc>> {
+        self.windows.values_mut().find(|w| w.dom.id() == doc_id)
+    }
 }
 
 impl<Doc: DocumentLike> ApplicationHandler<BlitzEvent> for Application<Doc> {
@@ -111,8 +115,9 @@ impl<Doc: DocumentLike> ApplicationHandler<BlitzEvent> for Application<Doc> {
                 };
             }
 
-            BlitzEvent::ResourceLoad { window_id, data } => {
-                if let Some(window) = self.windows.get_mut(&window_id) {
+            BlitzEvent::ResourceLoad { doc_id, data } => {
+                // TODO: Handle multiple documents per window
+                if let Some(window) = self.window_mut_by_doc_id(doc_id) {
                     window.dom.as_mut().load_resource(data);
                     window.request_redraw();
                 }

--- a/packages/dioxus-native/src/waker.rs
+++ b/packages/dioxus-native/src/waker.rs
@@ -14,7 +14,7 @@ pub enum BlitzEvent {
     },
 
     ResourceLoad {
-        window_id: WindowId,
+        doc_id: usize,
         data: Resource,
     },
 
@@ -36,12 +36,9 @@ pub enum BlitzEvent {
     // NewWindow,
     // CloseWindow,
 }
-impl From<(WindowId, Resource)> for BlitzEvent {
-    fn from((window_id, resource): (WindowId, Resource)) -> Self {
-        BlitzEvent::ResourceLoad {
-            window_id,
-            data: resource,
-        }
+impl From<(usize, Resource)> for BlitzEvent {
+    fn from((doc_id, data): (usize, Resource)) -> Self {
+        BlitzEvent::ResourceLoad { doc_id, data }
     }
 }
 

--- a/packages/dioxus-native/src/window.rs
+++ b/packages/dioxus-native/src/window.rs
@@ -1,6 +1,6 @@
 use crate::accessibility::AccessibilityState;
+use crate::stylo_to_winit;
 use crate::waker::{create_waker, BlitzEvent};
-use crate::{stylo_to_winit, Callback};
 use blitz_dom::events::{EventData, RendererEvent};
 use blitz_dom::{DocumentLike, Viewport};
 use blitz_renderer_vello::Renderer;
@@ -20,28 +20,18 @@ use crate::menu::init_menu;
 pub struct WindowConfig<Doc: DocumentLike> {
     doc: Doc,
     attributes: WindowAttributes,
-    callback: Option<Arc<Callback>>,
 }
 
 impl<Doc: DocumentLike> WindowConfig<Doc> {
-    pub fn new(doc: Doc, callback: Option<Arc<Callback>>) -> Self {
+    pub fn new(doc: Doc) -> Self {
         WindowConfig {
             doc,
             attributes: Window::default_attributes(),
-            callback,
         }
     }
 
-    pub fn with_attributes(
-        doc: Doc,
-        attributes: WindowAttributes,
-        callback: Option<Arc<Callback>>,
-    ) -> Self {
-        WindowConfig {
-            doc,
-            attributes,
-            callback,
-        }
+    pub fn with_attributes(doc: Doc, attributes: WindowAttributes) -> Self {
+        WindowConfig { doc, attributes }
     }
 }
 
@@ -82,10 +72,6 @@ impl<Doc: DocumentLike> View<Doc> {
         proxy: &EventLoopProxy<BlitzEvent>,
     ) -> Self {
         let winit_window = Arc::from(event_loop.create_window(config.attributes).unwrap());
-
-        if let Some(callback) = config.callback {
-            callback.init(winit_window.id(), proxy);
-        }
 
         // TODO: make this conditional on text input focus
         winit_window.set_ime_allowed(true);

--- a/packages/dioxus-native/src/window.rs
+++ b/packages/dioxus-native/src/window.rs
@@ -1,5 +1,5 @@
 use crate::accessibility::AccessibilityState;
-use crate::waker::{create_waker, BlitzEvent, BlitzWindowEvent};
+use crate::waker::{create_waker, BlitzEvent};
 use crate::{stylo_to_winit, Callback};
 use blitz_dom::events::{EventData, RendererEvent};
 use blitz_dom::{DocumentLike, Viewport};
@@ -256,30 +256,9 @@ impl<Doc: DocumentLike> View<Doc> {
         }
     }
 
-    pub fn handle_blitz_event(&mut self, event: BlitzWindowEvent) {
-        match event {
-            BlitzWindowEvent::Poll => {
-                self.poll();
-            }
-            BlitzWindowEvent::ResourceLoad(resource) => {
-                self.dom.as_mut().load_resource(resource);
-                self.request_redraw();
-            }
-            #[cfg(feature = "accessibility")]
-            BlitzWindowEvent::Accessibility(accessibility_event) => {
-                match &*accessibility_event {
-                    accesskit_winit::WindowEvent::InitialTreeRequested => {
-                        self.accessibility.build_tree(self.dom.as_ref());
-                    }
-                    accesskit_winit::WindowEvent::AccessibilityDeactivated => {
-                        // TODO
-                    }
-                    accesskit_winit::WindowEvent::ActionRequested(_req) => {
-                        // TODO
-                    }
-                }
-            }
-        }
+    #[cfg(feature = "accessibility")]
+    pub fn build_accessibility_tree(&mut self) {
+        self.accessibility.build_tree(self.dom.as_ref());
     }
 
     pub fn handle_winit_event(&mut self, event: WindowEvent) {


### PR DESCRIPTION
This changes the net traits to pass the DocumentId through the chain of functions, which means that the `NetCallback` doesn't need to capture the WindowId when it is created. Which simplifies the whole setup.