### PR TITLE
perf: optimize box-shadow clipping

### DIFF
--- a/packages/blitz-paint/src/render/box_shadow.rs
+++ b/packages/blitz-paint/src/render/box_shadow.rs
@@ -7,14 +7,22 @@ use peniko::{Compose, Fill, Mix};
 impl ElementCx<'_> {
     pub(super) fn draw_outset_box_shadow(&self, scene: &mut impl PaintScene) {
         let box_shadow = &self.style.get_effects().box_shadow.0;
-
-        // TODO: Only apply clip if element has transparency
         let has_outset_shadow = box_shadow.iter().any(|s| !s.inset);
         if !has_outset_shadow {
             return;
         }
 
         let current_color = self.style.clone_color();
+        let opacity = self.style.get_effects().opacity;
+        let bg_color = self
+            .style
+            .get_background()
+            .background_color
+            .resolve_to_absolute(&current_color)
+            .as_srgb_color();
+        let bg_is_opaque = bg_color.components[3] >= 1.0;
+        let needs_clip = opacity < 1.0 || !bg_is_opaque;
+
         let max_shadow_rect = box_shadow.iter().fold(Rect::ZERO, |prev, shadow| {
             let x = shadow.base.horizontal.px() as f64 * self.scale;
             let y = shadow.base.vertical.px() as f64 * self.scale;
@@ -29,7 +37,7 @@ impl ElementCx<'_> {
 
         self.context.layer_manager.maybe_with_layer(
             scene,
-            has_outset_shadow,
+            needs_clip,
             1.0,
             self.transform,
             &self.frame.shadow_clip(max_shadow_rect),


### PR DESCRIPTION
## Summary

### 1. Box-shadow clip optimization (`box_shadow.rs`)

Previously, a clip/layer was always created when an element had an outset box-shadow, even if the element was fully opaque (`opacity == 1.0`). This is unnecessary because the shadow can only show through when there's transparency.

**Fix:** Only create the clip layer when `opacity < 1.0`, avoiding layer creation for the common case of fully opaque elements.

## Testing

- `cargo check -p blitz-paint` passes
- `cargo check -p wpt` passes
- `cargo test -p blitz-paint` passes