### PR TITLE
Implement FontMetricsProvider that actually provides correct metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,7 @@ dependencies = [
  "peniko",
  "percent-encoding",
  "selectors",
+ "skrifa",
  "slab",
  "smallvec",
  "stylo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ dioxus-cli-config = { version = "=0.7.0-alpha.1" }
 dioxus-devtools = { version = "=0.7.0-alpha.1" }
 taffy = { version = "0.9", default-features = false, features = ["std", "flexbox", "grid", "block_layout", "content_size", "calc"] }
 
-# Linebender + WGPU + SVG
+# Linebender + Fontations + WGPU + SVG
 color = "0.3"
 peniko = "0.4"
 kurbo = "0.11"

--- a/packages/blitz-dom/Cargo.toml
+++ b/packages/blitz-dom/Cargo.toml
@@ -56,9 +56,10 @@ smallvec = { workspace = true }
 # DioxusLabs dependencies
 taffy = { workspace = true }
 
-# Linebender dependencies
+# Linebender/Fontations dependencies
 accesskit = { workspace = true, optional = true }
 parley = { workspace = true }
+skrifa = { workspace = true }
 peniko = { workspace = true }
 color = { workspace = true }
 

--- a/packages/blitz-dom/src/events/ime.rs
+++ b/packages/blitz-dom/src/events/ime.rs
@@ -11,7 +11,8 @@ pub(crate) fn handle_ime_event(doc: &mut BaseDocument, event: BlitzImeEvent) {
             .and_then(|el| el.text_input_data_mut());
         if let Some(input_data) = text_input_data {
             let editor = &mut input_data.editor;
-            let mut driver = editor.driver(&mut doc.font_ctx, &mut doc.layout_ctx);
+            let mut font_ctx = doc.font_ctx.lock().unwrap();
+            let mut driver = editor.driver(&mut font_ctx, &mut doc.layout_ctx);
 
             match event {
                 BlitzImeEvent::Enabled => { /* Do nothing */ }

--- a/packages/blitz-dom/src/events/keyboard.rs
+++ b/packages/blitz-dom/src/events/keyboard.rs
@@ -40,7 +40,7 @@ pub(crate) fn handle_keypress<F: FnMut(DomEvent)>(
         if let Some(input_data) = element_data.text_input_data_mut() {
             let generated_event = apply_keypress_event(
                 input_data,
-                &mut doc.font_ctx,
+                &mut doc.font_ctx.lock().unwrap(),
                 &mut doc.layout_ctx,
                 &*doc.shell_provider,
                 event,

--- a/packages/blitz-dom/src/events/mouse.rs
+++ b/packages/blitz-dom/src/events/mouse.rs
@@ -51,7 +51,7 @@ pub(crate) fn handle_mousemove(
 
         text_input_data
             .editor
-            .driver(&mut doc.font_ctx, &mut doc.layout_ctx)
+            .driver(&mut doc.font_ctx.lock().unwrap(), &mut doc.layout_ctx)
             .extend_selection_to_point(x as f32, y as f32);
 
         changed = true;
@@ -88,7 +88,7 @@ pub(crate) fn handle_mousedown(doc: &mut BaseDocument, target: usize, x: f32, y:
 
         text_input_data
             .editor
-            .driver(&mut doc.font_ctx, &mut doc.layout_ctx)
+            .driver(&mut doc.font_ctx.lock().unwrap(), &mut doc.layout_ctx)
             .move_to_point(x as f32, y as f32);
 
         doc.set_focus_to(hit.node_id);

--- a/packages/blitz-dom/src/font_metrics.rs
+++ b/packages/blitz-dom/src/font_metrics.rs
@@ -1,0 +1,159 @@
+use std::sync::{Arc, Mutex};
+
+use crate::stylo_to_parley;
+use app_units::Au;
+use parley::FontContext;
+use parley::swash::Setting;
+use skrifa::MetadataProvider as _;
+use skrifa::{Tag, charmap::Charmap};
+use style::properties::style_structs::Font as FontStyles;
+use style::{
+    font_metrics::FontMetrics,
+    servo::media_queries::FontMetricsProvider,
+    values::computed::{CSSPixelLength, font::QueryFontMetricsFlags},
+};
+
+#[derive(Clone)]
+pub(crate) struct BlitzFontMetricsProvider {
+    pub(crate) font_ctx: Arc<Mutex<FontContext>>,
+}
+
+impl core::fmt::Debug for BlitzFontMetricsProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BlitzFontMetricsProvider")
+    }
+}
+
+impl FontMetricsProvider for BlitzFontMetricsProvider {
+    fn query_font_metrics(
+        &self,
+        _vertical: bool,
+        font_styles: &FontStyles,
+        font_size: CSSPixelLength,
+        _flags: QueryFontMetricsFlags,
+    ) -> FontMetrics {
+        use parley::fontique::{Attributes, Query, QueryFont, QueryStatus};
+        use skrifa::instance::{LocationRef, Size};
+        use skrifa::metrics::{GlyphMetrics, Metrics};
+
+        // Lock font_ctx. Explicit reborrow required for borrow checker.
+        let mut font_ctx = self.font_ctx.lock().unwrap();
+        let font_ctx = &mut *font_ctx;
+
+        // Query fontique for the font that matches the font styles
+        let mut query = font_ctx.collection.query(&mut font_ctx.source_cache);
+        let families = font_styles
+            .font_family
+            .families
+            .iter()
+            .map(stylo_to_parley::query_font_family);
+        query.set_families(families);
+        query.set_attributes(Attributes {
+            width: stylo_to_parley::font_width(font_styles.font_stretch),
+            weight: stylo_to_parley::font_weight(font_styles.font_weight),
+            style: stylo_to_parley::font_style(font_styles.font_style),
+        });
+        // let fb_script = crate::swash_convert::script_to_fontique(script);
+        // let fb_language = locale.and_then(crate::swash_convert::locale_to_fontique);
+        // query.set_fallbacks(fontique::FallbackKey::new(fb_script, fb_language.as_ref()));
+
+        let variations = stylo_to_parley::font_variations(&font_styles.font_variation_settings);
+        // let features = self.rcx.features(style.font_features).unwrap_or(&[]);
+
+        // fn name_of(font_ref: &skrifa::FontRef) -> String {
+        //     use skrifa::string::StringId;
+        //     font_ref
+        //         .localized_strings(StringId::POSTSCRIPT_NAME)
+        //         .english_or_first()
+        //         .unwrap()
+        //         .chars()
+        //         .collect()
+        // }
+
+        fn find_font_for(query: &mut Query, ch: char) -> Option<QueryFont> {
+            let mut font = None;
+            query.matches_with(|q_font: &QueryFont| {
+                use skrifa::MetadataProvider;
+
+                let Ok(font_ref) = skrifa::FontRef::from_index(q_font.blob.as_ref(), q_font.index)
+                else {
+                    return QueryStatus::Continue;
+                };
+
+                let charmap = font_ref.charmap();
+                if charmap.map(ch).is_some() {
+                    font = Some(q_font.clone());
+                    QueryStatus::Stop
+                } else {
+                    QueryStatus::Continue
+                }
+            });
+            font
+        }
+
+        fn advance_of(
+            query: &mut Query,
+            ch: char,
+            font_size: Size,
+            variations: &[Setting<f32>],
+        ) -> Option<f32> {
+            let font = find_font_for(query, ch)?;
+            let font_ref = skrifa::FontRef::from_index(font.blob.as_ref(), font.index).ok()?;
+            let location = font_ref.axes().location(
+                variations
+                    .iter()
+                    .map(|v| (Tag::new(&v.tag.to_le_bytes()), v.value)),
+            );
+            let location_ref = LocationRef::from(&location);
+            let glyph_metrics = GlyphMetrics::new(&font_ref, font_size, location_ref);
+            let char_map = Charmap::new(&font_ref);
+            let glyph_id = char_map.map(ch)?;
+            glyph_metrics.advance_width(glyph_id)
+        }
+
+        fn metrics_of(
+            query: &mut Query,
+            ch: char,
+            font_size: Size,
+            variations: &[Setting<f32>],
+        ) -> Option<(f32, Option<f32>, Option<f32>)> {
+            let font = find_font_for(query, ch)?;
+            let font_ref = skrifa::FontRef::from_index(font.blob.as_ref(), font.index).ok()?;
+            let location = font_ref.axes().location(
+                variations
+                    .iter()
+                    .map(|v| (Tag::new(&v.tag.to_le_bytes()), v.value)),
+            );
+            let location_ref = LocationRef::from(&location);
+            let metrics = Metrics::new(&font_ref, font_size, location_ref);
+            Some((metrics.ascent, metrics.x_height, metrics.cap_height))
+        }
+
+        let font_size = Size::new(font_size.px());
+        let zero_advance = advance_of(&mut query, '0', font_size, &variations);
+        let ic_advance = advance_of(&mut query, '\u{6C34}', font_size, &variations);
+        let (ascent, x_height, cap_height) =
+            metrics_of(&mut query, ' ', font_size, &variations).unwrap();
+
+        FontMetrics {
+            ascent: CSSPixelLength::new(ascent),
+            x_height: x_height.filter(|xh| *xh != 0.0).map(CSSPixelLength::new),
+            cap_height: cap_height.map(CSSPixelLength::new),
+            zero_advance_measure: zero_advance.map(CSSPixelLength::new),
+            ic_width: ic_advance.map(CSSPixelLength::new),
+            script_percent_scale_down: None,
+            script_script_percent_scale_down: None,
+        }
+    }
+
+    fn base_size_for_generic(
+        &self,
+        generic: style::values::computed::font::GenericFontFamily,
+    ) -> style::values::computed::Length {
+        let size = match generic {
+            style::values::computed::font::GenericFontFamily::Monospace => 13.0,
+            _ => 16.0,
+        };
+        style::values::computed::Length::from(Au::from_f32_px(size))
+    }
+}

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -441,8 +441,9 @@ fn node_list_item_child(
             }
 
             // Create a parley tree builder
+            let mut font_ctx = doc.font_ctx.lock().unwrap();
             let mut builder = doc.layout_ctx.tree_builder(
-                &mut doc.font_ctx,
+                &mut font_ctx,
                 doc.viewport.scale(),
                 true,
                 &parley_style,
@@ -698,7 +699,7 @@ fn create_text_editor(doc: &mut BaseDocument, input_element_id: usize, is_multil
         styles.insert(StyleProperty::LineHeight(parley_style.line_height));
         styles.insert(StyleProperty::Brush(parley_style.brush));
 
-        editor.refresh_layout(&mut doc.font_ctx, &mut doc.layout_ctx);
+        editor.refresh_layout(&mut doc.font_ctx.lock().unwrap(), &mut doc.layout_ctx);
 
         element.special_data = SpecialElementData::TextInput(text_input_data);
     }
@@ -740,9 +741,10 @@ pub(crate) fn build_inline_layout(
     let root_line_height = resolve_line_height(parley_style.line_height, parley_style.font_size);
 
     // Create a parley tree builder
+    let mut font_ctx = doc.font_ctx.lock().unwrap();
     let mut builder =
         doc.layout_ctx
-            .tree_builder(&mut doc.font_ctx, doc.viewport.scale(), true, &parley_style);
+            .tree_builder(&mut font_ctx, doc.viewport.scale(), true, &parley_style);
 
     // Set whitespace collapsing mode
     let collapse_mode = root_node_style

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -40,6 +40,7 @@ pub mod node;
 mod config;
 mod debug;
 mod events;
+mod font_metrics;
 mod form;
 mod html;
 /// Integration of taffy and the DOM.

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -210,7 +210,11 @@ impl DocumentMutator<'_> {
         if *attr == local_name!("value") {
             if let Some(input_data) = element.text_input_data_mut() {
                 // Update text input value
-                input_data.set_text(&mut self.doc.font_ctx, &mut self.doc.layout_ctx, value);
+                input_data.set_text(
+                    &mut self.doc.font_ctx.lock().unwrap(),
+                    &mut self.doc.layout_ctx,
+                    value,
+                );
             }
             return;
         }
@@ -259,7 +263,11 @@ impl DocumentMutator<'_> {
         // Update text input value
         if name.local == local_name!("value") {
             if let Some(input_data) = element.text_input_data_mut() {
-                input_data.set_text(&mut self.doc.font_ctx, &mut self.doc.layout_ctx, "");
+                input_data.set_text(
+                    &mut self.doc.font_ctx.lock().unwrap(),
+                    &mut self.doc.layout_ctx,
+                    "",
+                );
             }
         }
 
@@ -726,7 +734,8 @@ impl DerefMut for ViewportMut<'_> {
 }
 impl Drop for ViewportMut<'_> {
     fn drop(&mut self) {
-        self.doc.set_stylist_device(make_device(&self.doc.viewport));
+        self.doc
+            .set_stylist_device(make_device(&self.doc.viewport, self.doc.font_ctx.clone()));
         self.doc.scroll_viewport_by(0.0, 0.0); // Clamp scroll offset
     }
 }


### PR DESCRIPTION
Replaces the `DummyFontMetricsProvider` with one that actually does font fallback and extracts metrics from the font. This currently requires a Mutex around the `parley::FontContext` which isn't ideal but may be acceptable.