### PR TITLE
Add the ability to follow links

### DIFF
--- a/apps/readme/src/readme_application.rs
+++ b/apps/readme/src/readme_application.rs
@@ -124,6 +124,10 @@ impl ApplicationHandler<BlitzEvent> for ReadmeApplication {
                     self.reload_document();
                 }
             }
+            BlitzEvent::Navigate(url) => {
+                self.raw_url = url;
+                self.reload_document();
+            }
             event => self.inner.user_event(event_loop, event),
         }
     }

--- a/apps/readme/src/readme_application.rs
+++ b/apps/readme/src/readme_application.rs
@@ -4,7 +4,7 @@ use blitz_dom::net::Resource;
 use blitz_html::HtmlDocument;
 use blitz_renderer_vello::BlitzVelloRenderer;
 use blitz_shell::{BlitzApplication, BlitzEvent, View, WindowConfig};
-use blitz_traits::navigation::SharedNavigationProvider;
+use blitz_traits::navigation::NavigationProvider;
 use blitz_traits::net::NetProvider;
 use tokio::runtime::Handle;
 use winit::application::ApplicationHandler;
@@ -24,7 +24,7 @@ pub struct ReadmeApplication {
     net_provider: Arc<dyn NetProvider<Data = Resource>>,
     raw_url: String,
     keyboard_modifiers: Modifiers,
-    navigation_provider: SharedNavigationProvider,
+    navigation_provider: Arc<dyn NavigationProvider>,
 }
 
 impl ReadmeApplication {
@@ -32,7 +32,7 @@ impl ReadmeApplication {
         proxy: EventLoopProxy<BlitzEvent>,
         raw_url: String,
         net_provider: Arc<dyn NetProvider<Data = Resource>>,
-        navigation_provider: SharedNavigationProvider,
+        navigation_provider: Arc<dyn NavigationProvider>,
     ) -> Self {
         let handle = Handle::current();
         Self {

--- a/apps/readme/src/readme_application.rs
+++ b/apps/readme/src/readme_application.rs
@@ -4,6 +4,7 @@ use blitz_dom::net::Resource;
 use blitz_html::HtmlDocument;
 use blitz_renderer_vello::BlitzVelloRenderer;
 use blitz_shell::{BlitzApplication, BlitzEvent, View, WindowConfig};
+use blitz_traits::navigation::SharedNavigationProvider;
 use blitz_traits::net::NetProvider;
 use tokio::runtime::Handle;
 use winit::application::ApplicationHandler;
@@ -23,6 +24,7 @@ pub struct ReadmeApplication {
     net_provider: Arc<dyn NetProvider<Data = Resource>>,
     raw_url: String,
     keyboard_modifiers: Modifiers,
+    navigation_provider: SharedNavigationProvider,
 }
 
 impl ReadmeApplication {
@@ -30,6 +32,7 @@ impl ReadmeApplication {
         proxy: EventLoopProxy<BlitzEvent>,
         raw_url: String,
         net_provider: Arc<dyn NetProvider<Data = Resource>>,
+        navigation_provider: SharedNavigationProvider,
     ) -> Self {
         let handle = Handle::current();
         Self {
@@ -38,6 +41,7 @@ impl ReadmeApplication {
             raw_url,
             net_provider,
             keyboard_modifiers: Default::default(),
+            navigation_provider,
         }
     }
 
@@ -66,6 +70,7 @@ impl ReadmeApplication {
             stylesheets,
             self.net_provider.clone(),
             None,
+            self.navigation_provider.clone(),
         );
         self.window_mut().replace_document(doc);
     }

--- a/apps/wpt/src/attr_test.rs
+++ b/apps/wpt/src/attr_test.rs
@@ -40,6 +40,7 @@ pub async fn parse_and_resolve_document(
         Vec::new(),
         Arc::clone(&ctx.net_provider) as SharedProvider<Resource>,
         Some(clone_font_ctx(&ctx.font_ctx)),
+        ctx.navigation_provider.clone(),
     );
 
     document.as_mut().set_viewport(ctx.viewport.clone());

--- a/apps/wpt/src/main.rs
+++ b/apps/wpt/src/main.rs
@@ -1,5 +1,6 @@
 use blitz_dom::net::Resource;
 use blitz_renderer_vello::VelloImageRenderer;
+use blitz_traits::navigation::{DummyNavigationProvider, NavigationProvider};
 use blitz_traits::{ColorScheme, Viewport};
 use parley::FontContext;
 use pollster::FutureExt as _;
@@ -170,6 +171,7 @@ impl Buffers {
 struct ThreadCtx {
     viewport: Viewport,
     net_provider: Arc<WptNetProvider<Resource>>,
+    navigation_provider: Arc<dyn NavigationProvider>,
     renderer: VelloImageRenderer,
     font_ctx: FontContext,
     buffers: Buffers,
@@ -327,6 +329,7 @@ fn main() {
                             .unwrap();
 
                     let dummy_base_url = Url::parse("http://dummy.local").unwrap();
+                    let navigation_provider = Arc::new(DummyNavigationProvider);
 
                     RefCell::new(ThreadCtx {
                         viewport,
@@ -349,6 +352,7 @@ fn main() {
                         out_dir: out_dir.clone(),
                         wpt_dir: wpt_dir.clone(),
                         dummy_base_url,
+                        navigation_provider,
                     })
                 })
                 .borrow_mut();

--- a/apps/wpt/src/ref_test.rs
+++ b/apps/wpt/src/ref_test.rs
@@ -111,6 +111,7 @@ async fn render_html_to_buffer(
         Vec::new(),
         Arc::clone(&ctx.net_provider) as SharedProvider<Resource>,
         Some(clone_font_ctx(&ctx.font_ctx)),
+        ctx.navigation_provider.clone(),
     );
 
     document.as_mut().set_viewport(ctx.viewport.clone());

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -4,6 +4,7 @@ use blitz_dom::net::Resource;
 use blitz_html::HtmlDocument;
 use blitz_net::{MpscCallback, Provider};
 use blitz_renderer_vello::render_to_buffer;
+use blitz_traits::navigation::DummyNavigationProvider;
 use blitz_traits::net::SharedProvider;
 use blitz_traits::{ColorScheme, Viewport};
 use reqwest::Url;
@@ -64,6 +65,8 @@ async fn main() {
     let callback = Arc::new(callback);
     let net = Arc::new(Provider::new(callback));
 
+    let navigation_provider = Arc::new(DummyNavigationProvider);
+
     timer.time("Setup document prerequisites");
 
     // Create HtmlDocument
@@ -73,6 +76,7 @@ async fn main() {
         Vec::new(),
         Arc::clone(&net) as SharedProvider<Resource>,
         None,
+        navigation_provider,
     );
 
     timer.time("Parsed document");

--- a/packages/blitz-html/src/html_document.rs
+++ b/packages/blitz-html/src/html_document.rs
@@ -1,7 +1,8 @@
 use crate::DocumentHtmlParser;
 
 use blitz_dom::{
-    events::RendererEvent, net::Resource, Document, DocumentLike, FontContext, DEFAULT_CSS,
+    document::DocumentEvent, events::RendererEvent, net::Resource, Document, DocumentLike,
+    FontContext, DEFAULT_CSS,
 };
 use blitz_traits::{net::SharedProvider, ColorScheme, Viewport};
 
@@ -27,8 +28,8 @@ impl From<HtmlDocument> for Document {
     }
 }
 impl DocumentLike for HtmlDocument {
-    fn handle_event(&mut self, event: RendererEvent) {
-        self.inner.as_mut().handle_event(event);
+    fn handle_event(&mut self, event: RendererEvent) -> Option<DocumentEvent> {
+        self.inner.as_mut().handle_event(event)
     }
 }
 

--- a/packages/blitz-html/src/html_document.rs
+++ b/packages/blitz-html/src/html_document.rs
@@ -1,10 +1,11 @@
 use crate::DocumentHtmlParser;
 
 use blitz_dom::{
-    document::DocumentEvent, events::RendererEvent, net::Resource, Document, DocumentLike,
-    FontContext, DEFAULT_CSS,
+    events::RendererEvent, net::Resource, Document, DocumentLike, FontContext, DEFAULT_CSS,
 };
-use blitz_traits::{net::SharedProvider, ColorScheme, Viewport};
+use blitz_traits::{
+    navigation::SharedNavigationProvider, net::SharedProvider, ColorScheme, Viewport,
+};
 
 pub struct HtmlDocument {
     inner: Document,
@@ -28,7 +29,7 @@ impl From<HtmlDocument> for Document {
     }
 }
 impl DocumentLike for HtmlDocument {
-    fn handle_event(&mut self, event: RendererEvent) -> Option<DocumentEvent> {
+    fn handle_event(&mut self, event: RendererEvent) {
         self.inner.as_mut().handle_event(event)
     }
 }
@@ -40,6 +41,7 @@ impl HtmlDocument {
         stylesheets: Vec<String>,
         net_provider: SharedProvider<Resource>,
         font_ctx: Option<FontContext>,
+        navigation_provider: SharedNavigationProvider,
     ) -> Self {
         // Spin up the virtualdom and include the default stylesheet
         let viewport = Viewport::new(0, 0, 1.0, ColorScheme::Light);
@@ -55,6 +57,9 @@ impl HtmlDocument {
 
         // Set the net provider
         doc.set_net_provider(net_provider.clone());
+
+        // Set the navigation provider
+        doc.set_navigation_provider(navigation_provider.clone());
 
         // Include default and user-specified stylesheets
         doc.add_user_agent_stylesheet(DEFAULT_CSS);

--- a/packages/blitz-html/src/html_document.rs
+++ b/packages/blitz-html/src/html_document.rs
@@ -1,11 +1,11 @@
+use std::sync::Arc;
+
 use crate::DocumentHtmlParser;
 
 use blitz_dom::{
     events::RendererEvent, net::Resource, Document, DocumentLike, FontContext, DEFAULT_CSS,
 };
-use blitz_traits::{
-    navigation::SharedNavigationProvider, net::SharedProvider, ColorScheme, Viewport,
-};
+use blitz_traits::{navigation::NavigationProvider, net::SharedProvider, ColorScheme, Viewport};
 
 pub struct HtmlDocument {
     inner: Document,
@@ -41,7 +41,7 @@ impl HtmlDocument {
         stylesheets: Vec<String>,
         net_provider: SharedProvider<Resource>,
         font_ctx: Option<FontContext>,
-        navigation_provider: SharedNavigationProvider,
+        navigation_provider: Arc<dyn NavigationProvider>,
     ) -> Self {
         // Spin up the virtualdom and include the default stylesheet
         let viewport = Viewport::new(0, 0, 1.0, ColorScheme::Light);

--- a/packages/blitz-shell/src/application.rs
+++ b/packages/blitz-shell/src/application.rs
@@ -132,6 +132,9 @@ impl<Doc: DocumentLike, Rend: DocumentRenderer> ApplicationHandler<BlitzEvent>
             BlitzEvent::Embedder(_) => {
                 // Do nothing. Should be handled by embedders (if required).
             }
+            BlitzEvent::Navigate(_url) => {
+                // Do nothing. Should be handled by embedders (if required).
+            }
         }
     }
 }

--- a/packages/blitz-shell/src/event.rs
+++ b/packages/blitz-shell/src/event.rs
@@ -26,6 +26,9 @@ pub enum BlitzEvent {
 
     /// An arbitary event from the Blitz embedder
     Embedder(Arc<dyn Any + Send + Sync>),
+
+    /// Navigate to another URL (triggered by e.g. clicking a link)
+    Navigate(String),
 }
 impl BlitzEvent {
     pub fn embedder_event<T: Any + Send + Sync>(value: T) -> Self {

--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -270,7 +270,7 @@ impl<Doc: DocumentLike, Rend: DocumentRenderer> View<Doc, Rend> {
                         y: self.dom_mouse_pos.1,
                         mods: self.keyboard_modifiers,
                     },
-                })
+                });
             }
         }
     }

--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -1,4 +1,5 @@
 use crate::event::{create_waker, BlitzEvent};
+use blitz_dom::document::DocumentEvent;
 use blitz_dom::events::{EventData, RendererEvent};
 use blitz_dom::{DocumentLike, DocumentRenderer};
 use blitz_traits::{ColorScheme, Devtools, Viewport};
@@ -263,14 +264,18 @@ impl<Doc: DocumentLike, Rend: DocumentRenderer> View<Doc, Rend> {
             if button == "left" {
                 // If we hit a node, then we collect the node to its parents, check for listeners, and then
                 // call those listeners
-                self.doc.handle_event(RendererEvent {
-                    target: node_id,
-                    data: EventData::Click {
-                        x: self.dom_mouse_pos.0,
-                        y: self.dom_mouse_pos.1,
-                        mods: self.keyboard_modifiers,
-                    },
-                });
+                if let Some(DocumentEvent::ClickedLink(url)) =
+                    self.doc.handle_event(RendererEvent {
+                        target: node_id,
+                        data: EventData::Click {
+                            x: self.dom_mouse_pos.0,
+                            y: self.dom_mouse_pos.1,
+                            mods: self.keyboard_modifiers,
+                        },
+                    })
+                {
+                    let _ = self.event_loop_proxy.send_event(BlitzEvent::Navigate(url));
+                };
             }
         }
     }

--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -1,5 +1,4 @@
 use crate::event::{create_waker, BlitzEvent};
-use blitz_dom::document::DocumentEvent;
 use blitz_dom::events::{EventData, RendererEvent};
 use blitz_dom::{DocumentLike, DocumentRenderer};
 use blitz_traits::{ColorScheme, Devtools, Viewport};
@@ -264,18 +263,14 @@ impl<Doc: DocumentLike, Rend: DocumentRenderer> View<Doc, Rend> {
             if button == "left" {
                 // If we hit a node, then we collect the node to its parents, check for listeners, and then
                 // call those listeners
-                if let Some(DocumentEvent::ClickedLink(url)) =
-                    self.doc.handle_event(RendererEvent {
-                        target: node_id,
-                        data: EventData::Click {
-                            x: self.dom_mouse_pos.0,
-                            y: self.dom_mouse_pos.1,
-                            mods: self.keyboard_modifiers,
-                        },
-                    })
-                {
-                    let _ = self.event_loop_proxy.send_event(BlitzEvent::Navigate(url));
-                };
+                self.doc.handle_event(RendererEvent {
+                    target: node_id,
+                    data: EventData::Click {
+                        x: self.dom_mouse_pos.0,
+                        y: self.dom_mouse_pos.1,
+                        mods: self.keyboard_modifiers,
+                    },
+                })
             }
         }
     }

--- a/packages/blitz-traits/src/lib.rs
+++ b/packages/blitz-traits/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod net;
 
+pub mod navigation;
+
 mod devtools;
 pub use devtools::Devtools;
 

--- a/packages/blitz-traits/src/navigation.rs
+++ b/packages/blitz-traits/src/navigation.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+
+pub type SharedNavigationProvider = Arc<dyn NavigationProvider>;
+
+/// A provider to enable a document to bubble up navigation events (e.g. clicking a link)
+pub trait NavigationProvider {
+    fn navigate_new_page(&self, url: String);
+}
+
+pub struct DummyNavigationProvider;
+
+impl NavigationProvider for DummyNavigationProvider {
+    fn navigate_new_page(&self, _url: String) {
+        // Default impl: do nothing
+    }
+}

--- a/packages/blitz-traits/src/navigation.rs
+++ b/packages/blitz-traits/src/navigation.rs
@@ -1,9 +1,5 @@
-use std::sync::Arc;
-
-pub type SharedNavigationProvider = Arc<dyn NavigationProvider>;
-
 /// A provider to enable a document to bubble up navigation events (e.g. clicking a link)
-pub trait NavigationProvider {
+pub trait NavigationProvider: Send + Sync + 'static {
     fn navigate_new_page(&self, url: String);
 }
 

--- a/packages/blitz/Cargo.toml
+++ b/packages/blitz/Cargo.toml
@@ -18,6 +18,7 @@ blitz-renderer-vello = { path = "../blitz-renderer-vello" }
 blitz-html = { path = "../blitz-html" }
 blitz-shell = { path = "../blitz-shell" }
 blitz-net = { path = "../blitz-net", optional = true }
+blitz-traits = { path = "../blitz-traits" }
 
 # IO & Networking
 url = { workspace = true, features = ["serde"], optional = true }

--- a/packages/blitz/src/lib.rs
+++ b/packages/blitz/src/lib.rs
@@ -9,12 +9,15 @@
 //!  - `menu`: Enables the [`muda`] menubar.
 //!  - `tracing`: Enables tracing support.
 
+use std::sync::Arc;
+
 use blitz_html::HtmlDocument;
 use blitz_renderer_vello::BlitzVelloRenderer;
 use blitz_shell::{
     create_default_event_loop, BlitzApplication, BlitzEvent, BlitzShellNetCallback, Config,
     WindowConfig,
 };
+use blitz_traits::navigation::DummyNavigationProvider;
 
 #[cfg(feature = "net")]
 pub fn launch_url(url: &str) {
@@ -74,7 +77,16 @@ fn launch_internal(html: &str, cfg: Config) {
         Arc::new(DummyNetProvider::default())
     };
 
-    let doc = HtmlDocument::from_html(html, cfg.base_url, cfg.stylesheets, net_provider, None);
+    let navigation_provider = Arc::new(DummyNavigationProvider);
+
+    let doc = HtmlDocument::from_html(
+        html,
+        cfg.base_url,
+        cfg.stylesheets,
+        net_provider,
+        None,
+        navigation_provider,
+    );
     let window: WindowConfig<HtmlDocument, BlitzVelloRenderer> = WindowConfig::new(doc);
 
     // Create application


### PR DESCRIPTION
 For this we added another Variant to the BlitzEvent Enum and also made
 DocumentLike return an Option<DocumentEvent> which currently just has
 one Variant for following links.

 I consider this a working POC, which needs to be fleshed out.
 I didn't invest any time to make sure the DioxusSide still works. It
 most likely won't because of the change in the trait definition.

@nicoburns If this is about what you want, I am happy to work on this, as my time allows. If I've diverged too far from your vision, that's also fine!

It's a working POC. When I open the readme app and click a link, the Document is replaced.