### PR TITLE
Add BaseDocument::set_media_type for paged/print use cases

### DIFF
--- a/apps/browser/src/main.rs
+++ b/apps/browser/src/main.rs
@@ -122,6 +122,7 @@ fn app() -> Element {
             shell_provider: None,
             html_parser_provider: Some(Arc::new(HtmlProvider)),
             font_ctx: Some(loader.font_ctx.clone()),
+            media_type: None,
         };
         let mut document = HtmlDocument::from_html(view_source_html, config).into_inner();
         if let Some(parent_id) = document.get_element_by_id("source") {
@@ -544,6 +545,7 @@ impl DocumentLoader {
                         shell_provider: Some(consume_context::<Arc<dyn ShellProvider>>()),
                         html_parser_provider: Some(Arc::new(HtmlProvider)),
                         font_ctx: Some(font_ctx),
+                        media_type: None,
                     };
 
                     let html = if bytes.is_empty() {
@@ -571,6 +573,7 @@ impl DocumentLoader {
                         shell_provider: Some(consume_context::<Arc<dyn ShellProvider>>()),
                         html_parser_provider: Some(Arc::new(HtmlProvider)),
                         font_ctx: Some(font_ctx),
+                        media_type: None,
                     };
 
                     let error_html = include_str!("../assets/error.html");

--- a/packages/blitz-dom/src/config.rs
+++ b/packages/blitz-dom/src/config.rs
@@ -6,6 +6,7 @@ use blitz_traits::{
 };
 use parley::FontContext;
 use std::sync::Arc;
+use style::media_queries::MediaType;
 
 /// Options used when constructing a [`BaseDocument`](crate::BaseDocument)
 #[derive(Default)]
@@ -26,4 +27,7 @@ pub struct DocumentConfig {
     pub html_parser_provider: Option<Arc<dyn HtmlParserProvider>>,
     /// Parley `FontContext`
     pub font_ctx: Option<FontContext>,
+    /// The CSS media type used to evaluate `@media` rules.
+    /// Defaults to [`MediaType::screen`].
+    pub media_type: Option<MediaType>,
 }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -188,6 +188,8 @@ pub struct BaseDocument {
     pub(crate) viewport: Viewport,
     // Scroll within our viewport
     pub(crate) viewport_scroll: crate::Point<f64>,
+    /// CSS media type used to evaluate `@media` rules.
+    pub(crate) media_type: MediaType,
 
     // Events
     pub(crate) tx: Sender<DocumentEvent>,
@@ -290,14 +292,18 @@ pub struct BaseDocument {
     pub html_parser_provider: Arc<dyn HtmlParserProvider>,
 }
 
-pub(crate) fn make_device(viewport: &Viewport, font_ctx: Arc<Mutex<FontContext>>) -> Device {
+pub(crate) fn make_device(
+    viewport: &Viewport,
+    media_type: Option<MediaType>,
+    font_ctx: Arc<Mutex<FontContext>>,
+) -> Device {
     let width = viewport.window_size.0 as f32 / viewport.scale();
     let height = viewport.window_size.1 as f32 / viewport.scale();
     let viewport_size = euclid::Size2D::new(width, height);
     let device_pixel_ratio = euclid::Scale::new(viewport.scale());
 
     Device::new(
-        MediaType::screen(),
+        media_type.unwrap_or_else(MediaType::screen),
         selectors::matching::QuirksMode::NoQuirks,
         viewport_size,
         device_pixel_ratio,
@@ -347,7 +353,8 @@ impl BaseDocument {
         style_config::set_pref!("layout.threads", -1);
 
         let viewport = config.viewport.unwrap_or_default();
-        let device = make_device(&viewport, font_ctx.clone());
+        let media_type = config.media_type.unwrap_or_else(MediaType::screen);
+        let device = make_device(&viewport, Some(media_type.clone()), font_ctx.clone());
         let stylist = Stylist::new(device, QuirksMode::NoQuirks);
         let snapshots = SnapshotMap::new();
         let nodes = Box::new(Slab::new());
@@ -386,6 +393,7 @@ impl BaseDocument {
             snapshots,
             nodes_to_id,
             viewport,
+            media_type,
             devtool_settings: DevtoolSettings::default(),
             viewport_scroll: crate::Point::ZERO,
             url: base_url,
@@ -1253,13 +1261,36 @@ impl BaseDocument {
     pub fn set_viewport(&mut self, viewport: Viewport) {
         let scale_has_changed = viewport.scale_f64() != self.viewport.scale_f64();
         self.viewport = viewport;
-        self.set_stylist_device(make_device(&self.viewport, self.font_ctx.clone()));
+        self.set_stylist_device(make_device(
+            &self.viewport,
+            Some(self.media_type.clone()),
+            self.font_ctx.clone(),
+        ));
         self.scroll_viewport_by(0.0, 0.0); // Clamp scroll offset
 
         if scale_has_changed {
             self.invalidate_inline_contexts();
             self.shell_provider.request_redraw();
         }
+    }
+
+    /// Returns the current CSS media type used to evaluate `@media` rules.
+    pub fn media_type(&self) -> &MediaType {
+        &self.media_type
+    }
+
+    /// Sets the CSS media type used to evaluate `@media` rules (e.g. `screen` or `print`)
+    /// and rebuilds the stylist device so updated rules apply on the next restyle.
+    pub fn set_media_type(&mut self, media_type: MediaType) {
+        if self.media_type == media_type {
+            return;
+        }
+        self.media_type = media_type;
+        self.set_stylist_device(make_device(
+            &self.viewport,
+            Some(self.media_type.clone()),
+            self.font_ctx.clone(),
+        ));
     }
 
     pub fn viewport(&self) -> &Viewport {

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -294,7 +294,7 @@ pub struct BaseDocument {
 
 pub(crate) fn make_device(
     viewport: &Viewport,
-    media_type: Option<MediaType>,
+    media_type: MediaType,
     font_ctx: Arc<Mutex<FontContext>>,
 ) -> Device {
     let width = viewport.window_size.0 as f32 / viewport.scale();
@@ -303,7 +303,7 @@ pub(crate) fn make_device(
     let device_pixel_ratio = euclid::Scale::new(viewport.scale());
 
     Device::new(
-        media_type.unwrap_or_else(MediaType::screen),
+        media_type,
         selectors::matching::QuirksMode::NoQuirks,
         viewport_size,
         device_pixel_ratio,
@@ -354,7 +354,7 @@ impl BaseDocument {
 
         let viewport = config.viewport.unwrap_or_default();
         let media_type = config.media_type.unwrap_or_else(MediaType::screen);
-        let device = make_device(&viewport, Some(media_type.clone()), font_ctx.clone());
+        let device = make_device(&viewport, media_type.clone(), font_ctx.clone());
         let stylist = Stylist::new(device, QuirksMode::NoQuirks);
         let snapshots = SnapshotMap::new();
         let nodes = Box::new(Slab::new());
@@ -1263,7 +1263,7 @@ impl BaseDocument {
         self.viewport = viewport;
         self.set_stylist_device(make_device(
             &self.viewport,
-            Some(self.media_type.clone()),
+            self.media_type.clone(),
             self.font_ctx.clone(),
         ));
         self.scroll_viewport_by(0.0, 0.0); // Clamp scroll offset
@@ -1288,7 +1288,7 @@ impl BaseDocument {
         self.media_type = media_type;
         self.set_stylist_device(make_device(
             &self.viewport,
-            Some(self.media_type.clone()),
+            self.media_type.clone(),
             self.font_ctx.clone(),
         ));
     }

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -82,6 +82,7 @@ pub use node::{Attribute, ElementData, Node, NodeData, TextNodeData};
 pub use parley::FontContext;
 pub use style::Atom;
 pub use style::invalidation::element::restyle_hints::RestyleHint;
+pub use style::media_queries::MediaType;
 pub type SelectorList = selectors::SelectorList<style::selector_parser::SelectorImpl>;
 pub use events::{EventDriver, EventHandler, NoopEventHandler};
 pub use html::{DummyHtmlParserProvider, HtmlParserProvider};

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -931,8 +931,11 @@ impl Drop for ViewportMut<'_> {
             return;
         }
 
-        self.doc
-            .set_stylist_device(make_device(&self.doc.viewport, self.doc.font_ctx.clone()));
+        self.doc.set_stylist_device(make_device(
+            &self.doc.viewport,
+            Some(self.doc.media_type.clone()),
+            self.doc.font_ctx.clone(),
+        ));
         self.doc.scroll_viewport_by(0.0, 0.0); // Clamp scroll offset
 
         let scale_has_changed =
@@ -946,9 +949,37 @@ impl Drop for ViewportMut<'_> {
 
 #[cfg(test)]
 mod test {
+    use style::media_queries::MediaType;
     use style_dom::ElementState;
 
     use crate::{Attribute, BaseDocument, DocumentConfig, ElementData, NodeData, qual_name};
+
+    #[test]
+    fn media_type_defaults_to_screen() {
+        let mut document = BaseDocument::new(DocumentConfig::default());
+        assert_eq!(*document.media_type(), MediaType::screen());
+        assert_eq!(document.stylist_device().media_type(), MediaType::screen());
+    }
+
+    #[test]
+    fn media_type_honors_config() {
+        let mut document = BaseDocument::new(DocumentConfig {
+            media_type: Some(MediaType::print()),
+            ..Default::default()
+        });
+        assert_eq!(*document.media_type(), MediaType::print());
+        assert_eq!(document.stylist_device().media_type(), MediaType::print());
+    }
+
+    #[test]
+    fn set_media_type_updates_stylist_device() {
+        let mut document = BaseDocument::new(DocumentConfig::default());
+        assert_eq!(document.stylist_device().media_type(), MediaType::screen());
+
+        document.set_media_type(MediaType::print());
+        assert_eq!(*document.media_type(), MediaType::print());
+        assert_eq!(document.stylist_device().media_type(), MediaType::print());
+    }
 
     #[test]
     fn mutator_remove_disabled() {

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -933,7 +933,7 @@ impl Drop for ViewportMut<'_> {
 
         self.doc.set_stylist_device(make_device(
             &self.doc.viewport,
-            Some(self.doc.media_type.clone()),
+            self.doc.media_type.clone(),
             self.doc.font_ctx.clone(),
         ));
         self.doc.scroll_viewport_by(0.0, 0.0); // Clamp scroll offset


### PR DESCRIPTION
Refs #128.

As discussed in https://github.com/DioxusLabs/blitz/issues/128#issuecomment-4246086994, this adds a way to configure the CSS media type on `BaseDocument` so that `@media print { ... }` rules can be evaluated. Previously `make_device` hardcoded `MediaType::screen()`, which blocks any paged / print-styled rendering (e.g. PDF) on top of Blitz.

## Changes

- `DocumentConfig::media_type: Option<MediaType>` — defaults to `MediaType::screen` when `None`.
- `BaseDocument` now stores the resolved `MediaType` and threads it through `make_device` (initial build, `set_viewport`, `ViewportMut` drop). The internal `make_device` takes `MediaType` by value — every call site already has a concrete value, so there's no `Option` wrapping / hidden default.
- New `BaseDocument::media_type()` (getter) and `BaseDocument::set_media_type(MediaType)` — the setter rebuilds the stylist device and force-dirties origins so rules re-evaluate on the next restyle. Early-returns if the media type is unchanged.
- `style::media_queries::MediaType` is re-exported from `blitz_dom` so downstream crates don't need a direct `stylo` dependency just to switch media types.
- Updated the three `DocumentConfig` struct literals in `apps/browser` to include `media_type: None`.

## Tests

Added unit tests in `packages/blitz-dom/src/mutator.rs`:

- `media_type_defaults_to_screen` — default `DocumentConfig` → `screen`.
- `media_type_honors_config` — `DocumentConfig { media_type: Some(MediaType::print()), .. }` → `print`.
- `set_media_type_updates_stylist_device` — after `set_media_type(print)`, both `document.media_type()` and `document.stylist_device().media_type()` return `print`.

Verified with `cargo check --workspace` and `cargo test -p blitz-dom --lib` (16 passed).

## Usage

```rust
use blitz_dom::{BaseDocument, DocumentConfig, MediaType};

// At construction
let doc = BaseDocument::new(DocumentConfig {
    media_type: Some(MediaType::print()),
    ..Default::default()
});

// Or switch at runtime
doc.set_media_type(MediaType::print());
```

Validated end-to-end on top of [fulgur](https://github.com/mitsuru/fulgur) (HTML/CSS → PDF via Blitz + Krilla): `@media print` rules now apply correctly in rendered PDFs.