### PR TITLE
fix: key image cache on requested URL, not post-redirect URL (refs #435)

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -843,6 +843,7 @@ impl BaseDocument {
                                 self.tx.clone(),
                                 self.id,
                                 Some(node_id),
+                                resolved_href.to_string(),
                                 self.shell_provider.clone(),
                                 StylesheetHandler {
                                     source_url: resolved_href,
@@ -985,9 +986,7 @@ impl BaseDocument {
                 // Create the ImageData and cache it
                 let image = ImageData::Raster(RasterImageData::new(width, height, image_data));
 
-                let Some(url) = res.resolved_url.as_ref() else {
-                    return;
-                };
+                let url = &res.requested_url;
 
                 // Get all nodes waiting for this image
                 let waiting_nodes = self.pending_images.remove(url).unwrap_or_default();
@@ -1033,9 +1032,7 @@ impl BaseDocument {
                 // Create the ImageData and cache it
                 let image = ImageData::Svg(tree);
 
-                let Some(url) = res.resolved_url.as_ref() else {
-                    return;
-                };
+                let url = &res.requested_url;
 
                 // Get all nodes waiting for this image
                 let waiting_nodes = self.pending_images.remove(url).unwrap_or_default();
@@ -2023,7 +2020,7 @@ mod font_face_override_tests {
         let response = ResourceLoadResponse {
             request_id: 0,
             node_id: None,
-            resolved_url: Some(String::from("test://aliased-family")),
+            requested_url: String::from("test://aliased-family"),
             result: Ok(Resource::Font(
                 blitz_traits::net::Bytes::from_static(crate::BULLET_FONT),
                 FontFaceOverrides {

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -441,8 +441,9 @@ impl BaseDocument {
                                 // Start fetch and track as pending
                                 #[cfg(feature = "tracing")]
                                 tracing::info!("Fetching image {url_str}");
+                                let url_string = url_str.to_string();
                                 self.pending_images.insert(
-                                    url_str.to_string(),
+                                    url_string.clone(),
                                     vec![(node_id, ImageType::Background(idx))],
                                 );
 
@@ -453,6 +454,7 @@ impl BaseDocument {
                                         self.tx.clone(),
                                         doc_id,
                                         None, // Don't pass node_id, we'll handle via pending_images
+                                        url_string,
                                         self.shell_provider.clone(),
                                         ImageHandler::new(ImageType::Background(idx)),
                                     ),

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -777,6 +777,7 @@ impl<'doc> DocumentMutator<'doc> {
             self.doc.tx.clone(),
             self.doc.id(),
             Some(node.id),
+            url.to_string(),
             self.doc.shell_provider.clone(),
             StylesheetHandler {
                 source_url: url.clone(),
@@ -819,10 +820,10 @@ impl<'doc> DocumentMutator<'doc> {
         if let Some(raw_src) = node.attr(local_name!("src")) {
             if !raw_src.is_empty() {
                 let src = self.doc.resolve_url(raw_src);
-                let src_string = src.as_str();
+                let src_string = src.to_string();
 
                 // Check cache first
-                if let Some(cached_image) = self.doc.image_cache.get(src_string) {
+                if let Some(cached_image) = self.doc.image_cache.get(&src_string) {
                     #[cfg(feature = "tracing")]
                     tracing::info!("Loading image {src_string} from cache");
                     let node = &mut self.doc.nodes[target_id];
@@ -834,7 +835,7 @@ impl<'doc> DocumentMutator<'doc> {
                 }
 
                 // Check if there's already a pending request for this URL
-                if let Some(waiting_list) = self.doc.pending_images.get_mut(src_string) {
+                if let Some(waiting_list) = self.doc.pending_images.get_mut(&src_string) {
                     #[cfg(feature = "tracing")]
                     tracing::info!("Image {src_string} already pending, queueing node {target_id}");
                     waiting_list.push((target_id, ImageType::Image));
@@ -846,7 +847,7 @@ impl<'doc> DocumentMutator<'doc> {
                 tracing::info!("Fetching image {src_string}");
                 self.doc
                     .pending_images
-                    .insert(src_string.to_string(), vec![(target_id, ImageType::Image)]);
+                    .insert(src_string.clone(), vec![(target_id, ImageType::Image)]);
 
                 self.doc.net_provider.fetch(
                     self.doc.id(),
@@ -855,6 +856,7 @@ impl<'doc> DocumentMutator<'doc> {
                         self.doc.tx.clone(),
                         self.doc.id(),
                         None, // Don't pass node_id, we'll handle it via pending_images
+                        src_string,
                         self.doc.shell_provider.clone(),
                         ImageHandler::new(ImageType::Image),
                     ),

--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -61,6 +61,7 @@ pub(crate) struct ResourceHandler<T: Send + Sync + 'static> {
     doc_id: usize,
     request_id: usize,
     node_id: Option<usize>,
+    requested_url: String,
     tx: Sender<DocumentEvent>,
     shell_provider: Arc<dyn ShellProvider>,
     data: T,
@@ -71,6 +72,7 @@ impl<T: Send + Sync + 'static> ResourceHandler<T> {
         tx: Sender<DocumentEvent>,
         doc_id: usize,
         node_id: Option<usize>,
+        requested_url: String,
         shell_provider: Arc<dyn ShellProvider>,
         data: T,
     ) -> Self {
@@ -79,6 +81,7 @@ impl<T: Send + Sync + 'static> ResourceHandler<T> {
             request_id: REQUEST_ID_COUNTER.fetch_add(1, Ao::Relaxed),
             doc_id,
             node_id,
+            requested_url,
             tx,
             shell_provider,
             data,
@@ -89,24 +92,32 @@ impl<T: Send + Sync + 'static> ResourceHandler<T> {
         tx: Sender<DocumentEvent>,
         doc_id: usize,
         node_id: Option<usize>,
+        requested_url: String,
         shell_provider: Arc<dyn ShellProvider>,
         data: T,
     ) -> Box<dyn NetHandler>
     where
         ResourceHandler<T>: NetHandler,
     {
-        Box::new(Self::new(tx, doc_id, node_id, shell_provider, data)) as _
+        Box::new(Self::new(
+            tx,
+            doc_id,
+            node_id,
+            requested_url,
+            shell_provider,
+            data,
+        )) as _
     }
 
     pub(crate) fn request_id(&self) -> usize {
         self.request_id
     }
 
-    fn respond(&self, resolved_url: String, result: Result<Resource, String>) {
+    fn respond(&self, result: Result<Resource, String>) {
         let response = ResourceLoadResponse {
             request_id: self.request_id,
             node_id: self.node_id,
-            resolved_url: Some(resolved_url),
+            requested_url: self.requested_url.clone(),
             result,
         };
         let _ = self.tx.send(DocumentEvent::ResourceLoad(response));
@@ -118,7 +129,13 @@ impl<T: Send + Sync + 'static> ResourceHandler<T> {
 pub struct ResourceLoadResponse {
     pub request_id: usize,
     pub node_id: Option<usize>,
-    pub resolved_url: Option<String>,
+    /// The URL passed to `NetProvider::fetch` — i.e. pre-redirect. Used as the
+    /// key for image-cache / pending-image dedup so that lookups on the response
+    /// side match the keys recorded when the fetch was initiated. The post-
+    /// redirect URL (delivered to `NetHandler::bytes`) is intentionally not
+    /// surfaced here: keying on it caused issue #435 (intermittent image loads
+    /// on wikipedia.org) because the queue side had no access to it.
+    pub requested_url: String,
     pub result: Result<Resource, String>,
 }
 
@@ -129,9 +146,9 @@ pub struct StylesheetHandler {
 }
 
 impl NetHandler for ResourceHandler<StylesheetHandler> {
-    fn bytes(self: Box<Self>, resolved_url: String, bytes: Bytes) {
+    fn bytes(self: Box<Self>, _resolved_url: String, bytes: Bytes) {
         let Ok(css) = std::str::from_utf8(&bytes) else {
-            return self.respond(resolved_url, Err(String::from("Invalid UTF8")));
+            return self.respond(Err(String::from("Invalid UTF8")));
         };
 
         // NOTE(Nico): I don't *think* external stylesheets should have HTML entities escaped
@@ -154,10 +171,7 @@ impl NetHandler for ResourceHandler<StylesheetHandler> {
             AllowImportRules::Yes,
         );
 
-        self.respond(
-            resolved_url,
-            Ok(Resource::Css(DocumentStyleSheet(ServoArc::new(sheet)))),
-        );
+        self.respond(Ok(Resource::Css(DocumentStyleSheet(ServoArc::new(sheet)))));
     }
 }
 
@@ -205,6 +219,7 @@ impl ServoStylesheetLoader for StylesheetLoader {
                 self.tx.clone(),
                 self.doc_id,
                 None, // node_id
+                url.to_string(),
                 self.shell_provider.clone(),
                 NestedStylesheetHandler {
                     url: url.clone(),
@@ -231,9 +246,9 @@ struct NestedStylesheetHandler {
 }
 
 impl NetHandler for ResourceHandler<NestedStylesheetHandler> {
-    fn bytes(self: Box<Self>, resolved_url: String, bytes: Bytes) {
+    fn bytes(self: Box<Self>, _resolved_url: String, bytes: Bytes) {
         let Ok(css) = std::str::from_utf8(&bytes) else {
-            return self.respond(resolved_url, Err(String::from("Invalid UTF8")));
+            return self.respond(Err(String::from("Invalid UTF8")));
         };
 
         // NOTE(Nico): I don't *think* external stylesheets should have HTML entities escaped
@@ -266,7 +281,7 @@ impl NetHandler for ResourceHandler<NestedStylesheetHandler> {
         self.data.import_rule.write_with(&mut guard).stylesheet = ImportSheet::Sheet(sheet);
         drop(guard);
 
-        self.respond(resolved_url, Ok(Resource::None))
+        self.respond(Ok(Resource::None))
     }
 }
 
@@ -275,9 +290,9 @@ struct FontFaceHandler {
     overrides: FontFaceOverrides,
 }
 impl NetHandler for ResourceHandler<FontFaceHandler> {
-    fn bytes(mut self: Box<Self>, resolved_url: String, bytes: Bytes) {
+    fn bytes(mut self: Box<Self>, _resolved_url: String, bytes: Bytes) {
         let result = self.data.parse(bytes);
-        self.respond(resolved_url, result)
+        self.respond(result)
     }
 }
 impl FontFaceHandler {
@@ -446,11 +461,12 @@ pub(crate) fn fetch_font_face(
             if let Some((url, format)) = preferred_source {
                 network_provider.fetch(
                     doc_id,
-                    Request::get(url),
+                    Request::get(url.clone()),
                     ResourceHandler::boxed(
                         tx.clone(),
                         doc_id,
                         node_id,
+                        url.to_string(),
                         shell_provider.clone(),
                         FontFaceHandler { format, overrides },
                     ),
@@ -492,9 +508,9 @@ impl ImageHandler {
 }
 
 impl NetHandler for ResourceHandler<ImageHandler> {
-    fn bytes(self: Box<Self>, resolved_url: String, bytes: Bytes) {
+    fn bytes(self: Box<Self>, _resolved_url: String, bytes: Bytes) {
         let result = self.data.parse(bytes);
-        self.respond(resolved_url, result)
+        self.respond(result)
     }
 }
 


### PR DESCRIPTION
**Thesis:** PR #331's URL-keyed image cache uses the pre-fetch URL on the request side but the post-redirect URL (`reqwest::Response::url()`) on the response side, so any redirected image fetch silently drops its bytes — the likely cause of #435's intermittent image loads on wikipedia.org, where on-disk HTTP-cache hits dodge the redirect and work while fresh fetches that follow a redirect do not. This PR threads the original requested URL through `ResourceLoadResponse` and keys both the image cache and `pending_images` on it; `resolved_url` is dropped from the response struct since nothing else consumed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)