### PR TITLE
Update to wgpu 26, vello 0.6, vello_cpu 0.0.3, and parley pre-0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e074464580a518d16a7126262fffaaa47af89d4099d4cb403f8ed938ba12ee7d"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -256,15 +256,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "anyrender"
 version = "0.5.0"
 dependencies = [
- "kurbo",
+ "kurbo 0.12.0",
  "peniko",
  "raw-window-handle",
 ]
@@ -276,9 +276,9 @@ dependencies = [
  "anyrender",
  "anyrender_vello",
  "anyrender_vello_cpu",
- "kurbo",
+ "kurbo 0.12.0",
  "peniko",
- "wgpu 24.0.5",
+ "wgpu 26.0.1",
  "winit",
 ]
 
@@ -288,9 +288,9 @@ version = "0.5.0"
 dependencies = [
  "anyrender",
  "image",
- "kurbo",
+ "kurbo 0.12.0",
  "peniko",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "usvg",
 ]
 
@@ -301,14 +301,14 @@ dependencies = [
  "anyrender",
  "debug_timer",
  "futures-intrusive",
- "kurbo",
+ "kurbo 0.12.0",
  "peniko",
  "pollster 0.4.0",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "vello",
  "vello_encoding",
- "wgpu 24.0.5",
+ "wgpu 26.0.1",
 ]
 
 [[package]]
@@ -317,7 +317,7 @@ version = "0.6.0"
 dependencies = [
  "anyrender",
  "debug_timer",
- "kurbo",
+ "kurbo 0.12.0",
  "peniko",
  "pixels",
  "softbuffer",
@@ -384,7 +384,7 @@ version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading 0.8.8",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -406,7 +406,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus 5.10.0",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
  "async-lock",
  "blocking",
@@ -460,20 +460,20 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
  "async-channel",
  "async-io",
@@ -513,7 +513,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.0.8",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
 dependencies = [
  "async-io",
  "async-lock",
@@ -539,10 +539,10 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -662,7 +662,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -800,7 +800,7 @@ dependencies = [
  "euclid",
  "image",
  "mini-dxn",
- "png",
+ "png 0.17.16",
  "reqwest",
  "tokio",
  "tracing-subscriber",
@@ -836,7 +836,7 @@ dependencies = [
  "blitz-traits",
  "color",
  "euclid",
- "kurbo",
+ "kurbo 0.12.0",
  "parley",
  "peniko",
  "stylo",
@@ -940,7 +940,7 @@ name = "bump"
 version = "0.0.0"
 dependencies = [
  "semver",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -1030,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1048,9 +1048,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d458d63f0f0f482c8da9b7c8b76c21bd885a02056cc94c6404d861ca2b8206"
+checksum = "1a2c5f3bf25ec225351aa1c8e230d04d880d3bd89dea133537dafad4ae291e5c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -1121,10 +1121,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "color"
-version = "0.3.1"
+name = "codespan-reporting"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae467d04a8a8aea5d9a49018a6ade2e4221d92968e8ce55a48c0b1164e5f698"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.1",
+]
+
+[[package]]
+name = "color"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
 dependencies = [
  "bytemuck",
 ]
@@ -1514,7 +1525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
 dependencies = [
  "bitflags 2.9.4",
- "libloading 0.8.8",
+ "libloading 0.8.9",
  "winapi",
 ]
 
@@ -1640,9 +1651,9 @@ version = "0.1.1"
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -1734,7 +1745,7 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1816,7 +1827,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subsecond",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "tungstenite",
  "warnings",
@@ -2130,7 +2141,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.8",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2314,12 +2325,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2394,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "flate2"
@@ -2431,18 +2442,14 @@ name = "font-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
-name = "fontconfig-cache-parser"
-version = "0.2.0"
+name = "font-types"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f8afb20c8069fd676d27b214559a337cc619a605d25a87baa90b49a06f3b18"
+checksum = "511e2c18a516c666d27867d2f9821f76e7d591f762e9fc41dd6cc5c90fe54b0b"
 dependencies = [
  "bytemuck",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2471,24 +2478,23 @@ dependencies = [
 [[package]]
 name = "fontique"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f97079e1293b8c1e9fb03a2875d328bd2ee8f3b95ce62959c0acc04049c708"
+source = "git+https://github.com/rydb/parley?rev=e8a7111#e8a71119aa12c3096c11bdac51092330ae3be26d"
 dependencies = [
  "bytemuck",
- "fontconfig-cache-parser",
  "hashbrown 0.15.5",
- "icu_locid",
+ "icu_locale_core",
+ "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.2",
  "objc2-core-foundation",
  "objc2-core-text",
  "objc2-foundation 0.3.1",
- "peniko",
  "read-fonts",
  "roxmltree",
  "smallvec",
  "windows 0.58.0",
  "windows-core 0.58.0",
+ "yeslogic-fontconfig-sys",
 ]
 
 [[package]]
@@ -2709,7 +2715,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -2742,7 +2748,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2757,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gl_generator"
@@ -2959,6 +2965,20 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3fd23d35c2d8bcf34a1f0e9ea8c0ad263f0c8a9a47108eee23aac76e71645a"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytemuck",
+ "core_maths",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -2992,6 +3012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "hassle-rs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3000,7 +3026,7 @@ dependencies = [
  "bitflags 2.9.4",
  "com",
  "libc",
- "libloading 0.8.8",
+ "libloading 0.8.9",
  "thiserror 1.0.69",
  "widestring",
  "winapi",
@@ -3146,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64",
  "bytes",
@@ -3179,7 +3205,19 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap 0.8.0",
+ "tinystr 0.8.1",
+ "writeable 0.6.1",
 ]
 
 [[package]]
@@ -3189,9 +3227,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
+ "litemap 0.7.5",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
 ]
 
 [[package]]
@@ -3204,11 +3242,11 @@ dependencies = [
  "icu_locid",
  "icu_provider_macros",
  "stable_deref_trait",
- "tinystr",
- "writeable",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
  "yoke",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -3235,7 +3273,7 @@ dependencies = [
  "icu_provider",
  "icu_segmenter_data",
  "utf8_iter",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -3269,9 +3307,9 @@ checksum = "cfdf4f5d937a025381f5ab13624b1c5f51414bfe5c9885663226eae8d6d39560"
 
 [[package]]
 name = "image"
-version = "0.25.6"
+version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -3279,9 +3317,10 @@ dependencies = [
  "dav1d",
  "gif",
  "image-webp",
+ "moxcms",
  "mp4parse",
  "num-traits",
- "png",
+ "png 0.18.0",
  "zune-core",
  "zune-jpeg",
 ]
@@ -3304,21 +3343,21 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "immutable-chunkmap"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2194c61e2a29841937e84ec2264a905985c397ccccfbd4783191d3285fa92ef"
+checksum = "9a3e98b1520e49e252237edc238a39869da9f3241f2ec19dc788c1d24694d1e4"
 dependencies = [
  "arrayvec",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -3447,9 +3486,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3473,7 +3512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.8.8",
+ "libloading 0.8.9",
  "pkg-config",
 ]
 
@@ -3515,6 +3554,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy-js-bundle"
 version = "0.7.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,9 +3578,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
@@ -3544,12 +3594,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -3560,9 +3610,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
@@ -3589,15 +3639,21 @@ checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
@@ -3617,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "longest-increasing-subsequence"
@@ -3740,9 +3796,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memfd"
@@ -3750,7 +3806,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -3788,13 +3844,13 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
  "bitflags 2.9.4",
  "block",
- "core-graphics-types 0.1.3",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
  "log",
  "objc",
@@ -3839,7 +3895,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "tokio",
  "tracing",
- "wgpu 24.0.5",
+ "wgpu 26.0.1",
  "winit",
 ]
 
@@ -3866,6 +3922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "mp4parse"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,7 +3953,7 @@ checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
 dependencies = [
  "bit-set 0.5.3",
  "bitflags 2.9.4",
- "codespan-reporting",
+ "codespan-reporting 0.11.1",
  "hexf-parse",
  "indexmap",
  "log",
@@ -3901,24 +3967,28 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+checksum = "916cbc7cb27db60be930a4e2da243cf4bc39569195f22fd8ee419cd31d5b662c"
 dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
  "bitflags 2.9.4",
+ "cfg-if",
  "cfg_aliases 0.2.1",
- "codespan-reporting",
+ "codespan-reporting 0.12.0",
+ "half",
+ "hashbrown 0.15.5",
  "hexf-parse",
  "indexmap",
+ "libm",
  "log",
+ "num-traits",
+ "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "strum",
- "termcolor",
- "thiserror 2.0.16",
- "unicode-xid",
+ "thiserror 2.0.17",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4096,6 +4166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4432,9 +4503,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -4515,9 +4586,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.6.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
 ]
@@ -4555,9 +4626,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.2"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parking"
@@ -4591,12 +4662,12 @@ dependencies = [
 [[package]]
 name = "parley"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e57638545cf2ba4c3e72cc5715e53b1880b829cc3dbefda3d1700c58efe723"
+source = "git+https://github.com/rydb/parley?rev=e8a7111#e8a71119aa12c3096c11bdac51092330ae3be26d"
 dependencies = [
  "fontique",
+ "harfrust",
  "hashbrown 0.15.5",
- "peniko",
+ "linebender_resource_handle",
  "skrifa",
  "swash",
 ]
@@ -4609,13 +4680,13 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b44f9ddd2f480176b34278eb653ec1c8062f3b143a4e16eeff5ffac3334e288"
+checksum = "b3c76095c9a636173600478e0373218c7b955335048c2bcd12dc6a79657649d8"
 dependencies = [
  "bytemuck",
  "color",
- "kurbo",
+ "kurbo 0.12.0",
  "linebender_resource_handle",
  "smallvec",
 ]
@@ -4749,9 +4820,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
  "indexmap",
@@ -4774,17 +4845,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "polling"
-version = "3.10.0"
+name = "png"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.9.4",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4843,11 +4927,11 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.6",
 ]
 
 [[package]]
@@ -4912,6 +4996,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "pxfm"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f9b339b02259ada5c0f4a389b7fb472f933aa17ce176fd2ad98f28bb401fde"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4947,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -5053,12 +5146,13 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.29.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
- "font-types",
+ "core_maths",
+ "font-types 0.10.0",
 ]
 
 [[package]]
@@ -5103,9 +5197,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5115,9 +5209,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5268,22 +5362,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -5303,9 +5397,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5362,11 +5456,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5409,9 +5503,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5440,16 +5534,17 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -5475,10 +5570,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5487,14 +5591,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5505,7 +5610,7 @@ checksum = "f3faaf9e727533a19351a43cc5a8de957372163c7d35cc48c90b75cdda13c352"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5560,7 +5665,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "server_fn_macro_default",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "throw_error",
  "url",
  "xxhash-rust",
@@ -5659,9 +5764,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skrifa"
-version = "0.31.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbeb4ca4399663735553a09dd17ce7e49a0a0203f03b706b39628c4d913a8607"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -5866,28 +5971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "stylo"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6047,12 +6130,12 @@ checksum = "b14ed4d86ab065ffbfdb994fd3e44daf5244b02cb643bd52949d74b703f36605"
 dependencies = [
  "js-sys",
  "libc",
- "libloading 0.8.8",
+ "libloading 0.8.9",
  "memfd",
  "memmap2",
  "serde",
  "subsecond-types",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6091,15 +6174,15 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo",
+ "kurbo 0.11.3",
  "siphasher",
 ]
 
 [[package]]
 name = "swash"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f745de914febc7c9ab4388dfaf94bbc87e69f57bb41133a9b0c84d4be49856f3"
+checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
 dependencies = [
  "skrifa",
  "yazi",
@@ -6202,15 +6285,15 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6256,11 +6339,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -6276,9 +6359,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6305,11 +6388,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.42"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -6319,15 +6403,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6366,7 +6450,7 @@ checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
 dependencies = [
  "as-raw-xcb-connection",
  "ctor-lite",
- "libloading 0.8.8",
+ "libloading 0.8.9",
  "pkg-config",
  "tracing",
 ]
@@ -6378,6 +6462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -6472,9 +6566,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -6501,8 +6595,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -6515,6 +6609,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6523,8 +6626,29 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
  "winnow",
 ]
 
@@ -6679,7 +6803,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "utf-8",
 ]
 
@@ -6750,9 +6874,9 @@ checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-normalization"
@@ -6846,7 +6970,7 @@ dependencies = [
  "flate2",
  "fontdb",
  "imagesize",
- "kurbo",
+ "kurbo 0.11.3",
  "log",
  "pico-args",
  "roxmltree",
@@ -6901,27 +7025,25 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "vello"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df026e62e8b0d12d55ff5e91ae9114a20f82d9b856bedfdbf3abd5d1472dceed"
+source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
  "log",
  "peniko",
- "png",
+ "png 0.17.16",
  "skrifa",
  "static_assertions",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "vello_encoding",
  "vello_shaders",
- "wgpu 24.0.5",
+ "wgpu 26.0.1",
 ]
 
 [[package]]
 name = "vello_common"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f6e79f7c8fea850fb02a60ed6b55835dba89662da0ff4cc2af2157285e3824"
+version = "0.0.1"
+source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -6934,9 +7056,8 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301847c1214554b9b1612b1edfeef06cf32ad19a35340e1963dc9281579e5b5e"
+version = "0.0.1"
+source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -6949,8 +7070,7 @@ dependencies = [
 [[package]]
 name = "vello_encoding"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5702642f6ea77eedc12d119e1eebead0dba3cf91fe5c5d1f3efc12bf0cfaf1"
+source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -6962,12 +7082,12 @@ dependencies = [
 [[package]]
 name = "vello_shaders"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381790a3779021edd9f88267c1b13b49546cb0fb164f329ee2f2587869ddf459"
+source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
 dependencies = [
  "bytemuck",
- "naga 24.0.0",
- "thiserror 2.0.16",
+ "log",
+ "naga 26.0.0",
+ "thiserror 2.0.17",
  "vello_encoding",
 ]
 
@@ -7038,30 +7158,40 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -7073,9 +7203,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7086,9 +7216,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7096,9 +7226,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7109,9 +7239,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
@@ -7137,7 +7267,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -7150,7 +7280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.9.4",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -7172,7 +7302,7 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "wayland-client",
  "xcursor",
 ]
@@ -7240,9 +7370,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7303,18 +7433,21 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "24.0.5"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
+checksum = "70b6ff82bbf6e9206828e1a3178e851f8c20f1c9028e74dd3a8090741ccd5798"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.4",
+ "cfg-if",
  "cfg_aliases 0.2.1",
  "document-features",
+ "hashbrown 0.15.5",
  "js-sys",
  "log",
- "naga 24.0.0",
+ "naga 26.0.0",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -7322,9 +7455,9 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core 24.0.5",
- "wgpu-hal 24.0.4",
- "wgpu-types 24.0.0",
+ "wgpu-core 26.0.1",
+ "wgpu-hal 26.0.4",
+ "wgpu-types 26.0.0",
 ]
 
 [[package]]
@@ -7337,7 +7470,7 @@ dependencies = [
  "bit-vec 0.6.3",
  "bitflags 2.9.4",
  "cfg_aliases 0.1.1",
- "codespan-reporting",
+ "codespan-reporting 0.11.1",
  "indexmap",
  "log",
  "naga 0.19.2",
@@ -7355,27 +7488,60 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "24.0.5"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
+checksum = "d5f62f1053bd28c2268f42916f31588f81f64796e2ff91b81293515017ca8bd9"
 dependencies = [
  "arrayvec",
+ "bit-set 0.8.0",
  "bit-vec 0.8.0",
  "bitflags 2.9.4",
  "cfg_aliases 0.2.1",
  "document-features",
+ "hashbrown 0.15.5",
  "indexmap",
  "log",
- "naga 24.0.0",
+ "naga 26.0.0",
  "once_cell",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.16",
- "wgpu-hal 24.0.4",
- "wgpu-types 24.0.0",
+ "thiserror 2.0.17",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal 26.0.4",
+ "wgpu-types 26.0.0",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "26.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18ae5fbde6a4cbebae38358aa73fcd6e0f15c6144b67ef5dc91ded0db125dbdf"
+dependencies = [
+ "wgpu-hal 26.0.4",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "26.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7670e390f416006f746b4600fdd9136455e3627f5bd763abf9a65daa216dd2d"
+dependencies = [
+ "wgpu-hal 26.0.4",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "26.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720a5cb9d12b3d337c15ff0e24d3e97ed11490ff3f7506e7f3d98c68fa5d6f14"
+dependencies = [
+ "wgpu-hal 26.0.4",
 ]
 
 [[package]]
@@ -7402,7 +7568,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.8",
+ "libloading 0.8.9",
  "log",
  "metal 0.27.0",
  "naga 0.19.2",
@@ -7425,9 +7591,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "24.0.4"
+version = "26.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+checksum = "7df2c64ac282a91ad7662c90bc4a77d4a2135bc0b2a2da5a4d4e267afc034b9e"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7436,35 +7602,37 @@ dependencies = [
  "bitflags 2.9.4",
  "block",
  "bytemuck",
+ "cfg-if",
  "cfg_aliases 0.2.1",
- "core-graphics-types 0.1.3",
+ "core-graphics-types 0.2.0",
  "glow 0.16.0",
  "glutin_wgl_sys 0.6.1",
  "gpu-alloc",
  "gpu-allocator 0.27.0",
  "gpu-descriptor 0.3.2",
+ "hashbrown 0.15.5",
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.8",
+ "libloading 0.8.9",
  "log",
- "metal 0.31.0",
- "naga 24.0.0",
- "ndk-sys 0.5.0+25.2.9519653",
+ "metal 0.32.0",
+ "naga 26.0.0",
+ "ndk-sys 0.6.0+11769913",
  "objc",
- "once_cell",
  "ordered-float",
  "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
  "profiling",
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types 24.0.0",
+ "wgpu-types 26.0.0",
  "windows 0.58.0",
  "windows-core 0.58.0",
 ]
@@ -7482,13 +7650,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+checksum = "eca7a8d8af57c18f57d393601a1fb159ace8b2328f1b6b5f80893f7d672c9ae2"
 dependencies = [
  "bitflags 2.9.4",
+ "bytemuck",
  "js-sys",
  "log",
+ "thiserror 2.0.17",
  "web-sys",
 ]
 
@@ -7507,7 +7677,7 @@ dependencies = [
  "dioxus",
  "mini-dxn",
  "pollster 0.4.0",
- "wgpu 24.0.5",
+ "wgpu 26.0.1",
 ]
 
 [[package]]
@@ -7544,11 +7714,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -7628,12 +7798,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -7653,7 +7829,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7672,7 +7848,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7708,7 +7884,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -7744,11 +7929,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -7960,9 +8145,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "woff"
@@ -7996,7 +8181,7 @@ dependencies = [
  "os_info",
  "owo-colors",
  "parley",
- "png",
+ "png 0.17.16",
  "pollster 0.4.0",
  "rayon",
  "regex",
@@ -8028,16 +8213,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
-name = "wuff"
-version = "0.2.0"
+name = "writeable"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f67124f400e901e797c3d300a633d9a147250b547fe059630c5fc07b998484"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wuff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a267ddde5dc265fb7176bd82ba2c2596c8345be3865f29ba314da5080e7bf1"
 dependencies = [
  "arrayvec",
  "brotli-decompressor",
  "bytes",
  "flate2",
- "font-types",
+ "font-types 0.9.0",
 ]
 
 [[package]]
@@ -8060,9 +8251,9 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading 0.8.8",
+ "libloading 0.8.9",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "x11rb-protocol",
 ]
 
@@ -8142,6 +8333,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8205,9 +8407,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.10.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a073be99ace1adc48af593701c8015cd9817df372e14a1a6b0ee8f8bf043be"
+checksum = "2d07e46d035fb8e375b2ce63ba4e4ff90a7f73cf2ffb0138b29e1158d2eaadf7"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -8231,7 +8433,7 @@ dependencies = [
  "uds_windows",
  "windows-sys 0.60.2",
  "winnow",
- "zbus_macros 5.10.0",
+ "zbus_macros 5.11.0",
  "zbus_names 4.2.0",
  "zvariant 5.7.0",
 ]
@@ -8275,9 +8477,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.10.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e80cd713a45a49859dcb648053f63265f4f2851b6420d47a958e5697c68b131"
+checksum = "57e797a9c847ed3ccc5b6254e8bcce056494b375b511b3d6edcec0aeb4defaca"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8332,18 +8534,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8373,9 +8575,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerovec"
@@ -8386,6 +8588,15 @@ dependencies = [
  "yoke",
  "zerofrom",
  "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "zerofrom",
 ]
 
 [[package]]
@@ -8407,9 +8618,9 @@ checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1f7e205ce79eb2da3cd71c5f55f3589785cb7c79f6a03d1c8d1491bda5d089"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7024,8 +7024,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vello"
-version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71acbd6b5f7f19841425845c113a89a54bbf60556ae39e7d0182a6f80ce37f5b"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -7042,8 +7043,9 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a368a0edbbe19080297a7bbd9e24860ba3a224226b189d6bf14cf8187459921"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -7056,8 +7058,9 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "401cfde7308b9193bdfe53649648b10020664c556f2e17724c39366cc220b9d1"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -7069,8 +7072,9 @@ dependencies = [
 
 [[package]]
 name = "vello_encoding"
-version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd5e0b9fec91df34a09fbcbbed474cec68d05691b590a911c7af83c4860ae42"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -7081,8 +7085,9 @@ dependencies = [
 
 [[package]]
 name = "vello_shaders"
-version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=462fd4e#462fd4e88297e96a74164aa1c4150e8dd8616e0d"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c381dde4e7d0d7957df0c0e3f8a7cc0976762d3972d97da5c71464e57ffefd3"
 dependencies = [
  "bytemuck",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,9 +92,9 @@ skrifa = { version = "0.37" } # Should match parley version
 wgpu = "26"
 softbuffer = "0.4"
 pixels = "0.15"
-vello = { git = "https://github.com/linebender/vello", rev = "462fd4e", features = [ "wgpu" ] }
-vello_encoding = { git = "https://github.com/linebender/vello", rev = "462fd4e", default-features = false }
-vello_cpu = { git = "https://github.com/linebender/vello", rev = "462fd4e", default-features = false, features = ["std", "text"]}
+vello = { version = "0.6", features = [ "wgpu" ] }
+vello_encoding = { version = "0.6", default-features = false }
+vello_cpu = { version = "0.0.3", default-features = false, features = ["std", "text"]}
 usvg = "0.45.1"
 
 # Windowing & Input

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,16 +85,16 @@ taffy = { version = "0.9", default-features = false, features = ["std", "flexbox
 # Linebender + Fontations + WGPU + SVG
 color = "0.3"
 linebender_resource_handle = "0.1"
-peniko = "0.4.1"
-kurbo = "0.11"
-parley = { version = "0.5", default-features = false, features = ["std"] }
-skrifa = { version = "0.31" } # Should match parley version
-wgpu = "24"
+peniko = "0.5.0"
+kurbo = "0.12"
+parley = { git = "https://github.com/rydb/parley", rev = "e8a7111", default-features = false, features = ["std"] }
+skrifa = { version = "0.37" } # Should match parley version
+wgpu = "26"
 softbuffer = "0.4"
 pixels = "0.15"
-vello = { version = "=0.5.0", features = [ "wgpu" ] }
-vello_encoding = { version = "=0.5.0", default-features = false }
-vello_cpu = { version = "0.0.2", default-features = false, features = ["std", "text"]}
+vello = { git = "https://github.com/linebender/vello", rev = "462fd4e", features = [ "wgpu" ] }
+vello_encoding = { git = "https://github.com/linebender/vello", rev = "462fd4e", default-features = false }
+vello_cpu = { git = "https://github.com/linebender/vello", rev = "462fd4e", default-features = false, features = ["std", "text"]}
 usvg = "0.45.1"
 
 # Windowing & Input

--- a/examples/wgpu_texture/src/demo_renderer.rs
+++ b/examples/wgpu_texture/src/demo_renderer.rs
@@ -210,6 +210,7 @@ impl ActiveDemoRenderer {
                         load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
                         store: wgpu::StoreOp::Store,
                     },
+                    depth_slice: None,
                 })],
                 depth_stencil_attachment: None,
                 timestamp_writes: None,

--- a/examples/wgpu_texture/src/demo_renderer.rs
+++ b/examples/wgpu_texture/src/demo_renderer.rs
@@ -170,11 +170,13 @@ impl ActiveDemoRenderer {
         start_time: &Instant,
     ) -> Option<TextureHandle> {
         // If "next texture" size doesn't match specified size then unregister and drop texture
-        if let Some(next) = &self.next_texture {
-            if next.texture.width() != width || next.texture.height() != height {
-                ctx.unregister_texture(next.handle.clone());
-                self.next_texture = None;
-            }
+        if self
+            .next_texture
+            .as_ref()
+            .is_some_and(|tex| tex.texture.width() != width || tex.texture.height() != height)
+        {
+            let handle = self.next_texture.take().unwrap().handle;
+            ctx.unregister_texture(handle);
         }
 
         // If there is no "next texture" then create one and register it.

--- a/examples/wgpu_texture/src/demo_renderer.rs
+++ b/examples/wgpu_texture/src/demo_renderer.rs
@@ -172,7 +172,7 @@ impl ActiveDemoRenderer {
         // If "next texture" size doesn't match specified size then unregister and drop texture
         if let Some(next) = &self.next_texture {
             if next.texture.width() != width || next.texture.height() != height {
-                ctx.unregister_texture(next.handle);
+                ctx.unregister_texture(next.handle.clone());
                 self.next_texture = None;
             }
         }
@@ -189,7 +189,7 @@ impl ActiveDemoRenderer {
         };
 
         let next_texture = &texture_and_handle.texture;
-        let next_texture_handle = texture_and_handle.handle;
+        let next_texture_handle = texture_and_handle.handle.clone();
 
         let elapsed: f32 = start_time.elapsed().as_millis() as f32 / 500.;
         let [light_red, light_green, light_blue] = light;

--- a/packages/anyrender/src/lib.rs
+++ b/packages/anyrender/src/lib.rs
@@ -28,7 +28,7 @@
 //!  - [anyrender_vello_cpu](https://docs.rs/anyrender_vello_cpu)
 
 use kurbo::{Affine, Rect, Shape, Stroke};
-use peniko::{BlendMode, BrushRef, Color, Fill, Font, Image, StyleRef};
+use peniko::{BlendMode, BrushRef, Color, Fill, FontData, ImageBrushRef, StyleRef};
 use std::sync::Arc;
 
 pub mod wasm_send_sync;
@@ -113,7 +113,7 @@ pub trait PaintScene {
     #[allow(clippy::too_many_arguments)]
     fn draw_glyphs<'a, 's: 'a>(
         &'s mut self,
-        font: &'a Font,
+        font: &'a FontData,
         font_size: f32,
         hint: bool,
         normalized_coords: &'a [NormalizedCoord],
@@ -138,13 +138,18 @@ pub trait PaintScene {
     // --- Provided methods
 
     /// Utility method to draw an image at it's natural size. For more advanced image drawing use the `fill` method
-    fn draw_image(&mut self, image: &Image, transform: Affine) {
+    fn draw_image(&mut self, image: ImageBrushRef, transform: Affine) {
         self.fill(
             Fill::NonZero,
             transform,
             image,
             None,
-            &Rect::new(0.0, 0.0, image.width as f64, image.height as f64),
+            &Rect::new(
+                0.0,
+                0.0,
+                image.image.width as f64,
+                image.image.height as f64,
+            ),
         );
     }
 }

--- a/packages/anyrender/src/types.rs
+++ b/packages/anyrender/src/types.rs
@@ -1,6 +1,6 @@
 //! Types that are used within the Anyrender traits
 
-use peniko::{BrushRef, Color, Gradient, Image};
+use peniko::{BrushRef, Color, Gradient, ImageBrushRef};
 use std::{any::Any, sync::Arc};
 
 pub type NormalizedCoord = i16;
@@ -28,7 +28,7 @@ pub enum Paint<'a> {
     /// Gradient brush.
     Gradient(&'a Gradient),
     /// Image brush.
-    Image(&'a Image),
+    Image(ImageBrushRef<'a>),
     /// Custom paint (type erased as each backend will have their own)
     Custom(Arc<dyn Any + Send + Sync>),
 }
@@ -42,8 +42,8 @@ impl<'a> From<&'a Gradient> for Paint<'a> {
         Paint::Gradient(value)
     }
 }
-impl<'a> From<&'a Image> for Paint<'a> {
-    fn from(value: &'a Image) -> Self {
+impl<'a> From<ImageBrushRef<'a>> for Paint<'a> {
+    fn from(value: ImageBrushRef<'a>) -> Self {
         Paint::Image(value)
     }
 }

--- a/packages/anyrender_svg/src/render.rs
+++ b/packages/anyrender_svg/src/render.rs
@@ -44,7 +44,7 @@ pub(crate) fn render_group<S: PaintScene, F: FnMut(&mut S, &usvg::Node)>(
                         true
                     }
                     // Else if there is blending to be done then push a layer with a rectangular clip
-                    // rydb: push_layer_clip() doesn't exist?
+                    #[allow(deprecated)]
                     _ if mix != peniko::Mix::Clip => {
                         // Use bounding box as the clip path.
                         let bounding_box = g.layer_bounding_box();

--- a/packages/anyrender_svg/src/render.rs
+++ b/packages/anyrender_svg/src/render.rs
@@ -44,6 +44,7 @@ pub(crate) fn render_group<S: PaintScene, F: FnMut(&mut S, &usvg::Node)>(
                         true
                     }
                     // Else if there is blending to be done then push a layer with a rectangular clip
+                    // rydb: push_layer_clip() doesn't exist?
                     _ if mix != peniko::Mix::Clip => {
                         // Use bounding box as the clip path.
                         let bounding_box = g.layer_bounding_box();
@@ -109,7 +110,7 @@ pub(crate) fn render_group<S: PaintScene, F: FnMut(&mut S, &usvg::Node)>(
                             };
                             let image = util::into_image(decoded_image);
                             let image_ts = global_transform * util::to_affine(&img.abs_transform());
-                            scene.draw_image(&image, image_ts);
+                            scene.draw_image(image.as_ref(), image_ts);
                         }
 
                         #[cfg(not(feature = "image"))]

--- a/packages/anyrender_svg/src/util.rs
+++ b/packages/anyrender_svg/src/util.rs
@@ -47,7 +47,7 @@ pub(crate) fn to_mix(blend_mode: usvg::BlendMode, is_fully_opaque: bool) -> Mix 
     match blend_mode {
         usvg::BlendMode::Normal => {
             if is_fully_opaque {
-                // rydb: push_layer_clip doesn't exist?
+                #[allow(deprecated)]
                 Mix::Clip
             } else {
                 Mix::Normal

--- a/packages/anyrender_svg/src/util.rs
+++ b/packages/anyrender_svg/src/util.rs
@@ -7,7 +7,7 @@ use peniko::color::{self, DynamicColor};
 use peniko::{Brush, Color, Fill, Mix};
 
 #[cfg(feature = "image")]
-use peniko::{Blob, Image};
+use peniko::{Blob, ImageBrush};
 
 pub(crate) fn to_affine(ts: &usvg::Transform) -> Affine {
     let usvg::Transform {
@@ -47,6 +47,7 @@ pub(crate) fn to_mix(blend_mode: usvg::BlendMode, is_fully_opaque: bool) -> Mix 
     match blend_mode {
         usvg::BlendMode::Normal => {
             if is_fully_opaque {
+                // rydb: push_layer_clip doesn't exist?
                 Mix::Clip
             } else {
                 Mix::Normal
@@ -121,15 +122,18 @@ pub(crate) fn to_bez_path(path: &usvg::Path) -> BezPath {
 }
 
 #[cfg(feature = "image")]
-pub(crate) fn into_image(image: image::ImageBuffer<image::Rgba<u8>, Vec<u8>>) -> Image {
+pub(crate) fn into_image(image: image::ImageBuffer<image::Rgba<u8>, Vec<u8>>) -> ImageBrush {
+    use peniko::ImageData;
+
     let (width, height) = (image.width(), image.height());
     let image_data: Vec<u8> = image.into_vec();
-    Image::new(
-        Blob::new(std::sync::Arc::new(image_data)),
-        peniko::ImageFormat::Rgba8,
+    ImageBrush::new(ImageData {
+        data: Blob::new(std::sync::Arc::new(image_data)),
+        format: peniko::ImageFormat::Rgba8,
+        alpha_type: peniko::ImageAlphaType::Alpha,
         width,
         height,
-    )
+    })
 }
 
 pub(crate) fn to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Brush, Affine)> {

--- a/packages/anyrender_vello/src/custom_paint_source.rs
+++ b/packages/anyrender_vello/src/custom_paint_source.rs
@@ -1,7 +1,7 @@
 use crate::wgpu_context::DeviceHandle;
 use peniko::ImageData;
 use vello::Renderer as VelloRenderer;
-use wgpu::{Instance, TexelCopyTextureInfoBase, Texture};
+use wgpu::{Instance, Texture};
 
 pub trait CustomPaintSource: 'static {
     fn resume(&mut self, instance: &Instance, device_handle: &DeviceHandle);
@@ -28,20 +28,10 @@ impl CustomPaintCtx<'_> {
     }
 
     pub fn register_texture(&mut self, texture: Texture) -> TextureHandle {
-        let dummy_image = self.renderer.register_texture(texture.clone());
-
-        let base = TexelCopyTextureInfoBase {
-            texture: texture,
-            mip_level: 0,
-            origin: wgpu::Origin3d::ZERO,
-            aspect: wgpu::TextureAspect::All,
-        };
-        self.renderer.override_image(&dummy_image, Some(base));
-
-        TextureHandle(dummy_image)
+        TextureHandle(self.renderer.register_texture(texture))
     }
 
     pub fn unregister_texture(&mut self, handle: TextureHandle) {
-        self.renderer.override_image(&handle.0, None);
+        self.renderer.unregister_texture(handle.0);
     }
 }

--- a/packages/anyrender_vello/src/custom_paint_source.rs
+++ b/packages/anyrender_vello/src/custom_paint_source.rs
@@ -1,7 +1,5 @@
-use std::sync::Arc;
-
 use crate::wgpu_context::DeviceHandle;
-use peniko::{Blob, ImageBrush, ImageData};
+use peniko::ImageData;
 use vello::Renderer as VelloRenderer;
 use wgpu::{Instance, TexelCopyTextureInfoBase, Texture};
 
@@ -21,18 +19,8 @@ pub struct CustomPaintCtx<'r> {
     pub(crate) renderer: &'r mut VelloRenderer,
 }
 
-#[derive(Copy, Clone, PartialEq, Hash)]
-pub struct TextureHandle {
-    pub(crate) id: u64,
-    pub(crate) width: u32,
-    pub(crate) height: u32,
-}
-
-impl TextureHandle {
-    pub(crate) fn dummy_image(&self) -> ImageBrush {
-        dummy_image(Some(self.id), self.width, self.height)
-    }
-}
+#[derive(Clone, PartialEq)]
+pub struct TextureHandle(pub ImageData);
 
 impl CustomPaintCtx<'_> {
     pub(crate) fn new<'a>(renderer: &'a mut VelloRenderer) -> CustomPaintCtx<'a> {
@@ -40,41 +28,20 @@ impl CustomPaintCtx<'_> {
     }
 
     pub fn register_texture(&mut self, texture: Texture) -> TextureHandle {
-        let dummy_image = dummy_image(None, texture.width(), texture.height());
-        let handle = TextureHandle {
-            id: dummy_image.image.data.id(),
-            width: texture.width(),
-            height: texture.height(),
-        };
+        let dummy_image = self.renderer.register_texture(texture.clone());
+
         let base = TexelCopyTextureInfoBase {
-            texture,
+            texture: texture,
             mip_level: 0,
             origin: wgpu::Origin3d::ZERO,
             aspect: wgpu::TextureAspect::All,
         };
-        self.renderer.override_image(&dummy_image.image, Some(base));
+        self.renderer.override_image(&dummy_image, Some(base));
 
-        handle
+        TextureHandle(dummy_image)
     }
 
     pub fn unregister_texture(&mut self, handle: TextureHandle) {
-        let dummy_image = dummy_image(Some(handle.id), handle.width, handle.height);
-        self.renderer.override_image(&dummy_image.image, None);
+        self.renderer.override_image(&handle.0, None);
     }
-}
-
-// Everything except blob id, width, and height is ignored
-fn dummy_image(id: Option<u64>, width: u32, height: u32) -> ImageBrush {
-    let blob = match id {
-        Some(id) => Blob::from_raw_parts(Arc::new([]), id),
-        None => Blob::new(Arc::new([])),
-    };
-
-    ImageBrush::new(ImageData {
-        data: blob,
-        width,
-        height,
-        format: vello::peniko::ImageFormat::Rgba8,
-        alpha_type: vello::peniko::ImageAlphaType::Alpha,
-    })
 }

--- a/packages/anyrender_vello/src/image_renderer.rs
+++ b/packages/anyrender_vello/src/image_renderer.rs
@@ -158,17 +158,7 @@ impl VelloImageRenderer {
                 panic!("channel inaccessible: {:#}", err);
             })
         {
-            let result = match recv_result {
-                Some(result) => result,
-                None => panic!("channel closed"),
-            };
-            match result {
-                Ok(_) => {}
-                Err(_err) => {
-                    // rydb: Should this be an panic? There is no logging crate to make this less severe.
-                    // panic!("channel buffer async error: {:#}", err)
-                }
-            }
+            let _ = recv_result.unwrap();
         }
 
         let data = buf_slice.get_mapped_range();

--- a/packages/anyrender_vello/src/scene.rs
+++ b/packages/anyrender_vello/src/scene.rs
@@ -1,6 +1,6 @@
 use anyrender::{CustomPaint, NormalizedCoord, Paint, PaintScene};
 use kurbo::{Affine, Rect, Shape, Stroke};
-use peniko::{BlendMode, BrushRef, Color, Fill, Font, StyleRef};
+use peniko::{BlendMode, BrushRef, Color, Fill, FontData, StyleRef};
 use rustc_hash::FxHashMap;
 use vello::Renderer as VelloRenderer;
 
@@ -13,7 +13,7 @@ pub struct VelloScenePainter<'r> {
 }
 
 impl VelloScenePainter<'_> {
-    fn render_custom_source(&mut self, custom_paint: CustomPaint) -> Option<peniko::Image> {
+    fn render_custom_source(&mut self, custom_paint: CustomPaint) -> Option<peniko::ImageBrush> {
         let CustomPaint {
             source_id,
             width,
@@ -78,8 +78,8 @@ impl PaintScene for VelloScenePainter<'_> {
     ) {
         let paint: Paint<'_> = paint.into();
 
-        let dummy_image: peniko::Image;
-        let brush_ref = match paint {
+        let dummy_image: peniko::ImageBrush;
+        let brush_ref: BrushRef<'_> = match paint {
             Paint::Solid(color) => BrushRef::Solid(color),
             Paint::Gradient(gradient) => BrushRef::Gradient(gradient),
             Paint::Image(image) => BrushRef::Image(image),
@@ -91,7 +91,7 @@ impl PaintScene for VelloScenePainter<'_> {
                     return;
                 };
                 dummy_image = image;
-                BrushRef::Image(&dummy_image)
+                BrushRef::Image(dummy_image.as_ref())
             }
         };
 
@@ -101,7 +101,7 @@ impl PaintScene for VelloScenePainter<'_> {
 
     fn draw_glyphs<'a, 's: 'a>(
         &'a mut self,
-        font: &'a Font,
+        font: &'a FontData,
         font_size: f32,
         hint: bool,
         normalized_coords: &'a [NormalizedCoord],

--- a/packages/anyrender_vello/src/scene.rs
+++ b/packages/anyrender_vello/src/scene.rs
@@ -1,6 +1,6 @@
 use anyrender::{CustomPaint, NormalizedCoord, Paint, PaintScene};
 use kurbo::{Affine, Rect, Shape, Stroke};
-use peniko::{BlendMode, BrushRef, Color, Fill, FontData, StyleRef};
+use peniko::{BlendMode, BrushRef, Color, Fill, FontData, ImageBrush, StyleRef};
 use rustc_hash::FxHashMap;
 use vello::Renderer as VelloRenderer;
 
@@ -27,7 +27,7 @@ impl VelloScenePainter<'_> {
         let texture_handle = source.render(ctx, width, height, scale)?;
 
         // Return dummy image
-        Some(texture_handle.dummy_image())
+        Some(ImageBrush::new(texture_handle.0))
     }
 }
 

--- a/packages/anyrender_vello/src/wgpu_context.rs
+++ b/packages/anyrender_vello/src/wgpu_context.rs
@@ -7,8 +7,9 @@ use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
 use wgpu::{
-    Adapter, Device, Features, Instance, Limits, MemoryHints, Queue, Surface, SurfaceConfiguration,
-    SurfaceTarget, Texture, TextureFormat, TextureView, util::TextureBlitter,
+    Adapter, Device, Features, Instance, Limits, MemoryHints, PollError, Queue,
+    RequestAdapterError, RequestDeviceError, Surface, SurfaceConfiguration, SurfaceTarget, Texture,
+    TextureFormat, TextureView, util::TextureBlitter,
 };
 
 // Errors that can occur in WgpuContext.
@@ -25,6 +26,12 @@ pub enum WgpuContextError {
     /// or [`TextureFormat::Bgra8Unorm`] as texture formats.
     // TODO: Why does this restriction exist?
     UnsupportedSurfaceFormat,
+    /// Wgpu failed to request an adapter
+    RequestAdapterError(RequestAdapterError),
+    /// Wgpu failed to request a device
+    RequestDeviceError(RequestDeviceError),
+    /// Wgpu failed to poll a device
+    PollError(PollError),
 }
 
 impl Display for WgpuContextError {
@@ -41,6 +48,15 @@ impl Display for WgpuContextError {
                     "Couldn't find `Rgba8Unorm` or `Bgra8Unorm` texture formats for surface"
                 )
             }
+            Self::RequestAdapterError(inner) => {
+                writeln!(f, "Couldn't request an adapter: {:#}", inner)
+            }
+            Self::RequestDeviceError(inner) => {
+                writeln!(f, "Couldn't request a device: {:#}", inner)
+            }
+            Self::PollError(inner) => {
+                writeln!(f, "Couldn't poll a device: {:#}", inner)
+            }
         }
     }
 }
@@ -49,6 +65,18 @@ impl Error for WgpuContextError {}
 impl From<wgpu::CreateSurfaceError> for WgpuContextError {
     fn from(value: wgpu::CreateSurfaceError) -> Self {
         Self::WgpuCreateSurfaceError(value)
+    }
+}
+
+impl From<RequestAdapterError> for WgpuContextError {
+    fn from(value: RequestAdapterError) -> Self {
+        Self::RequestAdapterError(value)
+    }
+}
+
+impl From<RequestDeviceError> for WgpuContextError {
+    fn from(value: RequestDeviceError) -> Self {
+        Self::RequestDeviceError(value)
     }
 }
 
@@ -88,6 +116,7 @@ impl WGPUContext {
                 backends: wgpu::Backends::from_env().unwrap_or_default(),
                 flags: wgpu::InstanceFlags::from_build_config().with_env(),
                 backend_options: wgpu::BackendOptions::from_env_or_default(),
+                memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
             }),
             device_pool: Vec::new(),
             extra_features,
@@ -110,7 +139,7 @@ impl WGPUContext {
         let dev_id = self
             .find_or_create_device(Some(&surface))
             .await
-            .ok_or(WgpuContextError::NoCompatibleDevice)?;
+            .or(Err(WgpuContextError::NoCompatibleDevice))?;
         let device_handle = self.device_pool[dev_id].clone();
 
         RenderSurface::new(surface, device_handle, dev_id, width, height, present_mode).await
@@ -120,9 +149,9 @@ impl WGPUContext {
     pub async fn find_or_create_device(
         &mut self,
         compatible_surface: Option<&Surface<'_>>,
-    ) -> Option<usize> {
+    ) -> Result<usize, WgpuContextError> {
         match self.find_existing_device(compatible_surface) {
-            Some(device_id) => Some(device_id),
+            Some(device_id) => Ok(device_id),
             None => self.create_device(compatible_surface).await,
         }
     }
@@ -141,7 +170,10 @@ impl WGPUContext {
     }
 
     /// Creates a compatible device handle id.
-    async fn create_device(&mut self, compatible_surface: Option<&Surface<'_>>) -> Option<usize> {
+    async fn create_device(
+        &mut self,
+        compatible_surface: Option<&Surface<'_>>,
+    ) -> Result<usize, WgpuContextError> {
         let adapter =
             wgpu::util::initialize_adapter_from_env_or_default(&self.instance, compatible_surface)
                 .await?;
@@ -162,8 +194,9 @@ impl WGPUContext {
             required_features,
             required_limits,
             memory_hints: MemoryHints::default(),
+            trace: wgpu::Trace::default(),
         };
-        let (device, queue) = adapter.request_device(&descripter, None).await.ok()?;
+        let (device, queue) = adapter.request_device(&descripter).await?;
 
         // Create the device handle and store in the pool
         let device_handle = DeviceHandle {
@@ -174,7 +207,7 @@ impl WGPUContext {
         self.device_pool.push(device_handle);
 
         // Return the ID
-        Some(self.device_pool.len() - 1)
+        Ok(self.device_pool.len() - 1)
     }
 }
 
@@ -313,7 +346,7 @@ impl<'s> RenderSurface<'s> {
 ///
 /// This will deadlock if the future is awaiting anything other than GPU progress.
 #[cfg_attr(docsrs, doc(hidden))]
-pub fn block_on_wgpu<F: Future>(device: &Device, fut: F) -> F::Output {
+pub fn block_on_wgpu<F: Future>(device: &Device, fut: F) -> Result<F::Output, WgpuContextError> {
     if cfg!(target_arch = "wasm32") {
         panic!("WGPU is inherently async on WASM, so blocking doesn't work.");
     }
@@ -332,10 +365,11 @@ pub fn block_on_wgpu<F: Future>(device: &Device, fut: F) -> F::Output {
     let mut fut = std::pin::pin!(fut);
     loop {
         match fut.as_mut().poll(&mut context) {
-            std::task::Poll::Pending => {
-                device.poll(wgpu::Maintain::Wait);
-            }
-            std::task::Poll::Ready(item) => break item,
+            std::task::Poll::Pending => match device.poll(wgpu::PollType::Wait) {
+                Ok(_) => continue,
+                Err(err) => return Err(WgpuContextError::PollError(err)),
+            },
+            std::task::Poll::Ready(item) => break Ok(item),
         }
     }
 }

--- a/packages/anyrender_vello/src/window_renderer.rs
+++ b/packages/anyrender_vello/src/window_renderer.rs
@@ -220,7 +220,6 @@ impl WindowRenderer for VelloWindowRenderer {
         surface_texture.present();
         timer.record_time("present");
 
-        // rydb: should this return an error somewhere?
         let _ = device_handle.device.poll(wgpu::PollType::Wait);
 
         timer.record_time("wait");

--- a/packages/anyrender_vello/src/window_renderer.rs
+++ b/packages/anyrender_vello/src/window_renderer.rs
@@ -220,7 +220,7 @@ impl WindowRenderer for VelloWindowRenderer {
         surface_texture.present();
         timer.record_time("present");
 
-        let _ = device_handle.device.poll(wgpu::PollType::Wait);
+        device_handle.device.poll(wgpu::PollType::Wait).unwrap();
 
         timer.record_time("wait");
         timer.print_times("Frame time: ");

--- a/packages/anyrender_vello/src/window_renderer.rs
+++ b/packages/anyrender_vello/src/window_renderer.rs
@@ -220,7 +220,8 @@ impl WindowRenderer for VelloWindowRenderer {
         surface_texture.present();
         timer.record_time("present");
 
-        device_handle.device.poll(wgpu::Maintain::Wait);
+        // rydb: should this return an error somewhere?
+        let _ = device_handle.device.poll(wgpu::PollType::Wait);
 
         timer.record_time("wait");
         timer.print_times("Frame time: ");

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -143,10 +143,10 @@ impl BaseDocument {
                             TextAlignKeyword::Start => Alignment::Start,
                             TextAlignKeyword::Left => Alignment::Left,
                             TextAlignKeyword::Right => Alignment::Right,
-                            TextAlignKeyword::Center => Alignment::Middle,
-                            TextAlignKeyword::Justify => Alignment::Justified,
+                            TextAlignKeyword::Center => Alignment::Center,
+                            TextAlignKeyword::Justify => Alignment::Justify,
                             TextAlignKeyword::End => Alignment::End,
-                            TextAlignKeyword::MozCenter => Alignment::Middle,
+                            TextAlignKeyword::MozCenter => Alignment::Center,
                             TextAlignKeyword::MozLeft => Alignment::Left,
                             TextAlignKeyword::MozRight => Alignment::Right,
                         }

--- a/packages/blitz-paint/src/gradient.rs
+++ b/packages/blitz-paint/src/gradient.rs
@@ -1,7 +1,7 @@
 use crate::color::{Color, ToColorColor};
 use color::DynamicColor;
 use kurbo::{self, Affine, Point, Rect, Vec2};
-use peniko::{self, ColorStop, Gradient};
+use peniko::{self, ColorStop, Gradient, LinearGradientPosition, SweepGradientPosition};
 use style::color::AbsoluteColor;
 use style::{
     OwnedSlice,
@@ -149,10 +149,10 @@ fn linear_gradient(
         repeating,
     );
     if repeating && gradient.stops.len() > 1 {
-        gradient.kind = peniko::GradientKind::Linear {
+        gradient.kind = peniko::GradientKind::Linear(LinearGradientPosition {
             start: start + (end - start) * first_offset as f64,
             end: end + (start - end) * (1.0 - last_offset) as f64,
-        };
+        });
     }
 
     (gradient, None)
@@ -290,11 +290,11 @@ fn conic_gradient(
         repeating,
     );
     if repeating && gradient.stops.len() >= 2 {
-        gradient.kind = peniko::GradientKind::Sweep {
+        gradient.kind = peniko::GradientKind::Sweep(SweepGradientPosition {
             center: Point::new(0.0, 0.0),
             start_angle: std::f32::consts::PI * 2.0 * first_offset,
             end_angle: std::f32::consts::PI * 2.0 * last_offset,
-        };
+        });
     }
 
     let gradient_transform = Some(

--- a/packages/blitz-paint/src/layers.rs
+++ b/packages/blitz-paint/src/layers.rs
@@ -47,8 +47,8 @@ pub(crate) fn maybe_push_layer(
     if !layers_available {
         return false;
     }
-
     let blend_mode = if opacity == 1.0 {
+        // rydb: `Mix::Clip` deprecation warning recommends using `push_clip_layer`, but peniko doesn't have that function?
         Mix::Clip
     } else {
         Mix::Normal

--- a/packages/blitz-paint/src/layers.rs
+++ b/packages/blitz-paint/src/layers.rs
@@ -48,7 +48,7 @@ pub(crate) fn maybe_push_layer(
         return false;
     }
     let blend_mode = if opacity == 1.0 {
-        // rydb: `Mix::Clip` deprecation warning recommends using `push_clip_layer`, but peniko doesn't have that function?
+        #[allow(deprecated)]
         Mix::Clip
     } else {
         Mix::Normal

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -400,8 +400,8 @@ struct ElementCx<'a> {
     devtools: &'a DevtoolSettings,
 }
 
-///TODO: If BoundingBox implements `Shape`, remove this. This exists to side-step it not currently doing that.
-fn convert_rect(rect: &parley::BoundingBox) -> peniko::kurbo::Rect {
+/// Converts parley BoundingBox into peniko Rect
+fn convert_rect(rect: &parley::BoundingBox) -> kurbo::Rect {
     peniko::kurbo::Rect::new(rect.x0, rect.y0, rect.x1, rect.y1)
 }
 

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -322,7 +322,7 @@ impl ElementCx<'_> {
                     scene.fill(
                         peniko::Fill::NonZero,
                         transform,
-                        &to_peniko_image(image_data, quality),
+                        to_peniko_image(image_data, quality).as_ref(),
                         None,
                         &Rect::new(0.0, 0.0, origin_rect.width(), origin_rect.height()),
                     );
@@ -332,7 +332,7 @@ impl ElementCx<'_> {
             scene.fill(
                 peniko::Fill::NonZero,
                 transform,
-                &to_peniko_image(image_data, quality),
+                to_peniko_image(image_data, quality).as_ref(),
                 None,
                 &Rect::new(0.0, 0.0, origin_rect.width(), origin_rect.height()),
             );


### PR DESCRIPTION
This pr updates blitz to use wgpu 26 and related dependencies to accommodate this update.

I've left a few questions marked with `//rydb:`, but otherwise, once vello and parley are updated, I can update those plus add any additional changes to this.