### PR TITLE
Implement `set_inner_html`

### DIFF
--- a/examples/inner_html.rs
+++ b/examples/inner_html.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use anyrender_vello::VelloWindowRenderer;
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_shell::{BlitzApplication, BlitzShellEvent, WindowConfig, create_default_event_loop};
+
+pub fn main() {
+    // Create renderer
+
+    // Parse the HTML into a Blitz document
+    let mut doc = HtmlDocument::from_html(
+        HTML,
+        DocumentConfig {
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+
+    let node_id = doc.query_selector("#content_area").unwrap().unwrap();
+    doc.mutate().set_inner_html(node_id, INNER_HTML);
+    doc.resolve();
+
+    // Create the Winit application and window
+    let event_loop = create_default_event_loop::<BlitzShellEvent>();
+    let mut application = BlitzApplication::new(event_loop.create_proxy());
+    let renderer = VelloWindowRenderer::new();
+    let window = WindowConfig::new(Box::new(doc), renderer);
+    application.add_window(window);
+
+    // Run event loop
+    event_loop.run_app(&mut application).unwrap()
+}
+
+static HTML: &str = r#"
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <style type="text/css">
+            #content_area {
+                padding: 12px;
+                border: 1px solid black;
+            }
+        </style>
+    </head>
+    <body>
+        <main id="main">
+            <h1>Inner HTML Demo</h1>
+            <p>Text set with innerHTML should appear below:</p>
+            <div id="content_area"></div>
+        </main>
+    </body>
+    </html>
+"#;
+
+static INNER_HTML: &str = r#"
+    INNER <b>HTML</b> <i>TEXT</i> HERE
+"#;

--- a/packages/blitz-dom/src/config.rs
+++ b/packages/blitz-dom/src/config.rs
@@ -1,4 +1,4 @@
-use crate::net::Resource;
+use crate::{HtmlParserProvider, net::Resource};
 use blitz_traits::{
     navigation::NavigationProvider,
     net::NetProvider,
@@ -22,6 +22,8 @@ pub struct DocumentConfig {
     pub navigation_provider: Option<Arc<dyn NavigationProvider>>,
     /// Shell provider to redraw requests, clipboard, etc
     pub shell_provider: Option<Arc<dyn ShellProvider>>,
+    /// HTML parser provider. Used to parse HTML for setInnerHTML
+    pub html_parser_provider: Option<Arc<dyn HtmlParserProvider>>,
     /// Parley `FontContext`
     pub font_ctx: Option<FontContext>,
 }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -8,8 +8,8 @@ use crate::traversal::TreeTraverser;
 use crate::url::DocumentUrl;
 use crate::util::ImageType;
 use crate::{
-    DEFAULT_CSS, DocumentConfig, DocumentMutator, ElementData, EventDriver, Node, NodeData,
-    NoopEventHandler, TextNodeData,
+    DEFAULT_CSS, DocumentConfig, DocumentMutator, DummyHtmlParserProvider, ElementData,
+    EventDriver, HtmlParserProvider, Node, NodeData, NoopEventHandler, TextNodeData,
 };
 use app_units::Au;
 use blitz_traits::devtools::DevtoolSettings;
@@ -169,6 +169,8 @@ pub struct BaseDocument {
     pub navigation_provider: Arc<dyn NavigationProvider>,
     /// Shell provider. Can be used to request a redraw or set the cursor icon
     pub shell_provider: Arc<dyn ShellProvider>,
+    /// HTML parser provider. Used to parse HTML for setInnerHTML
+    pub html_parser_provider: Arc<dyn HtmlParserProvider>,
 }
 
 pub(crate) fn make_device(viewport: &Viewport) -> Device {
@@ -234,6 +236,9 @@ impl BaseDocument {
         let shell_provider = config
             .shell_provider
             .unwrap_or_else(|| Arc::new(DummyShellProvider));
+        let html_parser_provider = config
+            .html_parser_provider
+            .unwrap_or_else(|| Arc::new(DummyHtmlParserProvider));
 
         let mut doc = Self {
             id,
@@ -261,6 +266,7 @@ impl BaseDocument {
             net_provider,
             navigation_provider,
             shell_provider,
+            html_parser_provider,
         };
 
         // Initialise document with root Document node
@@ -305,6 +311,11 @@ impl BaseDocument {
     /// Set the Document's shell provider
     pub fn set_shell_provider(&mut self, shell_provider: Arc<dyn ShellProvider>) {
         self.shell_provider = shell_provider;
+    }
+
+    /// Set the Document's html parser provider
+    pub fn set_html_parser_provider(&mut self, html_parser_provider: Arc<dyn HtmlParserProvider>) {
+        self.html_parser_provider = html_parser_provider;
     }
 
     /// Set base url for resolving linked resources (stylesheets, images, fonts, etc)

--- a/packages/blitz-dom/src/html.rs
+++ b/packages/blitz-dom/src/html.rs
@@ -1,0 +1,29 @@
+use crate::DocumentMutator;
+
+pub trait HtmlParserProvider {
+    fn parse_inner_html<'m, 'doc>(
+        &self,
+        mutr: &'m mut DocumentMutator<'doc>,
+        element_id: usize,
+        html: &str,
+    );
+}
+
+pub struct DummyHtmlParserProvider;
+impl HtmlParserProvider for DummyHtmlParserProvider {
+    fn parse_inner_html<'m, 'doc>(
+        &self,
+        mutr: &'m mut DocumentMutator<'doc>,
+        element_id: usize,
+        html: &str,
+    ) {
+        let _ = mutr;
+        let _ = element_id;
+        let _ = html;
+        // Do nothing for now
+        //
+        // TODO: do something:
+        // - Print warning?
+        // - Parse HTML as plain text?
+    }
+}

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -41,6 +41,7 @@ mod config;
 mod debug;
 mod events;
 mod form;
+mod html;
 /// Integration of taffy and the DOM.
 mod layout;
 mod mutator;
@@ -71,3 +72,4 @@ pub use style::Atom;
 pub use style::invalidation::element::restyle_hints::RestyleHint;
 pub type SelectorList = selectors::SelectorList<style::selector_parser::SelectorImpl>;
 pub use events::{EventDriver, EventHandler, NoopEventHandler};
+pub use html::{DummyHtmlParserProvider, HtmlParserProvider};

--- a/packages/blitz-html/src/html_document.rs
+++ b/packages/blitz-html/src/html_document.rs
@@ -40,7 +40,9 @@ impl HtmlDocument {
             }
         }
         let mut doc = BaseDocument::new(config);
-        DocumentHtmlParser::parse_into_doc(&mut doc, html);
+        let mut mutr = doc.mutate();
+        DocumentHtmlParser::parse_into_mutator(&mut mutr, html);
+        drop(mutr);
         HtmlDocument { inner: doc }
     }
 

--- a/packages/blitz-html/src/lib.rs
+++ b/packages/blitz-html/src/lib.rs
@@ -3,3 +3,4 @@ mod html_sink;
 
 pub use html_document::HtmlDocument;
 pub use html_sink::DocumentHtmlParser;
+pub use html_sink::HtmlProvider;


### PR DESCRIPTION
# Objective

- Provide `innerHTML` setter functionality
- Bltiz side of #240

## Changes Made

- Add `HtmlParserProvider` trait so that we can inject HTML parsing functionality into `blitz-dom` (and users still have the option to bring their own HTML parser rather than being coupled to html5ever)
- Implement `HtmlParserProvider` in `blitz-html`
- Add `set_inner_html` method to `DocumentMutator`
- Add `children` method to `DocumentMutator`
- Add `inner_html` example to test functionlity