### PR TITLE
Give NavigationProvider options 

### DIFF
--- a/apps/readme/src/main.rs
+++ b/apps/readme/src/main.rs
@@ -3,7 +3,7 @@ mod readme_application;
 
 use blitz_html::HtmlDocument;
 use blitz_net::Provider;
-use blitz_traits::navigation::NavigationProvider;
+use blitz_traits::navigation::{NavigationOptions, NavigationProvider};
 use markdown::{markdown_to_html, BLITZ_MD_STYLES, GITHUB_MD_STYLES};
 use notify::{Error as NotifyError, Event as NotifyEvent, RecursiveMode, Watcher as _};
 use readme_application::{ReadmeApplication, ReadmeEvent};
@@ -27,8 +27,10 @@ struct ReadmeNavigationProvider {
 }
 
 impl NavigationProvider for ReadmeNavigationProvider {
-    fn navigate_new_page(&self, url: String) {
-        let _ = self.proxy.send_event(BlitzShellEvent::Navigate(url));
+    fn navigate_new_page(&self, navigation: NavigationOptions) {
+        let _ = self
+            .proxy
+            .send_event(BlitzShellEvent::Navigate(Box::new(navigation)));
     }
 }
 

--- a/apps/readme/src/readme_application.rs
+++ b/apps/readme/src/readme_application.rs
@@ -130,8 +130,8 @@ impl ApplicationHandler<BlitzShellEvent> for ReadmeApplication {
                     self.reload_document(true);
                 }
             }
-            BlitzShellEvent::Navigate(url) => {
-                self.raw_url = url;
+            BlitzShellEvent::Navigate(opts) => {
+                self.raw_url = opts.url.into();
                 self.reload_document(false);
             }
             event => self.inner.user_event(event_loop, event),

--- a/packages/blitz-dom/src/events/mouse.rs
+++ b/packages/blitz-dom/src/events/mouse.rs
@@ -1,7 +1,7 @@
+use crate::{node::NodeSpecificData, util::resolve_url, BaseDocument, Node};
+use blitz_traits::navigation::NavigationOptions;
 use blitz_traits::HitResult;
 use markup5ever::local_name;
-
-use crate::{node::NodeSpecificData, util::resolve_url, BaseDocument, Node};
 
 fn parent_hit(node: &Node, x: f32, y: f32) -> Option<HitResult> {
     node.layout_parent.get().map(|parent_id| HitResult {
@@ -73,7 +73,8 @@ pub(crate) fn handle_click(doc: &mut BaseDocument, _target: usize, x: f32, y: f3
         } else if el.name.local == local_name!("a") {
             if let Some(href) = el.attr(local_name!("href")) {
                 if let Some(url) = resolve_url(&doc.base_url, href) {
-                    doc.navigation_provider.navigate_new_page(url.into());
+                    doc.navigation_provider
+                        .navigate_new_page(NavigationOptions::new(url, doc.id()));
                 } else {
                     println!(
                         "{href} is not parseable as a url. : {base_url:?}",

--- a/packages/blitz-shell/src/event.rs
+++ b/packages/blitz-shell/src/event.rs
@@ -5,6 +5,7 @@ use winit::{event_loop::EventLoopProxy, window::WindowId};
 #[cfg(feature = "accessibility")]
 use accesskit_winit::{Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
 use blitz_dom::net::Resource;
+use blitz_traits::navigation::NavigationOptions;
 
 #[derive(Debug, Clone)]
 pub enum BlitzShellEvent {
@@ -28,7 +29,7 @@ pub enum BlitzShellEvent {
     Embedder(Arc<dyn Any + Send + Sync>),
 
     /// Navigate to another URL (triggered by e.g. clicking a link)
-    Navigate(String),
+    Navigate(Box<NavigationOptions>),
 }
 impl BlitzShellEvent {
     pub fn embedder_event<T: Any + Send + Sync>(value: T) -> Self {

--- a/packages/blitz-traits/src/navigation.rs
+++ b/packages/blitz-traits/src/navigation.rs
@@ -1,12 +1,50 @@
+use url::Url;
+
 /// A provider to enable a document to bubble up navigation events (e.g. clicking a link)
 pub trait NavigationProvider: Send + Sync + 'static {
-    fn navigate_new_page(&self, url: String);
+    fn navigate_new_page(&self, navigation: NavigationOptions);
 }
 
 pub struct DummyNavigationProvider;
 
 impl NavigationProvider for DummyNavigationProvider {
-    fn navigate_new_page(&self, _url: String) {
+    fn navigate_new_page(&self, _navigation: NavigationOptions) {
         // Default impl: do nothing
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct NavigationOptions {
+    /// The URL to navigate to
+    pub url: Url,
+
+    /// Source document for the navigation
+    pub source_document: usize,
+
+    pub referrer_policy: String,
+}
+
+impl Default for NavigationOptions {
+    fn default() -> Self {
+        Self {
+            url: Url::parse("http://localhost").unwrap(),
+            source_document: 0,
+            referrer_policy: String::new(),
+        }
+    }
+}
+
+impl NavigationOptions {
+    pub fn new(url: Url, source_document: usize) -> Self {
+        Self {
+            url,
+            source_document,
+            ..Default::default()
+        }
+    }
+    pub fn with_referrer_policy(mut self, resource: String) -> Self {
+        self.referrer_policy = resource;
+        self
     }
 }


### PR DESCRIPTION
This adds a type which represents a Navigation  
(https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation)
The `NavigationOptions` are expanded later when adding something like forms.
