### PR TITLE
fix: check for visibility changes for damage

### DIFF
--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -152,6 +152,7 @@ pub(crate) fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) 
         if old_box.display != new_box.display
             || old_box.float != new_box.float
             || old_box.position != new_box.position
+            || old.clone_visibility() != new.clone_visibility()
         {
             return true;
         }


### PR DESCRIPTION
This fixes #335, by adding restyle damage on visibility changes.