### PR TITLE
refactor: use extract_if instead of retain

### DIFF
--- a/wpt/runner/src/net_provider.rs
+++ b/wpt/runner/src/net_provider.rs
@@ -223,22 +223,11 @@ impl<T> InternalQueue<T> {
     pub fn for_each(&self, mut cb: impl FnMut(T)) {
         // Note: we use a temporary Vec here so that the mutex is unlocked prior to any of the callbacks being called.
         // This prevents the mutex from being poisoned if any of the callbacks panic, allowing it to be reused for further tests.
-        //
-        // TODO: replace .retain with .extract_if once Rust 1.87 is stable
         let mut requests = self.requests.lock().unwrap_or_else(|err| err.into_inner());
-        let mut completed: Vec<Result<T, ()>> = Vec::new();
-        requests.retain(|_id, req| match req.status {
-            RequestStatus::InProgress => true,
-            RequestStatus::Success => {
-                let data = req.data.take().ok_or(());
-                completed.push(data);
-                false
-            }
-            RequestStatus::Error => {
-                completed.push(Err(()));
-                false
-            }
-        });
+        let completed: Vec<Result<T, ()>> = requests
+            .extract_if(|_, req| !matches!(req.status, RequestStatus::InProgress))
+            .map(|(_, mut req)| req.data.take().ok_or(()))
+            .collect();
         drop(requests);
 
         for data in completed.into_iter().flatten() {


### PR DESCRIPTION
## Summary

Refactor `wpt/runner/src/net_provider.rs` to use `extract_if` instead of `retain` for cleaning up completed network requests.

## Motivation

The previous implementation used `.retain()` with side effects inside the predicate (pushing to `completed` vector). This is poor style because:

1. Side effects in predicates are hard to reason about
2. The intent is unclear - `.retain()` is for filtering, not extracting

## Changes

Replace the `.retain()` pattern with a cleaner `extract_if` + `map` approach:

```rust
// Before
requests.retain(|_id, req| match req.status {
    RequestStatus::InProgress => true,
    RequestStatus::Success => { completed.push(data); false }
    RequestStatus::Error => { completed.push(Err(())); false }
});

// After
let completed: Vec<Result<T, ()>> = requests
    .extract_if(|_, req| !matches!(req.status, RequestStatus::InProgress))
    .map(|(_, mut req)| req.data.take().ok_or(()))
    .collect();
```

This:
- Uses `matches!` for readable status checking
- Has no side effects in the predicate
- Uses iterator methods to transform extracted items
- Is more idiomatic Rust