### PR TITLE
Make dioxus_native::launch_cfg work on WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6501,16 +6501,11 @@ name = "seven_guis"
 version = "0.1.0"
 dependencies = [
  "anyrender_vello_hybrid",
- "blitz-dom",
- "blitz-shell",
  "console_error_panic_hook",
- "dioxus-core",
  "dioxus-native",
  "futures-timer",
  "idna_adapter",
- "parley",
  "wasm-bindgen",
- "winit",
 ]
 
 [[package]]
@@ -7448,16 +7443,11 @@ version = "0.1.0"
 dependencies = [
  "android-activity",
  "anyrender_vello_hybrid",
- "blitz-dom",
- "blitz-shell",
  "console_error_panic_hook",
- "dioxus-core",
  "dioxus-native",
  "idna_adapter",
- "parley",
  "tracing-subscriber",
  "wasm-bindgen",
- "winit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3.98"
 web-time = "1"
+console_error_panic_hook = "0.1"
 
 # Other dependencies
 rustc-hash = "2.1.2"

--- a/examples/seven_guis/Cargo.toml
+++ b/examples/seven_guis/Cargo.toml
@@ -34,10 +34,6 @@ dioxus-native = { workspace = true, features = ["system-fonts"] }
 # WASM-only: additive wasm-bindgen feature on futures-timer
 futures-timer = { version = "3", features = ["wasm-bindgen"] }
 anyrender_vello_hybrid = { version = "0.4", features = ["webgl"] }
-blitz-dom   = { workspace = true, default-features = false, features = ["woff"] }
-blitz-shell = { workspace = true, default-features = false }
-dioxus-core = { workspace = true }
-winit = "=0.31.0-beta.2"
-parley = { version = "0.9", default-features = false, features = ["std"] }
+dioxus-native = { workspace = true, features = ["woff"] }
 wasm-bindgen = { workspace = true }
-console_error_panic_hook = "0.1"
+console_error_panic_hook = { workspace = true }

--- a/examples/seven_guis/src/lib.rs
+++ b/examples/seven_guis/src/lib.rs
@@ -3,84 +3,19 @@ pub mod tasks;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm_entry {
-    use std::sync::Arc;
-
-    use blitz_dom::{DocumentConfig, FontContext, decode_font_bytes};
-    use blitz_shell::{BlitzShellProxy, WindowConfig};
-    use dioxus_core::VirtualDom;
-    use dioxus_native::{DioxusDocument, DioxusNativeApplication, DioxusNativeWindowRenderer};
-    use parley::fontique::{Blob, Collection, CollectionOptions, GenericFamily, SourceCache};
+    use dioxus_native::{Config, build_single_font_ctx};
     use wasm_bindgen::prelude::*;
-    use winit::event_loop::{ControlFlow, EventLoop};
-    use winit::platform::web::WindowAttributesWeb;
-    use winit::window::WindowAttributes;
 
-    /// DejaVu Sans bundled so the document has a real font on wasm32 (browsers
-    /// don't expose system fonts to wasm). License: Bitstream Vera / DejaVu (permissive).
     const DEJAVU_SANS: &[u8] = include_bytes!("../assets/DejaVuSans.woff2");
 
-    fn build_font_context() -> FontContext {
-        let mut ctx = FontContext {
-            source_cache: SourceCache::new_shared(),
-            collection: Collection::new(CollectionOptions {
-                shared: false,
-                system_fonts: false,
-            }),
-        };
-        let font_bytes = decode_font_bytes(DEJAVU_SANS).into_owned();
-        let registered = ctx
-            .collection
-            .register_fonts(Blob::new(Arc::new(font_bytes) as _), None);
-        let family_ids: Vec<_> = registered.iter().map(|(id, _)| *id).collect();
-        for generic in [
-            GenericFamily::SansSerif,
-            GenericFamily::Serif,
-            GenericFamily::Monospace,
-            GenericFamily::SystemUi,
-        ] {
-            ctx.collection
-                .append_generic_families(generic, family_ids.iter().copied());
-        }
-        ctx
-    }
-
     #[wasm_bindgen(start)]
-    pub fn start() -> Result<(), JsValue> {
+    pub fn start() {
         console_error_panic_hook::set_once();
-
-        let event_loop = EventLoop::new().map_err(|e| JsValue::from_str(&format!("{e}")))?;
-        // Wait avoids main-thread saturation but throttles timer-driven renders to
-        // ~1Hz on web (winit's web backend uses a long-interval fallback when
-        // there's no rAF pending). Poll fixes the timer but lags the address bar.
-        event_loop.set_control_flow(ControlFlow::Wait);
-        let winit_proxy = event_loop.create_proxy();
-        let (proxy, event_queue) = BlitzShellProxy::new(winit_proxy);
-
-        let vdom = VirtualDom::new(super::app::app);
-        let doc = DioxusDocument::new(
-            vdom,
-            DocumentConfig {
-                font_ctx: Some(build_font_context()),
-                ..Default::default()
-            },
+        let font_ctx = build_single_font_ctx(DEJAVU_SANS);
+        dioxus_native::launch_cfg(
+            super::app::app,
+            vec![],
+            vec![Box::new(Config::new().with_font_ctx(font_ctx))],
         );
-
-        // DioxusNativeWindowRenderer wraps VelloHybridWindowRenderer when the
-        // `vello-hybrid` feature is active (dioxus_renderer.rs:28-29).
-        let renderer = DioxusNativeWindowRenderer::new();
-
-        // Intentionally no `.with_surface_size(...)` on wasm: letting winit-web set the
-        // canvas size writes fixed inline CSS (canvas.style.width/height) that overrides
-        // host stylesheet rules and suppresses ResizeObserver. Host CSS sizes the canvas.
-        let attrs = WindowAttributes::default()
-            .with_platform_attributes(Box::new(WindowAttributesWeb::default().with_append(true)));
-
-        let config = WindowConfig::with_attributes(Box::new(doc) as _, renderer, attrs);
-        let application = DioxusNativeApplication::new(proxy, event_queue, config);
-
-        event_loop
-            .run_app(application)
-            .map_err(|e| JsValue::from_str(&format!("{e}")))?;
-        Ok(())
     }
 }

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -39,15 +39,10 @@ idna_adapter = "=1.0.0"
 dioxus-native = { workspace = true, features = ["svg", "system-fonts", "data-uri", "prelude"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-dioxus-native = { workspace = true, features = ["svg", "data-uri", "prelude", "vello-hybrid"] }
+dioxus-native = { workspace = true, features = ["svg", "data-uri", "prelude", "vello-hybrid", "woff"] }
 anyrender_vello_hybrid = { version = "0.4", features = ["webgl"] }
-blitz-dom   = { workspace = true, default-features = false, features = ["woff"] }
-blitz-shell = { workspace = true, default-features = false }
-dioxus-core = { workspace = true }
-winit = "=0.31.0-beta.2"
-parley = { version = "0.9", default-features = false, features = ["std"] }
 wasm-bindgen = { workspace = true }
-console_error_panic_hook = "0.1"
+console_error_panic_hook = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android-activity = { version = "0.6.0", features = ["native-activity"] }

--- a/examples/todomvc/src/wasm.rs
+++ b/examples/todomvc/src/wasm.rs
@@ -1,73 +1,15 @@
-use std::sync::Arc;
-
-use blitz_dom::{DocumentConfig, FontContext, decode_font_bytes};
-use blitz_shell::{BlitzShellProxy, WindowConfig};
-use dioxus_core::VirtualDom;
-use dioxus_native::{DioxusDocument, DioxusNativeApplication, DioxusNativeWindowRenderer};
-use parley::fontique::{Blob, Collection, CollectionOptions, GenericFamily, SourceCache};
+use dioxus_native::{Config, build_single_font_ctx};
 use wasm_bindgen::prelude::*;
-use winit::event_loop::{ControlFlow, EventLoop};
-use winit::platform::web::WindowAttributesWeb;
-use winit::window::WindowAttributes;
 
 const DEJAVU_SANS: &[u8] = include_bytes!("../assets/DejaVuSans.woff2");
 
-fn build_font_context() -> FontContext {
-    let mut ctx = FontContext {
-        source_cache: SourceCache::new_shared(),
-        collection: Collection::new(CollectionOptions {
-            shared: false,
-            system_fonts: false,
-        }),
-    };
-    let font_bytes = decode_font_bytes(DEJAVU_SANS).into_owned();
-    let registered = ctx
-        .collection
-        .register_fonts(Blob::new(Arc::new(font_bytes) as _), None);
-    let family_ids: Vec<_> = registered.iter().map(|(id, _)| *id).collect();
-    for generic in [
-        GenericFamily::SansSerif,
-        GenericFamily::Serif,
-        GenericFamily::Monospace,
-        GenericFamily::SystemUi,
-    ] {
-        ctx.collection
-            .append_generic_families(generic, family_ids.iter().copied());
-    }
-    ctx
-}
-
 #[wasm_bindgen(start)]
-pub fn start() -> Result<(), JsValue> {
+pub fn start() {
     console_error_panic_hook::set_once();
-
-    let event_loop = EventLoop::new().map_err(|e| JsValue::from_str(&format!("{e}")))?;
-    event_loop.set_control_flow(ControlFlow::Wait);
-    let winit_proxy = event_loop.create_proxy();
-    let (proxy, event_queue) = BlitzShellProxy::new(winit_proxy);
-
-    let vdom = VirtualDom::new(super::app::app);
-    let doc = DioxusDocument::new(
-        vdom,
-        DocumentConfig {
-            font_ctx: Some(build_font_context()),
-            ..Default::default()
-        },
+    let font_ctx = build_single_font_ctx(DEJAVU_SANS);
+    dioxus_native::launch_cfg(
+        super::app::app,
+        vec![],
+        vec![Box::new(Config::new().with_font_ctx(font_ctx))],
     );
-
-    let renderer = DioxusNativeWindowRenderer::new();
-
-    // Intentionally no `.with_surface_size(...)` on wasm: letting winit-web set the
-    // canvas size writes fixed inline CSS (canvas.style.width/height) that overrides
-    // host stylesheet rules and suppresses ResizeObserver. Host CSS sizes the canvas.
-    let attrs = WindowAttributes::default()
-        .with_platform_attributes(Box::new(WindowAttributesWeb::default().with_append(true)));
-
-    let config = WindowConfig::with_attributes(Box::new(doc) as _, renderer, attrs);
-    let application = DioxusNativeApplication::new(proxy, event_queue, config);
-
-    event_loop
-        .run_app(application)
-        .map_err(|e| JsValue::from_str(&format!("{e}")))?;
-    Ok(())
 }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -343,7 +343,10 @@ impl BaseDocument {
                     source_cache: SourceCache::new_shared(),
                     collection: Collection::new(CollectionOptions {
                         shared: false,
-                        system_fonts: true,
+                        system_fonts: cfg!(all(
+                            feature = "system_fonts",
+                            not(target_arch = "wasm32")
+                        )),
                     }),
                 };
                 font_ctx

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -90,3 +90,36 @@ pub type SelectorList = selectors::SelectorList<style::selector_parser::Selector
 pub use events::{EventDriver, EventHandler, NoopEventHandler};
 pub use html::{DummyHtmlParserProvider, HtmlParserProvider};
 pub use util::{Point, decode_font_bytes};
+
+/// Convenience builder for the one-font case: produces a [`FontContext`] with
+/// system-font discovery disabled and the supplied font registered as the
+/// fallback for every generic family. The standard setup for WASM, where
+/// browsers don't expose system fonts. WOFF/WOFF2 inputs are decoded
+/// automatically.
+pub fn build_single_font_ctx(font_data: &[u8]) -> FontContext {
+    use parley::fontique::{Blob, Collection, CollectionOptions, GenericFamily, SourceCache};
+    use std::sync::Arc;
+
+    let mut ctx = FontContext {
+        source_cache: SourceCache::new_shared(),
+        collection: Collection::new(CollectionOptions {
+            shared: false,
+            system_fonts: false,
+        }),
+    };
+    let decoded = decode_font_bytes(font_data).into_owned();
+    let registered = ctx
+        .collection
+        .register_fonts(Blob::new(Arc::new(decoded) as _), None);
+    let family_ids: Vec<_> = registered.iter().map(|(id, _)| *id).collect();
+    for generic in [
+        GenericFamily::SansSerif,
+        GenericFamily::Serif,
+        GenericFamily::Monospace,
+        GenericFamily::SystemUi,
+    ] {
+        ctx.collection
+            .append_generic_families(generic, family_ids.iter().copied());
+    }
+    ctx
+}

--- a/packages/dioxus-native/Cargo.toml
+++ b/packages/dioxus-native/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://dioxuslabs.com/learn/0.7/getting_started"
 keywords = ["dom", "ui", "gui", "react"]
 
 [features]
-default = ["accessibility", "hot-reload", "net", "html", "svg", "system-fonts", "clipboard", "file_dialog", "vello", "incremental"]
+default = ["accessibility", "hot-reload", "net", "html", "svg", "system-fonts", "clipboard", "file_dialog", "vello", "incremental", "woff"]
 prelude = ["dep:dioxus-core-macro", "dep:dioxus-hooks", "dep:dioxus-signals", "dep:dioxus-stores", "dep:manganis"]
 
 # DOM features
@@ -19,6 +19,9 @@ floats = ["blitz-dom/floats"]
 incremental = ["blitz-dom/incremental"]
 autofocus = ["blitz-dom/autofocus"]
 system-fonts = ["blitz-dom/system_fonts"]
+# WOFF/WOFF2 decoder. Default-on so wasm callers (which can't use system fonts)
+# can bundle compressed fonts without extra setup.
+woff = ["blitz-dom/woff"]
 
 # Shell Features
 clipboard = ["blitz-shell/clipboard"]
@@ -38,6 +41,8 @@ vello-cpu-base = ["alt-renderer", "dep:anyrender_vello_cpu"]
 alt-renderer = []
 
 # Other features
+# No-op on wasm32 (blitz_net::Provider needs tokio's threaded runtime); launch_cfg
+# falls back to the in-process DioxusNativeNetProvider there.
 net = ["dep:tokio", "dep:blitz-net"]
 html = ["dep:blitz-html"]
 

--- a/packages/dioxus-native/src/config.rs
+++ b/packages/dioxus-native/src/config.rs
@@ -1,19 +1,37 @@
+use blitz_dom::FontContext;
 use dioxus_core::LaunchConfig;
 use winit::window::WindowAttributes;
 
-/// The configuration for the desktop application.
+/// Launch-time configuration for a dioxus-native application.
 pub struct Config {
     pub(crate) window_attributes: WindowAttributes,
+    pub(crate) font_ctx: Option<FontContext>,
 }
 
 impl LaunchConfig for Config {}
 
 impl Default for Config {
     fn default() -> Self {
+        let window_attributes = WindowAttributes::default()
+            .with_title(dioxus_cli_config::app_title().unwrap_or_else(|| "Dioxus App".to_string()));
+
+        // On WASM, append the canvas to the document body. Surface size is
+        // intentionally not seeded: winit-web's with_surface_size writes inline
+        // canvas.style.width/height that overrides host CSS. View::init reads
+        // the canvas's CSS layout box when winit reports a 0×0 initial size.
+        // To target an existing `<canvas>`, replace these attributes via
+        // [`Config::with_window_attributes`].
+        #[cfg(target_arch = "wasm32")]
+        let window_attributes = {
+            use winit::platform::web::WindowAttributesWeb;
+            window_attributes.with_platform_attributes(Box::new(
+                WindowAttributesWeb::default().with_append(true),
+            ))
+        };
+
         Self {
-            window_attributes: WindowAttributes::default().with_title(
-                dioxus_cli_config::app_title().unwrap_or_else(|| "Dioxus App".to_string()),
-            ),
+            window_attributes,
+            font_ctx: None,
         }
     }
 }
@@ -25,8 +43,17 @@ impl Config {
 
     /// Set the configuration for the window.
     pub fn with_window_attributes(mut self, attrs: WindowAttributes) -> Self {
-        // We need to do a swap because the window builder only takes itself as muy self
         self.window_attributes = attrs;
+        self
+    }
+
+    /// Set a custom [`FontContext`] for the document.
+    ///
+    /// On WASM, browsers don't expose system fonts, so a `FontContext` with
+    /// bundled fonts must be provided. Use [`crate::build_single_font_ctx`] for
+    /// the common one-font case.
+    pub fn with_font_ctx(mut self, font_ctx: FontContext) -> Self {
+        self.font_ctx = Some(font_ctx);
         self
     }
 }

--- a/packages/dioxus-native/src/lib.rs
+++ b/packages/dioxus-native/src/lib.rs
@@ -19,7 +19,7 @@ mod link_handler;
 #[cfg(feature = "prelude")]
 pub mod prelude;
 
-#[cfg(feature = "net")]
+#[cfg(all(feature = "net", not(target_arch = "wasm32")))]
 use blitz_traits::net::NetProvider;
 #[doc(inline)]
 pub use dioxus_native_dom::*;
@@ -59,7 +59,7 @@ pub use {
     dioxus_renderer::{Features, Limits},
 };
 
-pub use blitz_dom::Widget;
+pub use blitz_dom::{FontContext, Widget, build_single_font_ctx};
 pub use config::Config;
 pub use winit::dpi::{LogicalSize, PhysicalSize};
 pub use winit::window::WindowAttributes;
@@ -182,17 +182,15 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
         })
     }
 
-    // Spin up the virtualdom
-    // We're going to need to hit it with a special waker
-    // Note that we are delaying the initialization of window-specific contexts (net provider, document, etc)
+    // Build the vdom first; the net provider, document, and other window-bound
+    // contexts are attached below once the event-loop proxy exists.
     let mut vdom = VirtualDom::new_with_props(app, props);
 
-    // Add contexts
     for context in contexts {
         vdom.insert_any_root_context(context());
     }
 
-    #[cfg(feature = "net")]
+    #[cfg(all(feature = "net", not(target_arch = "wasm32")))]
     let net_provider = {
         let net_waker = Some(Arc::new(proxy.clone()) as _);
         let inner_net_provider = Arc::new(blitz_net::Provider::new(net_waker));
@@ -204,7 +202,7 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
         )) as Arc<dyn NetProvider>
     };
 
-    #[cfg(not(feature = "net"))]
+    #[cfg(any(not(feature = "net"), target_arch = "wasm32"))]
     let net_provider = DioxusNativeNetProvider::shared(proxy.clone());
 
     vdom.provide_root_context(Arc::clone(&net_provider));
@@ -227,6 +225,7 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
             net_provider: Some(net_provider),
             html_parser_provider,
             navigation_provider,
+            font_ctx: config.font_ctx,
             ..Default::default()
         },
     );


### PR DESCRIPTION
Adds `Config::with_font_ctx` and seeds a `with_append(true)` wasm canvas default so `dioxus_native::launch_cfg` compiles and runs on `wasm32` (with the tokio-backed `blitz_net::Provider` gated off there). The seven_guis and todomvc examples collapse their hand-rolled wasm entry points to a single `launch_cfg` call.