### PR TITLE
Add support for rendering table row backgrounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ cssparser = { version = "0.36" }
 
 # HTML5ever dependencies
 markup5ever = "0.36.1" # needs to match stylo web_atoms version
-html5ever = "0.36.1" # needs to match stylo web_atoms version
-xml5ever = "0.36.1" # needs to match stylo web_atoms version
+html5ever = "0.36.1"   # needs to match stylo web_atoms version
+xml5ever = "0.36.1"    # needs to match stylo web_atoms version
 
 # Other Servo dependencies
 euclid = "0.22"
@@ -84,7 +84,16 @@ dioxus-cli-config = { version = "0.7" }
 # Dioxus Prelude
 dioxus-core-macro = { version = "0.7" }
 
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "22868d2812bf903cc4d1dc514cf82197d9849a0b", default-features = false, features = ["std", "flexbox", "grid", "block_layout", "content_size", "calc"] }
+# Taffy
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "22868d2812bf903cc4d1dc514cf82197d9849a0b", default-features = false, features = [
+  "std",
+  "flexbox",
+  "grid",
+  "block_layout",
+  "content_size",
+  "calc",
+  "detailed_layout_info",
+] }
 
 # AnyRender
 anyrender = { version = "0.6" }
@@ -100,14 +109,21 @@ color = "0.3"
 linebender_resource_handle = "0.1"
 peniko = "0.5.0"
 kurbo = "0.12"
-parley = { git = "https://github.com/linebender/parley", rev = "f6a8485c35367b581b03bd6da55c8465f24e16ef", default-features = false, features = ["std"] }
-skrifa = { version = "0.37", default-features = false, features = ["std"] } # Should match parley version
+parley = { git = "https://github.com/linebender/parley", rev = "f6a8485c35367b581b03bd6da55c8465f24e16ef", default-features = false, features = [
+  "std",
+] }
+skrifa = { version = "0.37", default-features = false, features = [
+  "std",
+] } # Should match parley version
 wgpu = "26"
 softbuffer = "0.4"
 pixels = "0.15"
-vello = { version = "0.6", features = [ "wgpu" ] }
+vello = { version = "0.6", features = ["wgpu"] }
 vello_encoding = { version = "0.6", default-features = false }
-vello_cpu = { version = "0.0.3", default-features = false, features = ["std", "text"]}
+vello_cpu = { version = "0.0.3", default-features = false, features = [
+  "std",
+  "text",
+] }
 usvg = "0.45.1"
 
 # Windowing & Input

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -244,7 +244,13 @@ impl BaseDocument {
                         doc: self,
                         ctx: context,
                     };
-                    return compute_grid_layout(&mut table_wrapper, node_id, inputs);
+                    let mut output = compute_grid_layout(&mut table_wrapper, node_id, inputs);
+
+                    // HACK: Cap content size at node size to prevent scrolling
+                    output.content_size.width = output.content_size.width.min(output.size.width);
+                    output.content_size.height = output.content_size.height.min(output.size.height);
+
+                    return output;
                 }
 
                 if node.flags.is_inline_root() {

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -223,6 +223,7 @@ impl BlitzDomPainter<'_> {
         cx.draw_outline(scene);
         cx.draw_outset_box_shadow(scene);
         cx.draw_background(scene);
+        cx.draw_table_row_backgrounds(scene);
         cx.draw_inset_box_shadow(scene);
         cx.draw_border(scene);
 


### PR DESCRIPTION
## Motivation

Tables often have "zebra striping" where an alternating background color is rendered for each row. Additionally some pages such as https://blitz.is/status/css have more elaborate row coloring schemes. However, Blitz did not previously support rendering background colors for table rows so this coloring did not render.

This PR adds that support. Additionally it includes a fix which prevents table containers from scrolling.

## Screenshots

Taffy README:

<img width="1171" height="934" alt="Screenshot 2025-11-30 at 15 57 24" src="https://github.com/user-attachments/assets/b09739cb-04b9-45b3-bd4d-c7f6364f8c87" />

https://blitz.is/status

<img width="1624" height="1056" alt="Screenshot 2025-11-30 at 15 56 54" src="https://github.com/user-attachments/assets/7739861d-5ba8-4164-8581-5036f1157016" />
