### PR TITLE
Implement table border collapsing (border-collapse:collapse)

### DIFF
--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -106,12 +106,12 @@ impl ElementCx<'_> {
             (cols.sizes.iter().sum::<f32>() + cols.gutters.iter().sum::<f32>()) as f64;
 
         let rows = &grid_info.rows;
-        let mut y = 0.0;
+        let mut y = rows.gutters.first().copied().unwrap_or_default() as f64;
         for ((row, &height), &gutter) in table
             .rows
             .iter()
             .zip(rows.sizes.iter())
-            .zip(rows.gutters.iter())
+            .zip(rows.gutters.iter().skip(1))
         {
             let row_node = &self.context.dom.get_node(row.node_id).unwrap();
             let Some(style) = row_node.primary_styles() else {


### PR DESCRIPTION
## Objective

Support the border-collapse property (https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/border-collapse).

This PR implements the common case where all collapsed borders are the same width and color.

## Screenshots

Taffy README:

<img width="1184" height="859" alt="Screenshot 2025-11-30 at 18 00 39" src="https://github.com/user-attachments/assets/227e17b2-dce8-4b5a-bfe8-1b4327d9d41c" />


<img width="1624" height="1056" alt="Screenshot 2025-11-30 at 18 00 57" src="https://github.com/user-attachments/assets/5615c35b-8d04-4f6d-97e7-2a3254359f8f" />
