### PR TITLE
Support Dioxus style attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "bitflags 2.9.1",
  "blitz-traits",
  "color",
+ "cssparser",
  "cursor-icon",
  "euclid",
  "html-escape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,8 @@ style = { version = "0.4", package = "stylo" }
 style_traits = { version = "0.4", package = "stylo_traits" }
 style_config = { version = "0.4", package = "stylo_config" }
 style_dom = { version = "0.4", package = "stylo_dom" }
-selectors = { version = "0.29", package = "selectors" }
+selectors = { version = "0.29" }
+cssparser = { version = "0.35" }
 
 markup5ever = "0.35" # needs to match stylo web_atoms version
 html5ever = "0.35" # needs to match stylo web_atoms version

--- a/packages/blitz-dom/Cargo.toml
+++ b/packages/blitz-dom/Cargo.toml
@@ -32,6 +32,7 @@ stylo_taffy = { workspace = true, features = ["default"] }
 # Servo dependencies
 style = { workspace = true }
 selectors = { workspace = true }
+cssparser = { workspace = true }
 style_config = { workspace = true }
 style_traits = { workspace = true }
 style_dom = { workspace = true }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -29,8 +29,8 @@ use style::Atom;
 use style::attr::{AttrIdentifier, AttrValue};
 use style::data::{ElementData as StyloElementData, ElementStyles};
 use style::media_queries::MediaType;
-use style::properties::ComputedValues;
 use style::properties::style_structs::Font;
+use style::properties::{ComputedValues, PropertyId};
 use style::queries::values::PrefersColorScheme;
 use style::selector_parser::ServoElementSnapshot;
 use style::servo::media_queries::FontMetricsProvider;
@@ -372,6 +372,20 @@ impl BaseDocument {
                 }
             }
         }
+    }
+
+    pub fn set_style_property(&mut self, node_id: usize, name: &str, value: &str) {
+        self.nodes[node_id]
+            .element_data_mut()
+            .unwrap()
+            .set_style_property(name, value, &self.guard, self.base_url.clone());
+    }
+
+    pub fn remove_style_property(&mut self, node_id: usize, name: &str) {
+        self.nodes[node_id]
+            .element_data_mut()
+            .unwrap()
+            .remove_style_property(name, &self.guard, self.base_url.clone());
     }
 
     pub fn root_node(&self) -> &Node {

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -1,17 +1,21 @@
 use color::{AlphaColor, Srgb};
+use cssparser::ParserInput;
 use markup5ever::{LocalName, QualName, local_name};
 use parley::{FontContext, LayoutContext};
 use selectors::matching::QuirksMode;
 use std::str::FromStr;
 use std::sync::Arc;
 use style::Atom;
-use style::stylesheets::{DocumentStyleSheet, UrlExtraData};
+use style::parser::ParserContext;
+use style::properties::{Importance, PropertyDeclaration, PropertyId, SourcePropertyDeclaration};
+use style::stylesheets::{DocumentStyleSheet, Origin, UrlExtraData};
 use style::{
     properties::{PropertyDeclarationBlock, parse_style_attribute},
     servo_arc::Arc as ServoArc,
     shared_lock::{Locked, SharedRwLock},
     stylesheets::CssRuleType,
 };
+use style_traits::ParsingMode;
 use url::Url;
 
 use super::{Attribute, Attributes};
@@ -262,6 +266,90 @@ impl ElementData {
                 CssRuleType::Style,
             )))
         });
+    }
+
+    pub fn set_style_property(
+        &mut self,
+        name: &str,
+        value: &str,
+        guard: &SharedRwLock,
+        base_url: Option<Url>,
+    ) {
+        let url_data = UrlExtraData::from(base_url.clone().unwrap_or_else(|| {
+            "data:text/css;charset=utf-8;base64,"
+                .parse::<Url>()
+                .unwrap()
+        }));
+        let context = ParserContext::new(
+            Origin::Author,
+            &url_data,
+            Some(CssRuleType::Style),
+            ParsingMode::DEFAULT,
+            QuirksMode::NoQuirks,
+            /* namespaces = */ Default::default(),
+            None,
+            None,
+        );
+
+        let Ok(property_id) = PropertyId::parse(name, &context) else {
+            eprintln!("Warning: unsupported property {name}");
+            return;
+        };
+        let mut source_property_declaration = SourcePropertyDeclaration::default();
+        let mut input = ParserInput::new(value);
+        let mut parser = style::values::Parser::new(&mut input);
+        let Ok(_) = PropertyDeclaration::parse_into(
+            &mut source_property_declaration,
+            property_id,
+            &context,
+            &mut parser,
+        ) else {
+            eprintln!("Warning: invalid property value for {name}: {value}");
+            return;
+        };
+
+        // TODO: instantiate style_attribute if not already instantiated
+        if let Some(style) = &mut self.style_attribute {
+            style
+                .write_with(&mut guard.write())
+                .extend(source_property_declaration.drain(), Importance::Normal);
+        }
+    }
+
+    pub fn remove_style_property(
+        &mut self,
+        name: &str,
+        guard: &SharedRwLock,
+        base_url: Option<Url>,
+    ) {
+        let url_data = UrlExtraData::from(base_url.clone().unwrap_or_else(|| {
+            "data:text/css;charset=utf-8;base64,"
+                .parse::<Url>()
+                .unwrap()
+        }));
+        let context = ParserContext::new(
+            Origin::Author,
+            &url_data,
+            Some(CssRuleType::Style),
+            ParsingMode::DEFAULT,
+            QuirksMode::NoQuirks,
+            /* namespaces = */ Default::default(),
+            None,
+            None,
+        );
+        let Ok(property_id) = PropertyId::parse(name, &context) else {
+            eprintln!("Warning: unsupported property {name}");
+            return;
+        };
+
+        // TODO: instantiate style_attribute if not already instantiated
+        if let Some(style) = &mut self.style_attribute {
+            let mut guard = guard.write();
+            let style = style.write_with(&mut guard);
+            if let Some(index) = style.first_declaration_to_remove(&property_id) {
+                style.remove_property(&property_id, index);
+            }
+        }
     }
 
     pub fn take_inline_layout(&mut self) -> Option<Box<TextLayout>> {


### PR DESCRIPTION
Support for directly specifying style attributes on elements (rather than passing a string to the `style` property):

```rust
div {
    color: "red"
 }
 ```

Mostly implemented, but needs testing and blocked on a resolution to https://github.com/DioxusLabs/dioxus/issues/4389.