### PR TITLE
Initial `user-select:none` implementation

### DIFF
--- a/apps/browser/assets/browser.css
+++ b/apps/browser/assets/browser.css
@@ -92,6 +92,7 @@ body,
   white-space: nowrap;
   font-size: 12px;
   font-family: sans-serif;
+  user-select: none;
 }
 
 .tab__close {

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -49,7 +49,7 @@ use style::queries::values::PrefersColorScheme;
 use style::selector_parser::ServoElementSnapshot;
 use style::servo_arc::Arc as ServoArc;
 use style::values::GenericAtomIdent;
-use style::values::computed::Overflow;
+use style::values::computed::{Overflow, UserSelect};
 use style::{
     device::Device,
     dom::{TDocument, TNode},
@@ -1372,6 +1372,7 @@ impl BaseDocument {
         }
 
         let style = node.primary_styles()?;
+        let user_select = style.clone_user_select();
         let keyword = stylo_to_cursor_icon(style.clone_cursor().keyword);
 
         // Return cursor from style if it is non-auto
@@ -1399,7 +1400,10 @@ impl BaseDocument {
 
         // Return text cursor for text nodes
         if self.hover_node_is_text {
-            return Some(CursorIcon::Text);
+            return Some(match user_select {
+                UserSelect::Text => CursorIcon::Text,
+                _ => CursorIcon::Default,
+            });
         }
 
         // Else fallback to default cursor

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -12,6 +12,7 @@ use blitz_traits::{
 };
 use keyboard_types::Modifiers;
 use markup5ever::local_name;
+use style::values::computed::UserSelect;
 
 use crate::{BaseDocument, node::SpecialElementData};
 
@@ -157,7 +158,25 @@ pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
         if dx.abs() > 2.0 || dy.abs() > 2.0 {
             match event.id {
                 BlitzPointerId::Mouse | BlitzPointerId::Pen => {
-                    doc.drag_mode = DragMode::Selecting;
+                    let node = &doc.nodes[doc.mousedown_node_id.unwrap()];
+                    if let Some(style) = node.primary_styles() {
+                        let user_select = style.clone_user_select();
+                        if user_select == UserSelect::None {
+                            // Do nothing. Continue with rest of function
+                        } else if user_select == UserSelect::Auto {
+                            if let Some(parent) = node.parent {
+                                let node = &doc.nodes[parent];
+                                if let Some(style) = node.primary_styles() {
+                                    let user_select = style.clone_user_select();
+                                    if user_select == UserSelect::None {
+                                        // Do nothing. Continue with rest of function
+                                    } else {
+                                        doc.drag_mode = DragMode::Selecting;
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
                 BlitzPointerId::Finger(_) => {
                     doc.drag_mode = DragMode::Panning(PanState {
@@ -202,7 +221,10 @@ pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
     let node = &mut doc.nodes[target];
     let Some(el) = node.data.downcast_element_mut() else {
         // Handle text selection extension for non-element nodes
-        if buttons != MouseEventButtons::None && doc.extend_text_selection_to_point(x, y) {
+        if buttons != MouseEventButtons::None
+            && doc.drag_mode == DragMode::Selecting
+            && doc.extend_text_selection_to_point(x, y)
+        {
             changed = true;
         }
         return changed;
@@ -242,6 +264,7 @@ pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
         changed = true;
     } else if event.is_mouse()
         && buttons != MouseEventButtons::None
+        && doc.drag_mode == DragMode::Selecting
         && doc.extend_text_selection_to_point(x, y)
     {
         changed = true;


### PR DESCRIPTION
This implementation only prevents starting a selection in the node, and does not prevent selecting pseudo-elements with `user-select: auto`.

~~Blocked on next Stylo v0.17 release~~ (now released)