### PR TITLE
Add reproducible dev environment setup

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.89"
+components = ["rustfmt", "clippy"]

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Blitz development environment setup (Linux)
+# Installs system dependencies and ensures the correct Rust toolchain.
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "This script targets Linux. On Windows, install Python from the Microsoft Store (see CONTRIBUTING.MD)."
+  exit 1
+fi
+
+echo "==> Installing Linux build dependencies..."
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  libasound2-dev \
+  libatk1.0-dev \
+  libgtk-3-dev \
+  libudev-dev \
+  libpango1.0-dev \
+  libxdo-dev \
+  libssl-dev \
+  pkg-config
+
+echo "==> Ensuring Rust 1.89+ toolchain..."
+if command -v rustup >/dev/null 2>&1; then
+  rustup toolchain install 1.89 -c rustfmt -c clippy
+  rustup default 1.89
+else
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.89
+  # shellcheck disable=SC1091
+  source "$HOME/.cargo/env"
+fi
+
+echo "==> Verifying toolchain..."
+rustc --version
+cargo --version
+
+echo "==> Building workspace..."
+cargo build --workspace
+
+echo ""
+echo "Development environment is ready."
+echo ""
+echo "Quick verification:"
+echo "  cargo test --workspace"
+echo "  cargo run --example screenshot -- file:///path/to/local.html"
+echo ""
+echo "GUI applications:"
+echo "  cargo run --release --package browser"
+echo "  cargo run --release --package todomvc --bin todomvc_native"
+echo "  cargo run --release --package rdme -- ./README.md"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds tooling to make Blitz development environment setup reproducible on Linux:

- **`rust-toolchain.toml`** — pins Rust 1.89 (the workspace MSRV) with `rustfmt` and `clippy`
- **`scripts/setup-dev.sh`** — installs Linux system dependencies (GTK, ALSA, etc.) and builds the workspace

## Verification

Environment was set up and verified on Linux:

- `cargo build --workspace` — success
- `cargo test --workspace` — 62 tests passed
- `cargo run --example screenshot -- file:///workspace/examples/assets/border.html` — rendered 2400×1872 PNG successfully

## Usage

```sh
./scripts/setup-dev.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-441f8640-354e-47b4-b2f6-77b788da7aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-441f8640-354e-47b4-b2f6-77b788da7aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

