### PR TITLE
fix: Fixed the actual color displayed when border-color is transparent

### DIFF
--- a/examples/assets/border.html
+++ b/examples/assets/border.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Document</title>
+        <style>
+            .colorful {
+                border-right-color: #000;
+                border-left-color: #ff0;
+                border-top-color: #f01;
+                border-bottom-color: #0f0;
+            }
+            #a {
+                height: 300px;
+                background-color: gray;
+                border: 1px solid black;
+                border-radius: 50px 20px;
+                border-top-color: red;
+                padding: 20px;
+                margin: 20px;
+                border-radius: 10% 30% 50% 70%;
+                border-left: 4px solid #000;
+                border-top: 10px solid #ff0;
+                border-right: 3px solid #f01;
+                border-bottom: 9px solid #0f0;
+                box-shadow: 10px 10px gray;
+            }
+
+            #b {
+                border: 20px solid black;
+                background-color: red;
+                border-radius: 10px;
+                border-top-width: 32px;
+                border-left-width: 4px;
+                border-right-width: 4px;
+            }
+            #c {
+                border: 20px solid black;
+                background-color: red;
+                border-top-left-radius: 0px;
+                border-top-right-radius: 40px;
+                border-top-width: 32px;
+                border-left-width: 8px;
+                border-right-width: 16px;
+            }
+            #d {
+                border: 20px solid black;
+                background-color: red;
+                border-top-width: 32px;
+                border-left-width: 8px;
+                border-right-width: 16px;
+                border-bottom-width: 20px;
+            }
+            #e {
+                background-color: pink;
+                border: 20px solid black;
+                border-radius: 30px;
+                border-right-color: #000;
+                border-left-color: #ff0;
+                border-top-color: #f01;
+                border-bottom-color: #0f0;
+            }
+            #border-box {
+                padding: 20px;
+                border: 20px solid transparent;
+                background-color: red;
+                box-sizing: border-box;
+                border-radius: 10px;
+            }
+            #clip-border-box {
+                padding: 20px;
+                border: 20px solid transparent;
+                background-color: red;
+                background-clip: border-box;
+                border-radius: 10px;
+            }
+            #clip-padding-box {
+                padding: 20px;
+                border: 20px solid transparent;
+                background-color: red;
+                background-clip: padding-box;
+                border-radius: 30px;
+            }
+            #clip-content-box {
+                padding: 20px;
+                border: 20px solid transparent;
+                background-color: red;
+                background-clip: content-box;
+                border-radius: 50px;
+            }
+        </style>
+    </head>
+    <body>
+        <div>hi</div>
+        <div class="colorful" id="a">
+            Dioxus12312312312321\n\n\n\n\n\n\n\n hi
+        </div>
+        <div class="colorful" id="b">
+            Dioxus12312312312321\n\n\n\n\n\n\n\n hi
+        </div>
+        <div class="colorful" id="c">
+            Dioxus12312312312321\n\n\n\n\n\n\n\n hi
+        </div>
+        <div class="colorful" id="d">
+            Dioxus12312312312321\n\n\n\n\n\n\n\n hi
+        </div>
+        <div class="colorful" id="e">
+            Dioxus12312312312321\n\n\n\n\n\n\n\n hi
+        </div>
+        <div id="border-box">box-sizing: border-box</div>
+        <div id="clip-border-box">background-clip: border-box</div>
+        <div id="clip-padding-box">background-clip: padding-box</div>
+        <div id="clip-content-box">background-clip: content-box</div>
+    </body>
+</html>

--- a/examples/border.rs
+++ b/examples/border.rs
@@ -18,6 +18,11 @@ fn app() -> Element {
         div { class: "colorful", id: "c", "    Dioxus12312312312321\n\n\n\n\n\n\n\n        hi " }
         div { class: "colorful", id: "d", "    Dioxus12312312312321\n\n\n\n\n\n\n\n        hi " }
         div { class: "colorful", id: "e", "    Dioxus12312312312321\n\n\n\n\n\n\n\n        hi " }
+
+        div { id: "border-box", "box-sizing: border-box" }
+        div { id: "clip-border-box", "background-clip: border-box" }
+        div { id: "clip-padding-box", "background-clip: padding-box" }
+        div { id: "clip-content-box", "background-clip: content-box" }
     }
 }
 
@@ -78,7 +83,34 @@ const CSS: &str = r#"
     border-top-color: #F01;
     border-bottom-color: #0f0;
 }
-
+#border-box {
+    padding: 20px;
+    border: 20px solid transparent;
+    background-color: red;
+    box-sizing: border-box;
+    border-radius: 10px;
+}
+#clip-border-box {
+    padding: 20px;
+    border: 20px solid transparent;
+    background-color: red;
+    background-clip: border-box;
+    border-radius: 10px;
+}
+#clip-padding-box {
+    padding: 20px;
+    border: 20px solid transparent;
+    background-color: red;
+    background-clip: padding-box;
+    border-radius: 30px;
+}
+#clip-content-box {
+    padding: 20px;
+    border: 20px solid transparent;
+    background-color: red;
+    background-clip: content-box;
+    border-radius: 50px;
+}
 "#;
 
 // border-radius: 1px;

--- a/packages/blitz-renderer-vello/src/renderer/multicolor_rounded_rect.rs
+++ b/packages/blitz-renderer-vello/src/renderer/multicolor_rounded_rect.rs
@@ -24,6 +24,11 @@ pub struct ElementFrame {
     pub content_box: Rect,
     pub outline_width: f64,
 
+    pub padding_top_width: f64,
+    pub padding_left_width: f64,
+    pub padding_right_width: f64,
+    pub padding_bottom_width: f64,
+
     pub border_top_width: f64,
     pub border_left_width: f64,
     pub border_right_width: f64,
@@ -93,10 +98,10 @@ impl ElementFrame {
 
         // Correct the border radii if they are too big if two border radii would intersect, then we need to shrink
         // ALL border radii by the same factor such that they do not
-        let top_overlap_factor = padding_box.width() / (border_top_left_radius_width + border_top_right_radius_width);
-        let bottom_overlap_factor = padding_box.width() / (border_bottom_left_radius_width + border_bottom_right_radius_width);
-        let left_overlap_factor = padding_box.height() / (border_top_left_radius_height + border_bottom_left_radius_height);
-        let right_overlap_factor = padding_box.height() / (border_top_right_radius_height + border_bottom_right_radius_height);
+        let top_overlap_factor = border_box.width() / (border_top_left_radius_width + border_top_right_radius_width);
+        let bottom_overlap_factor = border_box.width() / (border_bottom_left_radius_width + border_bottom_right_radius_width);
+        let left_overlap_factor = border_box.height() / (border_top_left_radius_height + border_bottom_left_radius_height);
+        let right_overlap_factor = border_box.height() / (border_top_right_radius_height + border_bottom_right_radius_height);
 
         let min_factor = top_overlap_factor.min(bottom_overlap_factor).min(left_overlap_factor).min(right_overlap_factor).min(1.0);
         if min_factor < 1.0 {
@@ -115,6 +120,10 @@ impl ElementFrame {
             border_box,
             content_box,
             outline_width,
+            padding_top_width: padding.top,
+            padding_left_width: padding.left,
+            padding_right_width: padding.right,
+            padding_bottom_width: padding.bottom,
             border_top_width: border.top,
             border_left_width: border.left,
             border_right_width: border.right,
@@ -151,7 +160,7 @@ impl ElementFrame {
 
         // 1. First corner
         // if the radius is bigger than the border, we need to draw the inner arc to fill in the gap
-        if self.is_sharp(c0) {
+        if self.is_sharp(c0, Outer) {
             path.move_to(self.corner(c0, Inner));
             path.line_to(self.corner(c0, Outer));
         } else {
@@ -163,7 +172,7 @@ impl ElementFrame {
         }
 
         // 2. Second corner
-        if self.is_sharp(c1) {
+        if self.is_sharp(c1, Outer) {
             path.line_to(self.corner(c1, Outer));
             path.line_to(self.corner(c1, Inner));
         } else {
@@ -200,6 +209,27 @@ impl ElementFrame {
         path
     }
 
+    /// Construct a bezpath drawing the frame border
+    pub fn frame_border(&self) -> BezPath {
+        let mut path = BezPath::new();
+        self.shape(&mut path, ArcSide::Outer, Direction::Clockwise);
+        path
+    }
+
+    /// Construct a bezpath drawing the frame padding
+    pub fn frame_padding(&self) -> BezPath {
+        let mut path = BezPath::new();
+        self.shape(&mut path, ArcSide::Inner, Direction::Clockwise);
+        path
+    }
+
+    /// Construct a bezpath drawing the frame content
+    pub fn frame_content(&self) -> BezPath {
+        let mut path = BezPath::new();
+        self.shape(&mut path, ArcSide::Content, Direction::Clockwise);
+        path
+    }
+
     fn shape(&self, path: &mut BezPath, line: ArcSide, direction: Direction) {
         use Corner::*;
 
@@ -209,7 +239,7 @@ impl ElementFrame {
         };
 
         for corner in route {
-            if self.is_sharp(corner) {
+            if self.is_sharp(corner, line) {
                 path.insert_point(self.corner(corner, line));
             } else {
                 path.insert_arc(self.full_arc(corner, line, direction));
@@ -231,7 +261,7 @@ impl ElementFrame {
             path.insert_point(self.shadow_clip_corner(corner, 100.0));
         }
 
-        if self.is_sharp(TopLeft) {
+        if self.is_sharp(TopLeft, ArcSide::Outer) {
             path.move_to(self.corner(TopLeft, ArcSide::Outer));
         } else {
             const TOLERANCE: f64 = 0.1;
@@ -241,7 +271,7 @@ impl ElementFrame {
         }
 
         for corner in [/*TopLeft, */ BottomLeft, BottomRight, TopRight] {
-            if self.is_sharp(corner) {
+            if self.is_sharp(corner, ArcSide::Outer) {
                 path.insert_point(self.corner(corner, ArcSide::Outer));
             } else {
                 path.insert_arc(self.full_arc(corner, ArcSide::Outer, Direction::Anticlockwise));
@@ -254,24 +284,40 @@ impl ElementFrame {
 
         let (x, y) = match corner {
             Corner::TopLeft => match side {
+                ArcSide::Content => (
+                    x0 + self.border_left_width + self.padding_left_width,
+                    y0 + self.border_top_width + self.padding_top_width,
+                ),
                 ArcSide::Inner => (x0 + self.border_left_width, y0 + self.border_top_width),
                 ArcSide::Outer => (x0, y0),
                 ArcSide::Outline => (x0 - self.outline_width, y0 - self.outline_width),
                 ArcSide::Middle => unimplemented!(),
             },
             Corner::TopRight => match side {
+                ArcSide::Content => (
+                    x1 - self.border_left_width - self.padding_left_width,
+                    y0 + self.border_top_width + self.padding_top_width,
+                ),
                 ArcSide::Inner => (x1 - self.border_right_width, y0 + self.border_top_width),
                 ArcSide::Outer => (x1, y0),
                 ArcSide::Outline => (x1 + self.outline_width, y0 - self.outline_width),
                 ArcSide::Middle => unimplemented!(),
             },
             Corner::BottomRight => match side {
+                ArcSide::Content => (
+                    x1 - self.border_right_width - self.padding_right_width,
+                    y1 - self.border_bottom_width - self.padding_bottom_width,
+                ),
                 ArcSide::Inner => (x1 - self.border_right_width, y1 - self.border_bottom_width),
                 ArcSide::Outer => (x1, y1),
                 ArcSide::Outline => (x1 + self.outline_width, y1 + self.outline_width),
                 ArcSide::Middle => unimplemented!(),
             },
             Corner::BottomLeft => match side {
+                ArcSide::Content => (
+                    x0 + self.border_left_width + self.padding_left_width,
+                    y1 - self.border_bottom_width - self.padding_bottom_width,
+                ),
                 ArcSide::Inner => (x0 + self.border_left_width, y1 - self.border_bottom_width),
                 ArcSide::Outer => (x0, y1),
                 ArcSide::Outline => (x0 - self.outline_width, y1 + self.outline_width),
@@ -443,24 +489,97 @@ impl ElementFrame {
     }
 
     /// Check if a corner is sharp (IE the absolute radius is 0)
-    fn is_sharp(&self, corner: Corner) -> bool {
-        match corner {
-            Corner::TopLeft => {
+    fn is_sharp(&self, corner: Corner, side: ArcSide) -> bool {
+        use ArcSide::*;
+        use Corner::*;
+
+        let is_sharp = match corner {
+            TopLeft => {
                 self.border_top_left_radius_width == 0.0
                     || self.border_top_left_radius_height == 0.0
             }
-            Corner::TopRight => {
+            TopRight => {
                 self.border_top_right_radius_width == 0.0
                     || self.border_top_right_radius_height == 0.0
             }
-            Corner::BottomRight => {
+            BottomRight => {
                 self.border_bottom_right_radius_width == 0.0
                     || self.border_bottom_right_radius_height == 0.0
             }
-            Corner::BottomLeft => {
+            BottomLeft => {
                 self.border_bottom_left_radius_width == 0.0
                     || self.border_bottom_left_radius_height == 0.0
             }
+        };
+
+        if is_sharp {
+            return true;
+        }
+
+        if side == Inner {
+            match corner {
+                TopLeft => {
+                    self.border_top_left_radius_width - self.border_left_width <= 0.0
+                        || self.border_top_left_radius_height - self.border_top_width <= 0.0
+                }
+                TopRight => {
+                    self.border_top_right_radius_width - self.border_right_width <= 0.0
+                        || self.border_top_right_radius_height - self.border_top_width <= 0.0
+                }
+                BottomRight => {
+                    self.border_bottom_right_radius_width - self.border_right_width <= 0.0
+                        || self.border_bottom_right_radius_height - self.border_bottom_width <= 0.0
+                }
+                BottomLeft => {
+                    self.border_bottom_left_radius_width - self.border_left_width <= 0.0
+                        || self.border_bottom_left_radius_height - self.border_bottom_width <= 0.0
+                }
+            }
+        } else if side == Content {
+            match corner {
+                TopLeft => {
+                    self.border_top_left_radius_width
+                        - self.border_left_width
+                        - self.padding_left_width
+                        <= 0.0
+                        || self.border_top_left_radius_height
+                            - self.border_top_width
+                            - self.padding_top_width
+                            <= 0.0
+                }
+                TopRight => {
+                    self.border_top_right_radius_width
+                        - self.border_right_width
+                        - self.padding_right_width
+                        <= 0.0
+                        || self.border_top_right_radius_height
+                            - self.border_top_width
+                            - self.padding_top_width
+                            <= 0.0
+                }
+                BottomRight => {
+                    self.border_bottom_right_radius_width
+                        - self.border_right_width
+                        - self.padding_right_width
+                        <= 0.0
+                        || self.border_bottom_right_radius_height
+                            - self.border_bottom_width
+                            - self.padding_bottom_width
+                            <= 0.0
+                }
+                BottomLeft => {
+                    self.border_bottom_left_radius_width
+                        - self.border_left_width
+                        - self.padding_left_width
+                        <= 0.0
+                        || self.border_bottom_left_radius_height
+                            - self.border_bottom_width
+                            - self.padding_bottom_width
+                            <= 0.0
+                }
+            }
+        } else {
+            is_sharp
         }
     }
 
@@ -469,6 +588,10 @@ impl ElementFrame {
         use {Corner::*, ArcSide::*};
         let ElementFrame {
             border_box: rect,
+            padding_top_width,
+            padding_left_width,
+            padding_right_width,
+            padding_bottom_width,
             border_top_width,
             border_left_width,
             border_right_width,
@@ -514,6 +637,12 @@ impl ElementFrame {
                 BottomRight => (border_bottom_right_radius_width - border_right_width, border_bottom_right_radius_height - border_bottom_width),
                 BottomLeft => (border_bottom_left_radius_width - border_left_width, border_bottom_left_radius_height - border_bottom_width),
             },
+            Content => match corner {
+                TopLeft => (border_top_left_radius_width - border_left_width - padding_left_width, border_top_left_radius_height - border_top_width - padding_top_width),
+                TopRight => (border_top_right_radius_width - border_right_width - padding_right_width, border_top_right_radius_height - border_top_width - padding_top_width),
+                BottomRight => (border_bottom_right_radius_width - border_right_width - padding_right_width, border_bottom_right_radius_height - border_bottom_width - padding_bottom_width),
+                BottomLeft => (border_bottom_left_radius_width - border_left_width - padding_left_width, border_bottom_left_radius_height - border_bottom_width - padding_bottom_width),
+            },
         };
 
         Ellipse::new(rect.origin() + center, radii, 0.0)
@@ -556,13 +685,13 @@ pub enum Edge {
 ///    |    |    *----------------------------------------------*    |   |  <--- ArcSide::Middle
 ///    |    |    |                    Border Inner              |    |   |
 ///    |    |    |    *------------------------------------*    |    |   |  <--- ArcSide::Inner
-///    |    |    |    |                                    |    |    |   |
-///    |    |    |    |                                    |    |    |   |
-///    |    |    |    |                                    |    |    |   |
-///    |    |    |    |                                    |    |    |   |
-///    |    |    |    |                                    |    |    |   |
-///    |    |    |    |                                    |    |    |   |
-///    |    |    |    |                                    |    |    |   |
+///    |    |    |    |               Padding              |    |    |   |
+///    |    |    |    |    *--------------------------*    |    |    |   |  <--- ArcSide::Content
+///    |    |    |    |    |                          |    |    |    |   |
+///    |    |    |    |    |                          |    |    |    |   |
+///    |    |    |    |    |                          |    |    |    |   |
+///    |    |    |    |    |                          |    |    |    |   |
+///    |    |    |    |    *--------------------------*    |    |    |   |
 ///    |    |    |    |                                    |    |    |   |
 ///    |    |    |    *------------------------------------*    |    |   |
 ///    |    |    |                                              |    |   |
@@ -580,13 +709,14 @@ enum Corner {
     BottomRight,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum ArcSide {
     Outline,
     Outer,
     #[allow(unused)]
     Middle,
     Inner,
+    Content,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/packages/blitz-renderer-vello/src/renderer/render.rs
+++ b/packages/blitz-renderer-vello/src/renderer/render.rs
@@ -18,7 +18,11 @@ use style::{
     dom::TElement,
     properties::{
         ComputedValues,
-        generated::longhands::visibility::computed_value::T as StyloVisibility,
+        generated::longhands::{
+            background_clip::single_value::computed_value::T as StyloBackgroundClip,
+            background_origin::single_value::computed_value::T as StyloBackgroundOrigin,
+            visibility::computed_value::T as StyloVisibility,
+        },
         style_structs::{Font, Outline},
     },
     values::{
@@ -58,6 +62,23 @@ use vello::{
 use vello_svg::usvg;
 
 type GradientItem<T> = GenericGradientItem<GenericColor<Percentage>, T>;
+type LinearGradient<'a> = (
+    &'a LineDirection,
+    &'a [GradientItem<LengthPercentage>],
+    GradientFlags,
+);
+type RadialGradient<'a> = (
+    &'a EndingShape<NonNegative<CSSPixelLength>, NonNegative<LengthPercentage>>,
+    &'a GenericPosition<LengthPercentage, LengthPercentage>,
+    &'a OwnedSlice<GenericGradientItem<GenericColor<Percentage>, LengthPercentage>>,
+    GradientFlags,
+);
+type ConicGradient<'a> = (
+    &'a Angle,
+    &'a GenericPosition<LengthPercentage, LengthPercentage>,
+    &'a OwnedSlice<GenericGradientItem<GenericColor<Percentage>, AngleOrPercentage>>,
+    GradientFlags,
+);
 
 const CLIP_LIMIT: usize = 1024;
 static CLIPS_USED: AtomicUsize = AtomicUsize::new(0);
@@ -577,16 +598,14 @@ impl VelloSceneGenerator<'_> {
     }
 }
 
-#[cfg(feature = "svg")]
 fn compute_background_size(
     style: &ComputedValues,
     container_w: f32,
     container_h: f32,
     bg_idx: usize,
-    bg_w: f32,
-    bg_h: f32,
+    mode: BackgroundSizeComputeMode,
     scale: f32,
-) -> kurbo::Size {
+) -> (Point, kurbo::Size) {
     use style::values::computed::{BackgroundSize, Length};
     use style::values::generics::length::GenericLengthPercentageOrAuto as Lpa;
 
@@ -598,6 +617,8 @@ fn compute_background_size(
         .cloned()
         .unwrap_or(BackgroundSize::auto());
 
+    let mut offset = Point::new(0.0, 0.0);
+
     let (width, height): (f32, f32) = match bg_size {
         BackgroundSize::ExplicitSize { width, height } => {
             let width = width.map(|w| w.0.resolve(Length::new(container_w)));
@@ -605,49 +626,117 @@ fn compute_background_size(
 
             match (width, height) {
                 (Lpa::LengthPercentage(width), Lpa::LengthPercentage(height)) => {
-                    (width.px(), height.px())
+                    let width = width.px();
+                    let height = height.px();
+                    match mode {
+                        BackgroundSizeComputeMode::Auto => (width, height),
+                        BackgroundSizeComputeMode::Ratio(ratio) => {
+                            let bg_width = height * ratio;
+                            let bg_height = width / ratio;
+
+                            if bg_width <= width {
+                                offset.x = (width - bg_width) as f64;
+                                (bg_width, height)
+                            } else if bg_height <= height {
+                                offset.y = (height - bg_height) as f64;
+                                (width, bg_height)
+                            } else {
+                                unreachable!()
+                            }
+                        }
+                        BackgroundSizeComputeMode::Size(_, _) => (width, height),
+                    }
                 }
                 (Lpa::LengthPercentage(width), Lpa::Auto) => {
-                    let height = (width.px() / bg_w) * bg_h;
-                    (width.px(), height)
+                    let width = width.px();
+                    let height = match mode {
+                        BackgroundSizeComputeMode::Auto => container_h,
+                        BackgroundSizeComputeMode::Ratio(ratio) => width / ratio,
+                        BackgroundSizeComputeMode::Size(bg_w, bg_h) => (width / bg_w) * bg_h,
+                    };
+                    (width, height)
                 }
                 (Lpa::Auto, Lpa::LengthPercentage(height)) => {
-                    let width = (height.px() / bg_h) * bg_w;
-                    (width, height.px())
+                    let height = height.px();
+                    let width = match mode {
+                        BackgroundSizeComputeMode::Auto => container_w,
+                        BackgroundSizeComputeMode::Ratio(ratio) => height * ratio,
+                        BackgroundSizeComputeMode::Size(bg_w, bg_h) => (height / bg_h) * bg_w,
+                    };
+                    (width, height)
                 }
-                (Lpa::Auto, Lpa::Auto) => (bg_w * scale, bg_h * scale),
+                (Lpa::Auto, Lpa::Auto) => match mode {
+                    BackgroundSizeComputeMode::Auto => (container_w, container_h),
+                    BackgroundSizeComputeMode::Ratio(ratio) => {
+                        if container_w < container_h {
+                            let height = container_w / ratio;
+                            (container_w, height)
+                        } else {
+                            let width = container_h * ratio;
+                            (width, container_h)
+                        }
+                    }
+                    BackgroundSizeComputeMode::Size(bg_w, bg_h) => (bg_w * scale, bg_h * scale),
+                },
             }
         }
-        BackgroundSize::Cover => {
-            let x_ratio = container_w / bg_w;
-            let y_ratio = container_h / bg_h;
+        BackgroundSize::Cover => match mode {
+            BackgroundSizeComputeMode::Auto => (container_w, container_h),
+            BackgroundSizeComputeMode::Ratio(ratio) => {
+                if container_w > container_h {
+                    let height = container_w / ratio;
+                    (container_w, height)
+                } else {
+                    let width = container_h * ratio;
+                    (width, container_h)
+                }
+            }
+            BackgroundSizeComputeMode::Size(bg_w, bg_h) => {
+                let x_ratio = container_w / bg_w;
+                let y_ratio = container_h / bg_h;
 
-            let ratio = if x_ratio < 1.0 || y_ratio < 1.0 {
-                x_ratio.min(y_ratio)
-            } else {
-                x_ratio.max(y_ratio)
-            };
+                let ratio = if x_ratio < 1.0 || y_ratio < 1.0 {
+                    x_ratio.min(y_ratio)
+                } else {
+                    x_ratio.max(y_ratio)
+                };
 
-            (bg_w * ratio, bg_h * ratio)
-        }
-        BackgroundSize::Contain => {
-            let x_ratio = container_w / bg_w;
-            let y_ratio = container_h / bg_h;
+                (bg_w * ratio, bg_h * ratio)
+            }
+        },
+        BackgroundSize::Contain => match mode {
+            BackgroundSizeComputeMode::Auto => (container_w, container_h),
+            BackgroundSizeComputeMode::Ratio(ratio) => {
+                if container_w < container_h {
+                    let height = container_w / ratio;
+                    (container_w, height)
+                } else {
+                    let width = container_h * ratio;
+                    (width, container_h)
+                }
+            }
+            BackgroundSizeComputeMode::Size(bg_w, bg_h) => {
+                let x_ratio = container_w / bg_w;
+                let y_ratio = container_h / bg_h;
 
-            let ratio = if x_ratio < 1.0 || y_ratio < 1.0 {
-                x_ratio.max(y_ratio)
-            } else {
-                x_ratio.min(y_ratio)
-            };
+                let ratio = if x_ratio < 1.0 || y_ratio < 1.0 {
+                    x_ratio.max(y_ratio)
+                } else {
+                    x_ratio.min(y_ratio)
+                };
 
-            (bg_w * ratio, bg_h * ratio)
-        }
+                (bg_w * ratio, bg_h * ratio)
+            }
+        },
     };
 
-    kurbo::Size {
-        width: width as f64,
-        height: height as f64,
-    }
+    (
+        offset,
+        kurbo::Size {
+            width: width as f64,
+            height: height as f64,
+        },
+    )
 }
 
 /// Ensure that the `resized_image` field has a correctly sized image
@@ -910,23 +999,43 @@ impl ElementCx<'_> {
             return;
         };
 
-        let frame_w = self.frame.padding_box.width() as f32;
-        let frame_h = self.frame.padding_box.height() as f32;
+        let background_origin = self
+            .style
+            .get_background()
+            .background_origin
+            .0
+            .get(idx)
+            .cloned()
+            .unwrap_or(StyloBackgroundOrigin::PaddingBox);
+
+        let origin_rect = match background_origin {
+            StyloBackgroundOrigin::BorderBox => self.frame.border_box,
+            StyloBackgroundOrigin::PaddingBox => self.frame.padding_box,
+            StyloBackgroundOrigin::ContentBox => self.frame.content_box,
+        };
+
+        let frame_w = origin_rect.width() as f32;
+        let frame_h = origin_rect.height() as f32;
 
         let svg_size = svg.size();
-        let bg_size = compute_background_size(
+        let (bg_offset, bg_size) = compute_background_size(
             &self.style,
             frame_w,
             frame_h,
             idx,
-            svg_size.width() / self.scale as f32,
-            svg_size.height() / self.scale as f32,
+            BackgroundSizeComputeMode::Ratio(svg_size.width() / svg_size.height()),
             self.scale as f32,
         );
         let bg_size = bg_size * self.scale;
 
-        let x_ratio = bg_size.width as f64 / svg_size.width() as f64;
-        let y_ratio = bg_size.height as f64 / svg_size.height() as f64;
+        let mut x_ratio = bg_size.width / svg_size.width() as f64;
+        let mut y_ratio = bg_size.height / svg_size.height() as f64;
+
+        if x_ratio < y_ratio {
+            y_ratio = x_ratio;
+        } else if x_ratio > y_ratio {
+            x_ratio = y_ratio;
+        }
 
         let bg_pos_x = self
             .style
@@ -949,11 +1058,13 @@ impl ElementCx<'_> {
             .resolve(Length::new(frame_h - bg_size.height as f32))
             .px() as f64;
 
-        let transform = Affine::translate((
-            (self.pos.x * self.scale) + bg_pos_x,
-            (self.pos.y * self.scale) + bg_pos_y,
-        ))
-        .pre_scale_non_uniform(x_ratio, y_ratio);
+        let transform = self
+            .transform
+            .then_translate(Vec2 {
+                x: (origin_rect.x0 * self.scale) + bg_pos_x + bg_offset.x,
+                y: (origin_rect.y0 * self.scale) + bg_pos_y + bg_offset.y,
+            })
+            .pre_scale_non_uniform(x_ratio, y_ratio);
 
         let fragment = vello_svg::render_tree(svg);
         scene.append(&fragment, Some(transform));
@@ -978,25 +1089,93 @@ impl ElementCx<'_> {
     }
 
     fn draw_raster_bg_image(&self, scene: &mut Scene, idx: usize) {
+        use style::{Zero as _, values::computed::Length};
+
         let bg_image = self.element.background_images.get(idx);
 
-        if let Some(Some(bg_image)) = bg_image.as_ref() {
-            if let ImageData::Raster(image) = &bg_image.image {
-                let width = self.frame.padding_box.width() as u32;
-                let height = self.frame.padding_box.height() as u32;
-                let x = self.frame.content_box.origin().x;
-                let y = self.frame.content_box.origin().y;
+        let Some(Some(bg_image)) = bg_image.as_ref() else {
+            return;
+        };
+        let ImageData::Raster(image_data) = &bg_image.image else {
+            return;
+        };
 
-                let x_scale = width as f64 / image.width as f64;
-                let y_scale = height as f64 / image.height as f64;
-                let transform = self
-                    .transform
-                    .pre_scale_non_uniform(x_scale, y_scale)
-                    .then_translate(Vec2 { x, y });
+        let background_origin = self
+            .style
+            .get_background()
+            .background_origin
+            .0
+            .get(idx)
+            .cloned()
+            .unwrap_or(StyloBackgroundOrigin::PaddingBox);
 
-                scene.draw_image(&to_peniko_image(image), transform);
-            }
-        }
+        let origin_rect = match background_origin {
+            StyloBackgroundOrigin::BorderBox => self.frame.border_box,
+            StyloBackgroundOrigin::PaddingBox => Rect {
+                x0: self.frame.padding_box.x0,
+                y0: self.frame.padding_box.y0,
+                x1: self.frame.border_box.x1,
+                y1: self.frame.border_box.y1,
+            },
+            StyloBackgroundOrigin::ContentBox => Rect {
+                x0: self.frame.content_box.x0,
+                y0: self.frame.content_box.y0,
+                x1: self.frame.border_box.x1,
+                y1: self.frame.border_box.y1,
+            },
+        };
+
+        let frame_w = origin_rect.width() as f32;
+        let frame_h = origin_rect.height() as f32;
+
+        let image_width = image_data.width as f64;
+        let image_height = image_data.height as f64;
+        let (_, bg_size) = compute_background_size(
+            &self.style,
+            frame_w,
+            frame_h,
+            idx,
+            BackgroundSizeComputeMode::Size(
+                (image_width / self.scale) as f32,
+                (image_height / self.scale) as f32,
+            ),
+            self.scale as f32,
+        );
+        let bg_size = bg_size * self.scale;
+
+        let x_ratio = bg_size.width / image_width;
+        let y_ratio = bg_size.height / image_height;
+
+        let bg_pos_x = self
+            .style
+            .get_background()
+            .background_position_x
+            .0
+            .get(idx)
+            .cloned()
+            .unwrap_or(LengthPercentage::zero())
+            .resolve(Length::new(frame_w - (bg_size.width as f32)))
+            .px() as f64;
+        let bg_pos_y = self
+            .style
+            .get_background()
+            .background_position_y
+            .0
+            .get(idx)
+            .cloned()
+            .unwrap_or(LengthPercentage::zero())
+            .resolve(Length::new(frame_h - bg_size.height as f32))
+            .px() as f64;
+
+        let transform = self
+            .transform
+            .then_translate(Vec2 {
+                x: (origin_rect.x0 * self.scale) + bg_pos_x,
+                y: (origin_rect.y0 * self.scale) + bg_pos_y,
+            })
+            .pre_scale_non_uniform(x_ratio, y_ratio);
+
+        scene.draw_image(&to_peniko_image(image_data), transform);
     }
 
     fn stroke_devtools(&self, scene: &mut Scene) {
@@ -1025,25 +1204,34 @@ impl ElementCx<'_> {
 
     fn draw_background(&self, scene: &mut Scene) {
         use GenericImage::*;
+        use StyloBackgroundClip::*;
+
+        let segments = &self.style.get_background().background_clip.0;
+        let background_clip = segments.iter().next().cloned().unwrap_or(BorderBox);
+        let background_clip_path = match background_clip {
+            BorderBox => self.frame.frame_border(),
+            PaddingBox => self.frame.frame_padding(),
+            ContentBox => self.frame.frame_content(),
+        };
 
         CLIPS_WANTED.fetch_add(1, atomic::Ordering::SeqCst);
         let clips_available = CLIPS_USED.load(atomic::Ordering::SeqCst) <= CLIP_LIMIT;
         if clips_available {
-            scene.push_layer(Mix::Clip, 1.0, self.transform, &self.frame.frame());
+            scene.push_layer(Mix::Clip, 1.0, self.transform, &background_clip_path);
             CLIPS_USED.fetch_add(1, atomic::Ordering::SeqCst);
             let depth = CLIP_DEPTH.fetch_add(1, atomic::Ordering::SeqCst) + 1;
             CLIP_DEPTH_USED.fetch_max(depth, atomic::Ordering::SeqCst);
         }
 
         // Draw background color (if any)
-        self.draw_solid_frame(scene);
+        self.draw_solid_frame(scene, &background_clip_path);
         let segments = &self.style.get_background().background_image.0;
         for (idx, segment) in segments.iter().enumerate().rev() {
             match segment {
                 None => {
                     // Do nothing
                 }
-                Gradient(gradient) => self.draw_gradient_frame(scene, gradient),
+                Gradient(gradient) => self.draw_gradient_frame(scene, gradient, idx),
                 Url(_) => {
                     self.draw_raster_bg_image(scene, idx);
                     #[cfg(feature = "svg")]
@@ -1059,7 +1247,61 @@ impl ElementCx<'_> {
         CLIP_DEPTH.fetch_sub(1, atomic::Ordering::SeqCst);
     }
 
-    fn draw_gradient_frame(&self, scene: &mut Scene, gradient: &StyloGradient) {
+    fn draw_gradient_frame(&self, scene: &mut Scene, gradient: &StyloGradient, idx: usize) {
+        use style::{Zero as _, values::computed::Length};
+
+        let background_origin = self
+            .style
+            .get_background()
+            .background_origin
+            .0
+            .get(idx)
+            .cloned()
+            .unwrap_or(StyloBackgroundOrigin::PaddingBox);
+
+        let origin_rect = match background_origin {
+            StyloBackgroundOrigin::BorderBox => self.frame.border_box,
+            StyloBackgroundOrigin::PaddingBox => self.frame.padding_box,
+            StyloBackgroundOrigin::ContentBox => self.frame.content_box,
+        };
+
+        let frame_w = origin_rect.width() as f32;
+        let frame_h = origin_rect.height() as f32;
+
+        let (_, bg_size) = compute_background_size(
+            &self.style,
+            frame_w,
+            frame_h,
+            idx,
+            BackgroundSizeComputeMode::Auto,
+            self.scale as f32,
+        );
+
+        let bg_size = bg_size * self.scale;
+        let origin_rect = origin_rect.with_size(bg_size);
+
+        let bg_pos_x = self
+            .style
+            .get_background()
+            .background_position_x
+            .0
+            .get(idx)
+            .cloned()
+            .unwrap_or(LengthPercentage::zero())
+            .resolve(Length::new(frame_w - (bg_size.width as f32)))
+            .px() as f64;
+        let bg_pos_y = self
+            .style
+            .get_background()
+            .background_position_y
+            .0
+            .get(idx)
+            .cloned()
+            .unwrap_or(LengthPercentage::zero())
+            .resolve(Length::new(frame_h - bg_size.height as f32))
+            .px() as f64;
+        let bg_position = Point::new(bg_pos_x, bg_pos_y);
+
         match gradient {
             // https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient
             GenericGradient::Linear {
@@ -1068,7 +1310,12 @@ impl ElementCx<'_> {
                 flags,
                 // compat_mode,
                 ..
-            } => self.draw_linear_gradient(scene, direction, items, *flags),
+            } => self.draw_linear_gradient(
+                scene,
+                (direction, items, *flags),
+                origin_rect,
+                bg_position,
+            ),
             GenericGradient::Radial {
                 shape,
                 position,
@@ -1076,30 +1323,40 @@ impl ElementCx<'_> {
                 flags,
                 // compat_mode,
                 ..
-            } => self.draw_radial_gradient(scene, shape, position, items, *flags),
+            } => self.draw_radial_gradient(
+                scene,
+                (shape, position, items, *flags),
+                origin_rect,
+                bg_position,
+            ),
             GenericGradient::Conic {
                 angle,
                 position,
                 items,
                 flags,
                 ..
-            } => self.draw_conic_gradient(scene, angle, position, items, *flags),
+            } => self.draw_conic_gradient(
+                scene,
+                (angle, position, items, *flags),
+                origin_rect,
+                bg_position,
+            ),
         };
     }
 
     fn draw_linear_gradient(
         &self,
         scene: &mut Scene,
-        direction: &LineDirection,
-        items: &[GradientItem<LengthPercentage>],
-        flags: GradientFlags,
+        gradient: LinearGradient,
+        origin_rect: Rect,
+        bg_position: Point,
     ) {
+        let (direction, items, flags) = gradient;
         let bb = self.frame.border_box.bounding_box();
         let current_color = self.style.clone_color();
 
-        let shape = self.frame.frame();
         let center = bb.center();
-        let rect = self.frame.padding_box;
+        let rect = origin_rect;
         let (start, end) = match direction {
             LineDirection::Angle(angle) => {
                 let angle = -angle.radians64() + std::f64::consts::PI;
@@ -1109,28 +1366,16 @@ impl ElementCx<'_> {
                 (center - offset_vec, center + offset_vec)
             }
             LineDirection::Horizontal(horizontal) => {
-                let start = Point::new(
-                    self.frame.padding_box.x0,
-                    self.frame.padding_box.y0 + rect.height() / 2.0,
-                );
-                let end = Point::new(
-                    self.frame.padding_box.x1,
-                    self.frame.padding_box.y0 + rect.height() / 2.0,
-                );
+                let start = Point::new(rect.x0, rect.y0 + rect.height() / 2.0);
+                let end = Point::new(rect.x1, rect.y0 + rect.height() / 2.0);
                 match horizontal {
                     HorizontalPositionKeyword::Right => (start, end),
                     HorizontalPositionKeyword::Left => (end, start),
                 }
             }
             LineDirection::Vertical(vertical) => {
-                let start = Point::new(
-                    self.frame.padding_box.x0 + rect.width() / 2.0,
-                    self.frame.padding_box.y0,
-                );
-                let end = Point::new(
-                    self.frame.padding_box.x0 + rect.width() / 2.0,
-                    self.frame.padding_box.y1,
-                );
+                let start = Point::new(rect.x0 + rect.width() / 2.0, rect.y0);
+                let end = Point::new(rect.x0 + rect.width() / 2.0, rect.y1);
                 match vertical {
                     VerticalPositionKeyword::Top => (end, start),
                     VerticalPositionKeyword::Bottom => (start, end),
@@ -1138,20 +1383,12 @@ impl ElementCx<'_> {
             }
             LineDirection::Corner(horizontal, vertical) => {
                 let (start_x, end_x) = match horizontal {
-                    HorizontalPositionKeyword::Right => {
-                        (self.frame.padding_box.x0, self.frame.padding_box.x1)
-                    }
-                    HorizontalPositionKeyword::Left => {
-                        (self.frame.padding_box.x1, self.frame.padding_box.x0)
-                    }
+                    HorizontalPositionKeyword::Right => (rect.x0, rect.x1),
+                    HorizontalPositionKeyword::Left => (rect.x1, rect.x0),
                 };
                 let (start_y, end_y) = match vertical {
-                    VerticalPositionKeyword::Top => {
-                        (self.frame.padding_box.y1, self.frame.padding_box.y0)
-                    }
-                    VerticalPositionKeyword::Bottom => {
-                        (self.frame.padding_box.y0, self.frame.padding_box.y1)
-                    }
+                    VerticalPositionKeyword::Top => (rect.y1, rect.y0),
+                    VerticalPositionKeyword::Bottom => (rect.y0, rect.y1),
                 };
                 (Point::new(start_x, start_y), Point::new(end_x, end_y))
             }
@@ -1179,8 +1416,19 @@ impl ElementCx<'_> {
                 end: end + (start - end) * (1.0 - last_offset) as f64,
             };
         }
+
+        let transform = self.transform.then_translate(Vec2 {
+            x: bg_position.x,
+            y: bg_position.y,
+        });
         let brush = peniko::BrushRef::Gradient(&gradient);
-        scene.fill(peniko::Fill::NonZero, self.transform, brush, None, &shape);
+        scene.fill(
+            peniko::Fill::NonZero,
+            transform,
+            brush,
+            None,
+            &origin_rect.to_path(0.1),
+        );
     }
 
     #[inline]
@@ -1469,7 +1717,7 @@ impl ElementCx<'_> {
         }
     }
 
-    fn draw_solid_frame(&self, scene: &mut Scene) {
+    fn draw_solid_frame(&self, scene: &mut Scene, shape: &BezPath) {
         let current_color = self.style.clone_color();
         let background_color = &self.style.get_background().background_color;
         let bg_color = background_color
@@ -1477,10 +1725,8 @@ impl ElementCx<'_> {
             .as_srgb_color();
 
         if bg_color != Color::TRANSPARENT {
-            let shape = self.frame.frame();
-
             // Fill the color
-            scene.fill(Fill::NonZero, self.transform, bg_color, None, &shape);
+            scene.fill(Fill::NonZero, self.transform, bg_color, None, shape);
         }
     }
 
@@ -1549,7 +1795,10 @@ impl ElementCx<'_> {
                 .as_srgb_color(),
         };
 
-        sb.fill(Fill::NonZero, self.transform, color, None, &path);
+        let alpha = color.components[3];
+        if alpha != 0.0 {
+            sb.fill(Fill::NonZero, self.transform, color, None, &path);
+        }
     }
 
     /// ❌ dotted - Defines a dotted border
@@ -1628,13 +1877,12 @@ impl ElementCx<'_> {
     fn draw_radial_gradient(
         &self,
         scene: &mut Scene,
-        shape: &EndingShape<NonNegative<CSSPixelLength>, NonNegative<LengthPercentage>>,
-        position: &GenericPosition<LengthPercentage, LengthPercentage>,
-        items: &OwnedSlice<GenericGradientItem<GenericColor<Percentage>, LengthPercentage>>,
-        flags: GradientFlags,
+        gradient: RadialGradient,
+        origin_rect: Rect,
+        bg_position: Point,
     ) {
-        let bez_path = self.frame.frame();
-        let rect = self.frame.padding_box;
+        let (shape, position, items, flags) = gradient;
+        let rect = origin_rect;
         let repeating = flags.contains(GradientFlags::REPEATING);
         let current_color = self.style.clone_color();
 
@@ -1737,26 +1985,29 @@ impl ElementCx<'_> {
             }
         };
 
+        let transform = self.transform.then_translate(Vec2 {
+            x: bg_position.x,
+            y: bg_position.y,
+        });
         let brush = peniko::BrushRef::Gradient(&gradient);
         scene.fill(
             peniko::Fill::NonZero,
-            self.transform,
+            transform,
             brush,
             gradient_transform,
-            &bez_path,
+            &origin_rect.to_path(0.1),
         );
     }
 
     fn draw_conic_gradient(
         &self,
         scene: &mut Scene,
-        angle: &Angle,
-        position: &GenericPosition<LengthPercentage, LengthPercentage>,
-        items: &OwnedSlice<GenericGradientItem<GenericColor<Percentage>, AngleOrPercentage>>,
-        flags: GradientFlags,
+        gradient: ConicGradient,
+        origin_rect: Rect,
+        bg_position: Point,
     ) {
-        let bez_path = self.frame.frame();
-        let rect = self.frame.padding_box;
+        let (angle, position, items, flags) = gradient;
+        let rect = origin_rect;
         let current_color = self.style.clone_color();
 
         let repeating = flags.contains(GradientFlags::REPEATING);
@@ -1782,17 +2033,21 @@ impl ElementCx<'_> {
             };
         }
 
+        let transform = self.transform.then_translate(Vec2 {
+            x: bg_position.x,
+            y: bg_position.y,
+        });
         let brush = peniko::BrushRef::Gradient(&gradient);
 
         scene.fill(
             peniko::Fill::NonZero,
-            self.transform,
+            transform,
             brush,
             Some(
                 Affine::rotate(angle.radians() as f64 - std::f64::consts::PI / 2.0)
                     .then_translate(self.get_translation(position, rect)),
             ),
-            &bez_path,
+            &origin_rect.to_path(0.1),
         );
     }
 
@@ -1803,12 +2058,12 @@ impl ElementCx<'_> {
         rect: Rect,
     ) -> Vec2 {
         Vec2::new(
-            self.frame.padding_box.x0
+            rect.x0
                 + position
                     .horizontal
                     .resolve(CSSPixelLength::new(rect.width() as f32))
                     .px() as f64,
-            self.frame.padding_box.y0
+            rect.y0
                 + position
                     .vertical
                     .resolve(CSSPixelLength::new(rect.height() as f32))
@@ -1916,4 +2171,10 @@ impl<'a> std::ops::Deref for ElementCx<'a> {
     fn deref(&self) -> &Self::Target {
         self.context
     }
+}
+
+enum BackgroundSizeComputeMode {
+    Auto,
+    Ratio(f32),
+    Size(f32, f32),
 }


### PR DESCRIPTION
When using the following styles, the `border-color` should appear `red` instead of `transparent`.

```css
#transparent {
    border: 20px solid transparent;
    background-color: red;
}
```