### PR TITLE
Use color attribute for text cursor color in text inputs

### DIFF
--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -452,12 +452,13 @@ impl ElementCx<'_> {
                     );
                 }
                 if let Some(cursor) = input_data.editor.cursor_geometry(1.5) {
-                    let color = self.style.clone_color();
+                    // TODO: Use the `caret-color` attribute here if present.
+                    let color = self.style.get_inherited_text().color;
+
                     scene.fill(
                         Fill::NonZero,
                         transform,
-                        // TODO: Use the `caret-color` attribute here if present.
-                        Color::new(*color.raw_components()),
+                        color.as_srgb_color(),
                         None,
                         &convert_rect(&cursor),
                     );


### PR DESCRIPTION
The more correct solution for this would be to use the `caret-color` style attribute, but I think just this is an improvement from always drawing a black text cursor.

From https://developer.mozilla.org/en-US/docs/Web/CSS/caret-color#description:
> The auto value sets the insertion caret to currentColor, which is the [color](https://developer.mozilla.org/en-US/docs/Web/CSS/color) of the text that is being added or deleted.