### PR TITLE
todomvc: hide console window on Windows

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -1,3 +1,6 @@
+// On Windows do NOT show a console window when opening the app
+#![cfg_attr(all(not(test), target_os = "windows"), windows_subsystem = "windows")]
+
 //! The typical TodoMVC app, implemented in Dioxus.
 
 use dioxus::prelude::*;


### PR DESCRIPTION
mark the app as GUI