### PR TITLE
Remove use of the `todo` macro in event handling and add a comment about it being a todo

### DIFF
--- a/packages/dioxus-native/src/dioxus_document.rs
+++ b/packages/dioxus-native/src/dioxus_document.rs
@@ -279,8 +279,9 @@ impl DocumentLike for DioxusDocument {
                     }
                 }
             }
-            EventData::Ime(_) => todo!(),
-            EventData::Hover => todo!(),
+            // TODO: Implement IME and Hover events handling
+            EventData::Ime(_) => {}
+            EventData::Hover => {}
         }
 
         if !prevent_default {


### PR DESCRIPTION
Using the `todo` macro causes a panic when this event is encountered. Noop is preferable in this case as it does not crash the application. This is especially annoying on platforms where `Ime::Enabled` event is sent upon application start even when the user is using a keyboard layout that does not need an IME support. 

There was added a "TODO" comment that informs about this feature being missing. Most IDEs and code editors have support/plugins/extensions to work with this type of comment and this type of comment is already used widely across the codebase. As such, the information about this feature not being implemented is not lost.