### PR TITLE
Upgrade to Stylo `main` + use updated Stylo ImportSheet API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5570,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.32.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -5701,7 +5701,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.2"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6012,7 +6012,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6069,7 +6069,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6078,12 +6078,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 
 [[package]]
 name = "stylo_derive"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -6095,7 +6095,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -6104,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "app_units",
  "cssparser",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 
 [[package]]
 name = "stylo_taffy"
@@ -6135,7 +6135,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -6516,7 +6516,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6529,7 +6529,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=e272be8#e272be8e5320da67ef514592d56908859b0fbaec"
+source = "git+https://github.com/servo/stylo?rev=85ae0b1#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,12 @@ mini-dxn = { path = "./packages/mini-dxn", default-features = false }
 debug_timer = { version = "0.1.2", path = "./packages/debug_timer" }
 
 # Servo dependencies
-style = { git = "https://github.com/servo/stylo", rev = "e272be8", package = "stylo" }
-style_traits = { git = "https://github.com/servo/stylo", rev = "e272be8", package = "stylo_traits" }
-style_atoms = { git = "https://github.com/servo/stylo", rev = "e272be8", package = "stylo_atoms" }
-style_config = { git = "https://github.com/servo/stylo", rev = "e272be8", package = "stylo_config" }
-style_dom = { git = "https://github.com/servo/stylo", rev = "e272be8", package = "stylo_dom" }
-selectors = { git = "https://github.com/servo/stylo", rev = "e272be8", package = "selectors" }
+style = { git = "https://github.com/servo/stylo", rev = "85ae0b1", package = "stylo" }
+style_traits = { git = "https://github.com/servo/stylo", rev = "85ae0b1", package = "stylo_traits" }
+style_atoms = { git = "https://github.com/servo/stylo", rev = "85ae0b1", package = "stylo_atoms" }
+style_config = { git = "https://github.com/servo/stylo", rev = "85ae0b1", package = "stylo_config" }
+style_dom = { git = "https://github.com/servo/stylo", rev = "85ae0b1", package = "stylo_dom" }
+selectors = { git = "https://github.com/servo/stylo", rev = "85ae0b1", package = "selectors" }
 cssparser = { version = "0.35" }
 
 # HTML5ever dependencies

--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -252,6 +252,7 @@ fn fetch_font_face(
     read_guard: &SharedRwLockReadGuard,
 ) {
     sheet
+        .contents(read_guard)
         .rules(read_guard)
         .iter()
         .filter_map(|rule| match rule {


### PR DESCRIPTION
This will be required for the next Stylo upgrade due to https://github.com/servo/stylo/pull/250