### PR TITLE
Add word-spacing.

### DIFF
--- a/packages/blitz-dom/src/stylo_to_parley.rs
+++ b/packages/blitz-dom/src/stylo_to_parley.rs
@@ -125,6 +125,11 @@ pub(crate) fn style(
         .resolve(Length::new(font_size))
         .px();
 
+    let word_spacing = itext_styles
+        .word_spacing
+        .resolve(Length::new(font_size))
+        .px();
+
     // Convert Bold/Italic
     let font_weight = self::font_weight(font_styles.font_weight);
     let font_style = self::font_style(font_styles.font_style);
@@ -192,7 +197,7 @@ pub(crate) fn style(
         font_features: parley::FontFeatures::List(Cow::Borrowed(&[])),
         locale: Default::default(),
         line_height,
-        word_spacing: Default::default(),
+        word_spacing,
         letter_spacing,
         text_wrap_mode,
         overflow_wrap,


### PR DESCRIPTION

When running with the border fix this change should ensure this test passes.

wpt/css/CSS2/borders/border-003-ref.xht

Previous:
<img width="820" height="655" alt="Screenshot from 2026-03-06 00-05-46" src="https://github.com/user-attachments/assets/aed2c4c5-b036-49f4-afe2-8ed684c4bbbd" />

With Change:
<img width="820" height="655" alt="Screenshot from 2026-03-06 00-04-45" src="https://github.com/user-attachments/assets/94d935d5-7734-400f-8e08-f4ca9c197f5c" />
