### PR TITLE
perf(browser): move favicon probe off the page-load critical path

### DIFF
--- a/apps/browser/src/browser_history.rs
+++ b/apps/browser/src/browser_history.rs
@@ -77,10 +77,7 @@ impl<Lens> Store<BrowsingHistory, Lens> {
 //
 // Lives as a free function so it can be unit-tested without a Dioxus runtime;
 // the Store method above is the public surface.
-fn record_visit_into(
-    history: &mut VecDeque<HistoryEntry>,
-    entry: HistoryEntry,
-) -> HistoryEntryId {
+fn record_visit_into(history: &mut VecDeque<HistoryEntry>, entry: HistoryEntry) -> HistoryEntryId {
     if let Some(latest) = history.front_mut() {
         if latest.url == entry.url {
             latest.title = entry.title;

--- a/apps/browser/src/browser_history.rs
+++ b/apps/browser/src/browser_history.rs
@@ -46,11 +46,18 @@ pub struct BrowsingHistory {
 
 #[store(pub)]
 impl<Lens> Store<BrowsingHistory, Lens> {
-    fn record_visit(&self, entry: HistoryEntry)
+    fn record_visit(&self, entry: HistoryEntry) -> HistoryEntryId
     where
         Lens: Writable,
     {
-        record_visit_into(&mut self.entries().write(), entry);
+        record_visit_into(&mut self.entries().write(), entry)
+    }
+
+    fn set_favicon(&self, id: HistoryEntryId, favicon_url: Url)
+    where
+        Lens: Writable,
+    {
+        set_favicon_for_entry(&mut self.entries().write(), id, favicon_url);
     }
 
     fn clear(&self)
@@ -70,18 +77,37 @@ impl<Lens> Store<BrowsingHistory, Lens> {
 //
 // Lives as a free function so it can be unit-tested without a Dioxus runtime;
 // the Store method above is the public surface.
-fn record_visit_into(history: &mut VecDeque<HistoryEntry>, entry: HistoryEntry) {
+fn record_visit_into(
+    history: &mut VecDeque<HistoryEntry>,
+    entry: HistoryEntry,
+) -> HistoryEntryId {
     if let Some(latest) = history.front_mut() {
         if latest.url == entry.url {
             latest.title = entry.title;
             latest.favicon_url = entry.favicon_url;
             latest.visited_at = entry.visited_at;
-            return;
+            return latest.id;
         }
     }
+    let id = entry.id;
     history.push_front(entry);
     if history.len() > MAX_HISTORY_ENTRIES {
         history.truncate(MAX_HISTORY_ENTRIES);
+    }
+    id
+}
+
+// Patch a previously recorded entry's favicon. Used by the background favicon
+// probe to fill in the icon after the visit has already been recorded with
+// favicon=None. Silently no-ops if the entry has since aged out — that just
+// means the user navigated past it before the probe finished.
+fn set_favicon_for_entry(
+    history: &mut VecDeque<HistoryEntry>,
+    id: HistoryEntryId,
+    favicon_url: Url,
+) {
+    if let Some(entry) = history.iter_mut().find(|e| e.id == id) {
+        entry.favicon_url = Some(favicon_url);
     }
 }
 

--- a/apps/browser/src/document_loader.rs
+++ b/apps/browser/src/document_loader.rs
@@ -10,7 +10,7 @@ use dioxus_native::{SubDocumentAttr, prelude::*};
 use linebender_resource_handle::Blob;
 
 use crate::StdNetProvider;
-use crate::favicon::resolve_favicon_url;
+use crate::favicon::favicon_candidate;
 use crate::history::{BrowserNavProvider, History, SyncStore};
 
 pub enum DocumentLoaderStatus {
@@ -23,7 +23,11 @@ pub struct LoadedDocument {
     pub document: SubDocumentAttr,
     pub html_source: String,
     pub title: String,
-    pub favicon_url: Option<Url>,
+    // The favicon URL we'd probe for this page, computed without I/O. The
+    // actual fetch+decode runs in the background after the tab applies the
+    // load, so it doesn't block document swap-in. None means we couldn't even
+    // form a candidate (e.g. an error page with no base URL).
+    pub favicon_candidate: Option<Url>,
     // True for synthesized error/404 pages. Callers use this to gate side
     // effects that should only fire on real loads (e.g. recording history).
     pub is_error: bool,
@@ -92,7 +96,6 @@ impl DocumentLoader {
             Ok((resolved_url, bytes)) => {
                 tracing::info!("Loaded {}", resolved_url);
                 let base_url = resolved_url.clone();
-                let net_for_favicon = Arc::clone(&net_provider);
                 let config = make_doc_config(Some(resolved_url), net_provider, history, font_ctx);
 
                 let body_text;
@@ -108,17 +111,13 @@ impl DocumentLoader {
                     .find_title_node()
                     .map(|n| n.text_content())
                     .unwrap_or_default();
-                let favicon_url = resolve_favicon_url(
-                    &base_url,
-                    document.favicon_url().as_deref(),
-                    &net_for_favicon,
-                )
-                .await;
+                let favicon_candidate =
+                    favicon_candidate(base_url.as_str(), document.favicon_url().as_deref());
                 LoadedDocument {
                     document: SubDocumentAttr::new(document),
                     html_source: html.to_string(),
                     title: parsed_title,
-                    favicon_url,
+                    favicon_candidate,
                     is_error,
                 }
             }
@@ -145,7 +144,7 @@ impl DocumentLoader {
                     document: SubDocumentAttr::new(document),
                     html_source: error_html.to_string(),
                     title: parsed_title,
-                    favicon_url: None,
+                    favicon_candidate: None,
                     is_error: true,
                 }
             }

--- a/apps/browser/src/favicon.rs
+++ b/apps/browser/src/favicon.rs
@@ -14,16 +14,20 @@ use crate::StdNetProvider;
 static FAVICON_CACHE: LazyLock<RwLock<HashMap<Url, Url>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
-pub async fn resolve_favicon_url(
-    base_url: &str,
-    favicon_href: Option<&str>,
+// Synchronously resolve which URL we'd probe, without doing any I/O. This is
+// what the document loader hands to the tab so the load can return immediately;
+// the actual probe runs in the background via `probe_favicon_cached`.
+pub fn favicon_candidate(base_url: &str, favicon_href: Option<&str>) -> Option<Url> {
+    let base = Url::parse(base_url).ok()?;
+    favicon_href
+        .and_then(|href| base.join(href).ok())
+        .or_else(|| base.join("/favicon.ico").ok())
+}
+
+pub async fn probe_favicon_cached(
+    candidate: Url,
     net_provider: &Arc<StdNetProvider>,
 ) -> Option<Url> {
-    let base = Url::parse(base_url).ok()?;
-    let candidate = favicon_href
-        .and_then(|href| base.join(href).ok())
-        .or_else(|| base.join("/favicon.ico").ok())?;
-
     if let Ok(cache) = FAVICON_CACHE.read() {
         if let Some(cached) = cache.get(&candidate) {
             return Some(cached.clone());

--- a/apps/browser/src/tab.rs
+++ b/apps/browser/src/tab.rs
@@ -13,6 +13,7 @@ use crate::StdNetProvider;
 use crate::about_pages::{AboutPage, AboutPageView};
 use crate::browser_history::{BrowsingHistory, BrowsingHistoryStoreImplExt, HistoryEntry};
 use crate::document_loader::{DocumentLoader, DocumentLoaderStatus, LoadedDocument};
+use crate::favicon::probe_favicon_cached;
 use crate::history::{History, HistoryNav, SyncStore};
 
 pub type TabId = u64;
@@ -77,7 +78,10 @@ impl<Lens> Store<Tab, Lens> {
     {
         *self.html_source().write_unchecked() = loaded.html_source;
         *self.title().write_unchecked() = loaded.title;
-        *self.favicon_url().write_unchecked() = loaded.favicon_url;
+        // The favicon is filled in asynchronously by the caller — clear any
+        // stale icon from the previous page so we don't briefly show the wrong
+        // one while the background probe runs.
+        *self.favicon_url().write_unchecked() = None;
         *self.document().write_unchecked() = Some(loaded.document);
     }
 
@@ -172,16 +176,42 @@ pub fn TabWebView(
     use_effect(move || {
         if loaded_document.read().is_some() {
             if let Some(loaded) = loaded_document.write_unchecked().take().flatten() {
+                let candidate = loaded.favicon_candidate.clone();
                 // Only successful loads count as a visit. Synthesized 404 /
                 // network-error pages parse a title (so the tab strip shows
                 // something sensible) but shouldn't pollute history.
-                if !loaded.is_error {
+                let entry_id = if !loaded.is_error {
                     let url = tab.nav_history().current_url().read().url.clone();
                     let title = display_title(&loaded.title, &url);
-                    let favicon = loaded.favicon_url.clone();
-                    browsing_history.record_visit(HistoryEntry::new(url, title, favicon));
-                }
+                    Some(browsing_history.record_visit(HistoryEntry::new(url, title, None)))
+                } else {
+                    None
+                };
                 tab.apply_loaded_document(loaded);
+
+                // Probe the favicon off the load critical path. The page is
+                // already swapped in; the icon will pop in when the probe
+                // resolves. If the user navigates away first, we drop the
+                // result on the tab side (history still gets patched by id).
+                if let Some(candidate) = candidate {
+                    let net_provider = Arc::clone(&tab.loader_rc().net_provider);
+                    let page_url = tab.nav_history().current_url().read().url.clone();
+                    spawn(async move {
+                        let Some(resolved) =
+                            probe_favicon_cached(candidate, &net_provider).await
+                        else {
+                            return;
+                        };
+                        let still_current =
+                            tab.nav_history().current_url().read().url == page_url;
+                        if still_current {
+                            *tab.favicon_url().write_unchecked() = Some(resolved.clone());
+                        }
+                        if let Some(id) = entry_id {
+                            browsing_history.set_favicon(id, resolved);
+                        }
+                    });
+                }
             }
         }
     });

--- a/apps/browser/src/tab.rs
+++ b/apps/browser/src/tab.rs
@@ -197,13 +197,11 @@ pub fn TabWebView(
                     let net_provider = Arc::clone(&tab.loader_rc().net_provider);
                     let page_url = tab.nav_history().current_url().read().url.clone();
                     spawn(async move {
-                        let Some(resolved) =
-                            probe_favicon_cached(candidate, &net_provider).await
+                        let Some(resolved) = probe_favicon_cached(candidate, &net_provider).await
                         else {
                             return;
                         };
-                        let still_current =
-                            tab.nav_history().current_url().read().url == page_url;
+                        let still_current = tab.nav_history().current_url().read().url == page_url;
                         if still_current {
                             *tab.favicon_url().write_unchecked() = Some(resolved.clone());
                         }


### PR DESCRIPTION
Page navigations were blocking on a favicon fetch plus a full image decode before swapping in the new document, adding a round-trip of latency to every load. This moves the probe into a background task spawned after the document is applied, with stale-probe guards on the tab and id-keyed patching of history entries so a late-arriving icon still updates the right row.