### PR TITLE
Add StyleThreading::Sequential opt-out for concurrent document resolves

### DIFF
--- a/apps/browser/src/document_loader.rs
+++ b/apps/browser/src/document_loader.rs
@@ -57,6 +57,7 @@ pub fn make_doc_config(
         html_parser_provider: Some(Arc::new(HtmlProvider)),
         font_ctx: Some(font_ctx),
         media_type: None,
+        ..Default::default()
     }
 }
 

--- a/apps/browser/src/toolbar.rs
+++ b/apps/browser/src/toolbar.rs
@@ -199,6 +199,7 @@ pub fn Toolbar(
             html_parser_provider: Some(Arc::new(HtmlProvider)),
             font_ctx: Some(tab.loader_rc().font_ctx.clone()),
             media_type: None,
+            ..Default::default()
         };
         let mut document = HtmlDocument::from_html(view_source_html, config).into_inner();
         if let Some(parent_id) = document.get_element_by_id("source") {

--- a/packages/blitz-dom/src/config.rs
+++ b/packages/blitz-dom/src/config.rs
@@ -8,6 +8,26 @@ use parley::FontContext;
 use std::sync::Arc;
 use style::media_queries::MediaType;
 
+/// Strategy for Stylo's style traversal during `resolve`.
+///
+/// Two `Document`s resolving on [`StyleThreading::Parallel`] concurrently
+/// share Stylo's global thread pool and can panic with
+/// `already mutably borrowed` — see
+/// <https://github.com/DioxusLabs/blitz/issues/430>. Set
+/// [`StyleThreading::Sequential`] on documents that may resolve from a
+/// user thread while another `Parallel` resolve is in flight.
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum StyleThreading {
+    /// Use Stylo's parallel traversal via its global rayon thread pool.
+    /// Fastest for a single document; panics if another `Parallel` resolve
+    /// is in flight on a different thread.
+    #[default]
+    Parallel,
+    /// Run style traversal sequentially on the calling thread, bypassing
+    /// the global pool. Safe to use from many user threads concurrently.
+    Sequential,
+}
+
 /// Options used when constructing a [`BaseDocument`](crate::BaseDocument)
 #[derive(Default)]
 pub struct DocumentConfig {
@@ -30,4 +50,7 @@ pub struct DocumentConfig {
     /// The CSS media type used to evaluate `@media` rules.
     /// Defaults to [`MediaType::screen`].
     pub media_type: Option<MediaType>,
+    /// Strategy for Stylo's style traversal.
+    /// Defaults to [`StyleThreading::Parallel`].
+    pub style_threading: StyleThreading,
 }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -14,7 +14,8 @@ use crate::url::DocumentUrl;
 use crate::util::ImageType;
 use crate::{
     DEFAULT_CSS, DocumentConfig, DocumentMutator, DummyHtmlParserProvider, ElementData,
-    EventDriver, HtmlParserProvider, Node, NodeData, NoopEventHandler, TextNodeData,
+    EventDriver, HtmlParserProvider, Node, NodeData, NoopEventHandler, StyleThreading,
+    TextNodeData,
 };
 use blitz_traits::devtools::DevtoolSettings;
 use blitz_traits::events::{BlitzScrollEvent, DomEvent, DomEventData, HitResult, UiEvent};
@@ -190,6 +191,8 @@ pub struct BaseDocument {
     pub(crate) viewport_scroll: crate::Point<f64>,
     /// CSS media type used to evaluate `@media` rules.
     pub(crate) media_type: MediaType,
+    /// Strategy for Stylo's style traversal during `resolve`.
+    pub(crate) style_threading: StyleThreading,
 
     // Events
     pub(crate) tx: Sender<DocumentEvent>,
@@ -401,6 +404,7 @@ impl BaseDocument {
             nodes_to_id,
             viewport,
             media_type,
+            style_threading: config.style_threading,
             devtool_settings: DevtoolSettings::default(),
             viewport_scroll: crate::Point::ZERO,
             url: base_url,

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -74,7 +74,7 @@ mod accessibility;
 #[cfg(feature = "custom-widget")]
 pub use crate::node::Widget;
 
-pub use config::DocumentConfig;
+pub use config::{DocumentConfig, StyleThreading};
 pub use document::{BaseDocument, DocGuard, DocGuardMut, Document, PlainDocument};
 pub use markup5ever::{
     LocalName, Namespace, NamespaceStaticSet, Prefix, PrefixStaticSet, QualName, local_name,

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -4,6 +4,7 @@
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering;
 
+use crate::StyleThreading;
 use crate::layout::damage::compute_layout_damage;
 use crate::node::Node;
 use crate::node::NodeData;
@@ -125,8 +126,11 @@ impl crate::document::BaseDocument {
         if token.should_traverse() {
             // Style the elements, resolving their data
             let traverser = RecalcStyle::new(context);
-            let rayon_pool = STYLE_THREAD_POOL.pool();
-            style::driver::traverse_dom(&traverser, token, rayon_pool.as_ref());
+            // `Sequential` bypasses Stylo's global pool. See `StyleThreading`.
+            let pool_guard = matches!(self.style_threading, StyleThreading::Parallel)
+                .then(|| STYLE_THREAD_POOL.pool());
+            let rayon_pool = pool_guard.as_ref().and_then(|g| g.as_ref());
+            style::driver::traverse_dom(&traverser, token, rayon_pool);
         }
 
         for opaque in self.snapshots.keys() {


### PR DESCRIPTION
Adds a `StyleThreading::Sequential` opt-in on `DocumentConfig` for callers that need to resolve documents from multiple threads concurrently (#430); the gate sits at the `traverse_dom` call site in `packages/blitz-dom/src/stylo.rs` rather than via `layout.threads`, because the pref is read once when `STYLE_THREAD_POOL` is first forced and would silently no-op for any document constructed after the pool exists.

Default stays `Parallel`; verified locally against the issue repro across all-`Sequential`, all-`Parallel` (panics, as a negative control), and pool-already-initialized mixed-mode scenarios.