### PR TITLE
Fix panic in resolve_stylist when animation entry is stale

### DIFF
--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -76,11 +76,17 @@ impl crate::document::BaseDocument {
             .flush(&guards)
             .process_style(root, Some(&self.snapshots));
 
-        // Mark actively animating nodes as dirty
+        // Mark actively animating nodes as dirty.
+        // Use get_mut to skip stale entries: stylo can hold animation keys for
+        // nodes already removed from the slab, and direct indexing panics on
+        // invalid keys. See https://github.com/DioxusLabs/blitz/issues/407
         let mut sets = self.animations.sets.write();
         for (key, set) in sets.iter_mut() {
             let node_id = key.node.id();
-            self.nodes[node_id].set_restyle_hint(RestyleHint::RESTYLE_SELF);
+            let Some(node) = self.nodes.get_mut(node_id) else {
+                continue; // stale animation entry — node removed from slab
+            };
+            node.set_restyle_hint(RestyleHint::RESTYLE_SELF);
 
             for animation in set.animations.iter_mut() {
                 if animation.state == AnimationState::Pending && animation.started_at <= now {

--- a/packages/blitz-dom/tests/stylo_test.rs
+++ b/packages/blitz-dom/tests/stylo_test.rs
@@ -1,0 +1,9 @@
+use blitz_dom::{BaseDocument, DocumentConfig};
+
+/// Smoke-test: resolve on an empty document must not panic.
+#[test]
+fn resolve_empty_document_does_not_panic() {
+    let mut doc = BaseDocument::new(DocumentConfig::default());
+    doc.resolve(0.0);
+    doc.resolve(0.1);
+}

--- a/packages/blitz-html/tests/html_document_test.rs
+++ b/packages/blitz-html/tests/html_document_test.rs
@@ -1,0 +1,28 @@
+use blitz_dom::DocumentConfig;
+use blitz_html::HtmlDocument;
+
+/// Regression test for https://github.com/DioxusLabs/blitz/issues/407
+///
+/// `resolve_stylist` used to panic with "invalid key" when a CSS-animated node
+/// was removed between two `resolve` calls. Verify the second resolve is safe.
+#[test]
+fn resolve_does_not_panic_after_removing_animated_node() {
+    let html = r#"
+        <style>
+          @keyframes pulse { 0% { opacity: 1; } 100% { opacity: 0.5; } }
+          .pulse { animation: pulse 2s infinite; }
+        </style>
+        <div id="pulse-node" class="pulse">animated</div>
+    "#;
+
+    let mut doc = HtmlDocument::from_html(html, DocumentConfig::default());
+    doc.resolve(0.0);
+
+    let pulse_id = doc.get_element_by_id("pulse-node");
+    if let Some(id) = pulse_id {
+        doc.mutate().remove_and_drop_node(id);
+    }
+
+    // Must not panic: stale animation entry should be skipped safely.
+    doc.resolve(0.1);
+}


### PR DESCRIPTION
## Summary

Fixes #407 — panic with `"invalid key"` in `resolve_stylist` when an animation
entry's Slab key is stale after node removal.

## Change

1-line fix using `get_mut` to skip stale entries safely:

```rust
let Some(node) = self.nodes.get_mut(node_id) else {
    continue; // stale animation entry — node removed from slab
};
node.set_restyle_hint(RestyleHint::RESTYLE_SELF);
```

## Verification

- Reproduction in #407 panics on `main` (verified locally)
- With this patch, the same reproduction runs cleanly through hundreds of frames
- Used in a downstream Rust app (HTML console) for ~1 day with no regressions
- Regression test added in `packages/blitz-html/tests/html_document_test.rs`

## Notes

If you'd prefer a different approach (e.g. cleaning up `animations.sets` on node
removal at the source), happy to rework — just let me know your preference.

---

_Drafted with Claude, fix and reproduction hand-verified._
