### PR TITLE
Build requests via NetHandler

### DIFF
--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -1,6 +1,6 @@
 use image::DynamicImage;
 use selectors::context::QuirksMode;
-use std::{io::Cursor, str::FromStr, sync::atomic::AtomicBool, sync::Arc};
+use std::{io::Cursor, sync::atomic::AtomicBool, sync::Arc};
 use style::{
     font_face::{FontFaceSourceFormat, FontFaceSourceFormatKeyword, Source},
     media_queries::MediaList,
@@ -17,7 +17,7 @@ use style::{
     values::{CssUrl, SourceLocation},
 };
 
-use blitz_traits::net::{Bytes, NetHandler, SharedCallback, SharedProvider};
+use blitz_traits::net::{Bytes, NetHandler, Request, SharedCallback, SharedProvider};
 
 use url::Url;
 
@@ -113,7 +113,7 @@ impl ServoStylesheetLoader for StylesheetLoader {
         let url = import.url.url().unwrap();
         self.1.fetch(
             self.0,
-            url.as_ref().clone(),
+            Request::get(url.as_ref().clone()),
             Box::new(StylesheetLoaderInner {
                 url: url.clone(),
                 loader: self.clone(),
@@ -248,11 +248,8 @@ fn fetch_font_face(
                 tracing::warn!("Skipping unsupported font of type {:?}", _font_format);
                 return;
             }
-            network_provider.fetch(
-                doc_id,
-                Url::from_str(url_source.url.as_str()).unwrap(),
-                Box::new(FontFaceHandler(format)),
-            )
+            let url = url_source.url.url().unwrap().as_ref().clone();
+            network_provider.fetch(doc_id, Request::get(url), Box::new(FontFaceHandler(format)))
         });
 }
 

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -100,7 +100,7 @@ impl crate::document::BaseDocument {
 
                             self.net_provider.fetch(
                                 doc_id,
-                                (**new_url).clone(),
+                                Request::get((**new_url).clone()),
                                 Box::new(ImageHandler::new(node_id, ImageType::Background(idx))),
                             );
 
@@ -1072,6 +1072,7 @@ impl RegisteredSpeculativePainters for RegisteredPaintersImpl {
     }
 }
 
+use blitz_traits::net::Request;
 use style::traversal::recalc_style_at;
 
 pub struct RecalcStyle<'a> {

--- a/packages/blitz-html/src/html_sink.rs
+++ b/packages/blitz-html/src/html_sink.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 
 use blitz_dom::node::{Attribute, ElementNodeData, Node, NodeData};
 use blitz_dom::BaseDocument;
-use blitz_traits::net::SharedProvider;
+use blitz_traits::net::{Request, SharedProvider};
 use html5ever::{
     local_name,
     tendril::{StrTendril, TendrilSink},
@@ -131,7 +131,7 @@ impl DocumentHtmlParser<'_> {
             let url = self.doc.borrow().resolve_url(href);
             self.net_provider.fetch(
                 self.doc_id,
-                url.clone(),
+                Request::get(url.clone()),
                 Box::new(CssHandler {
                     node: target_id,
                     source_url: url,
@@ -149,7 +149,7 @@ impl DocumentHtmlParser<'_> {
                 let src = self.doc.borrow().resolve_url(raw_src);
                 self.net_provider.fetch(
                     self.doc.borrow().id(),
-                    src,
+                    Request::get(src),
                     Box::new(ImageHandler::new(target_id, ImageType::Image)),
                 );
             }

--- a/packages/blitz-net/src/lib.rs
+++ b/packages/blitz-net/src/lib.rs
@@ -67,7 +67,7 @@ impl<D: 'static> Provider<D> {
                 let request = HttpRequest::builder()
                     .uri(url.as_str())
                     .header(http::header::USER_AGENT, USER_AGENT);
-                let request = handler.request(request).try_into()?;
+                let request = handler.request(request)?.try_into()?;
 
                 let response = client.execute(request).await?;
 

--- a/packages/blitz-net/src/lib.rs
+++ b/packages/blitz-net/src/lib.rs
@@ -64,6 +64,7 @@ impl<D: 'static> Provider<D> {
                 let response = client
                     .request(request.method, request.url)
                     .headers(request.headers)
+                    .header("User-Agent", USER_AGENT)
                     .body(request.body)
                     .send()
                     .await?;

--- a/packages/blitz-traits/src/net.rs
+++ b/packages/blitz-traits/src/net.rs
@@ -32,6 +32,7 @@ pub trait NetCallback: Send + Sync + 'static {
 
 #[non_exhaustive]
 #[derive(Debug)]
+/// A request type loosely representing https://fetch.spec.whatwg.org/#requests
 pub struct Request {
     pub url: Url,
     pub method: Method,
@@ -39,6 +40,7 @@ pub struct Request {
     pub body: Bytes,
 }
 impl Request {
+    /// A get request to the specified Url and an empty body
     pub fn get(url: Url) -> Self {
         Self {
             url,

--- a/packages/blitz-traits/src/net.rs
+++ b/packages/blitz-traits/src/net.rs
@@ -1,5 +1,5 @@
 pub use bytes::Bytes;
-pub use http::{self, request::Builder, Method, Request};
+pub use http::{self, HeaderMap, Method};
 use std::marker::PhantomData;
 use std::sync::Arc;
 pub use url::Url;
@@ -13,7 +13,7 @@ pub type SharedCallback<D> = Arc<dyn NetCallback<Data = D>>;
 /// This may be over the network via http(s), via the filesystem, or some other method.
 pub trait NetProvider: Send + Sync + 'static {
     type Data;
-    fn fetch(&self, doc_id: usize, url: Url, handler: BoxedHandler<Self::Data>);
+    fn fetch(&self, doc_id: usize, request: Request, handler: BoxedHandler<Self::Data>);
 }
 
 /// A type that parses raw bytes from a network request into a Self::Data and then calls
@@ -21,10 +21,6 @@ pub trait NetProvider: Send + Sync + 'static {
 pub trait NetHandler: Send + Sync + 'static {
     type Data;
     fn bytes(self: Box<Self>, doc_id: usize, bytes: Bytes, callback: SharedCallback<Self::Data>);
-    /// Builds the request used to fetch the data
-    fn request(&self, request: Builder) -> http::Result<Request<Bytes>> {
-        request.method(Method::GET).body(Bytes::new())
-    }
 }
 
 /// A type which accepts the parsed result of a network request and sends it back to the Document
@@ -32,6 +28,25 @@ pub trait NetHandler: Send + Sync + 'static {
 pub trait NetCallback: Send + Sync + 'static {
     type Data;
     fn call(&self, doc_id: usize, data: Self::Data);
+}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct Request {
+    pub url: Url,
+    pub method: Method,
+    pub headers: HeaderMap,
+    pub body: Bytes,
+}
+impl Request {
+    pub fn get(url: Url) -> Self {
+        Self {
+            url,
+            method: Method::GET,
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        }
+    }
 }
 
 /// A default noop NetProvider
@@ -43,7 +58,7 @@ impl<D> Default for DummyNetProvider<D> {
 }
 impl<D: Send + Sync + 'static> NetProvider for DummyNetProvider<D> {
     type Data = D;
-    fn fetch(&self, _doc_id: usize, _url: Url, _handler: BoxedHandler<D>) {}
+    fn fetch(&self, _doc_id: usize, _request: Request, _handler: BoxedHandler<D>) {}
 }
 
 /// A default noop NetCallback

--- a/packages/blitz-traits/src/net.rs
+++ b/packages/blitz-traits/src/net.rs
@@ -1,5 +1,5 @@
 pub use bytes::Bytes;
-pub use http::Method;
+pub use http::{self, request::Builder, Method, Request};
 use std::marker::PhantomData;
 use std::sync::Arc;
 pub use url::Url;
@@ -21,8 +21,9 @@ pub trait NetProvider: Send + Sync + 'static {
 pub trait NetHandler: Send + Sync + 'static {
     type Data;
     fn bytes(self: Box<Self>, doc_id: usize, bytes: Bytes, callback: SharedCallback<Self::Data>);
-    fn method(&self) -> Method {
-        Method::GET
+    /// Builds the request used to fetch the data
+    fn request(&self, request: Builder) -> Request<Bytes> {
+        request.method(Method::GET).body(Bytes::new()).unwrap()
     }
 }
 

--- a/packages/blitz-traits/src/net.rs
+++ b/packages/blitz-traits/src/net.rs
@@ -22,8 +22,8 @@ pub trait NetHandler: Send + Sync + 'static {
     type Data;
     fn bytes(self: Box<Self>, doc_id: usize, bytes: Bytes, callback: SharedCallback<Self::Data>);
     /// Builds the request used to fetch the data
-    fn request(&self, request: Builder) -> Request<Bytes> {
-        request.method(Method::GET).body(Bytes::new()).unwrap()
+    fn request(&self, request: Builder) -> http::Result<Request<Bytes>> {
+        request.method(Method::GET).body(Bytes::new())
     }
 }
 


### PR DESCRIPTION
This allows the `NetHandler` implementation to modify the request used to fetch.

This is required when we intend to implement forms in the future. 

