### PR TITLE
feat: Add mousedown and mouseup event

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -172,6 +172,7 @@ impl DocumentLike for Document {
         let target_node_id = event.target;
 
         match event.data {
+            EventData::MouseDown { .. } | EventData::MouseUp { .. } => {}
             EventData::Click { x, y, .. } => {
                 let hit = self.hit(x, y);
                 if let Some(hit) = hit {

--- a/packages/blitz-dom/src/events/mod.rs
+++ b/packages/blitz-dom/src/events/mod.rs
@@ -23,6 +23,8 @@ impl RendererEvent {
 
 #[derive(Debug, Clone)]
 pub enum EventData {
+    MouseDown { x: f32, y: f32, mods: Modifiers },
+    MouseUp { x: f32, y: f32, mods: Modifiers },
     Click { x: f32, y: f32, mods: Modifiers },
     KeyPress { event: KeyEvent, mods: Modifiers },
     Ime(Ime),
@@ -32,6 +34,8 @@ pub enum EventData {
 impl EventData {
     pub fn name(&self) -> &'static str {
         match self {
+            EventData::MouseDown { .. } => "mousedown",
+            EventData::MouseUp { .. } => "mouseup",
             EventData::Click { .. } => "click",
             EventData::KeyPress { .. } => "keypress",
             EventData::Ime { .. } => "input",

--- a/packages/blitz-dom/src/node.rs
+++ b/packages/blitz-dom/src/node.rs
@@ -223,6 +223,16 @@ impl Node {
             .remove(ElementState::FOCUS | ElementState::FOCUSRING);
         self.set_restyle_hint(RestyleHint::restyle_subtree());
     }
+
+    pub fn active(&mut self) {
+        self.element_state.insert(ElementState::ACTIVE);
+        self.set_restyle_hint(RestyleHint::restyle_subtree());
+    }
+
+    pub fn unactive(&mut self) {
+        self.element_state.remove(ElementState::ACTIVE);
+        self.set_restyle_hint(RestyleHint::restyle_subtree());
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -463,7 +463,7 @@ impl selectors::Element for BlitzNode<'_> {
         _context: &mut MatchingContext<Self::Impl>,
     ) -> bool {
         match *pseudo_class {
-            NonTSPseudoClass::Active => false,
+            NonTSPseudoClass::Active => self.element_state.contains(ElementState::ACTIVE),
             NonTSPseudoClass::AnyLink => self
                 .raw_dom_data
                 .downcast_element()

--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -251,6 +251,8 @@ impl<Doc: DocumentLike, Rend: DocumentRenderer> View<Doc, Rend> {
             return;
         };
 
+        self.doc.as_mut().active_node();
+
         // If we hit a node, then we collect the node to its parents, check for listeners, and then
         // call those listeners
         self.doc.handle_event(RendererEvent {
@@ -262,15 +264,15 @@ impl<Doc: DocumentLike, Rend: DocumentRenderer> View<Doc, Rend> {
             },
         });
 
-        if button == "left" {
-            self.mouse_down_node = Some(node_id);
-        }
+        self.mouse_down_node = Some(node_id);
     }
 
     pub fn mouse_up(&mut self, button: &str) {
         let Some(node_id) = self.doc.as_ref().get_hover_node_id() else {
             return;
         };
+
+        self.doc.as_mut().unactive_node();
 
         // If we hit a node, then we collect the node to its parents, check for listeners, and then
         // call those listeners
@@ -283,10 +285,8 @@ impl<Doc: DocumentLike, Rend: DocumentRenderer> View<Doc, Rend> {
             },
         });
 
-        if button == "left" {
-            if self.mouse_down_node == Some(node_id) {
-                self.click(button);
-            }
+        if self.mouse_down_node == Some(node_id) {
+            self.click(button);
         }
     }
 

--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -246,7 +246,7 @@ impl<Doc: DocumentLike, Rend: DocumentRenderer> View<Doc, Rend> {
         self.doc.as_mut().set_hover_to(dom_x, dom_y)
     }
 
-    pub fn mouse_down(&mut self, button: &str) {
+    pub fn mouse_down(&mut self, _button: &str) {
         let Some(node_id) = self.doc.as_ref().get_hover_node_id() else {
             return;
         };
@@ -268,11 +268,11 @@ impl<Doc: DocumentLike, Rend: DocumentRenderer> View<Doc, Rend> {
     }
 
     pub fn mouse_up(&mut self, button: &str) {
+        self.doc.as_mut().unactive_node();
+
         let Some(node_id) = self.doc.as_ref().get_hover_node_id() else {
             return;
         };
-
-        self.doc.as_mut().unactive_node();
 
         // If we hit a node, then we collect the node to its parents, check for listeners, and then
         // call those listeners


### PR DESCRIPTION
Click events are triggered after the mouse is pressed and released, and on the same node.