### PR TITLE
WASM canvas resize: skip with_surface_size on wasm (alt to #431)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,8 @@ dependencies = [
  "keyboard-types 0.7.0",
  "rfd",
  "tracing",
+ "wasm-bindgen",
+ "web-sys",
  "web-time",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,9 @@ webbrowser = "1.0"
 directories = "6.0.0"
 
 # WASM
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
+web-sys = "0.3.98"
 web-time = "1"
 
 # Other dependencies

--- a/examples/seven_guis/Cargo.toml
+++ b/examples/seven_guis/Cargo.toml
@@ -39,5 +39,5 @@ blitz-shell = { workspace = true, default-features = false }
 dioxus-core = { workspace = true }
 winit = "=0.31.0-beta.2"
 parley = { version = "0.9", default-features = false, features = ["std"] }
-wasm-bindgen = "0.2"
+wasm-bindgen = { workspace = true }
 console_error_panic_hook = "0.1"

--- a/examples/seven_guis/index.html
+++ b/examples/seven_guis/index.html
@@ -5,8 +5,8 @@
     <title>7GUIs — blitz-native in your browser</title>
     <link data-trunk rel="rust" data-wasm-opt="z" data-cargo-features="hybrid" data-cargo-no-default-features data-target-name="seven_guis" />
     <style>
-      html, body { margin: 0; padding: 0; height: 100%; background: #f5f5f5; }
-      canvas { display: block; }
+      html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: #f5f5f5; }
+      canvas { display: block; width: 100%; height: 100%; }
     </style>
   </head>
   <body></body>

--- a/examples/seven_guis/src/lib.rs
+++ b/examples/seven_guis/src/lib.rs
@@ -11,7 +11,6 @@ mod wasm_entry {
     use dioxus_native::{DioxusDocument, DioxusNativeApplication, DioxusNativeWindowRenderer};
     use parley::fontique::{Blob, Collection, CollectionOptions, GenericFamily, SourceCache};
     use wasm_bindgen::prelude::*;
-    use winit::dpi::PhysicalSize;
     use winit::event_loop::{ControlFlow, EventLoop};
     use winit::platform::web::WindowAttributesWeb;
     use winit::window::WindowAttributes;
@@ -70,8 +69,10 @@ mod wasm_entry {
         // `vello-hybrid` feature is active (dioxus_renderer.rs:28-29).
         let renderer = DioxusNativeWindowRenderer::new();
 
+        // Intentionally no `.with_surface_size(...)` on wasm: letting winit-web set the
+        // canvas size writes fixed inline CSS (canvas.style.width/height) that overrides
+        // host stylesheet rules and suppresses ResizeObserver. Host CSS sizes the canvas.
         let attrs = WindowAttributes::default()
-            .with_surface_size(PhysicalSize::new(1024u32, 768u32))
             .with_platform_attributes(Box::new(WindowAttributesWeb::default().with_append(true)));
 
         let config = WindowConfig::with_attributes(Box::new(doc) as _, renderer, attrs);

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -46,7 +46,7 @@ blitz-shell = { workspace = true, default-features = false }
 dioxus-core = { workspace = true }
 winit = "=0.31.0-beta.2"
 parley = { version = "0.9", default-features = false, features = ["std"] }
-wasm-bindgen = "0.2"
+wasm-bindgen = { workspace = true }
 console_error_panic_hook = "0.1"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -5,8 +5,8 @@
     <title>TodoMVC — blitz-native in your browser</title>
     <link data-trunk rel="rust" data-wasm-opt="z" data-cargo-features="hybrid" data-cargo-no-default-features data-target-name="todomvc" />
     <style>
-      html, body { margin: 0; padding: 0; height: 100%; background: #f5f5f5; }
-      canvas { display: block; }
+      html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: #f5f5f5; }
+      canvas { display: block; width: 100%; height: 100%; }
     </style>
   </head>
   <body></body>

--- a/examples/todomvc/src/wasm.rs
+++ b/examples/todomvc/src/wasm.rs
@@ -6,7 +6,6 @@ use dioxus_core::VirtualDom;
 use dioxus_native::{DioxusDocument, DioxusNativeApplication, DioxusNativeWindowRenderer};
 use parley::fontique::{Blob, Collection, CollectionOptions, GenericFamily, SourceCache};
 use wasm_bindgen::prelude::*;
-use winit::dpi::PhysicalSize;
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::platform::web::WindowAttributesWeb;
 use winit::window::WindowAttributes;
@@ -58,8 +57,10 @@ pub fn start() -> Result<(), JsValue> {
 
     let renderer = DioxusNativeWindowRenderer::new();
 
+    // Intentionally no `.with_surface_size(...)` on wasm: letting winit-web set the
+    // canvas size writes fixed inline CSS (canvas.style.width/height) that overrides
+    // host stylesheet rules and suppresses ResizeObserver. Host CSS sizes the canvas.
     let attrs = WindowAttributes::default()
-        .with_surface_size(PhysicalSize::new(1024u32, 768u32))
         .with_platform_attributes(Box::new(WindowAttributesWeb::default().with_append(true)));
 
     let config = WindowConfig::with_attributes(Box::new(doc) as _, renderer, attrs);

--- a/examples/wasm_hello/src/lib.rs
+++ b/examples/wasm_hello/src/lib.rs
@@ -12,7 +12,6 @@ use blitz_shell::{BlitzApplication, BlitzShellProxy, WindowConfig};
 use parley::fontique::{Blob, Collection, CollectionOptions, GenericFamily, SourceCache};
 use tracing::info;
 use wasm_bindgen::prelude::*;
-use winit::dpi::LogicalSize;
 use winit::event_loop::EventLoop;
 use winit::platform::web::WindowAttributesWeb;
 use winit::window::WindowAttributes;
@@ -109,9 +108,6 @@ pub fn start() -> Result<(), JsValue> {
     let canvas = document.get_element_by_id("blitz-target").unwrap();
     let canvas = canvas.dyn_into::<web_sys::HtmlCanvasElement>().unwrap();
 
-    let width = canvas.offset_width() as u32;
-    let height = canvas.offset_height() as u32;
-
     // Make sure the canvas can be given focus.
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
     canvas.set_tab_index(0);
@@ -131,10 +127,10 @@ pub fn start() -> Result<(), JsValue> {
         },
     );
 
-    // winit-web requires an attached canvas with a definite size before surface
-    // creation, so request the size up front and let winit auto-append the canvas.
+    // Intentionally no `.with_surface_size(...)` on wasm: letting winit-web set the
+    // canvas size writes fixed inline CSS (canvas.style.width/height) that overrides
+    // host stylesheet rules and suppresses ResizeObserver. Host CSS sizes the canvas.
     let attrs = WindowAttributes::default()
-        .with_surface_size(LogicalSize::new(width, height))
         .with_platform_attributes(Box::new(
             WindowAttributesWeb::default().with_canvas(Some(canvas)),
         ));

--- a/packages/blitz-shell/Cargo.toml
+++ b/packages/blitz-shell/Cargo.toml
@@ -45,6 +45,10 @@ data-url = { workspace = true, optional = true }
 # WASM
 web-time = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { workspace = true, features = ["HtmlCanvasElement", "Window"] }
+wasm-bindgen = { workspace = true }
+
 [target.'cfg(target_os = "android")'.dependencies]
 android-activity = { version = "0.6.0" }
 

--- a/packages/blitz-shell/src/application.rs
+++ b/packages/blitz-shell/src/application.rs
@@ -90,6 +90,12 @@ impl<Rend: WindowRenderer> BlitzApplication<Rend> {
             BlitzShellEvent::NavigationLoad { .. } => {
                 // Do nothing. Should be handled by embedders (if required).
             }
+            #[cfg(target_arch = "wasm32")]
+            BlitzShellEvent::ResizeSettleCheck { window_id } => {
+                if let Some(window) = self.windows.get_mut(&window_id) {
+                    window.apply_pending_resize_if_settled();
+                }
+            }
         }
     }
 }

--- a/packages/blitz-shell/src/event.rs
+++ b/packages/blitz-shell/src/event.rs
@@ -45,6 +45,14 @@ pub enum BlitzShellEvent {
         retain_scroll_position: bool,
         is_md: bool,
     },
+
+    /// Delivered after the WASM resize-debounce window expires. Route to
+    /// `View::apply_pending_resize_if_settled`, which applies the pending
+    /// size iff motion has actually settled.
+    #[cfg(target_arch = "wasm32")]
+    ResizeSettleCheck {
+        window_id: WindowId,
+    },
 }
 impl BlitzShellEvent {
     pub fn embedder_event<T: Any + Send + Sync>(value: T) -> Self {

--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -82,6 +82,16 @@ pub struct View<Rend: WindowRenderer> {
     pub is_visible: bool,
     pub safe_area_insets: PhysicalInsets<u32>,
 
+    #[cfg(target_arch = "wasm32")]
+    pending_resize: Option<winit::dpi::PhysicalSize<u32>>,
+    #[cfg(target_arch = "wasm32")]
+    last_resize_at: Option<web_time::Instant>,
+    /// True iff a setTimeout has been scheduled and not yet observed by
+    /// `apply_pending_resize_if_settled`. Prevents the timer storm that would
+    /// otherwise allocate a fresh `Closure` per resize event during a drag.
+    #[cfg(target_arch = "wasm32")]
+    resize_timer_scheduled: bool,
+
     #[cfg(feature = "accessibility")]
     /// Accessibility adapter for `accesskit`.
     pub accessibility: AccessibilityState,
@@ -126,6 +136,21 @@ impl<Rend: WindowRenderer> View<Rend> {
         {
             size = requested.to_physical(scale as f64);
         }
+        // On wasm, when the embedder didn't call `with_surface_size`, winit-web's
+        // initial `surface_size()` is 0×0 — its ResizeObserver hasn't fired yet.
+        // Resuming the renderer at 0×0 trips a wgpu swapchain-size-0 error, so
+        // seed from the canvas element's CSS layout box (host-stylesheet result).
+        #[cfg(target_arch = "wasm32")]
+        if size.width == 0 || size.height == 0 {
+            use winit::platform::web::WindowExtWeb;
+            if let Some(canvas) = winit_window.canvas() {
+                let css_w = canvas.offset_width().max(0) as u32;
+                let css_h = canvas.offset_height().max(0) as u32;
+                if css_w > 0 && css_h > 0 {
+                    size = winit::dpi::LogicalSize::new(css_w, css_h).to_physical(scale as f64);
+                }
+            }
+        }
         let safe_area_insets = get_safe_area_insets(&*winit_window);
         let theme = winit_window.theme().unwrap_or(Theme::Light);
         let color_scheme = theme_to_color_scheme(theme);
@@ -160,6 +185,12 @@ impl<Rend: WindowRenderer> View<Rend> {
             theme_override: None,
             buttons: MouseEventButtons::None,
             safe_area_insets,
+            #[cfg(target_arch = "wasm32")]
+            pending_resize: None,
+            #[cfg(target_arch = "wasm32")]
+            last_resize_at: None,
+            #[cfg(target_arch = "wasm32")]
+            resize_timer_scheduled: false,
             pointer_pos: Default::default(),
             is_visible: winit_window.is_visible().unwrap_or(true),
             #[cfg(feature = "accessibility")]
@@ -416,6 +447,57 @@ impl<Rend: WindowRenderer> View<Rend> {
         self.accessibility.update_tree(&inner);
     }
 
+    #[cfg(target_arch = "wasm32")]
+    const RESIZE_DEBOUNCE_MS: u32 = 100;
+
+    #[cfg(target_arch = "wasm32")]
+    fn schedule_resize_settle_check(&mut self, delay_ms: u32) {
+        use wasm_bindgen::JsCast;
+        use wasm_bindgen::closure::Closure;
+
+        let proxy = self.proxy.clone();
+        let window_id = self.window_id();
+        let cb = Closure::once_into_js(move || {
+            proxy.send_event(BlitzShellEvent::ResizeSettleCheck { window_id });
+        });
+        if let Some(win) = web_sys::window() {
+            let _ = win.set_timeout_with_callback_and_timeout_and_arguments_0(
+                cb.unchecked_ref(),
+                delay_ms as i32,
+            );
+            self.resize_timer_scheduled = true;
+        }
+    }
+
+    /// Applies the pending resize iff motion has been quiet for the debounce
+    /// window; otherwise re-arms the timer for the remaining time. Called
+    /// when a previously scheduled timer fires.
+    #[cfg(target_arch = "wasm32")]
+    pub fn apply_pending_resize_if_settled(&mut self) {
+        self.resize_timer_scheduled = false;
+        let Some(last) = self.last_resize_at else {
+            return;
+        };
+        let debounce = std::time::Duration::from_millis(Self::RESIZE_DEBOUNCE_MS as u64);
+        let elapsed = web_time::Instant::now().saturating_duration_since(last);
+        if elapsed < debounce {
+            // Motion ongoing — wait out the rest of the window before re-checking.
+            let remaining_ms = (debounce - elapsed).as_millis() as u32;
+            self.schedule_resize_settle_check(remaining_ms);
+            return;
+        }
+        let Some(size) = self.pending_resize.take() else {
+            return;
+        };
+        self.last_resize_at = None;
+
+        let insets = self.safe_area_insets;
+        let width = size.width.saturating_sub(insets.left + insets.right);
+        let height = size.height.saturating_sub(insets.top + insets.bottom);
+        self.with_viewport(|v| v.window_size = (width, height));
+        self.request_redraw();
+    }
+
     #[cfg(target_os = "macos")]
     pub fn handle_apple_standard_keybinding(&mut self, command: &str) {
         use blitz_traits::SmolStr;
@@ -447,11 +529,25 @@ impl<Rend: WindowRenderer> View<Rend> {
             },
             WindowEvent::SurfaceResized(physical_size) => {
                 self.safe_area_insets = get_safe_area_insets(&*self.window);
-                let insets = self.safe_area_insets;
-                let width = physical_size.width - insets.left - insets.right;
-                let height = physical_size.height - insets.top - insets.bottom;
-                self.with_viewport(|v| v.window_size = (width, height));
-                self.request_redraw();
+                // On WASM, defer the apply: wgpu's surface.configure clears the canvas,
+                // so running it every frame flickers during a drag. The browser stretches
+                // the stale backing store until the debounce timer settles.
+                #[cfg(target_arch = "wasm32")]
+                {
+                    self.pending_resize = Some(physical_size);
+                    self.last_resize_at = Some(web_time::Instant::now());
+                    if !self.resize_timer_scheduled {
+                        self.schedule_resize_settle_check(Self::RESIZE_DEBOUNCE_MS);
+                    }
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let insets = self.safe_area_insets;
+                    let width = physical_size.width - insets.left - insets.right;
+                    let height = physical_size.height - insets.top - insets.bottom;
+                    self.with_viewport(|v| v.window_size = (width, height));
+                    self.request_redraw();
+                }
             }
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
                 self.with_viewport(|v| v.set_hidpi_scale(scale_factor as f32));


### PR DESCRIPTION
Alternative to #431 implementing @nicoburns's hypothesis: drop `.with_surface_size(...)` on wasm so winit-web never writes inline `canvas.style.width/height`, letting host CSS size the canvas directly — no style-stripping needed. Same wgpu `surface.configure` debounce as #431 (with timer coalescing to avoid closure leaks during drag), plus a fallback that seeds the initial size from the canvas's CSS layout when winit-web reports 0×0 at init.