### PR TITLE
feat(blitz-dom): improve disabled attribute support

### DIFF
--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -22,6 +22,12 @@ use super::{Attribute, Attributes};
 use crate::Document;
 use crate::layout::table::TableContext;
 
+macro_rules! local_names {
+    ($($name:tt),+) => {
+        [$(local_name!($name),)+]
+    };
+}
+
 #[derive(Debug, Clone)]
 pub struct ElementData {
     /// The elements tag name, namespace and prefix
@@ -164,6 +170,10 @@ impl ElementData {
     /// Detects the presence of the attribute, treating *any* value as truthy.
     pub fn has_attr(&self, name: impl PartialEq<LocalName>) -> bool {
         self.attrs.iter().any(|attr| name == attr.name.local)
+    }
+
+    pub fn can_be_disabled(&self) -> bool {
+        local_names!("button", "input", "select", "textarea").contains(&self.name.local)
     }
 
     pub fn image_data(&self) -> Option<&ImageData> {

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -412,7 +412,7 @@ impl selectors::Element for BlitzNode<'_> {
             NonTSPseudoClass::Invalid => false,
             NonTSPseudoClass::Defined => false,
             NonTSPseudoClass::Disabled => self.element_state.contains(ElementState::DISABLED),
-            NonTSPseudoClass::Enabled => false,
+            NonTSPseudoClass::Enabled => self.element_state.contains(ElementState::ENABLED),
             NonTSPseudoClass::Focus => self.element_state.contains(ElementState::FOCUS),
             NonTSPseudoClass::FocusWithin => false,
             NonTSPseudoClass::FocusVisible => false,


### PR DESCRIPTION
Adds improved support for the `disabled` attribute on form controls.

The following parts of the HTML spec are not yet supported:

- Inherit disabled status (depends on `select` element support)
- Disable custom form controls (I'm not sure if those are supported by Blitz)