### PR TITLE
removing tracing from default features from all packages

### DIFF
--- a/examples/wgpu_texture/Cargo.toml
+++ b/examples/wgpu_texture/Cargo.toml
@@ -11,10 +11,10 @@ publish = false
 [dependencies]
 anyrender = { workspace = true }
 anyrender_vello = { workspace = true }
-blitz-traits = { workspace = true }
-blitz-dom = { workspace = true }
+blitz-traits = { workspace = true}
+blitz-dom = { workspace = true, features = ["tracing"]}
 blitz-html = { workspace = true }
-blitz-shell = { workspace = true }
+blitz-shell = { workspace = true, features = ["tracing"] }
 mini-dxn = { workspace = true, features = ["gpu", "system_fonts"] }
 wgpu_context = { workspace = true }
 dioxus = { workspace = true }

--- a/packages/blitz-dom/Cargo.toml
+++ b/packages/blitz-dom/Cargo.toml
@@ -12,7 +12,6 @@ rust-version.workspace = true
 
 [features]
 default = [
-    "tracing",
     "svg",
     "woff-rust",
     "accessibility",

--- a/packages/blitz-paint/Cargo.toml
+++ b/packages/blitz-paint/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["tracing", "svg"]
+default = ["svg"]
 tracing = ["dep:tracing"]
 svg = ["dep:anyrender_svg", "dep:usvg", "blitz-dom/svg"]
 

--- a/packages/blitz-shell/Cargo.toml
+++ b/packages/blitz-shell/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["accessibility", "clipboard", "tracing", "file_dialog"]
+default = ["accessibility", "clipboard", "file_dialog"]
 accessibility = [
     "dep:accesskit",
     "dep:accesskit_winit",

--- a/packages/blitz/Cargo.toml
+++ b/packages/blitz/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["net", "accessibility", "tracing"]
+default = ["net", "accessibility"]
 net = ["dep:tokio", "dep:url", "dep:blitz-net"]
 accessibility = ["blitz-shell/accessibility"]
 tracing = ["blitz-shell/tracing"]

--- a/packages/mini-dxn/Cargo.toml
+++ b/packages/mini-dxn/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 publish = false
 
 [features]
-default = ["accessibility", "hot-reload", "tracing", "net", "svg", "gpu"]
+default = ["accessibility", "hot-reload", "net", "svg", "gpu"]
 svg = ["blitz-dom/svg", "blitz-paint/svg"]
 system_fonts = ["blitz-dom/system_fonts"]
 net = ["dep:tokio", "dep:blitz-net"]


### PR DESCRIPTION
This pr moves `tracing out of default features and makes it an optional feature. 

When you want to turn off tracing in Dioxus, you need to disable default features for all downstream crates, including this one. This means re-enabling alot of features by hand for a lot of different crates, just to turn off 1 feature. 