### PR TITLE
Set IME cursor area. Only enable IME when a text input is focussed.

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -828,7 +828,8 @@ impl BaseDocument {
     /// Clear the focussed node
     pub fn clear_focus(&mut self) {
         if let Some(id) = self.focus_node_id {
-            self.snapshot_node_and(id, |node| node.blur());
+            let shell_provider = self.shell_provider.clone();
+            self.snapshot_node_and(id, |node| node.blur(shell_provider));
             self.focus_node_id = None;
         }
     }
@@ -844,13 +845,15 @@ impl BaseDocument {
         #[cfg(feature = "tracing")]
         tracing::info!("Focussed node {focus_node_id}");
 
+        let shell_provider = self.shell_provider.clone();
+
         // Remove focus from the old node
         if let Some(id) = self.focus_node_id {
-            self.snapshot_node_and(id, |node| node.blur());
+            self.snapshot_node_and(id, |node| node.blur(shell_provider.clone()));
         }
 
         // Focus the new node
-        self.snapshot_node_and(focus_node_id, |node| node.focus());
+        self.snapshot_node_and(focus_node_id, |node| node.focus(shell_provider));
 
         self.focus_node_id = Some(focus_node_id);
 

--- a/packages/blitz-shell/src/lib.rs
+++ b/packages/blitz-shell/src/lib.rs
@@ -40,6 +40,7 @@ pub use crate::net::DataUriNetProvider;
 use blitz_traits::shell::FileDialogFilter;
 use blitz_traits::shell::ShellProvider;
 use std::sync::Arc;
+use winit::dpi::{LogicalPosition, LogicalSize};
 pub use winit::event_loop::{ControlFlow, EventLoop, EventLoopProxy};
 pub use winit::window::{CursorIcon, Window};
 
@@ -100,6 +101,13 @@ impl ShellProvider for BlitzShellProvider {
     }
     fn set_window_title(&self, title: String) {
         self.window.set_title(&title);
+    }
+    fn set_ime_enabled(&self, is_enabled: bool) {
+        self.window.set_ime_allowed(is_enabled);
+    }
+    fn set_ime_cursor_area(&self, x: f32, y: f32, width: f32, height: f32) {
+        self.window
+            .set_ime_cursor_area(LogicalPosition::new(x, y), LogicalSize::new(width, height));
     }
 
     #[cfg(all(

--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -77,9 +77,6 @@ impl<Rend: WindowRenderer> View<Rend> {
     ) -> Self {
         let winit_window = Arc::from(event_loop.create_window(config.attributes).unwrap());
 
-        // TODO: make this conditional on text input focus
-        winit_window.set_ime_allowed(true);
-
         // Create viewport
         let size = winit_window.inner_size();
         let scale = winit_window.scale_factor() as f32;

--- a/packages/blitz-traits/src/shell.rs
+++ b/packages/blitz-traits/src/shell.rs
@@ -16,6 +16,15 @@ pub trait ShellProvider {
     fn set_window_title(&self, title: String) {
         let _ = title;
     }
+    fn set_ime_enabled(&self, is_enabled: bool) {
+        let _ = is_enabled;
+    }
+    fn set_ime_cursor_area(&self, x: f32, y: f32, width: f32, height: f32) {
+        let _ = x;
+        let _ = y;
+        let _ = width;
+        let _ = height;
+    }
     fn get_clipboard_text(&self) -> Result<String, ClipboardError> {
         Err(ClipboardError)
     }


### PR DESCRIPTION
- Fixes https://github.com/DioxusLabs/blitz/issues/287

@NullDict This should fix your IME Candidate Window Position issue. Please can you test?

Currently the position is only set when the input is first focussed. It does not update if the text input moves (e.g. due to scroll, window resize, or layout change). That can be implemented in a follow up.