### PR TITLE
feat(table): support rowspan attribute on td/th

### DIFF
--- a/examples/rowspan.html
+++ b/examples/rowspan.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>rowspan reproduction</title>
+<style>
+body { font-family: sans-serif; padding: 16px; }
+table { border-collapse: collapse; width: 400px; }
+td, th { border: 1px solid #333; padding: 8px; text-align: center; }
+thead { background: #eef; }
+.tall { background: #fec; }
+</style>
+</head>
+<body>
+<h1>rowspan minimal reproduction</h1>
+<p>Expected: cell "2" spans rows 2 and 3 (column B); cell "4" is in column A and "6" is in column C of row 3.</p>
+<table>
+  <thead>
+    <tr><th>A</th><th>B</th><th>C</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>1</td><td class="tall" rowspan="2">2 (rowspan=2)</td><td>3</td></tr>
+    <tr><td>4</td><td>6</td></tr>
+    <tr><td>7</td><td>8</td><td>9</td></tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -72,6 +72,12 @@ pub(crate) fn build_table_context(
 
     let mut style = stylo_taffy::to_taffy_style(&stylo_styles);
     style.item_is_table = true;
+    // Use `dense` row-flow so that each cell scans the row from its
+    // leftmost column for the first free track. Without `dense`,
+    // `place_definite_secondary_axis_item` keeps a per-item secondary
+    // cursor across rows, which means cells in later rows do not
+    // backfill columns freed up by rowspan cells from earlier rows.
+    style.grid_auto_flow = taffy::GridAutoFlow::RowDense;
     style.grid_auto_columns = Vec::new();
     style.grid_auto_rows = Vec::new();
 
@@ -246,6 +252,11 @@ pub(crate) fn collect_table_cells(
                 .attr(local_name!("colspan"))
                 .and_then(|val| val.parse().ok())
                 .unwrap_or(1);
+            let rowspan: u16 = node
+                .attr(local_name!("rowspan"))
+                .and_then(|val| val.parse::<u16>().ok())
+                .map(|v| v.clamp(1, 65534))
+                .unwrap_or(1);
             let mut style = stylo_taffy::to_taffy_style(stylo_style);
 
             if first_cell_border.is_none() {
@@ -279,13 +290,18 @@ pub(crate) fn collect_table_cells(
                 style.border = taffy::Rect::ZERO.map(style_helpers::length);
             }
 
+            // Let Taffy auto-place the column. Combined with
+            // `grid_auto_flow: RowDense` set on the table root, each cell
+            // scans from the first track in its row for a free position,
+            // which makes cells automatically skip columns occupied by
+            // rowspan cells from earlier rows.
             style.grid_column = taffy::Line {
-                start: style_helpers::line((*col + 1) as i16),
+                start: style_helpers::auto(),
                 end: style_helpers::span(colspan),
             };
             style.grid_row = taffy::Line {
                 start: style_helpers::line(*row as i16),
-                end: style_helpers::span(1),
+                end: style_helpers::span(rowspan),
             };
             style.size.width = style_helpers::auto();
             cells.push(TableCell { node_id, style });


### PR DESCRIPTION
Closes #394.

## What

Add support for the `rowspan` attribute on `<td>` / `<th>`, which was
previously ignored (`grid_row.end` was hardcoded to `span(1)`).

## How

Four changes in `packages/blitz-dom/src/layout/table.rs`:

1. Parse the `rowspan` attribute on table cells, clamped to
   `[1, 65534]` per the HTML Living Standard.
2. Apply it to `grid_row.end` (was `span(1)`, now `span(rowspan)`).
3. Switch `grid_column.start` on each cell from an explicit
   `line(col+1)` to `auto()`, so Taffy handles column placement.
4. Set `grid_auto_flow: RowDense` on the table root style.

Step 4 is load-bearing. With the default sparse row-flow,
`place_definite_secondary_axis_item` keeps a per-item secondary-axis
cursor that carries across rows, so a cell in row N+1 starts its
column search from wherever the previous cell ended rather than from
the first track of its own row. That makes it impossible to backfill
columns freed up by rowspan cells from earlier rows.

The `dense` branch resets the column search to the first track on every
item. Each cell still honors its explicit `grid_row`, so inter-row
ordering is preserved; only the within-row column search is restarted
— exactly the behavior required for HTML table layout with rowspan.

Diff is 18 lines.

## Testing

- `cargo test -p blitz-dom` — all existing tests pass.
- `examples/rowspan.html` (added in the first commit of this PR) —
  renders identically to Chrome after the patch. Before the patch the
  table is structurally broken (cell "6" collapses into column B,
  column C in row 3 is empty).
- Downstream smoke: applied the equivalent backport (branch
  [`rowspan-support-v0.2.x`](https://github.com/mitsuru/blitz/tree/rowspan-support-v0.2.x))
  to [fulgur][fulgur] via `[patch.crates-io]`. Its 497 unit tests
  continue to pass and its rowspan fixture renders correctly as a PDF.

[fulgur]: https://github.com/fulgur-rs/fulgur

## Follow-ups (not in this PR)

- `rowspan="0"` is clamped to `1` rather than interpreted as
  "span to end of row group" per HTML Living Standard §4.9.11.
  Browser behavior on the edge cases is inconsistent; happy to
  layer spec-exact semantics in a follow-up.
- A v0.2.x backport of the same change is available on
  [`rowspan-support-v0.2.x`](https://github.com/mitsuru/blitz/tree/rowspan-support-v0.2.x)
  if a 0.2.x point release is on the cards.
