### PR TITLE
fix clippy warning large size between variants

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -609,7 +609,7 @@ impl BaseDocument {
                 match kind {
                     ImageType::Image => {
                         node.element_data_mut().unwrap().node_specific_data =
-                            NodeSpecificData::Image(Box::new(ImageData::Svg(*tree)));
+                            NodeSpecificData::Image(Box::new(ImageData::Svg(tree)));
 
                         // Clear layout cache
                         node.cache.clear();
@@ -620,7 +620,7 @@ impl BaseDocument {
                             .and_then(|el| el.background_images.get_mut(idx))
                         {
                             bg_image.status = Status::Ok;
-                            bg_image.image = ImageData::Svg(*tree);
+                            bg_image.image = ImageData::Svg(tree);
                         }
                     }
                 }

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -83,8 +83,6 @@ pub(crate) fn collect_layout_children(
 
         #[cfg(feature = "svg")]
         if matches!(tag_name, "svg") {
-            use crate::node::ImageData;
-
             let mut outer_html = doc.get_node(container_node_id).unwrap().outer_html();
 
             // HACK: usvg fails to parse SVGs that don't have the SVG xmlns set. So inject it
@@ -100,8 +98,7 @@ pub(crate) fn collect_layout_children(
                         .unwrap()
                         .element_data_mut()
                         .unwrap()
-                        .node_specific_data =
-                        NodeSpecificData::Image(Box::new(ImageData::Svg(svg)));
+                        .node_specific_data = NodeSpecificData::Image(Box::new(svg.into()));
                 }
                 Err(err) => {
                     println!("{} SVG parse failed", container_node_id);

--- a/packages/blitz-dom/src/node.rs
+++ b/packages/blitz-dom/src/node.rs
@@ -559,7 +559,7 @@ impl RasterImageData {
 pub enum ImageData {
     Raster(RasterImageData),
     #[cfg(feature = "svg")]
-    Svg(usvg::Tree),
+    Svg(Box<usvg::Tree>),
     None,
 }
 impl From<Arc<DynamicImage>> for ImageData {
@@ -570,7 +570,7 @@ impl From<Arc<DynamicImage>> for ImageData {
 #[cfg(feature = "svg")]
 impl From<usvg::Tree> for ImageData {
     fn from(value: usvg::Tree) -> Self {
-        Self::Svg(value)
+        Self::Svg(Box::new(value))
     }
 }
 

--- a/packages/blitz-renderer-vello/src/renderer.rs
+++ b/packages/blitz-renderer-vello/src/renderer.rs
@@ -27,6 +27,7 @@ pub struct ActiveRenderState {
     surface: RenderSurface<'static>,
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum RenderState {
     Active(ActiveRenderState),
     Suspended,


### PR DESCRIPTION
Fixes this https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant Clippy lint