### PR TITLE
Handle single quotes in WPT reftest regex

### DIFF
--- a/apps/wpt/src/main.rs
+++ b/apps/wpt/src/main.rs
@@ -371,7 +371,7 @@ fn main() {
                         ColorScheme::Light,
                     );
                     let net_provider = Arc::new(WptNetProvider::new(&wpt_dir));
-                    let reftest_re = Regex::new(r#"<link\s+rel="match"\s+href="([^"]+)""#).unwrap();
+                    let reftest_re = Regex::new(r#"<link\s+rel=['"]match['"]\s+href=['"]([^'"]+)['"]"#).unwrap();
 
                     let float_re = Regex::new(r#"float:"#).unwrap();
                     let intrinsic_re =

--- a/apps/wpt/src/main.rs
+++ b/apps/wpt/src/main.rs
@@ -371,7 +371,8 @@ fn main() {
                         ColorScheme::Light,
                     );
                     let net_provider = Arc::new(WptNetProvider::new(&wpt_dir));
-                    let reftest_re = Regex::new(r#"<link\s+rel=['"]match['"]\s+href=['"]([^'"]+)['"]"#).unwrap();
+                    let reftest_re =
+                        Regex::new(r#"<link\s+rel=['"]match['"]\s+href=['"]([^'"]+)['"]"#).unwrap();
 
                     let float_re = Regex::new(r#"float:"#).unwrap();
                     let intrinsic_re =


### PR DESCRIPTION
Ran into this while testing https://github.com/linebender/parley/pull/315. This was causing a lot of reftests to be skipped.

Most of these tests still don't pass even with that Parley change, but it seems to be because the `width` attribute of the test `<div>` in the tests isn't being respected.