### PR TITLE
Implement the CSS `mask-*` properties

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1023,44 +1023,7 @@ impl BaseDocument {
                     return;
                 };
 
-                // Get all nodes waiting for this image
-                let waiting_nodes = self.pending_images.remove(url).unwrap_or_default();
-
-                #[cfg(feature = "tracing")]
-                tracing::info!(
-                    "Image {url} loaded, applying to {} nodes",
-                    waiting_nodes.len()
-                );
-
-                // Cache the image
-                self.image_cache.insert(url.clone(), image.clone());
-
-                // Apply to all waiting nodes
-                for (node_id, image_type) in waiting_nodes {
-                    let Some(node) = self.get_node_mut(node_id) else {
-                        continue;
-                    };
-
-                    match image_type {
-                        ImageType::Image => {
-                            node.element_data_mut().unwrap().special_data =
-                                SpecialElementData::Image(Box::new(image.clone()));
-
-                            // Clear layout cache
-                            node.cache.clear();
-                            node.insert_damage(ALL_DAMAGE);
-                        }
-                        ImageType::Background(idx) => {
-                            if let Some(Some(bg_image)) = node
-                                .element_data_mut()
-                                .and_then(|el| el.background_images.get_mut(idx))
-                            {
-                                bg_image.status = Status::Ok;
-                                bg_image.image = image.clone();
-                            }
-                        }
-                    }
-                }
+                self.apply_loaded_image(url, image);
             }
             #[cfg(feature = "svg")]
             Resource::Svg(_kind, tree) => {
@@ -1071,44 +1034,7 @@ impl BaseDocument {
                     return;
                 };
 
-                // Get all nodes waiting for this image
-                let waiting_nodes = self.pending_images.remove(url).unwrap_or_default();
-
-                #[cfg(feature = "tracing")]
-                tracing::info!(
-                    "SVG {url} loaded, applying to {} nodes",
-                    waiting_nodes.len()
-                );
-
-                // Cache the image
-                self.image_cache.insert(url.clone(), image.clone());
-
-                // Apply to all waiting nodes
-                for (node_id, image_type) in waiting_nodes {
-                    let Some(node) = self.get_node_mut(node_id) else {
-                        continue;
-                    };
-
-                    match image_type {
-                        ImageType::Image => {
-                            node.element_data_mut().unwrap().special_data =
-                                SpecialElementData::Image(Box::new(image.clone()));
-
-                            // Clear layout cache
-                            node.cache.clear();
-                            node.insert_damage(ALL_DAMAGE);
-                        }
-                        ImageType::Background(idx) => {
-                            if let Some(Some(bg_image)) = node
-                                .element_data_mut()
-                                .and_then(|el| el.background_images.get_mut(idx))
-                            {
-                                bg_image.status = Status::Ok;
-                                bg_image.image = image.clone();
-                            }
-                        }
-                    }
-                }
+                self.apply_loaded_image(url, image);
             }
             Resource::Font(bytes, overrides) => {
                 let font = Blob::new(Arc::new(bytes));
@@ -1151,6 +1077,53 @@ impl BaseDocument {
             }
             Resource::None => {
                 // Do nothing
+            }
+        }
+    }
+
+    /// Cache a loaded image and apply it to all nodes waiting on it
+    /// (`<img>` elements, `background-image` layers and `mask-image` layers).
+    fn apply_loaded_image(&mut self, url: &str, image: ImageData) {
+        // Get all nodes waiting for this image
+        let waiting_nodes = self.pending_images.remove(url).unwrap_or_default();
+
+        #[cfg(feature = "tracing")]
+        tracing::info!(
+            "Image {url} loaded, applying to {} nodes",
+            waiting_nodes.len()
+        );
+
+        // Cache the image
+        self.image_cache.insert(url.to_string(), image.clone());
+
+        // Apply to all waiting nodes
+        for (node_id, image_type) in waiting_nodes {
+            let Some(node) = self.get_node_mut(node_id) else {
+                continue;
+            };
+
+            match image_type {
+                ImageType::Image => {
+                    node.element_data_mut().unwrap().special_data =
+                        SpecialElementData::Image(Box::new(image.clone()));
+
+                    // Clear layout cache
+                    node.cache.clear();
+                    node.insert_damage(ALL_DAMAGE);
+                }
+                ImageType::Background(idx) | ImageType::Mask(idx) => {
+                    let layer_image = node.element_data_mut().and_then(|el| {
+                        let images = match image_type {
+                            ImageType::Background(_) => &mut el.background_images,
+                            _ => &mut el.mask_images,
+                        };
+                        images.get_mut(idx)
+                    });
+                    if let Some(Some(layer_image)) = layer_image {
+                        layer_image.status = Status::Ok;
+                        layer_image.image = image.clone();
+                    }
+                }
             }
         }
     }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1115,7 +1115,8 @@ impl BaseDocument {
                     let layer_image = node.element_data_mut().and_then(|el| {
                         let images = match image_type {
                             ImageType::Background(_) => &mut el.background_images,
-                            _ => &mut el.mask_images,
+                            ImageType::Mask(_) => &mut el.mask_images,
+                            ImageType::Image => unreachable!(),
                         };
                         images.get_mut(idx)
                     });

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use crate::net::ResourceHandler;
 use crate::node::NodeFlags;
 use crate::{
-    BaseDocument, net::ImageHandler, node::ImageResourceData, node::Status, util::ImageType,
+    BaseDocument, net::ImageHandler, node::ImageResourceData, node::Status, util::ImageLayerKind,
 };
 use crate::{NON_INCREMENTAL, Node};
 use style::properties::ComputedValues;
@@ -29,23 +29,6 @@ pub(crate) const ONLY_RELAYOUT: RestyleDamage =
 
 pub(crate) const ALL_DAMAGE: RestyleDamage =
     RestyleDamage::from_bits_retain(0b_0000_0000_0111_1111);
-
-/// Which kind of CSS image layer list (`background-image` or `mask-image`) to
-/// flush from style to dedicated storage on the node.
-#[derive(Clone, Copy)]
-enum ImageLayerKind {
-    Background,
-    Mask,
-}
-
-impl ImageLayerKind {
-    fn image_type(self, idx: usize) -> ImageType {
-        match self {
-            Self::Background => ImageType::Background(idx),
-            Self::Mask => ImageType::Mask(idx),
-        }
-    }
-}
 
 impl BaseDocument {
     #[cfg(feature = "incremental")]

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use crate::net::ResourceHandler;
 use crate::node::NodeFlags;
 use crate::{
-    BaseDocument, net::ImageHandler, node::BackgroundImageData, node::Status, util::ImageType,
+    BaseDocument, net::ImageHandler, node::ImageResourceData, node::Status, util::ImageType,
 };
 use crate::{NON_INCREMENTAL, Node};
 use style::properties::ComputedValues;
@@ -433,7 +433,7 @@ impl BaseDocument {
                     if let Some(cached_image) = self.image_cache.get(url_str) {
                         #[cfg(feature = "tracing")]
                         tracing::info!("Loading image {url_str} from cache");
-                        Some(BackgroundImageData {
+                        Some(ImageResourceData {
                             url: new_url.clone(),
                             status: Status::Ok,
                             image: cached_image.clone(),
@@ -443,7 +443,7 @@ impl BaseDocument {
                         #[cfg(feature = "tracing")]
                         tracing::info!("Image {url_str} already pending, queueing node {node_id}");
                         waiting_list.push((node_id, kind.image_type(idx)));
-                        Some(BackgroundImageData::new(new_url.clone()))
+                        Some(ImageResourceData::new(new_url.clone()))
                     } else {
                         // Start fetch and track as pending
                         #[cfg(feature = "tracing")]
@@ -466,7 +466,7 @@ impl BaseDocument {
                             ),
                         );
 
-                        Some(BackgroundImageData::new(new_url.clone()))
+                        Some(ImageResourceData::new(new_url.clone()))
                     }
                 }
                 _ => None,

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -30,6 +30,23 @@ pub(crate) const ONLY_RELAYOUT: RestyleDamage =
 pub(crate) const ALL_DAMAGE: RestyleDamage =
     RestyleDamage::from_bits_retain(0b_0000_0000_0111_1111);
 
+/// Which kind of CSS image layer list (`background-image` or `mask-image`) to
+/// flush from style to dedicated storage on the node.
+#[derive(Clone, Copy)]
+enum ImageLayerKind {
+    Background,
+    Mask,
+}
+
+impl ImageLayerKind {
+    fn image_type(self, idx: usize) -> ImageType {
+        match self {
+            Self::Background => ImageType::Background(idx),
+            Self::Mask => ImageType::Mask(idx),
+        }
+    }
+}
+
 impl BaseDocument {
     #[cfg(feature = "incremental")]
     pub(crate) fn propagate_damage_flags(
@@ -370,6 +387,96 @@ impl BaseDocument {
         self.flush_styles_to_layout_impl(node_id, None);
     }
 
+    /// Flush a CSS image layer list (`background-image` or `mask-image`) from style
+    /// to dedicated storage on the node, fetching any images which are not yet loaded.
+    fn flush_image_layers_from_style(
+        &mut self,
+        doc_id: usize,
+        node_id: usize,
+        kind: ImageLayerKind,
+    ) {
+        let node = self.nodes.get_mut(node_id).unwrap();
+        let stylo_element_data = node.stylo_element_data.get();
+        let primary_styles = stylo_element_data
+            .as_ref()
+            .and_then(|data| data.styles.get_primary());
+        let Some(style) = primary_styles else {
+            return;
+        };
+        let Some(elem) = node.data.downcast_element_mut() else {
+            return;
+        };
+
+        let (style_images, elem_images) = match kind {
+            ImageLayerKind::Background => (
+                &style.get_background().background_image.0,
+                &mut elem.background_images,
+            ),
+            ImageLayerKind::Mask => (&style.get_svg().mask_image.0, &mut elem.mask_images),
+        };
+
+        let len = style_images.len();
+        elem_images.resize_with(len, || None);
+
+        for idx in 0..len {
+            let style_image = &style_images[idx];
+            let new_image = match style_image {
+                StyloImage::Url(ComputedUrl::Valid(new_url)) => {
+                    let old_image = elem_images[idx].as_ref();
+                    let old_image_url = old_image.map(|data| &data.url);
+                    if old_image_url.is_some_and(|old_url| **new_url == **old_url) {
+                        break;
+                    }
+
+                    // Check cache first
+                    let url_str = new_url.as_str();
+                    if let Some(cached_image) = self.image_cache.get(url_str) {
+                        #[cfg(feature = "tracing")]
+                        tracing::info!("Loading image {url_str} from cache");
+                        Some(BackgroundImageData {
+                            url: new_url.clone(),
+                            status: Status::Ok,
+                            image: cached_image.clone(),
+                        })
+                    } else if let Some(waiting_list) = self.pending_images.get_mut(url_str) {
+                        // Image is already being fetched, queue this node
+                        #[cfg(feature = "tracing")]
+                        tracing::info!("Image {url_str} already pending, queueing node {node_id}");
+                        waiting_list.push((node_id, kind.image_type(idx)));
+                        Some(BackgroundImageData::new(new_url.clone()))
+                    } else {
+                        // Start fetch and track as pending
+                        #[cfg(feature = "tracing")]
+                        tracing::info!("Fetching image {url_str}");
+                        self.pending_images
+                            .insert(url_str.to_string(), vec![(node_id, kind.image_type(idx))]);
+
+                        self.net_provider.fetch(
+                            doc_id,
+                            crate::net::stamped_request(
+                                (**new_url).clone(),
+                                self.abort_signal.as_ref(),
+                            ),
+                            ResourceHandler::boxed(
+                                self.tx.clone(),
+                                doc_id,
+                                None, // Don't pass node_id, we'll handle via pending_images
+                                self.shell_provider.clone(),
+                                ImageHandler::new(kind.image_type(idx)),
+                            ),
+                        );
+
+                        Some(BackgroundImageData::new(new_url.clone()))
+                    }
+                }
+                _ => None,
+            };
+
+            // Element will always exist due to resize_with above
+            elem_images[idx] = new_image;
+        }
+    }
+
     /// Walk the whole tree, converting styles to layout
     fn flush_styles_to_layout_impl(
         &mut self,
@@ -380,6 +487,10 @@ impl BaseDocument {
 
         let mut new_stacking_context: HoistedPaintChildren = HoistedPaintChildren::new();
         let stacking_context = &mut new_stacking_context;
+
+        // Flush background/mask images from style to dedicated storage on the node
+        self.flush_image_layers_from_style(doc_id, node_id, ImageLayerKind::Background);
+        self.flush_image_layers_from_style(doc_id, node_id, ImageLayerKind::Mask);
 
         let display = {
             let node = self.nodes.get_mut(node_id).unwrap();
@@ -397,79 +508,6 @@ impl BaseDocument {
             node.style = stylo_taffy::to_taffy_style(style);
             node.display_constructed_as = style.clone_display();
             // }
-
-            // Flush background image from style to dedicated storage on the node
-            // TODO: handle multiple background images
-            if let Some(elem) = node.data.downcast_element_mut() {
-                let style_bgs = &style.get_background().background_image.0;
-                let elem_bgs = &mut elem.background_images;
-
-                let len = style_bgs.len();
-                elem_bgs.resize_with(len, || None);
-
-                for idx in 0..len {
-                    let background_image = &style_bgs[idx];
-                    let new_bg_image = match background_image {
-                        StyloImage::Url(ComputedUrl::Valid(new_url)) => {
-                            let old_bg_image = elem_bgs[idx].as_ref();
-                            let old_bg_image_url = old_bg_image.map(|data| &data.url);
-                            if old_bg_image_url.is_some_and(|old_url| **new_url == **old_url) {
-                                break;
-                            }
-
-                            // Check cache first
-                            let url_str = new_url.as_str();
-                            if let Some(cached_image) = self.image_cache.get(url_str) {
-                                #[cfg(feature = "tracing")]
-                                tracing::info!("Loading image {url_str} from cache");
-                                Some(BackgroundImageData {
-                                    url: new_url.clone(),
-                                    status: Status::Ok,
-                                    image: cached_image.clone(),
-                                })
-                            } else if let Some(waiting_list) = self.pending_images.get_mut(url_str)
-                            {
-                                // Image is already being fetched, queue this node
-                                #[cfg(feature = "tracing")]
-                                tracing::info!(
-                                    "Image {url_str} already pending, queueing node {node_id}"
-                                );
-                                waiting_list.push((node_id, ImageType::Background(idx)));
-                                Some(BackgroundImageData::new(new_url.clone()))
-                            } else {
-                                // Start fetch and track as pending
-                                #[cfg(feature = "tracing")]
-                                tracing::info!("Fetching image {url_str}");
-                                self.pending_images.insert(
-                                    url_str.to_string(),
-                                    vec![(node_id, ImageType::Background(idx))],
-                                );
-
-                                self.net_provider.fetch(
-                                    doc_id,
-                                    crate::net::stamped_request(
-                                        (**new_url).clone(),
-                                        self.abort_signal.as_ref(),
-                                    ),
-                                    ResourceHandler::boxed(
-                                        self.tx.clone(),
-                                        doc_id,
-                                        None, // Don't pass node_id, we'll handle via pending_images
-                                        self.shell_provider.clone(),
-                                        ImageHandler::new(ImageType::Background(idx)),
-                                    ),
-                                );
-
-                                Some(BackgroundImageData::new(new_url.clone()))
-                            }
-                        }
-                        _ => None,
-                    };
-
-                    // Element will always exist due to resize_with above
-                    elem_bgs[idx] = new_bg_image;
-                }
-            }
 
             // In non-incremental mode we unconditionally clear the Taffy cache.
             // In incremental mode this is handled as part of damage propagation.

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -372,12 +372,8 @@ impl BaseDocument {
 
     /// Flush a CSS image layer list (`background-image` or `mask-image`) from style
     /// to dedicated storage on the node, fetching any images which are not yet loaded.
-    fn flush_image_layers_from_style(
-        &mut self,
-        doc_id: usize,
-        node_id: usize,
-        kind: ImageLayerKind,
-    ) {
+    fn flush_image_layers_from_style(&mut self, node_id: usize, kind: ImageLayerKind) {
+        let doc_id = self.id();
         let node = self.nodes.get_mut(node_id).unwrap();
         let stylo_element_data = node.stylo_element_data.get();
         let primary_styles = stylo_element_data
@@ -466,14 +462,12 @@ impl BaseDocument {
         node_id: usize,
         parent_stacking_context: Option<&mut HoistedPaintChildren>,
     ) {
-        let doc_id = self.id();
-
         let mut new_stacking_context: HoistedPaintChildren = HoistedPaintChildren::new();
         let stacking_context = &mut new_stacking_context;
 
         // Flush background/mask images from style to dedicated storage on the node
-        self.flush_image_layers_from_style(doc_id, node_id, ImageLayerKind::Background);
-        self.flush_image_layers_from_style(doc_id, node_id, ImageLayerKind::Mask);
+        self.flush_image_layers_from_style(node_id, ImageLayerKind::Background);
+        self.flush_image_layers_from_style(node_id, ImageLayerKind::Mask);
 
         let display = {
             let node = self.nodes.get_mut(node_id).unwrap();

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -55,9 +55,9 @@ pub struct ElementData {
     ///   - The text editor for input/textarea elements
     pub special_data: SpecialElementData,
 
-    pub background_images: Vec<Option<BackgroundImageData>>,
+    pub background_images: Vec<Option<ImageResourceData>>,
 
-    pub mask_images: Vec<Option<BackgroundImageData>>,
+    pub mask_images: Vec<Option<ImageResourceData>>,
 
     /// Parley text layout (elements with inline inner display mode only)
     pub inline_layout_data: Option<Box<TextLayout>>,
@@ -517,7 +517,7 @@ pub enum Status {
 }
 
 #[derive(Debug, Clone)]
-pub struct BackgroundImageData {
+pub struct ImageResourceData {
     /// The url of the background image
     pub url: ServoArc<Url>,
     /// The loading status of the background image
@@ -526,7 +526,7 @@ pub struct BackgroundImageData {
     pub image: ImageData,
 }
 
-impl BackgroundImageData {
+impl ImageResourceData {
     pub fn new(url: ServoArc<Url>) -> Self {
         Self {
             url,

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -57,6 +57,8 @@ pub struct ElementData {
 
     pub background_images: Vec<Option<BackgroundImageData>>,
 
+    pub mask_images: Vec<Option<BackgroundImageData>>,
+
     /// Parley text layout (elements with inline inner display mode only)
     pub inline_layout_data: Option<Box<TextLayout>>,
 
@@ -157,6 +159,7 @@ impl ElementData {
             special_data: SpecialElementData::None,
             template_contents: None,
             background_images: Vec::new(),
+            mask_images: Vec::new(),
         };
         data.flush_is_focussable();
         data

--- a/packages/blitz-dom/src/node/mod.rs
+++ b/packages/blitz-dom/src/node/mod.rs
@@ -13,8 +13,8 @@ pub use custom_widget::{
     ComputedStyles, CustomWidgetData, CustomWidgetStatus, ProxyRenderContext, Widget,
 };
 pub use element::{
-    BackgroundImageData, CanvasData, ElementData, ImageData, ListItemLayout,
-    ListItemLayoutPosition, Marker, RasterImageData, SpecialElementData, SpecialElementType,
-    Status, TextBrush, TextInputData, TextLayout,
+    CanvasData, ElementData, ImageData, ImageResourceData, ListItemLayout, ListItemLayoutPosition,
+    Marker, RasterImageData, SpecialElementData, SpecialElementType, Status, TextBrush,
+    TextInputData, TextLayout,
 };
 pub use node::*;

--- a/packages/blitz-dom/src/util.rs
+++ b/packages/blitz-dom/src/util.rs
@@ -48,6 +48,7 @@ pub(crate) static FONT_DB: LazyLock<Arc<fontdb::Database>> = LazyLock::new(|| {
 pub enum ImageType {
     Image,
     Background(usize),
+    Mask(usize),
 }
 
 /// A point

--- a/packages/blitz-dom/src/util.rs
+++ b/packages/blitz-dom/src/util.rs
@@ -44,6 +44,23 @@ pub(crate) static FONT_DB: LazyLock<Arc<fontdb::Database>> = LazyLock::new(|| {
     Arc::new(db)
 });
 
+/// Which kind of CSS image layer list (`background-image` or `mask-image`) to
+/// flush from style to dedicated storage on the node.
+#[derive(Clone, Copy, Debug)]
+pub enum ImageLayerKind {
+    Background,
+    Mask,
+}
+
+impl ImageLayerKind {
+    pub fn image_type(self, idx: usize) -> ImageType {
+        match self {
+            Self::Background => ImageType::Background(idx),
+            Self::Mask => ImageType::Mask(idx),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum ImageType {
     Image,

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -2,6 +2,7 @@ mod background;
 mod box_shadow;
 mod clip_path;
 mod form_controls;
+mod mask;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -313,6 +314,13 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             None,
             None,
             |scene| {
+                // If the element has a CSS `mask`, then push an isolation layer for the
+                // masked content. The mask is applied when the layer is popped below.
+                let mask_layer_pushed = cx.maybe_push_css_mask_layer(scene);
+                // `cx.transform` is mutated to apply scroll offsets while drawing content.
+                // Save it so that the mask can be drawn untransformed by scroll offsets.
+                let unscrolled_transform = cx.transform;
+
                 let filter = convert_filters(&effects.filter.0).map(Arc::new);
                 let backdrop_filter = convert_filters(&effects.backdrop_filter.0).map(Arc::new);
 
@@ -395,6 +403,10 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                         );
                     },
                 );
+
+                // Apply the CSS `mask` (if any) to the content drawn above
+                cx.transform = unscrolled_transform;
+                cx.maybe_pop_css_mask_layer(scene, mask_layer_pushed);
             },
         );
     }

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -2,7 +2,7 @@ use super::{ElementCx, to_image_quality, to_peniko_image};
 use crate::color::{Color, ToColorColor};
 use crate::gradient::to_peniko_gradient;
 use anyrender::PaintScene;
-use blitz_dom::node::{ImageData, SpecialElementData};
+use blitz_dom::node::{ImageData, ImageResourceData, SpecialElementData};
 use kurbo::{self, BezPath, Point, Rect, Shape, Size, Vec2};
 use peniko::{self, Fill};
 use style::{
@@ -11,10 +11,13 @@ use style::{
             background_clip::single_value::computed_value::T as StyloBackgroundClip,
             background_origin::single_value::computed_value::T as StyloBackgroundOrigin,
         },
-        style_structs::Background,
+        style_structs::{Background, SVG},
     },
     values::{
-        computed::{BackgroundRepeat, Gradient as StyloGradient},
+        computed::{
+            BackgroundRepeat, Gradient as StyloGradient, Image as ComputedImage, LengthPercentage,
+            background::BackgroundSize,
+        },
         generics::image::GenericImage,
         specified::background::BackgroundRepeatKeyword,
     },
@@ -23,9 +26,40 @@ use style::{
 #[cfg(feature = "tracing")]
 use tracing::warn;
 
+/// The styles which control the sizing/positioning of the layers in a CSS image
+/// layer list. The `background-*` and `mask-*` properties share computed value
+/// types for these, which allows the layer painting code to be shared.
+pub(super) struct ImageLayerStyles<'a> {
+    pub position_x: &'a [LengthPercentage],
+    pub position_y: &'a [LengthPercentage],
+    pub repeat: &'a [BackgroundRepeat],
+    pub size: &'a [BackgroundSize],
+}
+
+impl<'a> ImageLayerStyles<'a> {
+    pub(super) fn from_background(bg_styles: &'a Background) -> Self {
+        Self {
+            position_x: &bg_styles.background_position_x.0,
+            position_y: &bg_styles.background_position_y.0,
+            repeat: &bg_styles.background_repeat.0,
+            size: &bg_styles.background_size.0,
+        }
+    }
+
+    pub(super) fn from_svg(svg_styles: &'a SVG) -> Self {
+        Self {
+            position_x: &svg_styles.mask_position_x.0,
+            position_y: &svg_styles.mask_position_y.0,
+            repeat: &svg_styles.mask_repeat.0,
+            size: &svg_styles.mask_size.0,
+        }
+    }
+}
+
 impl ElementCx<'_, '_> {
     pub(super) fn draw_background(&self, scene: &mut impl PaintScene) {
         let bg_styles = &self.style.get_background();
+        let layers = ImageLayerStyles::from_background(bg_styles);
 
         let background_clip = get_cyclic(
             &bg_styles.background_clip.0,
@@ -41,7 +75,8 @@ impl ElementCx<'_, '_> {
         self.draw_solid_bg(scene, &background_clip_path);
 
         for (idx, segment) in bg_styles.background_image.0.iter().enumerate().rev() {
-            let background_clip = get_cyclic(&bg_styles.background_clip.0, idx);
+            let background_clip = *get_cyclic(&bg_styles.background_clip.0, idx);
+            let background_origin = *get_cyclic(&bg_styles.background_origin.0, idx);
             let background_clip_path = match background_clip {
                 StyloBackgroundClip::BorderBox => self.frame.border_box_path(),
                 StyloBackgroundClip::PaddingBox => self.frame.padding_box_path(),
@@ -57,37 +92,60 @@ impl ElementCx<'_, '_> {
                 None,
                 None,
                 |scene| {
-                    match segment {
-                        GenericImage::None => {
-                            // Do nothing
-                        }
-                        GenericImage::Gradient(gradient) => {
-                            self.draw_gradient_bg(scene, gradient, idx, *background_clip)
-                        }
-                        GenericImage::Url(_) => {
-                            self.draw_raster_bg_image(scene, idx);
-                            #[cfg(feature = "svg")]
-                            self.draw_svg_bg_image(scene, idx);
-                        }
-                        GenericImage::LightDark(_) => {
-                            #[cfg(feature = "tracing")]
-                            warn!("Implement background drawing for ImageLightDark")
-                        }
-                        GenericImage::PaintWorklet(_) => {
-                            #[cfg(feature = "tracing")]
-                            warn!("Implement background drawing for Image::PaintWorklet")
-                        }
-                        GenericImage::CrossFade(_) => {
-                            #[cfg(feature = "tracing")]
-                            warn!("Implement background drawing for Image::CrossFade")
-                        }
-                        GenericImage::ImageSet(_) => {
-                            #[cfg(feature = "tracing")]
-                            warn!("Implement background drawing for Image::ImageSet")
-                        }
-                    }
+                    self.draw_image_layer(
+                        scene,
+                        segment,
+                        idx,
+                        &layers,
+                        background_clip,
+                        background_origin,
+                        &self.element.background_images,
+                    );
                 },
             );
+        }
+    }
+
+    /// Draw a single layer of a CSS image layer list (`background-image` or `mask-image`)
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn draw_image_layer(
+        &self,
+        scene: &mut impl PaintScene,
+        segment: &ComputedImage,
+        idx: usize,
+        layers: &ImageLayerStyles,
+        clip: StyloBackgroundClip,
+        origin: StyloBackgroundOrigin,
+        images: &[Option<ImageResourceData>],
+    ) {
+        match segment {
+            GenericImage::None => {
+                // Do nothing
+            }
+            GenericImage::Gradient(gradient) => {
+                self.draw_gradient_layer(scene, gradient, idx, layers, clip, origin)
+            }
+            GenericImage::Url(_) => {
+                self.draw_raster_image_layer(scene, idx, layers, origin, images);
+                #[cfg(feature = "svg")]
+                self.draw_svg_image_layer(scene, idx, layers, images);
+            }
+            GenericImage::LightDark(_) => {
+                #[cfg(feature = "tracing")]
+                warn!("Implement image layer drawing for ImageLightDark")
+            }
+            GenericImage::PaintWorklet(_) => {
+                #[cfg(feature = "tracing")]
+                warn!("Implement image layer drawing for Image::PaintWorklet")
+            }
+            GenericImage::CrossFade(_) => {
+                #[cfg(feature = "tracing")]
+                warn!("Implement image layer drawing for Image::CrossFade")
+            }
+            GenericImage::ImageSet(_) => {
+                #[cfg(feature = "tracing")]
+                warn!("Implement image layer drawing for Image::ImageSet")
+            }
         }
     }
 
@@ -148,10 +206,16 @@ impl ElementCx<'_, '_> {
     }
 
     #[cfg(feature = "svg")]
-    fn draw_svg_bg_image(&self, scene: &mut impl PaintScene, idx: usize) {
+    fn draw_svg_image_layer(
+        &self,
+        scene: &mut impl PaintScene,
+        idx: usize,
+        layers: &ImageLayerStyles,
+        images: &[Option<ImageResourceData>],
+    ) {
         use kurbo::Affine;
 
-        let bg_image = self.element.background_images.get(idx);
+        let bg_image = images.get(idx);
 
         let Some(Some(bg_image)) = bg_image.as_ref() else {
             return;
@@ -160,14 +224,12 @@ impl ElementCx<'_, '_> {
             return;
         };
 
-        let bg_styles = &self.style.get_background();
-
         let frame_w = (self.frame.padding_box.width() / self.scale) as f32;
         let frame_h = (self.frame.padding_box.height() / self.scale) as f32;
 
         let svg_size = svg.size();
-        let bg_size = compute_background_size(
-            bg_styles,
+        let bg_size = compute_layer_size(
+            layers,
             frame_w,
             frame_h,
             idx,
@@ -177,8 +239,8 @@ impl ElementCx<'_, '_> {
         let x_ratio = (bg_size.width / svg_size.width() as f64) * self.scale;
         let y_ratio = (bg_size.height / svg_size.height() as f64) * self.scale;
 
-        let bg_pos = compute_background_position(
-            bg_styles,
+        let bg_pos = compute_layer_position(
+            layers,
             idx,
             frame_w - bg_size.width as f32,
             frame_h - bg_size.height as f32,
@@ -191,10 +253,17 @@ impl ElementCx<'_, '_> {
         anyrender_svg::render_svg_tree(scene, svg, transform);
     }
 
-    fn draw_raster_bg_image(&self, scene: &mut impl PaintScene, idx: usize) {
+    fn draw_raster_image_layer(
+        &self,
+        scene: &mut impl PaintScene,
+        idx: usize,
+        layers: &ImageLayerStyles,
+        origin: StyloBackgroundOrigin,
+        images: &[Option<ImageResourceData>],
+    ) {
         use BackgroundRepeatKeyword::*;
 
-        let bg_image = self.element.background_images.get(idx);
+        let bg_image = images.get(idx);
 
         let Some(Some(bg_image)) = bg_image.as_ref() else {
             return;
@@ -206,10 +275,7 @@ impl ElementCx<'_, '_> {
         let image_rendering = self.style.clone_image_rendering();
         let quality = to_image_quality(image_rendering);
 
-        let bg_styles = &self.style.get_background();
-
-        let background_origin = get_cyclic(&bg_styles.background_origin.0, idx);
-        let origin_rect = match background_origin {
+        let origin_rect = match origin {
             StyloBackgroundOrigin::BorderBox => self.frame.border_box,
             StyloBackgroundOrigin::PaddingBox => self.frame.padding_box,
             StyloBackgroundOrigin::ContentBox => self.frame.content_box,
@@ -218,8 +284,8 @@ impl ElementCx<'_, '_> {
         let image_width = image_data.width as f64;
         let image_height = image_data.height as f64;
 
-        let (bg_pos, bg_size) = compute_background_position_and_background_size(
-            bg_styles,
+        let (bg_pos, bg_size) = compute_layer_position_and_size(
+            layers,
             origin_rect.width() / self.scale,
             origin_rect.height() / self.scale,
             idx,
@@ -233,7 +299,7 @@ impl ElementCx<'_, '_> {
         let x_ratio = bg_size.width / image_width;
         let y_ratio = bg_size.height / image_height;
 
-        let BackgroundRepeat(repeat_x, repeat_y) = get_cyclic(&bg_styles.background_repeat.0, idx);
+        let BackgroundRepeat(repeat_x, repeat_y) = get_cyclic(layers.repeat, idx);
 
         let transform = self.transform.pre_scale_non_uniform(x_ratio, y_ratio);
         let (origin_rect, transform) = match repeat_x {
@@ -375,26 +441,25 @@ impl ElementCx<'_, '_> {
         }
     }
 
-    fn draw_gradient_bg(
+    fn draw_gradient_layer(
         &self,
         scene: &mut impl PaintScene,
         gradient: &StyloGradient,
         idx: usize,
+        layers: &ImageLayerStyles,
         background_clip: StyloBackgroundClip,
+        background_origin: StyloBackgroundOrigin,
     ) {
         use BackgroundRepeatKeyword::*;
 
-        let bg_styles = &self.style.get_background();
-
-        let background_origin = *get_cyclic(&bg_styles.background_origin.0, idx);
         let origin_rect = match background_origin {
             StyloBackgroundOrigin::BorderBox => self.frame.border_box,
             StyloBackgroundOrigin::PaddingBox => self.frame.padding_box,
             StyloBackgroundOrigin::ContentBox => self.frame.content_box,
         };
 
-        let (bg_pos, bg_size) = compute_background_position_and_background_size(
-            bg_styles,
+        let (bg_pos, bg_size) = compute_layer_position_and_size(
+            layers,
             origin_rect.width() / self.scale,
             origin_rect.height() / self.scale,
             idx,
@@ -405,7 +470,7 @@ impl ElementCx<'_, '_> {
         let bg_pos_y = bg_pos.y * self.scale;
         let bg_size = bg_size * self.scale;
 
-        let BackgroundRepeat(repeat_x, repeat_y) = get_cyclic(&bg_styles.background_repeat.0, idx);
+        let BackgroundRepeat(repeat_x, repeat_y) = get_cyclic(layers.repeat, idx);
 
         let transform = self.transform;
         let (origin_rect, transform, width_count, width_gap) = match repeat_x {
@@ -638,8 +703,8 @@ impl ElementCx<'_, '_> {
     }
 }
 
-fn compute_background_position_and_background_size(
-    background: &Background,
+fn compute_layer_position_and_size(
+    layers: &ImageLayerStyles,
     container_w: f64,
     container_h: f64,
     bg_idx: usize,
@@ -647,22 +712,22 @@ fn compute_background_position_and_background_size(
 ) -> (Point, Size) {
     use BackgroundRepeatKeyword::*;
 
-    let bg_size = compute_background_size(
-        background,
+    let bg_size = compute_layer_size(
+        layers,
         container_w as f32,
         container_h as f32,
         bg_idx,
         size_mode,
     );
 
-    let bg_pos = compute_background_position(
-        background,
+    let bg_pos = compute_layer_position(
+        layers,
         bg_idx,
         (container_w - bg_size.width) as f32,
         (container_h - bg_size.height) as f32,
     );
 
-    let BackgroundRepeat(repeat_x, repeat_y) = get_cyclic(&background.background_repeat.0, bg_idx);
+    let BackgroundRepeat(repeat_x, repeat_y) = get_cyclic(layers.repeat, bg_idx);
 
     let bg_size = if matches!(repeat_x, Round) && matches!(repeat_y, Round) {
         let count = (container_w / bg_size.width).round();
@@ -688,35 +753,35 @@ fn compute_background_position_and_background_size(
 }
 
 #[inline]
-fn compute_background_position(
-    background: &Background,
+fn compute_layer_position(
+    layers: &ImageLayerStyles,
     bg_idx: usize,
     width: f32,
     height: f32,
 ) -> Point {
     use style::values::computed::Length;
 
-    let bg_pos_x = get_cyclic(&background.background_position_x.0, bg_idx)
+    let bg_pos_x = get_cyclic(layers.position_x, bg_idx)
         .resolve(Length::new(width))
         .px() as f64;
-    let bg_pos_y = get_cyclic(&background.background_position_y.0, bg_idx)
+    let bg_pos_y = get_cyclic(layers.position_y, bg_idx)
         .resolve(Length::new(height))
         .px() as f64;
 
     Point::new(bg_pos_x, bg_pos_y)
 }
 
-fn compute_background_size(
-    background: &Background,
+fn compute_layer_size(
+    layers: &ImageLayerStyles,
     container_w: f32,
     container_h: f32,
     bg_idx: usize,
     mode: BackgroundSizeComputeMode,
 ) -> kurbo::Size {
-    use style::values::computed::{BackgroundSize, Length};
+    use style::values::computed::Length;
     use style::values::generics::length::GenericLengthPercentageOrAuto as Lpa;
 
-    let bg_size = get_cyclic(&background.background_size.0, bg_idx);
+    let bg_size = get_cyclic(layers.size, bg_idx);
 
     let (width, height): (f32, f32) = match bg_size {
         BackgroundSize::ExplicitSize { width, height } => {
@@ -810,7 +875,7 @@ fn compute_space_count_and_gap(bg_size: f64, size: f64) -> (u32, f64) {
 }
 
 #[inline]
-fn get_cyclic<T>(values: &[T], layer_index: usize) -> &T {
+pub(super) fn get_cyclic<T>(values: &[T], layer_index: usize) -> &T {
     &values[layer_index % values.len()]
 }
 

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -79,74 +79,76 @@ impl From<StyloMaskOrigin> for BoxModelBox {
     }
 }
 
-/// The styles and image data for the layers in a CSS image layer list
+/// The styles and image data for a single layer of a CSS image layer list
 /// (`background-image` or `mask-image`). The `background-*` and `mask-*`
 /// properties share computed value types, which allows the layer painting code
 /// to be shared.
 pub(super) struct ImageLayerStyles<'a> {
-    /// The computed value of the `background-image`/`mask-image` property
-    pub stylo_image: &'a [ComputedImage],
-    /// The loaded image resources for the `url()` images in `stylo_image`
-    pub image_data: &'a [Option<ImageResourceData>],
-    pub position_x: &'a [LengthPercentage],
-    pub position_y: &'a [LengthPercentage],
-    pub repeat: &'a [BackgroundRepeat],
-    pub size: &'a [BackgroundSize],
-    pub clip: Vec<BoxModelBox>,
-    pub origin: Vec<BoxModelBox>,
+    /// The computed value of the `background-image`/`mask-image` layer
+    pub stylo_image: &'a ComputedImage,
+    /// The loaded image resource if `stylo_image` is a `url()` image
+    pub image_data: Option<&'a ImageResourceData>,
+    pub position_x: &'a LengthPercentage,
+    pub position_y: &'a LengthPercentage,
+    pub repeat: &'a BackgroundRepeat,
+    pub size: &'a BackgroundSize,
+    pub clip: BoxModelBox,
+    pub origin: BoxModelBox,
 }
 
 impl<'a> ImageLayerStyles<'a> {
     pub(super) fn from_background(
         bg_styles: &'a Background,
         image_data: &'a [Option<ImageResourceData>],
+        idx: usize,
     ) -> Self {
         Self {
-            stylo_image: &bg_styles.background_image.0,
-            image_data,
-            position_x: &bg_styles.background_position_x.0,
-            position_y: &bg_styles.background_position_y.0,
-            repeat: &bg_styles.background_repeat.0,
-            size: &bg_styles.background_size.0,
-            clip: convert_boxes(&bg_styles.background_clip.0),
-            origin: convert_boxes(&bg_styles.background_origin.0),
+            stylo_image: &bg_styles.background_image.0[idx],
+            image_data: image_data.get(idx).and_then(Option::as_ref),
+            position_x: get_cyclic(&bg_styles.background_position_x.0, idx),
+            position_y: get_cyclic(&bg_styles.background_position_y.0, idx),
+            repeat: get_cyclic(&bg_styles.background_repeat.0, idx),
+            size: get_cyclic(&bg_styles.background_size.0, idx),
+            clip: (*get_cyclic(&bg_styles.background_clip.0, idx)).into(),
+            origin: (*get_cyclic(&bg_styles.background_origin.0, idx)).into(),
         }
     }
 
     pub(super) fn from_svg(
         svg_styles: &'a SVG,
         image_data: &'a [Option<ImageResourceData>],
+        idx: usize,
     ) -> Self {
         Self {
-            stylo_image: &svg_styles.mask_image.0,
-            image_data,
-            position_x: &svg_styles.mask_position_x.0,
-            position_y: &svg_styles.mask_position_y.0,
-            repeat: &svg_styles.mask_repeat.0,
-            size: &svg_styles.mask_size.0,
-            clip: convert_boxes(&svg_styles.mask_clip.0),
-            origin: convert_boxes(&svg_styles.mask_origin.0),
+            stylo_image: &svg_styles.mask_image.0[idx],
+            image_data: image_data.get(idx).and_then(Option::as_ref),
+            position_x: get_cyclic(&svg_styles.mask_position_x.0, idx),
+            position_y: get_cyclic(&svg_styles.mask_position_y.0, idx),
+            repeat: get_cyclic(&svg_styles.mask_repeat.0, idx),
+            size: get_cyclic(&svg_styles.mask_size.0, idx),
+            clip: (*get_cyclic(&svg_styles.mask_clip.0, idx)).into(),
+            origin: (*get_cyclic(&svg_styles.mask_origin.0, idx)).into(),
         }
     }
-}
-
-fn convert_boxes<T: Copy + Into<BoxModelBox>>(boxes: &[T]) -> Vec<BoxModelBox> {
-    boxes.iter().map(|b| (*b).into()).collect()
 }
 
 impl ElementCx<'_, '_> {
     pub(super) fn draw_background(&self, scene: &mut impl PaintScene) {
         let bg_styles = &self.style.get_background();
-        let layers = ImageLayerStyles::from_background(bg_styles, &self.element.background_images);
+        let image_data = &self.element.background_images;
+        let layer_count = bg_styles.background_image.0.len();
 
-        let background_clip = *get_cyclic(&layers.clip, layers.stylo_image.len() - 1);
+        // The background color is clipped by the clip of the last layer in the list
+        let background_clip: BoxModelBox =
+            (*get_cyclic(&bg_styles.background_clip.0, layer_count - 1)).into();
         let background_clip_path = self.box_path(background_clip);
 
         // Draw background color (if any)
         self.draw_solid_bg(scene, &background_clip_path);
 
-        for idx in (0..layers.stylo_image.len()).rev() {
-            let background_clip_path = self.box_path(*get_cyclic(&layers.clip, idx));
+        for idx in (0..layer_count).rev() {
+            let layer = ImageLayerStyles::from_background(bg_styles, image_data, idx);
+            let background_clip_path = self.box_path(layer.clip);
 
             self.context.layer_manager.maybe_with_layer(
                 scene,
@@ -157,7 +159,7 @@ impl ElementCx<'_, '_> {
                 None,
                 None,
                 |scene| {
-                    self.draw_image_layer(scene, idx, &layers);
+                    self.draw_image_layer(scene, &layer);
                 },
             );
         }
@@ -182,23 +184,16 @@ impl ElementCx<'_, '_> {
     }
 
     /// Draw a single layer of a CSS image layer list (`background-image` or `mask-image`)
-    pub(super) fn draw_image_layer(
-        &self,
-        scene: &mut impl PaintScene,
-        idx: usize,
-        layers: &ImageLayerStyles,
-    ) {
-        match &layers.stylo_image[idx] {
+    pub(super) fn draw_image_layer(&self, scene: &mut impl PaintScene, layer: &ImageLayerStyles) {
+        match layer.stylo_image {
             GenericImage::None => {
                 // Do nothing
             }
-            GenericImage::Gradient(gradient) => {
-                self.draw_gradient_layer(scene, gradient, idx, layers)
-            }
+            GenericImage::Gradient(gradient) => self.draw_gradient_layer(scene, gradient, layer),
             GenericImage::Url(_) => {
-                self.draw_raster_image_layer(scene, idx, layers);
+                self.draw_raster_image_layer(scene, layer);
                 #[cfg(feature = "svg")]
-                self.draw_svg_image_layer(scene, idx, layers);
+                self.draw_svg_image_layer(scene, layer);
             }
             GenericImage::LightDark(_) => {
                 #[cfg(feature = "tracing")]
@@ -276,17 +271,10 @@ impl ElementCx<'_, '_> {
     }
 
     #[cfg(feature = "svg")]
-    fn draw_svg_image_layer(
-        &self,
-        scene: &mut impl PaintScene,
-        idx: usize,
-        layers: &ImageLayerStyles,
-    ) {
+    fn draw_svg_image_layer(&self, scene: &mut impl PaintScene, layer: &ImageLayerStyles) {
         use kurbo::Affine;
 
-        let bg_image = layers.image_data.get(idx);
-
-        let Some(Some(bg_image)) = bg_image.as_ref() else {
+        let Some(bg_image) = layer.image_data else {
             return;
         };
         let ImageData::Svg(svg) = &bg_image.image else {
@@ -298,10 +286,9 @@ impl ElementCx<'_, '_> {
 
         let svg_size = svg.size();
         let bg_size = compute_layer_size(
-            layers,
+            layer,
             frame_w,
             frame_h,
-            idx,
             BackgroundSizeComputeMode::Size(svg_size.width(), svg_size.height()),
         );
 
@@ -309,8 +296,7 @@ impl ElementCx<'_, '_> {
         let y_ratio = (bg_size.height / svg_size.height() as f64) * self.scale;
 
         let bg_pos = compute_layer_position(
-            layers,
-            idx,
+            layer,
             frame_w - bg_size.width as f32,
             frame_h - bg_size.height as f32,
         );
@@ -322,17 +308,10 @@ impl ElementCx<'_, '_> {
         anyrender_svg::render_svg_tree(scene, svg, transform);
     }
 
-    fn draw_raster_image_layer(
-        &self,
-        scene: &mut impl PaintScene,
-        idx: usize,
-        layers: &ImageLayerStyles,
-    ) {
+    fn draw_raster_image_layer(&self, scene: &mut impl PaintScene, layer: &ImageLayerStyles) {
         use BackgroundRepeatKeyword::*;
 
-        let bg_image = layers.image_data.get(idx);
-
-        let Some(Some(bg_image)) = bg_image.as_ref() else {
+        let Some(bg_image) = layer.image_data else {
             return;
         };
         let ImageData::Raster(image_data) = &bg_image.image else {
@@ -342,16 +321,15 @@ impl ElementCx<'_, '_> {
         let image_rendering = self.style.clone_image_rendering();
         let quality = to_image_quality(image_rendering);
 
-        let origin_rect = self.box_rect(*get_cyclic(&layers.origin, idx));
+        let origin_rect = self.box_rect(layer.origin);
 
         let image_width = image_data.width as f64;
         let image_height = image_data.height as f64;
 
         let (bg_pos, bg_size) = compute_layer_position_and_size(
-            layers,
+            layer,
             origin_rect.width() / self.scale,
             origin_rect.height() / self.scale,
-            idx,
             BackgroundSizeComputeMode::Size(image_width as f32, image_height as f32),
         );
 
@@ -362,7 +340,7 @@ impl ElementCx<'_, '_> {
         let x_ratio = bg_size.width / image_width;
         let y_ratio = bg_size.height / image_height;
 
-        let BackgroundRepeat(repeat_x, repeat_y) = get_cyclic(layers.repeat, idx);
+        let BackgroundRepeat(repeat_x, repeat_y) = layer.repeat;
 
         let transform = self.transform.pre_scale_non_uniform(x_ratio, y_ratio);
         let (origin_rect, transform) = match repeat_x {
@@ -508,20 +486,18 @@ impl ElementCx<'_, '_> {
         &self,
         scene: &mut impl PaintScene,
         gradient: &StyloGradient,
-        idx: usize,
-        layers: &ImageLayerStyles,
+        layer: &ImageLayerStyles,
     ) {
         use BackgroundRepeatKeyword::*;
 
-        let background_clip = *get_cyclic(&layers.clip, idx);
-        let background_origin = *get_cyclic(&layers.origin, idx);
+        let background_clip = layer.clip;
+        let background_origin = layer.origin;
         let origin_rect = self.box_rect(background_origin);
 
         let (bg_pos, bg_size) = compute_layer_position_and_size(
-            layers,
+            layer,
             origin_rect.width() / self.scale,
             origin_rect.height() / self.scale,
-            idx,
             BackgroundSizeComputeMode::Auto,
         );
 
@@ -529,7 +505,7 @@ impl ElementCx<'_, '_> {
         let bg_pos_y = bg_pos.y * self.scale;
         let bg_size = bg_size * self.scale;
 
-        let BackgroundRepeat(repeat_x, repeat_y) = get_cyclic(layers.repeat, idx);
+        let BackgroundRepeat(repeat_x, repeat_y) = layer.repeat;
 
         let transform = self.transform;
         let (origin_rect, transform, width_count, width_gap) = match repeat_x {
@@ -747,30 +723,22 @@ impl ElementCx<'_, '_> {
 }
 
 fn compute_layer_position_and_size(
-    layers: &ImageLayerStyles,
+    layer: &ImageLayerStyles,
     container_w: f64,
     container_h: f64,
-    bg_idx: usize,
     size_mode: BackgroundSizeComputeMode,
 ) -> (Point, Size) {
     use BackgroundRepeatKeyword::*;
 
-    let bg_size = compute_layer_size(
-        layers,
-        container_w as f32,
-        container_h as f32,
-        bg_idx,
-        size_mode,
-    );
+    let bg_size = compute_layer_size(layer, container_w as f32, container_h as f32, size_mode);
 
     let bg_pos = compute_layer_position(
-        layers,
-        bg_idx,
+        layer,
         (container_w - bg_size.width) as f32,
         (container_h - bg_size.height) as f32,
     );
 
-    let BackgroundRepeat(repeat_x, repeat_y) = get_cyclic(layers.repeat, bg_idx);
+    let BackgroundRepeat(repeat_x, repeat_y) = layer.repeat;
 
     let bg_size = if matches!(repeat_x, Round) && matches!(repeat_y, Round) {
         let count = (container_w / bg_size.width).round();
@@ -796,37 +764,25 @@ fn compute_layer_position_and_size(
 }
 
 #[inline]
-fn compute_layer_position(
-    layers: &ImageLayerStyles,
-    bg_idx: usize,
-    width: f32,
-    height: f32,
-) -> Point {
+fn compute_layer_position(layer: &ImageLayerStyles, width: f32, height: f32) -> Point {
     use style::values::computed::Length;
 
-    let bg_pos_x = get_cyclic(layers.position_x, bg_idx)
-        .resolve(Length::new(width))
-        .px() as f64;
-    let bg_pos_y = get_cyclic(layers.position_y, bg_idx)
-        .resolve(Length::new(height))
-        .px() as f64;
+    let bg_pos_x = layer.position_x.resolve(Length::new(width)).px() as f64;
+    let bg_pos_y = layer.position_y.resolve(Length::new(height)).px() as f64;
 
     Point::new(bg_pos_x, bg_pos_y)
 }
 
 fn compute_layer_size(
-    layers: &ImageLayerStyles,
+    layer: &ImageLayerStyles,
     container_w: f32,
     container_h: f32,
-    bg_idx: usize,
     mode: BackgroundSizeComputeMode,
 ) -> kurbo::Size {
     use style::values::computed::Length;
     use style::values::generics::length::GenericLengthPercentageOrAuto as Lpa;
 
-    let bg_size = get_cyclic(layers.size, bg_idx);
-
-    let (width, height): (f32, f32) = match bg_size {
+    let (width, height): (f32, f32) = match layer.size {
         BackgroundSize::ExplicitSize { width, height } => {
             let width = width.map(|w| w.0.resolve(Length::new(container_w)));
             let height = height.map(|h| h.0.resolve(Length::new(container_h)));

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -102,15 +102,19 @@ impl<'a> ImageLayerStyles<'a> {
         image_data: &'a [Option<ImageResourceData>],
         idx: usize,
     ) -> Self {
+        // The non-`background-image` property lists repeat cyclically if they are
+        // shorter than the `background-image` list. They all have the same length,
+        // so a single cyclic index can be used for all of them.
+        let cyclic_idx = idx % bg_styles.background_position_x.0.len();
         Self {
             stylo_image: &bg_styles.background_image.0[idx],
             image_data: image_data.get(idx).and_then(Option::as_ref),
-            position_x: get_cyclic(&bg_styles.background_position_x.0, idx),
-            position_y: get_cyclic(&bg_styles.background_position_y.0, idx),
-            repeat: get_cyclic(&bg_styles.background_repeat.0, idx),
-            size: get_cyclic(&bg_styles.background_size.0, idx),
-            clip: (*get_cyclic(&bg_styles.background_clip.0, idx)).into(),
-            origin: (*get_cyclic(&bg_styles.background_origin.0, idx)).into(),
+            position_x: &bg_styles.background_position_x.0[cyclic_idx],
+            position_y: &bg_styles.background_position_y.0[cyclic_idx],
+            repeat: &bg_styles.background_repeat.0[cyclic_idx],
+            size: &bg_styles.background_size.0[cyclic_idx],
+            clip: bg_styles.background_clip.0[cyclic_idx].into(),
+            origin: bg_styles.background_origin.0[cyclic_idx].into(),
         }
     }
 
@@ -119,15 +123,19 @@ impl<'a> ImageLayerStyles<'a> {
         image_data: &'a [Option<ImageResourceData>],
         idx: usize,
     ) -> Self {
+        // The non-`mask-image` property lists repeat cyclically if they are
+        // shorter than the `mask-image` list. They all have the same length,
+        // so a single cyclic index can be used for all of them.
+        let cyclic_idx = idx % svg_styles.mask_position_x.0.len();
         Self {
             stylo_image: &svg_styles.mask_image.0[idx],
             image_data: image_data.get(idx).and_then(Option::as_ref),
-            position_x: get_cyclic(&svg_styles.mask_position_x.0, idx),
-            position_y: get_cyclic(&svg_styles.mask_position_y.0, idx),
-            repeat: get_cyclic(&svg_styles.mask_repeat.0, idx),
-            size: get_cyclic(&svg_styles.mask_size.0, idx),
-            clip: (*get_cyclic(&svg_styles.mask_clip.0, idx)).into(),
-            origin: (*get_cyclic(&svg_styles.mask_origin.0, idx)).into(),
+            position_x: &svg_styles.mask_position_x.0[cyclic_idx],
+            position_y: &svg_styles.mask_position_y.0[cyclic_idx],
+            repeat: &svg_styles.mask_repeat.0[cyclic_idx],
+            size: &svg_styles.mask_size.0[cyclic_idx],
+            clip: svg_styles.mask_clip.0[cyclic_idx].into(),
+            origin: svg_styles.mask_origin.0[cyclic_idx].into(),
         }
     }
 }
@@ -139,8 +147,8 @@ impl ElementCx<'_, '_> {
         let layer_count = bg_styles.background_image.0.len();
 
         // The background color is clipped by the clip of the last layer in the list
-        let background_clip: BoxModelBox =
-            (*get_cyclic(&bg_styles.background_clip.0, layer_count - 1)).into();
+        let clip_list = &bg_styles.background_clip.0;
+        let background_clip: BoxModelBox = clip_list[(layer_count - 1) % clip_list.len()].into();
         let background_clip_path = self.box_path(background_clip);
 
         // Draw background color (if any)
@@ -871,11 +879,6 @@ fn compute_space_count_and_gap(bg_size: f64, size: f64) -> (u32, f64) {
     } + size;
 
     (count, gap)
-}
-
-#[inline]
-pub(super) fn get_cyclic<T>(values: &[T], layer_index: usize) -> &T {
-    &values[layer_index % values.len()]
 }
 
 fn extend(offset: f64, length: f64) -> f64 {

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -10,6 +10,8 @@ use style::{
         generated::longhands::{
             background_clip::single_value::computed_value::T as StyloBackgroundClip,
             background_origin::single_value::computed_value::T as StyloBackgroundOrigin,
+            mask_clip::single_value::computed_value::T as StyloMaskClip,
+            mask_origin::single_value::computed_value::T as StyloMaskOrigin,
         },
         style_structs::{Background, SVG},
     },
@@ -26,6 +28,57 @@ use style::{
 #[cfg(feature = "tracing")]
 use tracing::warn;
 
+/// A box from the CSS box model. Abstracts over the (structurally identical)
+/// computed value types of the `background-clip`/`background-origin` and
+/// `mask-clip`/`mask-origin` properties.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)] // The variants are named after the CSS keywords
+pub(super) enum BoxModelBox {
+    BorderBox,
+    PaddingBox,
+    ContentBox,
+}
+
+impl From<StyloBackgroundClip> for BoxModelBox {
+    fn from(value: StyloBackgroundClip) -> Self {
+        match value {
+            StyloBackgroundClip::BorderBox => Self::BorderBox,
+            StyloBackgroundClip::PaddingBox => Self::PaddingBox,
+            StyloBackgroundClip::ContentBox => Self::ContentBox,
+        }
+    }
+}
+
+impl From<StyloBackgroundOrigin> for BoxModelBox {
+    fn from(value: StyloBackgroundOrigin) -> Self {
+        match value {
+            StyloBackgroundOrigin::BorderBox => Self::BorderBox,
+            StyloBackgroundOrigin::PaddingBox => Self::PaddingBox,
+            StyloBackgroundOrigin::ContentBox => Self::ContentBox,
+        }
+    }
+}
+
+impl From<StyloMaskClip> for BoxModelBox {
+    fn from(value: StyloMaskClip) -> Self {
+        match value {
+            StyloMaskClip::BorderBox => Self::BorderBox,
+            StyloMaskClip::PaddingBox => Self::PaddingBox,
+            StyloMaskClip::ContentBox => Self::ContentBox,
+        }
+    }
+}
+
+impl From<StyloMaskOrigin> for BoxModelBox {
+    fn from(value: StyloMaskOrigin) -> Self {
+        match value {
+            StyloMaskOrigin::BorderBox => Self::BorderBox,
+            StyloMaskOrigin::PaddingBox => Self::PaddingBox,
+            StyloMaskOrigin::ContentBox => Self::ContentBox,
+        }
+    }
+}
+
 /// The styles which control the sizing/positioning of the layers in a CSS image
 /// layer list. The `background-*` and `mask-*` properties share computed value
 /// types for these, which allows the layer painting code to be shared.
@@ -34,6 +87,8 @@ pub(super) struct ImageLayerStyles<'a> {
     pub position_y: &'a [LengthPercentage],
     pub repeat: &'a [BackgroundRepeat],
     pub size: &'a [BackgroundSize],
+    pub clip: Vec<BoxModelBox>,
+    pub origin: Vec<BoxModelBox>,
 }
 
 impl<'a> ImageLayerStyles<'a> {
@@ -43,6 +98,8 @@ impl<'a> ImageLayerStyles<'a> {
             position_y: &bg_styles.background_position_y.0,
             repeat: &bg_styles.background_repeat.0,
             size: &bg_styles.background_size.0,
+            clip: convert_boxes(&bg_styles.background_clip.0),
+            origin: convert_boxes(&bg_styles.background_origin.0),
         }
     }
 
@@ -52,8 +109,14 @@ impl<'a> ImageLayerStyles<'a> {
             position_y: &svg_styles.mask_position_y.0,
             repeat: &svg_styles.mask_repeat.0,
             size: &svg_styles.mask_size.0,
+            clip: convert_boxes(&svg_styles.mask_clip.0),
+            origin: convert_boxes(&svg_styles.mask_origin.0),
         }
     }
+}
+
+fn convert_boxes<T: Copy + Into<BoxModelBox>>(boxes: &[T]) -> Vec<BoxModelBox> {
+    boxes.iter().map(|b| (*b).into()).collect()
 }
 
 impl ElementCx<'_, '_> {
@@ -61,27 +124,14 @@ impl ElementCx<'_, '_> {
         let bg_styles = &self.style.get_background();
         let layers = ImageLayerStyles::from_background(bg_styles);
 
-        let background_clip = get_cyclic(
-            &bg_styles.background_clip.0,
-            bg_styles.background_image.0.len() - 1,
-        );
-        let background_clip_path = match background_clip {
-            StyloBackgroundClip::BorderBox => self.frame.border_box_path(),
-            StyloBackgroundClip::PaddingBox => self.frame.padding_box_path(),
-            StyloBackgroundClip::ContentBox => self.frame.content_box_path(),
-        };
+        let background_clip = *get_cyclic(&layers.clip, bg_styles.background_image.0.len() - 1);
+        let background_clip_path = self.box_path(background_clip);
 
         // Draw background color (if any)
         self.draw_solid_bg(scene, &background_clip_path);
 
         for (idx, segment) in bg_styles.background_image.0.iter().enumerate().rev() {
-            let background_clip = *get_cyclic(&bg_styles.background_clip.0, idx);
-            let background_origin = *get_cyclic(&bg_styles.background_origin.0, idx);
-            let background_clip_path = match background_clip {
-                StyloBackgroundClip::BorderBox => self.frame.border_box_path(),
-                StyloBackgroundClip::PaddingBox => self.frame.padding_box_path(),
-                StyloBackgroundClip::ContentBox => self.frame.content_box_path(),
-            };
+            let background_clip_path = self.box_path(*get_cyclic(&layers.clip, idx));
 
             self.context.layer_manager.maybe_with_layer(
                 scene,
@@ -97,8 +147,6 @@ impl ElementCx<'_, '_> {
                         segment,
                         idx,
                         &layers,
-                        background_clip,
-                        background_origin,
                         &self.element.background_images,
                     );
                 },
@@ -106,16 +154,31 @@ impl ElementCx<'_, '_> {
         }
     }
 
+    /// The path of the given CSS box model box for this element
+    pub(super) fn box_path(&self, css_box: BoxModelBox) -> BezPath {
+        match css_box {
+            BoxModelBox::BorderBox => self.frame.border_box_path(),
+            BoxModelBox::PaddingBox => self.frame.padding_box_path(),
+            BoxModelBox::ContentBox => self.frame.content_box_path(),
+        }
+    }
+
+    /// The rect of the given CSS box model box for this element
+    fn box_rect(&self, css_box: BoxModelBox) -> Rect {
+        match css_box {
+            BoxModelBox::BorderBox => self.frame.border_box,
+            BoxModelBox::PaddingBox => self.frame.padding_box,
+            BoxModelBox::ContentBox => self.frame.content_box,
+        }
+    }
+
     /// Draw a single layer of a CSS image layer list (`background-image` or `mask-image`)
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn draw_image_layer(
         &self,
         scene: &mut impl PaintScene,
         segment: &ComputedImage,
         idx: usize,
         layers: &ImageLayerStyles,
-        clip: StyloBackgroundClip,
-        origin: StyloBackgroundOrigin,
         images: &[Option<ImageResourceData>],
     ) {
         match segment {
@@ -123,10 +186,10 @@ impl ElementCx<'_, '_> {
                 // Do nothing
             }
             GenericImage::Gradient(gradient) => {
-                self.draw_gradient_layer(scene, gradient, idx, layers, clip, origin)
+                self.draw_gradient_layer(scene, gradient, idx, layers)
             }
             GenericImage::Url(_) => {
-                self.draw_raster_image_layer(scene, idx, layers, origin, images);
+                self.draw_raster_image_layer(scene, idx, layers, images);
                 #[cfg(feature = "svg")]
                 self.draw_svg_image_layer(scene, idx, layers, images);
             }
@@ -258,7 +321,6 @@ impl ElementCx<'_, '_> {
         scene: &mut impl PaintScene,
         idx: usize,
         layers: &ImageLayerStyles,
-        origin: StyloBackgroundOrigin,
         images: &[Option<ImageResourceData>],
     ) {
         use BackgroundRepeatKeyword::*;
@@ -275,11 +337,7 @@ impl ElementCx<'_, '_> {
         let image_rendering = self.style.clone_image_rendering();
         let quality = to_image_quality(image_rendering);
 
-        let origin_rect = match origin {
-            StyloBackgroundOrigin::BorderBox => self.frame.border_box,
-            StyloBackgroundOrigin::PaddingBox => self.frame.padding_box,
-            StyloBackgroundOrigin::ContentBox => self.frame.content_box,
-        };
+        let origin_rect = self.box_rect(*get_cyclic(&layers.origin, idx));
 
         let image_width = image_data.width as f64;
         let image_height = image_data.height as f64;
@@ -447,16 +505,12 @@ impl ElementCx<'_, '_> {
         gradient: &StyloGradient,
         idx: usize,
         layers: &ImageLayerStyles,
-        background_clip: StyloBackgroundClip,
-        background_origin: StyloBackgroundOrigin,
     ) {
         use BackgroundRepeatKeyword::*;
 
-        let origin_rect = match background_origin {
-            StyloBackgroundOrigin::BorderBox => self.frame.border_box,
-            StyloBackgroundOrigin::PaddingBox => self.frame.padding_box,
-            StyloBackgroundOrigin::ContentBox => self.frame.content_box,
-        };
+        let background_clip = *get_cyclic(&layers.clip, idx);
+        let background_origin = *get_cyclic(&layers.origin, idx);
+        let origin_rect = self.box_rect(background_origin);
 
         let (bg_pos, bg_size) = compute_layer_position_and_size(
             layers,
@@ -476,10 +530,8 @@ impl ElementCx<'_, '_> {
         let (origin_rect, transform, width_count, width_gap) = match repeat_x {
             Repeat | Round => {
                 let (origin_rect, extend_width, count) = if (background_clip, background_origin)
-                    == (
-                        StyloBackgroundClip::BorderBox,
-                        StyloBackgroundOrigin::PaddingBox,
-                    ) {
+                    == (BoxModelBox::BorderBox, BoxModelBox::PaddingBox)
+                {
                     let extend_width = extend(self.frame.border_width.x0 + bg_pos_x, bg_size.width);
 
                     let width = self.frame.border_box.width() + extend_width;
@@ -492,10 +544,7 @@ impl ElementCx<'_, '_> {
 
                     (origin_rect, extend_width, count)
                 } else if (background_clip, background_origin)
-                    == (
-                        StyloBackgroundClip::BorderBox,
-                        StyloBackgroundOrigin::ContentBox,
-                    )
+                    == (BoxModelBox::BorderBox, BoxModelBox::ContentBox)
                 {
                     let extend_width = extend(
                         self.frame.border_width.x0 + self.frame.padding_width.x0 + bg_pos_x,
@@ -511,10 +560,7 @@ impl ElementCx<'_, '_> {
 
                     (origin_rect, extend_width, count)
                 } else if (background_clip, background_origin)
-                    == (
-                        StyloBackgroundClip::PaddingBox,
-                        StyloBackgroundOrigin::ContentBox,
-                    )
+                    == (BoxModelBox::PaddingBox, BoxModelBox::ContentBox)
                 {
                     let extend_width =
                         extend(self.frame.padding_width.x0 + bg_pos_x, bg_size.width);
@@ -572,10 +618,8 @@ impl ElementCx<'_, '_> {
         let (origin_rect, transform, height_count, height_gap) = match repeat_y {
             Repeat | Round => {
                 let (origin_rect, extend_height, count) = if (background_clip, background_origin)
-                    == (
-                        StyloBackgroundClip::BorderBox,
-                        StyloBackgroundOrigin::PaddingBox,
-                    ) {
+                    == (BoxModelBox::BorderBox, BoxModelBox::PaddingBox)
+                {
                     let extend_height =
                         extend(self.frame.border_width.y0 + bg_pos_y, bg_size.height);
                     let height = self.frame.border_box.height() + extend_height;
@@ -588,10 +632,7 @@ impl ElementCx<'_, '_> {
 
                     (origin_rect, extend_height, count)
                 } else if (background_clip, background_origin)
-                    == (
-                        StyloBackgroundClip::BorderBox,
-                        StyloBackgroundOrigin::ContentBox,
-                    )
+                    == (BoxModelBox::BorderBox, BoxModelBox::ContentBox)
                 {
                     let extend_height = extend(
                         self.frame.border_width.y0 + self.frame.padding_width.y0 + bg_pos_x,
@@ -607,10 +648,7 @@ impl ElementCx<'_, '_> {
 
                     (origin_rect, extend_height, count)
                 } else if (background_clip, background_origin)
-                    == (
-                        StyloBackgroundClip::PaddingBox,
-                        StyloBackgroundOrigin::ContentBox,
-                    )
+                    == (BoxModelBox::PaddingBox, BoxModelBox::ContentBox)
                 {
                     let extend_height =
                         extend(self.frame.padding_width.y0 + bg_pos_x, bg_size.height);

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -102,19 +102,15 @@ impl<'a> ImageLayerStyles<'a> {
         image_data: &'a [Option<ImageResourceData>],
         idx: usize,
     ) -> Self {
-        // The non-`background-image` property lists repeat cyclically if they are
-        // shorter than the `background-image` list. They all have the same length,
-        // so a single cyclic index can be used for all of them.
-        let cyclic_idx = idx % bg_styles.background_position_x.0.len();
         Self {
             stylo_image: &bg_styles.background_image.0[idx],
             image_data: image_data.get(idx).and_then(Option::as_ref),
-            position_x: &bg_styles.background_position_x.0[cyclic_idx],
-            position_y: &bg_styles.background_position_y.0[cyclic_idx],
-            repeat: &bg_styles.background_repeat.0[cyclic_idx],
-            size: &bg_styles.background_size.0[cyclic_idx],
-            clip: bg_styles.background_clip.0[cyclic_idx].into(),
-            origin: bg_styles.background_origin.0[cyclic_idx].into(),
+            position_x: get_cyclic(&bg_styles.background_position_x.0, idx),
+            position_y: get_cyclic(&bg_styles.background_position_y.0, idx),
+            repeat: get_cyclic(&bg_styles.background_repeat.0, idx),
+            size: get_cyclic(&bg_styles.background_size.0, idx),
+            clip: (*get_cyclic(&bg_styles.background_clip.0, idx)).into(),
+            origin: (*get_cyclic(&bg_styles.background_origin.0, idx)).into(),
         }
     }
 
@@ -123,19 +119,15 @@ impl<'a> ImageLayerStyles<'a> {
         image_data: &'a [Option<ImageResourceData>],
         idx: usize,
     ) -> Self {
-        // The non-`mask-image` property lists repeat cyclically if they are
-        // shorter than the `mask-image` list. They all have the same length,
-        // so a single cyclic index can be used for all of them.
-        let cyclic_idx = idx % svg_styles.mask_position_x.0.len();
         Self {
             stylo_image: &svg_styles.mask_image.0[idx],
             image_data: image_data.get(idx).and_then(Option::as_ref),
-            position_x: &svg_styles.mask_position_x.0[cyclic_idx],
-            position_y: &svg_styles.mask_position_y.0[cyclic_idx],
-            repeat: &svg_styles.mask_repeat.0[cyclic_idx],
-            size: &svg_styles.mask_size.0[cyclic_idx],
-            clip: svg_styles.mask_clip.0[cyclic_idx].into(),
-            origin: svg_styles.mask_origin.0[cyclic_idx].into(),
+            position_x: get_cyclic(&svg_styles.mask_position_x.0, idx),
+            position_y: get_cyclic(&svg_styles.mask_position_y.0, idx),
+            repeat: get_cyclic(&svg_styles.mask_repeat.0, idx),
+            size: get_cyclic(&svg_styles.mask_size.0, idx),
+            clip: (*get_cyclic(&svg_styles.mask_clip.0, idx)).into(),
+            origin: (*get_cyclic(&svg_styles.mask_origin.0, idx)).into(),
         }
     }
 }
@@ -147,8 +139,8 @@ impl ElementCx<'_, '_> {
         let layer_count = bg_styles.background_image.0.len();
 
         // The background color is clipped by the clip of the last layer in the list
-        let clip_list = &bg_styles.background_clip.0;
-        let background_clip: BoxModelBox = clip_list[(layer_count - 1) % clip_list.len()].into();
+        let background_clip: BoxModelBox =
+            (*get_cyclic(&bg_styles.background_clip.0, layer_count - 1)).into();
         let background_clip_path = self.box_path(background_clip);
 
         // Draw background color (if any)
@@ -879,6 +871,11 @@ fn compute_space_count_and_gap(bg_size: f64, size: f64) -> (u32, f64) {
     } + size;
 
     (count, gap)
+}
+
+#[inline]
+pub(super) fn get_cyclic<T>(values: &[T], layer_index: usize) -> &T {
+    &values[layer_index % values.len()]
 }
 
 fn extend(offset: f64, length: f64) -> f64 {

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -79,10 +79,15 @@ impl From<StyloMaskOrigin> for BoxModelBox {
     }
 }
 
-/// The styles which control the sizing/positioning of the layers in a CSS image
-/// layer list. The `background-*` and `mask-*` properties share computed value
-/// types for these, which allows the layer painting code to be shared.
+/// The styles and image data for the layers in a CSS image layer list
+/// (`background-image` or `mask-image`). The `background-*` and `mask-*`
+/// properties share computed value types, which allows the layer painting code
+/// to be shared.
 pub(super) struct ImageLayerStyles<'a> {
+    /// The computed value of the `background-image`/`mask-image` property
+    pub stylo_image: &'a [ComputedImage],
+    /// The loaded image resources for the `url()` images in `stylo_image`
+    pub image_data: &'a [Option<ImageResourceData>],
     pub position_x: &'a [LengthPercentage],
     pub position_y: &'a [LengthPercentage],
     pub repeat: &'a [BackgroundRepeat],
@@ -92,8 +97,13 @@ pub(super) struct ImageLayerStyles<'a> {
 }
 
 impl<'a> ImageLayerStyles<'a> {
-    pub(super) fn from_background(bg_styles: &'a Background) -> Self {
+    pub(super) fn from_background(
+        bg_styles: &'a Background,
+        image_data: &'a [Option<ImageResourceData>],
+    ) -> Self {
         Self {
+            stylo_image: &bg_styles.background_image.0,
+            image_data,
             position_x: &bg_styles.background_position_x.0,
             position_y: &bg_styles.background_position_y.0,
             repeat: &bg_styles.background_repeat.0,
@@ -103,8 +113,13 @@ impl<'a> ImageLayerStyles<'a> {
         }
     }
 
-    pub(super) fn from_svg(svg_styles: &'a SVG) -> Self {
+    pub(super) fn from_svg(
+        svg_styles: &'a SVG,
+        image_data: &'a [Option<ImageResourceData>],
+    ) -> Self {
         Self {
+            stylo_image: &svg_styles.mask_image.0,
+            image_data,
             position_x: &svg_styles.mask_position_x.0,
             position_y: &svg_styles.mask_position_y.0,
             repeat: &svg_styles.mask_repeat.0,
@@ -122,15 +137,15 @@ fn convert_boxes<T: Copy + Into<BoxModelBox>>(boxes: &[T]) -> Vec<BoxModelBox> {
 impl ElementCx<'_, '_> {
     pub(super) fn draw_background(&self, scene: &mut impl PaintScene) {
         let bg_styles = &self.style.get_background();
-        let layers = ImageLayerStyles::from_background(bg_styles);
+        let layers = ImageLayerStyles::from_background(bg_styles, &self.element.background_images);
 
-        let background_clip = *get_cyclic(&layers.clip, bg_styles.background_image.0.len() - 1);
+        let background_clip = *get_cyclic(&layers.clip, layers.stylo_image.len() - 1);
         let background_clip_path = self.box_path(background_clip);
 
         // Draw background color (if any)
         self.draw_solid_bg(scene, &background_clip_path);
 
-        for (idx, segment) in bg_styles.background_image.0.iter().enumerate().rev() {
+        for idx in (0..layers.stylo_image.len()).rev() {
             let background_clip_path = self.box_path(*get_cyclic(&layers.clip, idx));
 
             self.context.layer_manager.maybe_with_layer(
@@ -142,13 +157,7 @@ impl ElementCx<'_, '_> {
                 None,
                 None,
                 |scene| {
-                    self.draw_image_layer(
-                        scene,
-                        segment,
-                        idx,
-                        &layers,
-                        &self.element.background_images,
-                    );
+                    self.draw_image_layer(scene, idx, &layers);
                 },
             );
         }
@@ -176,12 +185,10 @@ impl ElementCx<'_, '_> {
     pub(super) fn draw_image_layer(
         &self,
         scene: &mut impl PaintScene,
-        segment: &ComputedImage,
         idx: usize,
         layers: &ImageLayerStyles,
-        images: &[Option<ImageResourceData>],
     ) {
-        match segment {
+        match &layers.stylo_image[idx] {
             GenericImage::None => {
                 // Do nothing
             }
@@ -189,9 +196,9 @@ impl ElementCx<'_, '_> {
                 self.draw_gradient_layer(scene, gradient, idx, layers)
             }
             GenericImage::Url(_) => {
-                self.draw_raster_image_layer(scene, idx, layers, images);
+                self.draw_raster_image_layer(scene, idx, layers);
                 #[cfg(feature = "svg")]
-                self.draw_svg_image_layer(scene, idx, layers, images);
+                self.draw_svg_image_layer(scene, idx, layers);
             }
             GenericImage::LightDark(_) => {
                 #[cfg(feature = "tracing")]
@@ -274,11 +281,10 @@ impl ElementCx<'_, '_> {
         scene: &mut impl PaintScene,
         idx: usize,
         layers: &ImageLayerStyles,
-        images: &[Option<ImageResourceData>],
     ) {
         use kurbo::Affine;
 
-        let bg_image = images.get(idx);
+        let bg_image = layers.image_data.get(idx);
 
         let Some(Some(bg_image)) = bg_image.as_ref() else {
             return;
@@ -321,11 +327,10 @@ impl ElementCx<'_, '_> {
         scene: &mut impl PaintScene,
         idx: usize,
         layers: &ImageLayerStyles,
-        images: &[Option<ImageResourceData>],
     ) {
         use BackgroundRepeatKeyword::*;
 
-        let bg_image = images.get(idx);
+        let bg_image = layers.image_data.get(idx);
 
         let Some(Some(bg_image)) = bg_image.as_ref() else {
             return;

--- a/packages/blitz-paint/src/render/mask.rs
+++ b/packages/blitz-paint/src/render/mask.rs
@@ -1,0 +1,164 @@
+//! Rendering for the CSS `mask` properties (`mask-image`, `mask-position`,
+//! `mask-size`, `mask-repeat`, `mask-clip`, `mask-origin`).
+//!
+//! Masks are applied by:
+//!
+//!  1. Pushing an isolation layer (clipped to the mask painting area) before the
+//!     element is painted
+//!  2. Painting the element (and its descendants) as normal
+//!  3. Pushing a `Compose::DestIn` layer and drawing the mask image layers into it,
+//!     which multiplies the alpha of the already-painted element by the alpha of
+//!     the mask
+//!  4. Popping both layers
+//!
+//! The mask image layers themselves are positioned/sized/repeated using the same
+//! code as `background-image` layers (see `background.rs`), as the `mask-*` and
+//! `background-*` properties share computed value types.
+use super::ElementCx;
+use super::background::{ImageLayerStyles, get_cyclic};
+use anyrender::PaintScene;
+use peniko::{BlendMode, Compose, Mix};
+use style::{
+    properties::generated::longhands::{
+        background_clip::single_value::computed_value::T as StyloBackgroundClip,
+        background_origin::single_value::computed_value::T as StyloBackgroundOrigin,
+        mask_clip::single_value::computed_value::T as StyloMaskClip,
+        mask_origin::single_value::computed_value::T as StyloMaskOrigin,
+    },
+    values::generics::image::GenericImage,
+};
+
+#[cfg(feature = "tracing")]
+use tracing::warn;
+
+/// An opacity just below 1.0, used to force the renderer to allocate an isolated
+/// buffer for the mask isolation layer. Renderers (e.g. vello_cpu) may optimize
+/// layers with `Mix::Normal`/`Compose::SrcOver` and an opacity of exactly 1.0 into
+/// plain non-isolated clip layers, in which case the `Compose::DestIn` mask
+/// compositing would erase the backdrop behind the element rather than just the
+/// element's own content.
+const ALMOST_OPAQUE: f32 = 1.0 - f32::EPSILON;
+
+impl ElementCx<'_, '_> {
+    /// Whether the element has any CSS `mask-image` layers
+    pub(super) fn has_css_mask(&self) -> bool {
+        self.style
+            .get_svg()
+            .mask_image
+            .0
+            .iter()
+            .any(|image| !matches!(image, GenericImage::None))
+    }
+
+    /// If the element has a CSS mask, push an isolation layer for the masked content
+    /// to be drawn into. Returns whether a layer was pushed, which should later be
+    /// passed to [`maybe_pop_css_mask_layer`](Self::maybe_pop_css_mask_layer).
+    pub(super) fn maybe_push_css_mask_layer(&self, scene: &mut impl PaintScene) -> bool {
+        if !self.has_css_mask() {
+            return false;
+        }
+
+        // Content outside of the mask painting area (at largest the border box) has
+        // a mask alpha of 0, so we can clip the isolation layer to the border box.
+        scene.push_layer(
+            Mix::Normal,
+            ALMOST_OPAQUE,
+            self.transform,
+            &self.frame.border_box_path(),
+            None,
+            None,
+        );
+        true
+    }
+
+    /// Apply the CSS mask to the content drawn since the corresponding
+    /// [`maybe_push_css_mask_layer`](Self::maybe_push_css_mask_layer) by drawing the
+    /// mask image layers with `Compose::DestIn`, then pop the isolation layer.
+    pub(super) fn maybe_pop_css_mask_layer(&self, scene: &mut impl PaintScene, layer_pushed: bool) {
+        if !layer_pushed {
+            return;
+        }
+
+        scene.push_layer(
+            BlendMode::new(Mix::Normal, Compose::DestIn),
+            1.0,
+            self.transform,
+            &self.frame.border_box_path(),
+            None,
+            None,
+        );
+        self.draw_css_mask(scene);
+        scene.pop_layer(); // Mask (DestIn) layer
+        scene.pop_layer(); // Isolation layer
+    }
+
+    /// Draw the mask image layers (analogous to `draw_background` for `background-image`)
+    fn draw_css_mask(&self, scene: &mut impl PaintScene) {
+        let svg_styles = self.style.get_svg();
+        let layers = ImageLayerStyles::from_svg(svg_styles);
+
+        for (idx, segment) in svg_styles.mask_image.0.iter().enumerate().rev() {
+            // The `mask-clip`/`mask-origin` and `background-clip`/`background-origin`
+            // longhands have distinct (but identical) computed value types. Map the
+            // mask values to the background ones so layer painting code can be shared.
+            let mask_clip = match get_cyclic(&svg_styles.mask_clip.0, idx) {
+                StyloMaskClip::BorderBox => StyloBackgroundClip::BorderBox,
+                StyloMaskClip::PaddingBox => StyloBackgroundClip::PaddingBox,
+                StyloMaskClip::ContentBox => StyloBackgroundClip::ContentBox,
+            };
+            let mask_origin = match get_cyclic(&svg_styles.mask_origin.0, idx) {
+                StyloMaskOrigin::BorderBox => StyloBackgroundOrigin::BorderBox,
+                StyloMaskOrigin::PaddingBox => StyloBackgroundOrigin::PaddingBox,
+                StyloMaskOrigin::ContentBox => StyloBackgroundOrigin::ContentBox,
+            };
+            let mask_clip_path = match mask_clip {
+                StyloBackgroundClip::BorderBox => self.frame.border_box_path(),
+                StyloBackgroundClip::PaddingBox => self.frame.padding_box_path(),
+                StyloBackgroundClip::ContentBox => self.frame.content_box_path(),
+            };
+
+            // TODO: support `mask-mode: luminance` (luminance masks are currently
+            // rendered as alpha masks) and `mask-composite` values other than `add`.
+            #[cfg(feature = "tracing")]
+            {
+                use style::properties::generated::longhands::{
+                    mask_composite::single_value::computed_value::T as StyloMaskComposite,
+                    mask_mode::single_value::computed_value::T as StyloMaskMode,
+                };
+                if matches!(
+                    get_cyclic(&svg_styles.mask_mode.0, idx),
+                    StyloMaskMode::Luminance
+                ) {
+                    warn!("mask-mode: luminance is not supported (falling back to alpha)");
+                }
+                if !matches!(
+                    get_cyclic(&svg_styles.mask_composite.0, idx),
+                    StyloMaskComposite::Add
+                ) {
+                    warn!("mask-composite values other than add are not supported");
+                }
+            }
+
+            self.context.layer_manager.maybe_with_layer(
+                scene,
+                true,
+                1.0,
+                self.transform,
+                &mask_clip_path,
+                None,
+                None,
+                |scene| {
+                    self.draw_image_layer(
+                        scene,
+                        segment,
+                        idx,
+                        &layers,
+                        mask_clip,
+                        mask_origin,
+                        &self.element.mask_images,
+                    );
+                },
+            );
+        }
+    }
+}

--- a/packages/blitz-paint/src/render/mask.rs
+++ b/packages/blitz-paint/src/render/mask.rs
@@ -87,9 +87,9 @@ impl ElementCx<'_, '_> {
     /// Draw the mask image layers (analogous to `draw_background` for `background-image`)
     fn draw_css_mask(&self, scene: &mut impl PaintScene) {
         let svg_styles = self.style.get_svg();
-        let layers = ImageLayerStyles::from_svg(svg_styles);
+        let layers = ImageLayerStyles::from_svg(svg_styles, &self.element.mask_images);
 
-        for (idx, segment) in svg_styles.mask_image.0.iter().enumerate().rev() {
+        for idx in (0..layers.stylo_image.len()).rev() {
             let mask_clip_path = self.box_path(*get_cyclic(&layers.clip, idx));
 
             // TODO: support `mask-mode: luminance` (luminance masks are currently
@@ -123,7 +123,7 @@ impl ElementCx<'_, '_> {
                 None,
                 None,
                 |scene| {
-                    self.draw_image_layer(scene, segment, idx, &layers, &self.element.mask_images);
+                    self.draw_image_layer(scene, idx, &layers);
                 },
             );
         }

--- a/packages/blitz-paint/src/render/mask.rs
+++ b/packages/blitz-paint/src/render/mask.rs
@@ -14,6 +14,8 @@
 //! The mask image layers themselves are positioned/sized/repeated using the same
 //! code as `background-image` layers (see `background.rs`), as the `mask-*` and
 //! `background-*` properties share computed value types.
+use crate::render::background::get_cyclic;
+
 use super::ElementCx;
 use super::background::ImageLayerStyles;
 use anyrender::PaintScene;
@@ -101,7 +103,7 @@ impl ElementCx<'_, '_> {
             {
                 use style::properties::generated::longhands::mask_mode::single_value::computed_value::T as StyloMaskMode;
                 let mask_mode = &svg_styles.mask_mode.0;
-                if matches!(mask_mode[idx % mask_mode.len()], StyloMaskMode::Luminance) {
+                if matches!(get_cyclic(&mask_mode, idx), StyloMaskMode::Luminance) {
                     warn!("mask-mode: luminance is not supported (falling back to alpha)");
                 }
             }
@@ -113,7 +115,7 @@ impl ElementCx<'_, '_> {
                 Compose::SrcOver
             } else {
                 let composite_list = &svg_styles.mask_composite.0;
-                match composite_list[idx % composite_list.len()] {
+                match get_cyclic(&composite_list, idx) {
                     StyloMaskComposite::Add => Compose::SrcOver,
                     StyloMaskComposite::Subtract => Compose::SrcOut,
                     StyloMaskComposite::Intersect => Compose::SrcIn,

--- a/packages/blitz-paint/src/render/mask.rs
+++ b/packages/blitz-paint/src/render/mask.rs
@@ -18,6 +18,7 @@ use super::ElementCx;
 use super::background::ImageLayerStyles;
 use anyrender::PaintScene;
 use peniko::{BlendMode, Compose, Mix};
+use style::properties::generated::longhands::mask_composite::single_value::computed_value::T as StyloMaskComposite;
 use style::values::generics::image::GenericImage;
 
 #[cfg(feature = "tracing")]
@@ -95,38 +96,44 @@ impl ElementCx<'_, '_> {
             let mask_clip_path = self.box_path(layer.clip);
 
             // TODO: support `mask-mode: luminance` (luminance masks are currently
-            // rendered as alpha masks) and `mask-composite` values other than `add`.
+            // rendered as alpha masks).
             #[cfg(feature = "tracing")]
             {
-                use style::properties::generated::longhands::{
-                    mask_composite::single_value::computed_value::T as StyloMaskComposite,
-                    mask_mode::single_value::computed_value::T as StyloMaskMode,
-                };
+                use style::properties::generated::longhands::mask_mode::single_value::computed_value::T as StyloMaskMode;
                 let mask_mode = &svg_styles.mask_mode.0;
                 if matches!(mask_mode[idx % mask_mode.len()], StyloMaskMode::Luminance) {
                     warn!("mask-mode: luminance is not supported (falling back to alpha)");
                 }
-                let mask_composite = &svg_styles.mask_composite.0;
-                if !matches!(
-                    mask_composite[idx % mask_composite.len()],
-                    StyloMaskComposite::Add
-                ) {
-                    warn!("mask-composite values other than add are not supported");
-                }
             }
 
-            self.context.layer_manager.maybe_with_layer(
-                scene,
-                true,
+            // Each mask layer is composited with the (already drawn) layers below it
+            // using the Porter-Duff operator given by its `mask-composite` value. The
+            // bottommost layer has no layers below it and is always drawn with SrcOver.
+            let compose = if idx == layer_count - 1 {
+                Compose::SrcOver
+            } else {
+                let composite_list = &svg_styles.mask_composite.0;
+                match composite_list[idx % composite_list.len()] {
+                    StyloMaskComposite::Add => Compose::SrcOver,
+                    StyloMaskComposite::Subtract => Compose::SrcOut,
+                    StyloMaskComposite::Intersect => Compose::SrcIn,
+                    StyloMaskComposite::Exclude => Compose::Xor,
+                }
+            };
+
+            // The layer is pushed unconditionally (even for `mask-image: none` layers,
+            // which draw nothing) as compositing a transparent black layer with e.g.
+            // `intersect` clears the mask built up so far.
+            scene.push_layer(
+                BlendMode::new(Mix::Normal, compose),
                 1.0,
                 self.transform,
                 &mask_clip_path,
                 None,
                 None,
-                |scene| {
-                    self.draw_image_layer(scene, &layer);
-                },
             );
+            self.draw_image_layer(scene, &layer);
+            scene.pop_layer();
         }
     }
 }

--- a/packages/blitz-paint/src/render/mask.rs
+++ b/packages/blitz-paint/src/render/mask.rs
@@ -15,7 +15,7 @@
 //! code as `background-image` layers (see `background.rs`), as the `mask-*` and
 //! `background-*` properties share computed value types.
 use super::ElementCx;
-use super::background::{ImageLayerStyles, get_cyclic};
+use super::background::ImageLayerStyles;
 use anyrender::PaintScene;
 use peniko::{BlendMode, Compose, Mix};
 use style::values::generics::image::GenericImage;
@@ -87,15 +87,18 @@ impl ElementCx<'_, '_> {
     /// Draw the mask image layers (analogous to `draw_background` for `background-image`)
     fn draw_css_mask(&self, scene: &mut impl PaintScene) {
         let svg_styles = self.style.get_svg();
-        let layers = ImageLayerStyles::from_svg(svg_styles, &self.element.mask_images);
+        let image_data = &self.element.mask_images;
+        let layer_count = svg_styles.mask_image.0.len();
 
-        for idx in (0..layers.stylo_image.len()).rev() {
-            let mask_clip_path = self.box_path(*get_cyclic(&layers.clip, idx));
+        for idx in (0..layer_count).rev() {
+            let layer = ImageLayerStyles::from_svg(svg_styles, image_data, idx);
+            let mask_clip_path = self.box_path(layer.clip);
 
             // TODO: support `mask-mode: luminance` (luminance masks are currently
             // rendered as alpha masks) and `mask-composite` values other than `add`.
             #[cfg(feature = "tracing")]
             {
+                use super::background::get_cyclic;
                 use style::properties::generated::longhands::{
                     mask_composite::single_value::computed_value::T as StyloMaskComposite,
                     mask_mode::single_value::computed_value::T as StyloMaskMode,
@@ -123,7 +126,7 @@ impl ElementCx<'_, '_> {
                 None,
                 None,
                 |scene| {
-                    self.draw_image_layer(scene, idx, &layers);
+                    self.draw_image_layer(scene, &layer);
                 },
             );
         }

--- a/packages/blitz-paint/src/render/mask.rs
+++ b/packages/blitz-paint/src/render/mask.rs
@@ -115,7 +115,7 @@ impl ElementCx<'_, '_> {
                 Compose::SrcOver
             } else {
                 let composite_list = &svg_styles.mask_composite.0;
-                match get_cyclic(&composite_list, idx) {
+                match get_cyclic(composite_list, idx) {
                     StyloMaskComposite::Add => Compose::SrcOver,
                     StyloMaskComposite::Subtract => Compose::SrcOut,
                     StyloMaskComposite::Intersect => Compose::SrcIn,

--- a/packages/blitz-paint/src/render/mask.rs
+++ b/packages/blitz-paint/src/render/mask.rs
@@ -18,15 +18,7 @@ use super::ElementCx;
 use super::background::{ImageLayerStyles, get_cyclic};
 use anyrender::PaintScene;
 use peniko::{BlendMode, Compose, Mix};
-use style::{
-    properties::generated::longhands::{
-        background_clip::single_value::computed_value::T as StyloBackgroundClip,
-        background_origin::single_value::computed_value::T as StyloBackgroundOrigin,
-        mask_clip::single_value::computed_value::T as StyloMaskClip,
-        mask_origin::single_value::computed_value::T as StyloMaskOrigin,
-    },
-    values::generics::image::GenericImage,
-};
+use style::values::generics::image::GenericImage;
 
 #[cfg(feature = "tracing")]
 use tracing::warn;
@@ -98,24 +90,7 @@ impl ElementCx<'_, '_> {
         let layers = ImageLayerStyles::from_svg(svg_styles);
 
         for (idx, segment) in svg_styles.mask_image.0.iter().enumerate().rev() {
-            // The `mask-clip`/`mask-origin` and `background-clip`/`background-origin`
-            // longhands have distinct (but identical) computed value types. Map the
-            // mask values to the background ones so layer painting code can be shared.
-            let mask_clip = match get_cyclic(&svg_styles.mask_clip.0, idx) {
-                StyloMaskClip::BorderBox => StyloBackgroundClip::BorderBox,
-                StyloMaskClip::PaddingBox => StyloBackgroundClip::PaddingBox,
-                StyloMaskClip::ContentBox => StyloBackgroundClip::ContentBox,
-            };
-            let mask_origin = match get_cyclic(&svg_styles.mask_origin.0, idx) {
-                StyloMaskOrigin::BorderBox => StyloBackgroundOrigin::BorderBox,
-                StyloMaskOrigin::PaddingBox => StyloBackgroundOrigin::PaddingBox,
-                StyloMaskOrigin::ContentBox => StyloBackgroundOrigin::ContentBox,
-            };
-            let mask_clip_path = match mask_clip {
-                StyloBackgroundClip::BorderBox => self.frame.border_box_path(),
-                StyloBackgroundClip::PaddingBox => self.frame.padding_box_path(),
-                StyloBackgroundClip::ContentBox => self.frame.content_box_path(),
-            };
+            let mask_clip_path = self.box_path(*get_cyclic(&layers.clip, idx));
 
             // TODO: support `mask-mode: luminance` (luminance masks are currently
             // rendered as alpha masks) and `mask-composite` values other than `add`.
@@ -148,15 +123,7 @@ impl ElementCx<'_, '_> {
                 None,
                 None,
                 |scene| {
-                    self.draw_image_layer(
-                        scene,
-                        segment,
-                        idx,
-                        &layers,
-                        mask_clip,
-                        mask_origin,
-                        &self.element.mask_images,
-                    );
+                    self.draw_image_layer(scene, segment, idx, &layers, &self.element.mask_images);
                 },
             );
         }

--- a/packages/blitz-paint/src/render/mask.rs
+++ b/packages/blitz-paint/src/render/mask.rs
@@ -98,19 +98,17 @@ impl ElementCx<'_, '_> {
             // rendered as alpha masks) and `mask-composite` values other than `add`.
             #[cfg(feature = "tracing")]
             {
-                use super::background::get_cyclic;
                 use style::properties::generated::longhands::{
                     mask_composite::single_value::computed_value::T as StyloMaskComposite,
                     mask_mode::single_value::computed_value::T as StyloMaskMode,
                 };
-                if matches!(
-                    get_cyclic(&svg_styles.mask_mode.0, idx),
-                    StyloMaskMode::Luminance
-                ) {
+                let mask_mode = &svg_styles.mask_mode.0;
+                if matches!(mask_mode[idx % mask_mode.len()], StyloMaskMode::Luminance) {
                     warn!("mask-mode: luminance is not supported (falling back to alpha)");
                 }
+                let mask_composite = &svg_styles.mask_composite.0;
                 if !matches!(
-                    get_cyclic(&svg_styles.mask_composite.0, idx),
+                    mask_composite[idx % mask_composite.len()],
                     StyloMaskComposite::Add
                 ) {
                     warn!("mask-composite values other than add are not supported");


### PR DESCRIPTION
The implementation is based on the implementation of background images which function very similarly to mask images. This applies both to:
   - Fetching and storing the images
   - Rendering the mask

Not implemented:
- Luminosity masks
- References to inline SVG masks