### PR TITLE
feat(blitz-dom): expose stylo thread count via DocumentConfig

### DIFF
--- a/packages/blitz-dom/src/config.rs
+++ b/packages/blitz-dom/src/config.rs
@@ -30,4 +30,47 @@ pub struct DocumentConfig {
     /// The CSS media type used to evaluate `@media` rules.
     /// Defaults to [`MediaType::screen`].
     pub media_type: Option<MediaType>,
+
+    /// Number of threads stylo uses for parallel style traversal.
+    ///
+    /// - `None` (default): blitz's historical default. The number of
+    ///   threads is chosen automatically (`num_cpus * 3/4`, capped at 6).
+    /// - `Some(1)`: disable parallel traversal. Stylo runs style work
+    ///   serially on the calling thread.
+    /// - `Some(n)` with `n >= 2`: use a pool of `n` worker threads.
+    ///
+    /// Set this to `Some(1)` when the embedder runs many small `Document`s
+    /// concurrently on separate OS threads (e.g. one `Document` per request
+    /// in a server, dispatched via `tokio::task::spawn_blocking`). Stylo's
+    /// [`STYLE_THREAD_POOL`] is process-global; two parallel traversals
+    /// landing on the same rayon worker will both try to borrow the
+    /// worker's thread-local sharing cache mutably and one will panic.
+    /// Pinning to a single thread keeps each render's stylo work on the
+    /// caller's OS thread, where the thread-local is uniquely owned.
+    ///
+    /// # One-shot
+    ///
+    /// Stylo's [`STYLE_THREAD_POOL`] is a `LazyLock` initialised on first
+    /// access. The value supplied here on the **first** `BaseDocument`
+    /// constructed in the process wins; later `BaseDocument`s inherit that
+    /// pool size regardless of what they pass.
+    ///
+    /// [`STYLE_THREAD_POOL`]: https://doc.servo.org/style/global_style_data/static.STYLE_THREAD_POOL.html
+    pub stylo_thread_count: Option<i32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards against a default-value drift on `stylo_thread_count`.
+    /// `None` is load-bearing: it's how `Document::new` knows to fall back
+    /// to the historical `-1` (auto) behaviour. A future refactor that
+    /// accidentally changed the default to `Some(0)` or `Some(1)` would
+    /// silently disable stylo parallelism for every existing caller.
+    #[test]
+    fn default_stylo_thread_count_is_none() {
+        let config = DocumentConfig::default();
+        assert!(config.stylo_thread_count.is_none());
+    }
 }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -360,7 +360,7 @@ impl BaseDocument {
         style_config::set_pref!("layout.grid.enabled", true);
         style_config::set_pref!("layout.unimplemented", true);
         style_config::set_pref!("layout.columns.enabled", true);
-        style_config::set_pref!("layout.threads", -1);
+        style_config::set_pref!("layout.threads", config.stylo_thread_count.unwrap_or(-1));
 
         let viewport = config.viewport.unwrap_or_default();
         let media_type = config.media_type.unwrap_or_else(MediaType::screen);


### PR DESCRIPTION
### Summary

Stylo's `STYLE_THREAD_POOL` is a process-global `LazyLock<ThreadPool>`. Each rayon worker thread in that pool holds a thread-local `AtomicRefCell<SharingCache>` borrowed **mutably** for the entire duration of a style traversal landing on that worker (see [`sharing/mod.rs:563-619`](https://github.com/servo/stylo/blob/v0.16.0/sharing/mod.rs#L563-L619)). The architectural contract is _"only one style traversal at a time touches the global pool"_ — true for Servo and Gecko (one layout thread per Document) but false for any embedder driving multiple `Document`s concurrently. When a second traversal lands on a worker mid-traversal of the first, it tries `borrow_mut` on an already-borrowed cell and panics with `already mutably borrowed`.

This PR adds an additive escape hatch on `DocumentConfig` so embedders can pin style traversal to a single thread (the calling thread, where each `Document`'s stylo work has uniquely-owned thread-locals). It does **not** change blitz's default behaviour.

### Repro

```rust
use std::thread;
use blitz_dom::{BaseDocument, DocumentConfig};

let handles: Vec<_> = (0..8).map(|_| thread::spawn(|| {
    let _doc = BaseDocument::new(DocumentConfig::default());
    // ... drive a style traversal on _doc ...
})).collect();
for h in handles { h.join().unwrap(); }
// → some thread panics with `already mutably borrowed`
```

With this PR:

```rust
let config = DocumentConfig {
    stylo_thread_count: Some(1),
    ..Default::default()
};
// ...
// → no panic; per-render parallelism within stylo is disabled but
//   parallelism across renders is preserved.
```

### Changes

- **`packages/blitz-dom/src/config.rs`**
  - New `pub stylo_thread_count: Option<i32>` field on `DocumentConfig`, with rustdoc covering the rationale and the "one-shot" gotcha (`STYLE_THREAD_POOL` is a `LazyLock`; the first `Document::new` call's value wins for the whole process).
  - 1 inline unit test guarding `default_stylo_thread_count_is_none` (regression-pin: `None` is load-bearing for the historical default).
- **`packages/blitz-dom/src/document.rs:353`**
  - Change `set_pref!("layout.threads", -1)` to `set_pref!("layout.threads", config.stylo_thread_count.unwrap_or(-1))`. `unwrap_or(-1)` preserves the historical auto-detect default for every existing caller.

### Compatibility

Fully additive: new field on a struct that already derives `Default`, so every existing call site is unaffected. Default value `None` preserves the historical `-1` (auto, capped at 6) behaviour.

### Test plan for reviewers

- [ ] Existing tests pass (no regressions in `cargo test --workspace`).
- [ ] `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p blitz-dom --no-deps`, `cargo build --workspace` on MSRV 1.92 — all unchanged from pre-PR baseline.
- [ ] Optional: run the repro above against `main` (panics) vs. this PR with `stylo_thread_count: Some(1)` (no panic).