### PR TITLE
WASM compile fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ dependencies = [
  "reqwest-middleware",
  "tokio",
  "tracing",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,9 @@ serde = "1"
 # Dioxus Native
 webbrowser = "1.0"
 
+# WASM
+wasm-bindgen-futures = "0.4"
+
 # Other dependencies
 rustc-hash = "1.1.0"
 bytes = "1.7.1"

--- a/apps/readme/Cargo.toml
+++ b/apps/readme/Cargo.toml
@@ -48,7 +48,7 @@ anyrender_skia = { workspace = true, optional = true }
 anyrender_vello_cpu = { workspace = true, features = ["multithreading"], optional = true }
 anyrender_vello_hybrid = { workspace = true, optional = true }
 
-tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt"] }
 reqwest = { workspace = true }
 url = { workspace = true }
 winit = { workspace = true }
@@ -57,3 +57,6 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["html
 image = { workspace = true, default-features = false, optional = true }
 notify = "8.0.0"
 tracing-subscriber = { workspace = true, optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"]}

--- a/packages/blitz-net/Cargo.toml
+++ b/packages/blitz-net/Cargo.toml
@@ -32,3 +32,6 @@ http-cache-reqwest = { workspace = true, optional = true, features = ["manager-c
 directories = { version = "6.0.0", optional = true }
 
 tracing = { workspace = true, optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = { workspace = true }

--- a/packages/blitz-net/src/lib.rs
+++ b/packages/blitz-net/src/lib.rs
@@ -6,7 +6,6 @@
 use blitz_traits::net::{AbortSignal, Body, Bytes, NetHandler, NetProvider, NetWaker, Request};
 use data_url::DataUrl;
 use std::{marker::PhantomData, pin::Pin, sync::Arc, task::Poll};
-use tokio::runtime::Handle;
 
 #[cfg(feature = "cache")]
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
@@ -35,8 +34,23 @@ fn get_cache_path() -> std::path::PathBuf {
     path
 }
 
+#[cfg(target_arch = "wasm32")]
+fn spawn(fut: impl Future + 'static) {
+    wasm_bindgen_futures::spawn_local(async move {
+        fut.await;
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn<F>(fut: F)
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    tokio::spawn(fut);
+}
+
 pub struct Provider {
-    rt: Handle,
     client: Client,
     waker: Arc<dyn NetWaker>,
 }
@@ -57,11 +71,7 @@ impl Provider {
             .build();
 
         let waker = waker.unwrap_or(Arc::new(DummyNetWaker));
-        Self {
-            rt: Handle::current(),
-            client,
-            waker,
-        }
+        Self { client, waker }
     }
     pub fn shared(waker: Option<Arc<dyn NetWaker>>) -> Arc<dyn NetProvider> {
         Arc::new(Self::new(waker))
@@ -114,7 +124,7 @@ impl Provider {
         let url = request.url.to_string();
 
         let client = self.client.clone();
-        self.rt.spawn(async move {
+        spawn(async move {
             let result = Self::fetch_inner(client, request).await;
 
             #[cfg(feature = "tracing")]
@@ -158,7 +168,7 @@ impl NetProvider for Provider {
         tracing::info!(url = request.url.as_str(), "Fetching");
 
         let waker = self.waker.clone();
-        self.rt.spawn(async move {
+        spawn(async move {
             #[cfg(feature = "tracing")]
             let url = request.url.to_string();
 
@@ -212,8 +222,8 @@ impl<F, T> AbortFetch<F, T> {
 
 impl<F, T> Future for AbortFetch<F, T>
 where
-    F: Future + Unpin + Send + 'static,
-    F::Output: Send + Into<Result<T, ProviderError>> + 'static,
+    F: Future + Unpin + 'static,
+    F::Output: Into<Result<T, ProviderError>> + 'static,
     T: Unpin,
 {
     type Output = Result<T, ProviderError>;

--- a/packages/blitz/Cargo.toml
+++ b/packages/blitz/Cargo.toml
@@ -28,9 +28,12 @@ blitz-net = { workspace = true, optional = true }
 
 # IO & Networking
 url = { workspace = true, features = ["serde"], optional = true }
-tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
 
 tracing = { workspace = true, optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/blitz/src/lib.rs
+++ b/packages/blitz/src/lib.rs
@@ -42,6 +42,7 @@ pub use blitz_shell as shell;
 pub use blitz_traits as traits;
 
 #[cfg(feature = "net")]
+#[cfg(not(target_arch = "wasm32"))]
 pub fn launch_url(url: &str) {
     // Assert that url is valid
     #[cfg(feature = "tracing")]
@@ -85,11 +86,13 @@ pub fn launch_static_html(html: &str) {
 pub fn launch_static_html_cfg(html: &str, cfg: Config) {
     // Turn on the runtime and enter it
     #[cfg(feature = "net")]
+    #[cfg(not(target_arch = "wasm32"))]
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap();
     #[cfg(feature = "net")]
+    #[cfg(not(target_arch = "wasm32"))]
     let _guard = rt.enter();
 
     let event_loop = create_default_event_loop();

--- a/packages/dioxus-native/Cargo.toml
+++ b/packages/dioxus-native/Cargo.toml
@@ -95,13 +95,16 @@ winit = { workspace = true }
 keyboard-types = { workspace = true }
 
 # IO & Networking
-tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
 webbrowser = { workspace = true }
 
 # Other dependencies
 tracing = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 futures-util = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android-activity = { version = "0.6", default-features = false }

--- a/packages/dioxus-native/src/lib.rs
+++ b/packages/dioxus-native/src/lib.rs
@@ -154,15 +154,18 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
 
     // Turn on the runtime and enter it
     #[cfg(feature = "net")]
+    #[cfg(not(target_arch = "wasm32"))]
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap();
     #[cfg(feature = "net")]
+    #[cfg(not(target_arch = "wasm32"))]
     let _guard = rt.enter();
 
     // Setup hot-reloading if enabled.
     #[cfg(all(feature = "hot-reload", debug_assertions))]
+    #[cfg(not(target_arch = "wasm32"))]
     {
         let proxy = proxy.clone();
         dioxus_devtools::connect(move |event| {


### PR DESCRIPTION
With this PR, the `blitz`, `dioxus-native` compile for wasm. And the `browser` package compiles without default features.