### PR TITLE
Ignore comment nodes in inline-vs-block layout classification

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -222,6 +222,16 @@ pub(crate) fn collect_layout_children(
                 .copied()
                 .map(|child_id| &doc.nodes[child_id])
             {
+                // Comment nodes generate no boxes and must not affect the
+                // inline-vs-block classification: an unstyled comment would
+                // default to display:inline below and force an inline
+                // formatting context on the container, swallowing element
+                // siblings into the inline layout (zero-sizing any
+                // out-of-flow ones).
+                if child.data.kind() == NodeKind::Comment {
+                    continue;
+                }
+
                 // Unwraps on Text and SVG nodes
                 let style = child.primary_styles();
                 let style = style.as_ref();

--- a/packages/blitz-html/tests/comment_layout.rs
+++ b/packages/blitz-html/tests/comment_layout.rs
@@ -1,0 +1,67 @@
+//! A comment node between block-level content must not affect layout.
+//!
+//! Regression test: a container holding [comment, block/abspos children] was
+//! classified as an inline root (the comment defaulted to display:inline and
+//! the abspos child was skipped as out-of-flow, leaving all_inline == true),
+//! which swallowed element children into a parley inline layout as zero-sized
+//! out-of-flow boxes.
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn layout_doc(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+#[test]
+fn comment_sibling_does_not_zero_abspos_child() {
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:300px; height:200px;">
+                <!-- dioxus placeholder -->
+                <div id="abs" style="position:absolute; top:0; left:0; right:0; bottom:0;"></div>
+            </div>
+        </body></html>"#,
+    );
+    let abs_id = doc.query_selector("#abs").unwrap().expect("#abs not found");
+    let layout = doc.get_node(abs_id).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (300.0, 200.0),
+        "absolute inset:0 child must stretch to its containing block even \
+         with a comment sibling"
+    );
+}
+
+#[test]
+fn comment_sibling_does_not_inline_block_child() {
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="width:300px;">
+                <!-- dioxus placeholder -->
+                <div id="block" style="height:50px;"></div>
+            </div>
+        </body></html>"#,
+    );
+    let block_id = doc
+        .query_selector("#block")
+        .unwrap()
+        .expect("#block not found");
+    let layout = doc.get_node(block_id).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (300.0, 50.0),
+        "block child must fill its parent's width even with a comment sibling"
+    );
+}


### PR DESCRIPTION
A comment node has no styles, so `collect_layout_children`'s child scan defaulted it to `display: inline`. A container whose other children are all out-of-flow — e.g. `[<!-- comment -->, <div style="position:absolute">]` — was therefore classified `all_inline` and became an inline root: element children were embedded into the parley inline layout as out-of-flow boxes and sized 0x0.

This hits any Dioxus Native app immediately: conditional rsx (`if cond {}`) renders a comment placeholder, so a `[placeholder, abspos page wrapper]` sibling pair makes entire pages invisible. Found while running a ~50k-line Dioxus app (a music player) on blitz — navigation-target pages rendered fully blank while the initial route worked.

Comments generate no boxes, so they are now skipped during classification (they were already filtered out of the resulting `layout_children` lists by the `push_*_children_and_pseudos` helpers).

Includes regression tests for both the abspos case (`(0, 0)` before this change) and the in-flow block case.
