### PR TITLE
Fix display:contents transparency in box-tree construction

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -203,25 +203,44 @@ pub(crate) fn collect_layout_children(
             // Take children array from node to avoid borrow checker issues.
             let children = std::mem::take(&mut doc.nodes[container_node_id].children);
 
+            // display:contents is transparent for box generation: hoist the
+            // children THEMSELVES (not their layout children) into the
+            // parent, recursing only through nested contents nodes.
             for child_id in children.iter().copied() {
-                collect_layout_children(doc, child_id, layout_children, anonymous_block_id)
+                let child = &doc.nodes[child_id];
+                if child.data.kind() == NodeKind::Comment || child.is_whitespace_node() {
+                    continue;
+                }
+                let child_display = child.display_style().unwrap_or(Display::inline());
+                if matches!(child_display.inside(), DisplayInside::Contents) {
+                    collect_layout_children(doc, child_id, layout_children, anonymous_block_id);
+                } else {
+                    layout_children.push(child_id);
+                }
             }
 
             // Put children array back
             doc.nodes[container_node_id].children = children;
         }
         DisplayInside::Flow | DisplayInside::FlowRoot | DisplayInside::TableCell => {
-            // TODO: make "all_inline" detection work in the presence of display:contents nodes
             let mut all_block = true;
             let mut all_inline = true;
             let mut all_out_of_flow = true;
             let mut has_contents = false;
-            for child in doc.nodes[container_node_id]
+            // display:contents children are transparent for box generation:
+            // their children participate in this container's formatting
+            // context, so classification must recurse into them. Work-stack
+            // in place of plain iteration (reversed so order is preserved,
+            // though classification is order-independent).
+            let mut classify_stack: Vec<usize> = doc.nodes[container_node_id]
                 .children
                 .iter()
                 .copied()
-                .map(|child_id| &doc.nodes[child_id])
-            {
+                .rev()
+                .collect();
+            while let Some(child_id) = classify_stack.pop() {
+                let child = &doc.nodes[child_id];
+
                 // Comment nodes generate no boxes and must not affect the
                 // inline-vs-block classification: an unstyled comment would
                 // default to display:inline below and force an inline
@@ -241,6 +260,7 @@ pub(crate) fn collect_layout_children(
                 if matches!(display.inside(), DisplayInside::Contents) {
                     has_contents = true;
                     all_out_of_flow = false;
+                    classify_stack.extend(child.children.iter().copied().rev());
                 } else {
                     let position = style
                         .map(|s| s.clone_position())
@@ -596,7 +616,11 @@ fn collect_complex_layout_children(
             // If anonymous block node only contains whitespace then delete it
             if let Some(anon_id) = *anonymous_block_id {
                 if block_is_only_whitespace(doc, anon_id) {
-                    layout_children.pop();
+                    // Remove by identity, not pop(): hoisted display:contents
+                    // children may have been pushed after the anon block.
+                    if let Some(pos) = layout_children.iter().rposition(|id| *id == anon_id) {
+                        layout_children.remove(pos);
+                    }
                     doc.nodes.remove(anon_id);
                 }
             }
@@ -609,7 +633,9 @@ fn collect_complex_layout_children(
     // If anonymous block node only contains whitespace then delete it
     if let Some(anon_id) = *anonymous_block_id {
         if block_is_only_whitespace(doc, anon_id) {
-            layout_children.pop();
+            if let Some(pos) = layout_children.iter().rposition(|id| *id == anon_id) {
+                layout_children.remove(pos);
+            }
             doc.nodes.remove(anon_id);
             *anonymous_block_id = None;
         }

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -65,6 +65,38 @@ fn push_children_and_pseudos(layout_children: &mut Vec<usize>, node: &Node) {
     }
 }
 
+/// Push the container's children (and ::before/::after pseudos) as layout
+/// children, hoisting transparently through display:contents nodes and
+/// filtering out comments and whitespace.
+fn push_hoisted_children_and_pseudos(
+    doc: &mut BaseDocument,
+    container_node_id: usize,
+    layout_children: &mut Vec<usize>,
+    anonymous_block_id: &mut Option<usize>,
+) {
+    if let Some(before) = doc.nodes[container_node_id].before {
+        layout_children.push(before);
+    }
+    // Take children array from node to avoid borrow checker issues.
+    let children = std::mem::take(&mut doc.nodes[container_node_id].children);
+    for child_id in children.iter().copied() {
+        let child = &doc.nodes[child_id];
+        if child.data.kind() == NodeKind::Comment || child.is_whitespace_node() {
+            continue;
+        }
+        let child_display = child.display_style().unwrap_or(Display::inline());
+        if matches!(child_display.inside(), DisplayInside::Contents) {
+            collect_layout_children(doc, child_id, layout_children, anonymous_block_id);
+        } else {
+            layout_children.push(child_id);
+        }
+    }
+    doc.nodes[container_node_id].children = children;
+    if let Some(after) = doc.nodes[container_node_id].after {
+        layout_children.push(after);
+    }
+}
+
 fn push_non_whitespace_children_and_pseudos(layout_children: &mut Vec<usize>, node: &Node) {
     if let Some(before) = node.before {
         layout_children.push(before);
@@ -200,27 +232,15 @@ pub(crate) fn collect_layout_children(
         DisplayInside::Contents => {
             doc.nodes[container_node_id]
                 .remove_damage(CONSTRUCT_BOX | CONSTRUCT_DESCENDENT | CONSTRUCT_FC);
-            // Take children array from node to avoid borrow checker issues.
-            let children = std::mem::take(&mut doc.nodes[container_node_id].children);
-
             // display:contents is transparent for box generation: hoist the
             // children THEMSELVES (not their layout children) into the
             // parent, recursing only through nested contents nodes.
-            for child_id in children.iter().copied() {
-                let child = &doc.nodes[child_id];
-                if child.data.kind() == NodeKind::Comment || child.is_whitespace_node() {
-                    continue;
-                }
-                let child_display = child.display_style().unwrap_or(Display::inline());
-                if matches!(child_display.inside(), DisplayInside::Contents) {
-                    collect_layout_children(doc, child_id, layout_children, anonymous_block_id);
-                } else {
-                    layout_children.push(child_id);
-                }
-            }
-
-            // Put children array back
-            doc.nodes[container_node_id].children = children;
+            push_hoisted_children_and_pseudos(
+                doc,
+                container_node_id,
+                layout_children,
+                anonymous_block_id,
+            );
         }
         DisplayInside::Flow | DisplayInside::FlowRoot | DisplayInside::TableCell => {
             let mut all_block = true;
@@ -229,9 +249,7 @@ pub(crate) fn collect_layout_children(
             let mut has_contents = false;
             // display:contents children are transparent for box generation:
             // their children participate in this container's formatting
-            // context, so classification must recurse into them. Work-stack
-            // in place of plain iteration (reversed so order is preserved,
-            // though classification is order-independent).
+            // context, so classification must recurse into them.
             let mut classify_stack: Vec<usize> = doc.nodes[container_node_id]
                 .children
                 .iter()
@@ -258,8 +276,9 @@ pub(crate) fn collect_layout_children(
                     .map(|s| s.clone_display())
                     .unwrap_or(Display::inline());
                 if matches!(display.inside(), DisplayInside::Contents) {
+                    // Transparent for box generation: the contents node casts
+                    // no vote itself — its children decide.
                     has_contents = true;
-                    all_out_of_flow = false;
                     classify_stack.extend(child.children.iter().copied().rev());
                 } else {
                     let position = style
@@ -302,9 +321,14 @@ pub(crate) fn collect_layout_children(
             }
 
             if all_out_of_flow {
-                return push_non_whitespace_children_and_pseudos(
+                // Contents-transparent: a display:contents child may be
+                // holding the out-of-flow elements (otherwise the contents
+                // node itself would be pushed as a layout box).
+                return push_hoisted_children_and_pseudos(
+                    doc,
+                    container_node_id,
                     layout_children,
-                    &doc.nodes[container_node_id],
+                    anonymous_block_id,
                 );
             }
 

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -52,6 +52,17 @@ pub(crate) enum ConstructionTaskResultData {
     InlineLayout(Box<TextLayout>),
 }
 
+/// Accumulator threaded through layout-child collection.
+///
+/// `children` is the list of layout children being built up, and
+/// `anonymous_block_id` is the currently-open anonymous block container (if
+/// any) that wrapping children are being appended to.
+#[derive(Default)]
+pub(crate) struct LayoutChildren {
+    pub(crate) children: Vec<usize>,
+    pub(crate) anonymous_block_id: Option<usize>,
+}
+
 fn push_children_and_pseudos(layout_children: &mut Vec<usize>, node: &Node) {
     if let Some(before) = node.before {
         layout_children.push(before);
@@ -71,11 +82,10 @@ fn push_children_and_pseudos(layout_children: &mut Vec<usize>, node: &Node) {
 fn push_hoisted_children_and_pseudos(
     doc: &mut BaseDocument,
     container_node_id: usize,
-    layout_children: &mut Vec<usize>,
-    anonymous_block_id: &mut Option<usize>,
+    out: &mut LayoutChildren,
 ) {
     if let Some(before) = doc.nodes[container_node_id].before {
-        layout_children.push(before);
+        out.children.push(before);
     }
     // Take children array from node to avoid borrow checker issues.
     let children = std::mem::take(&mut doc.nodes[container_node_id].children);
@@ -86,14 +96,14 @@ fn push_hoisted_children_and_pseudos(
         }
         let child_display = child.display_style().unwrap_or(Display::inline());
         if matches!(child_display.inside(), DisplayInside::Contents) {
-            collect_layout_children(doc, child_id, layout_children, anonymous_block_id);
+            collect_layout_children(doc, child_id, out);
         } else {
-            layout_children.push(child_id);
+            out.children.push(child_id);
         }
     }
     doc.nodes[container_node_id].children = children;
     if let Some(after) = doc.nodes[container_node_id].after {
-        layout_children.push(after);
+        out.children.push(after);
     }
 }
 
@@ -122,8 +132,7 @@ fn resolve_line_height(line_height: parley::LineHeight, font_size: f32) -> f32 {
 pub(crate) fn collect_layout_children(
     doc: &mut BaseDocument,
     container_node_id: usize,
-    layout_children: &mut Vec<usize>,
-    anonymous_block_id: &mut Option<usize>,
+    out: &mut LayoutChildren,
 ) {
     // Reset construction flags
     // TODO: make incremental and only remove this if the element is no longer an inline root
@@ -235,12 +244,7 @@ pub(crate) fn collect_layout_children(
             // display:contents is transparent for box generation: hoist the
             // children THEMSELVES (not their layout children) into the
             // parent, recursing only through nested contents nodes.
-            push_hoisted_children_and_pseudos(
-                doc,
-                container_node_id,
-                layout_children,
-                anonymous_block_id,
-            );
+            push_hoisted_children_and_pseudos(doc, container_node_id, out);
         }
         DisplayInside::Flow | DisplayInside::FlowRoot | DisplayInside::TableCell => {
             let mut all_block = true;
@@ -324,12 +328,7 @@ pub(crate) fn collect_layout_children(
                 // Contents-transparent: a display:contents child may be
                 // holding the out-of-flow elements (otherwise the contents
                 // node itself would be pushed as a layout box).
-                return push_hoisted_children_and_pseudos(
-                    doc,
-                    container_node_id,
-                    layout_children,
-                    anonymous_block_id,
-                );
+                return push_hoisted_children_and_pseudos(doc, container_node_id, out);
             }
 
             // TODO: fix display:contents
@@ -349,7 +348,7 @@ pub(crate) fn collect_layout_children(
                     .flags
                     .insert(NodeFlags::IS_INLINE_ROOT);
 
-                find_inline_layout_embedded_boxes(doc, container_node_id, layout_children);
+                find_inline_layout_embedded_boxes(doc, container_node_id, &mut out.children);
                 return;
             }
 
@@ -357,11 +356,11 @@ pub(crate) fn collect_layout_children(
             // as the layout children
             if all_block & !has_contents {
                 return push_non_whitespace_children_and_pseudos(
-                    layout_children,
+                    &mut out.children,
                     &doc.nodes[container_node_id],
                 );
             } else if all_inline & !has_contents {
-                return push_children_and_pseudos(layout_children, &doc.nodes[container_node_id]);
+                return push_children_and_pseudos(&mut out.children, &doc.nodes[container_node_id]);
             }
 
             fn block_item_needs_wrap(
@@ -373,8 +372,7 @@ pub(crate) fn collect_layout_children(
             collect_complex_layout_children(
                 doc,
                 container_node_id,
-                layout_children,
-                anonymous_block_id,
+                out,
                 false,
                 block_item_needs_wrap,
             );
@@ -393,7 +391,7 @@ pub(crate) fn collect_layout_children(
 
             if !has_text_node_or_contents {
                 return push_non_whitespace_children_and_pseudos(
-                    layout_children,
+                    &mut out.children,
                     &doc.nodes[container_node_id],
                 );
             }
@@ -407,8 +405,7 @@ pub(crate) fn collect_layout_children(
             collect_complex_layout_children(
                 doc,
                 container_node_id,
-                layout_children,
-                anonymous_block_id,
+                out,
                 true,
                 flex_or_grid_item_needs_wrap,
             );
@@ -427,17 +424,17 @@ pub(crate) fn collect_layout_children(
                 .unwrap()
                 .special_data = data;
             if let Some(before) = doc.nodes[container_node_id].before {
-                layout_children.push(before);
+                out.children.push(before);
             }
-            layout_children.extend_from_slice(&tlayout_children);
+            out.children.extend_from_slice(&tlayout_children);
             if let Some(after) = doc.nodes[container_node_id].after {
-                layout_children.push(after);
+                out.children.push(after);
             }
         }
 
         _ => {
             push_non_whitespace_children_and_pseudos(
-                layout_children,
+                &mut out.children,
                 &doc.nodes[container_node_id],
             );
         }
@@ -537,8 +534,7 @@ fn flush_pseudo_elements(doc: &mut BaseDocument, node_id: usize) {
 fn collect_complex_layout_children(
     doc: &mut BaseDocument,
     container_node_id: usize,
-    layout_children: &mut Vec<usize>,
-    anonymous_block_id: &mut Option<usize>,
+    out: &mut LayoutChildren,
     hide_whitespace: bool,
     needs_wrap: impl Fn(NodeKind, DisplayOutside) -> bool,
 ) {
@@ -580,14 +576,14 @@ fn collect_complex_layout_children(
         }
         // Recurse into `Display::Contents` nodes
         else if display_inside == DisplayInside::Contents {
-            collect_layout_children(doc, child_id, layout_children, anonymous_block_id)
+            collect_layout_children(doc, child_id, out)
         }
         // Push nodes that need wrapping into the current "anonymous block container".
         // If there is not an open one then we create one.
         else if needs_wrap(child_node_kind, display_outside) {
             use style::selector_parser::PseudoElement;
 
-            if anonymous_block_id.is_none() {
+            if out.anonymous_block_id.is_none() {
                 const NAME: QualName = QualName {
                     prefix: None,
                     ns: ns!(html),
@@ -627,41 +623,41 @@ fn collect_complex_layout_children(
                     .layout_parent
                     .set(Some(container_node_id));
 
-                layout_children.push(node_id);
-                *anonymous_block_id = Some(node_id);
+                out.children.push(node_id);
+                out.anonymous_block_id = Some(node_id);
             }
 
-            doc.nodes[anonymous_block_id.unwrap()]
+            doc.nodes[out.anonymous_block_id.unwrap()]
                 .children
                 .push(child_id);
         }
         // Else push the child directly (and close any open "anonymous block container")
         else {
             // If anonymous block node only contains whitespace then delete it
-            if let Some(anon_id) = *anonymous_block_id {
+            if let Some(anon_id) = out.anonymous_block_id {
                 if block_is_only_whitespace(doc, anon_id) {
                     // Remove by identity, not pop(): hoisted display:contents
                     // children may have been pushed after the anon block.
-                    if let Some(pos) = layout_children.iter().rposition(|id| *id == anon_id) {
-                        layout_children.remove(pos);
+                    if let Some(pos) = out.children.iter().rposition(|id| *id == anon_id) {
+                        out.children.remove(pos);
                     }
                     doc.nodes.remove(anon_id);
                 }
             }
 
-            *anonymous_block_id = None;
-            layout_children.push(child_id);
+            out.anonymous_block_id = None;
+            out.children.push(child_id);
         }
     });
 
     // If anonymous block node only contains whitespace then delete it
-    if let Some(anon_id) = *anonymous_block_id {
+    if let Some(anon_id) = out.anonymous_block_id {
         if block_is_only_whitespace(doc, anon_id) {
-            if let Some(pos) = layout_children.iter().rposition(|id| *id == anon_id) {
-                layout_children.remove(pos);
+            if let Some(pos) = out.children.iter().rposition(|id| *id == anon_id) {
+                out.children.remove(pos);
             }
             doc.nodes.remove(anon_id);
-            *anonymous_block_id = None;
+            out.anonymous_block_id = None;
         }
     }
 }

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -224,6 +224,97 @@ fn resolve_line_height(line_height: parley::LineHeight, font_size: f32) -> f32 {
     }
 }
 
+/// Result of classifying the in-flow children of a flow container as
+/// all-block, all-inline and/or all-out-of-flow.
+struct FlowClassification {
+    all_block: bool,
+    all_inline: bool,
+    all_out_of_flow: bool,
+    has_contents: bool,
+}
+
+impl Default for FlowClassification {
+    fn default() -> Self {
+        Self {
+            all_block: true,
+            all_inline: true,
+            all_out_of_flow: true,
+            has_contents: false,
+        }
+    }
+}
+
+/// Classify `children` for inline-vs-block layout, recursing transparently
+/// through display:contents nodes (whose children participate in the
+/// container's formatting context).
+fn classify_flow_children(
+    doc: &BaseDocument,
+    children: &[usize],
+    classification: &mut FlowClassification,
+) {
+    for child_id in children.iter().copied() {
+        let child = &doc.nodes[child_id];
+
+        // Comment nodes generate no boxes and must not affect the
+        // inline-vs-block classification: an unstyled comment would
+        // default to display:inline below and force an inline
+        // formatting context on the container, swallowing element
+        // siblings into the inline layout (zero-sizing any
+        // out-of-flow ones).
+        if child.data.kind() == NodeKind::Comment {
+            continue;
+        }
+
+        // Unwraps on Text and SVG nodes
+        let style = child.primary_styles();
+        let style = style.as_ref();
+        let display = style
+            .map(|s| s.clone_display())
+            .unwrap_or(Display::inline());
+        if matches!(display.inside(), DisplayInside::Contents) {
+            // Transparent for box generation: the contents node casts
+            // no vote itself — its children decide.
+            classification.has_contents = true;
+            classify_flow_children(doc, &child.children, classification);
+        } else {
+            let position = style
+                .map(|s| s.clone_position())
+                .unwrap_or(PositionProperty::Static);
+            let float = style.map(|s| s.clone_float()).unwrap_or(Float::None);
+
+            // Ignore nodes that are entirely whitespace
+            if child.is_whitespace_node() {
+                continue;
+            }
+
+            let is_in_flow = matches!(
+                position,
+                PositionProperty::Static | PositionProperty::Relative | PositionProperty::Sticky
+            ) && matches!(float, Float::None);
+
+            if !is_in_flow {
+                continue;
+            }
+
+            classification.all_out_of_flow = false;
+            match display.outside() {
+                DisplayOutside::None => {}
+                DisplayOutside::Block
+                | DisplayOutside::TableCaption
+                | DisplayOutside::InternalTable => classification.all_inline = false,
+                DisplayOutside::Inline => {
+                    classification.all_block = false;
+
+                    // We need the "complex" tree fixing when an inline contains a block
+                    if child.is_or_contains_block() {
+                        classification.all_inline = false;
+                    }
+                }
+            }
+        }
+    }
+}
+
 pub(crate) fn collect_layout_children(
     doc: &mut BaseDocument,
     container_node_id: usize,
@@ -342,84 +433,17 @@ pub(crate) fn collect_layout_children(
             push_hoisted_children_and_pseudos(doc, container_node_id, out);
         }
         DisplayInside::Flow | DisplayInside::FlowRoot | DisplayInside::TableCell => {
-            let mut all_block = true;
-            let mut all_inline = true;
-            let mut all_out_of_flow = true;
-            let mut has_contents = false;
             // display:contents children are transparent for box generation:
             // their children participate in this container's formatting
             // context, so classification must recurse into them.
-            let mut classify_stack: Vec<usize> = doc.nodes[container_node_id]
-                .children
-                .iter()
-                .copied()
-                .rev()
-                .collect();
-            while let Some(child_id) = classify_stack.pop() {
-                let child = &doc.nodes[child_id];
+            let mut classification = FlowClassification::default();
+            classify_flow_children(
+                doc,
+                &doc.nodes[container_node_id].children,
+                &mut classification,
+            );
 
-                // Comment nodes generate no boxes and must not affect the
-                // inline-vs-block classification: an unstyled comment would
-                // default to display:inline below and force an inline
-                // formatting context on the container, swallowing element
-                // siblings into the inline layout (zero-sizing any
-                // out-of-flow ones).
-                if child.data.kind() == NodeKind::Comment {
-                    continue;
-                }
-
-                // Unwraps on Text and SVG nodes
-                let style = child.primary_styles();
-                let style = style.as_ref();
-                let display = style
-                    .map(|s| s.clone_display())
-                    .unwrap_or(Display::inline());
-                if matches!(display.inside(), DisplayInside::Contents) {
-                    // Transparent for box generation: the contents node casts
-                    // no vote itself — its children decide.
-                    has_contents = true;
-                    classify_stack.extend(child.children.iter().copied().rev());
-                } else {
-                    let position = style
-                        .map(|s| s.clone_position())
-                        .unwrap_or(PositionProperty::Static);
-                    let float = style.map(|s| s.clone_float()).unwrap_or(Float::None);
-
-                    // Ignore nodes that are entirely whitespace
-                    if child.is_whitespace_node() {
-                        continue;
-                    }
-
-                    let is_in_flow = matches!(
-                        position,
-                        PositionProperty::Static
-                            | PositionProperty::Relative
-                            | PositionProperty::Sticky
-                    ) && matches!(float, Float::None);
-
-                    if !is_in_flow {
-                        continue;
-                    }
-
-                    all_out_of_flow = false;
-                    match display.outside() {
-                        DisplayOutside::None => {}
-                        DisplayOutside::Block
-                        | DisplayOutside::TableCaption
-                        | DisplayOutside::InternalTable => all_inline = false,
-                        DisplayOutside::Inline => {
-                            all_block = false;
-
-                            // We need the "complex" tree fixing when an inline contains a block
-                            if child.is_or_contains_block() {
-                                all_inline = false;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if all_out_of_flow {
+            if classification.all_out_of_flow {
                 // Contents-transparent: a display:contents child may be
                 // holding the out-of-flow elements (otherwise the contents
                 // node itself would be pushed as a layout box).
@@ -427,7 +451,7 @@ pub(crate) fn collect_layout_children(
             }
 
             // TODO: fix display:contents
-            if all_inline {
+            if classification.all_inline {
                 let existing_layout = doc.nodes[container_node_id]
                     .element_data_mut()
                     .and_then(|el| el.inline_layout_data.take());
@@ -449,12 +473,12 @@ pub(crate) fn collect_layout_children(
 
             // If the children are either all inline or all block then simply return the regular children
             // as the layout children
-            if all_block & !has_contents {
+            if classification.all_block & !classification.has_contents {
                 return push_non_whitespace_children_and_pseudos(
                     &mut out.children,
                     &doc.nodes[container_node_id],
                 );
-            } else if all_inline & !has_contents {
+            } else if classification.all_inline & !classification.has_contents {
                 return push_children_and_pseudos(&mut out.children, &doc.nodes[container_node_id]);
             }
 

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -63,6 +63,18 @@ pub(crate) struct LayoutChildren {
     pub(crate) anonymous_block_id: Option<usize>,
 }
 
+impl LayoutChildren {
+    /// Append a single layout child.
+    fn push(&mut self, child_id: usize) {
+        self.children.push(child_id);
+    }
+
+    /// Append all layout children in `slice`.
+    fn extend(&mut self, slice: &[usize]) {
+        self.children.extend_from_slice(slice);
+    }
+}
+
 fn push_children_and_pseudos(layout_children: &mut Vec<usize>, node: &Node) {
     if let Some(before) = node.before {
         layout_children.push(before);
@@ -85,7 +97,7 @@ fn push_hoisted_children_and_pseudos(
     out: &mut LayoutChildren,
 ) {
     if let Some(before) = doc.nodes[container_node_id].before {
-        out.children.push(before);
+        out.push(before);
     }
     // Take children array from node to avoid borrow checker issues.
     let children = std::mem::take(&mut doc.nodes[container_node_id].children);
@@ -98,12 +110,12 @@ fn push_hoisted_children_and_pseudos(
         if matches!(child_display.inside(), DisplayInside::Contents) {
             collect_layout_children(doc, child_id, out);
         } else {
-            out.children.push(child_id);
+            out.push(child_id);
         }
     }
     doc.nodes[container_node_id].children = children;
     if let Some(after) = doc.nodes[container_node_id].after {
-        out.children.push(after);
+        out.push(after);
     }
 }
 
@@ -424,11 +436,11 @@ pub(crate) fn collect_layout_children(
                 .unwrap()
                 .special_data = data;
             if let Some(before) = doc.nodes[container_node_id].before {
-                out.children.push(before);
+                out.push(before);
             }
-            out.children.extend_from_slice(&tlayout_children);
+            out.extend(&tlayout_children);
             if let Some(after) = doc.nodes[container_node_id].after {
-                out.children.push(after);
+                out.push(after);
             }
         }
 
@@ -623,7 +635,7 @@ fn collect_complex_layout_children(
                     .layout_parent
                     .set(Some(container_node_id));
 
-                out.children.push(node_id);
+                out.push(node_id);
                 out.anonymous_block_id = Some(node_id);
             }
 
@@ -646,7 +658,7 @@ fn collect_complex_layout_children(
             }
 
             out.anonymous_block_id = None;
-            out.children.push(child_id);
+            out.push(child_id);
         }
     });
 

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -65,13 +65,96 @@ pub(crate) struct LayoutChildren {
 
 impl LayoutChildren {
     /// Append a single layout child.
-    fn push(&mut self, child_id: usize) {
+    fn push(&mut self, child_id: usize, doc: &mut BaseDocument) {
+        self.maybe_push_anon_block(doc);
         self.children.push(child_id);
     }
 
     /// Append all layout children in `slice`.
-    fn extend(&mut self, slice: &[usize]) {
+    fn extend(&mut self, slice: &[usize], doc: &mut BaseDocument) {
+        self.maybe_push_anon_block(doc);
         self.children.extend_from_slice(slice);
+    }
+
+    fn maybe_push_anon_block(&mut self, doc: &mut BaseDocument) {
+        fn block_is_only_whitespace(doc: &BaseDocument, node_id: usize) -> bool {
+            for child_id in doc.nodes[node_id].children.iter().copied() {
+                let child = &doc.nodes[child_id];
+                if !child.is_whitespace_node() {
+                    return false;
+                }
+            }
+
+            true
+        }
+
+        // If anonymous block node only contains whitespace then delete it
+        if let Some(anon_id) = self.anonymous_block_id {
+            if block_is_only_whitespace(doc, anon_id) {
+                // Remove by identity, not pop(): hoisted display:contents
+                // children may have been pushed after the anon block.
+                if let Some(pos) = self.children.iter().rposition(|id| *id == anon_id) {
+                    self.children.remove(pos);
+                }
+                doc.nodes.remove(anon_id);
+            }
+        }
+
+        self.anonymous_block_id = None;
+    }
+
+    fn push_wrapped(&mut self, container_node_id: usize, child_id: usize, doc: &mut BaseDocument) {
+        if self.anonymous_block_id.is_none() {
+            self.create_anonymous_block(container_node_id, doc);
+        }
+        doc.nodes[self.anonymous_block_id.unwrap()]
+            .children
+            .push(child_id);
+    }
+
+    fn create_anonymous_block(&mut self, container_node_id: usize, doc: &mut BaseDocument) {
+        use style::selector_parser::PseudoElement;
+
+        const NAME: QualName = QualName {
+            prefix: None,
+            ns: ns!(html),
+            local: local_name!("div"),
+        };
+        let node_id = doc.create_node(NodeData::AnonymousBlock(ElementData::new(NAME, Vec::new())));
+
+        // Set style data
+        let parent_style = doc.nodes[container_node_id].primary_styles().unwrap();
+        let read_guard = doc.guard.read();
+        let guards = StylesheetGuards::same(&read_guard);
+        let style = doc.stylist.style_for_anonymous::<&Node>(
+            &guards,
+            &PseudoElement::ServoAnonymousBox,
+            &parent_style,
+        );
+        let mut stylo_element_data = StyloElementData {
+            damage: ALL_DAMAGE,
+            ..Default::default()
+        };
+        drop(parent_style);
+
+        stylo_element_data.styles.primary = Some(style);
+        stylo_element_data.set_restyled();
+
+        *doc.nodes[node_id].stylo_element_data.ensure_init_mut() = stylo_element_data;
+
+        if doc.nodes[container_node_id]
+            .flags
+            .contains(NodeFlags::IS_IN_DOCUMENT)
+        {
+            doc.nodes[node_id].flags.insert(NodeFlags::IS_IN_DOCUMENT);
+        }
+        doc.nodes[node_id].parent = Some(container_node_id);
+        doc.nodes[node_id]
+            .layout_parent
+            .set(Some(container_node_id));
+
+        self.children.push(node_id);
+        self.anonymous_block_id = Some(node_id);
     }
 }
 
@@ -97,7 +180,7 @@ fn push_hoisted_children_and_pseudos(
     out: &mut LayoutChildren,
 ) {
     if let Some(before) = doc.nodes[container_node_id].before {
-        out.push(before);
+        out.push(before, doc);
     }
     // Take children array from node to avoid borrow checker issues.
     let children = std::mem::take(&mut doc.nodes[container_node_id].children);
@@ -110,12 +193,12 @@ fn push_hoisted_children_and_pseudos(
         if matches!(child_display.inside(), DisplayInside::Contents) {
             collect_layout_children(doc, child_id, out);
         } else {
-            out.push(child_id);
+            out.push(child_id, doc);
         }
     }
     doc.nodes[container_node_id].children = children;
     if let Some(after) = doc.nodes[container_node_id].after {
-        out.push(after);
+        out.push(after, doc);
     }
 }
 
@@ -436,11 +519,11 @@ pub(crate) fn collect_layout_children(
                 .unwrap()
                 .special_data = data;
             if let Some(before) = doc.nodes[container_node_id].before {
-                out.push(before);
+                out.push(before, doc);
             }
-            out.extend(&tlayout_children);
+            out.extend(&tlayout_children, doc);
             if let Some(after) = doc.nodes[container_node_id].after {
-                out.push(after);
+                out.push(after, doc);
             }
         }
 
@@ -550,17 +633,6 @@ fn collect_complex_layout_children(
     hide_whitespace: bool,
     needs_wrap: impl Fn(NodeKind, DisplayOutside) -> bool,
 ) {
-    fn block_is_only_whitespace(doc: &BaseDocument, node_id: usize) -> bool {
-        for child_id in doc.nodes[node_id].children.iter().copied() {
-            let child = &doc.nodes[child_id];
-            if !child.is_whitespace_node() {
-                return false;
-            }
-        }
-
-        true
-    }
-
     doc.iter_children_and_pseudos_mut(container_node_id, |child_id, doc| {
         // Get node kind (text, element, comment, etc)
         let child_node_kind = doc.nodes[child_id].data.kind();
@@ -593,85 +665,16 @@ fn collect_complex_layout_children(
         // Push nodes that need wrapping into the current "anonymous block container".
         // If there is not an open one then we create one.
         else if needs_wrap(child_node_kind, display_outside) {
-            use style::selector_parser::PseudoElement;
-
-            if out.anonymous_block_id.is_none() {
-                const NAME: QualName = QualName {
-                    prefix: None,
-                    ns: ns!(html),
-                    local: local_name!("div"),
-                };
-                let node_id =
-                    doc.create_node(NodeData::AnonymousBlock(ElementData::new(NAME, Vec::new())));
-
-                // Set style data
-                let parent_style = doc.nodes[container_node_id].primary_styles().unwrap();
-                let read_guard = doc.guard.read();
-                let guards = StylesheetGuards::same(&read_guard);
-                let style = doc.stylist.style_for_anonymous::<&Node>(
-                    &guards,
-                    &PseudoElement::ServoAnonymousBox,
-                    &parent_style,
-                );
-                let mut stylo_element_data = StyloElementData {
-                    damage: ALL_DAMAGE,
-                    ..Default::default()
-                };
-                drop(parent_style);
-
-                stylo_element_data.styles.primary = Some(style);
-                stylo_element_data.set_restyled();
-
-                *doc.nodes[node_id].stylo_element_data.ensure_init_mut() = stylo_element_data;
-
-                if doc.nodes[container_node_id]
-                    .flags
-                    .contains(NodeFlags::IS_IN_DOCUMENT)
-                {
-                    doc.nodes[node_id].flags.insert(NodeFlags::IS_IN_DOCUMENT);
-                }
-                doc.nodes[node_id].parent = Some(container_node_id);
-                doc.nodes[node_id]
-                    .layout_parent
-                    .set(Some(container_node_id));
-
-                out.push(node_id);
-                out.anonymous_block_id = Some(node_id);
-            }
-
-            doc.nodes[out.anonymous_block_id.unwrap()]
-                .children
-                .push(child_id);
+            out.push_wrapped(container_node_id, child_id, doc);
         }
         // Else push the child directly (and close any open "anonymous block container")
         else {
-            // If anonymous block node only contains whitespace then delete it
-            if let Some(anon_id) = out.anonymous_block_id {
-                if block_is_only_whitespace(doc, anon_id) {
-                    // Remove by identity, not pop(): hoisted display:contents
-                    // children may have been pushed after the anon block.
-                    if let Some(pos) = out.children.iter().rposition(|id| *id == anon_id) {
-                        out.children.remove(pos);
-                    }
-                    doc.nodes.remove(anon_id);
-                }
-            }
-
-            out.anonymous_block_id = None;
-            out.push(child_id);
+            out.push(child_id, doc);
         }
     });
 
-    // If anonymous block node only contains whitespace then delete it
-    if let Some(anon_id) = out.anonymous_block_id {
-        if block_is_only_whitespace(doc, anon_id) {
-            if let Some(pos) = out.children.iter().rposition(|id| *id == anon_id) {
-                out.children.remove(pos);
-            }
-            doc.nodes.remove(anon_id);
-            out.anonymous_block_id = None;
-        }
-    }
+    // If anonymous block node only contains whitespace then delete it, else push it
+    out.maybe_push_anon_block(doc);
 }
 
 fn create_text_editor(doc: &mut BaseDocument, input_element_id: usize, is_multiline: bool) {

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -30,7 +30,8 @@ use crate::{
     layout::{
         construct::{
             ConstructionTask, ConstructionTaskData, ConstructionTaskResult,
-            ConstructionTaskResultData, build_inline_layout_into, collect_layout_children,
+            ConstructionTaskResultData, LayoutChildren, build_inline_layout_into,
+            collect_layout_children,
         },
         damage::{ALL_DAMAGE, CONSTRUCT_BOX, CONSTRUCT_DESCENDENT, CONSTRUCT_FC},
     },
@@ -226,9 +227,9 @@ impl BaseDocument {
 
             if NON_INCREMENTAL || damage.intersects(CONSTRUCT_FC | CONSTRUCT_BOX) {
                 //} || flags.contains(NodeFlags::IS_INLINE_ROOT) {
-                let mut layout_children = Vec::new();
-                let mut anonymous_block: Option<usize> = None;
-                collect_layout_children(doc, node_id, &mut layout_children, &mut anonymous_block);
+                let mut collected = LayoutChildren::default();
+                collect_layout_children(doc, node_id, &mut collected);
+                let layout_children = collected.children;
 
                 // Recurse into newly collected layout children
                 for child_id in layout_children.iter().copied() {

--- a/packages/blitz-html/tests/comment_layout.rs
+++ b/packages/blitz-html/tests/comment_layout.rs
@@ -65,3 +65,49 @@ fn comment_sibling_does_not_inline_block_child() {
         "block child must fill its parent's width even with a comment sibling"
     );
 }
+
+#[test]
+fn abspos_inset_child_of_scroll_container_sizes_to_padding_box() {
+    // An absolute inset:0 child of a relative scroll container must size to
+    // the container's padding box, not to its scrollable content area.
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:300px; height:200px; overflow-y:auto;">
+                <div id="abs" style="position:absolute; inset:0;">
+                    <div style="height:5000px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let abs_id = doc.query_selector("#abs").unwrap().expect("#abs not found");
+    let layout = doc.get_node(abs_id).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (300.0, 200.0),
+        "absolute inset:0 child of a scroll container must match the padding box"
+    );
+}
+
+#[test]
+fn abspos_calc_var_inset_stretches() {
+    // Tailwind v4 emits `inset: calc(var(--spacing) * 0)` for inset-0.
+    let doc = layout_doc(
+        r#"<html><head><style>
+            :root { --spacing: 0.25rem; }
+            .inset-0 { inset: calc(var(--spacing) * 0); }
+        </style></head><body style="margin:0">
+            <div style="position:relative; width:300px; height:200px; overflow-y:auto;">
+                <div id="abs" class="inset-0" style="position:absolute;">
+                    <div style="height:5000px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let abs_id = doc.query_selector("#abs").unwrap().expect("#abs not found");
+    let layout = doc.get_node(abs_id).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (300.0, 200.0),
+        "calc(var()*0) insets must stretch the abspos child to its containing block"
+    );
+}

--- a/packages/blitz-html/tests/display_contents.rs
+++ b/packages/blitz-html/tests/display_contents.rs
@@ -1,0 +1,115 @@
+//! display:contents — children must lay out as if they were children of the
+//! contents element's parent.
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn layout_doc(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+#[test]
+fn contents_block_children_stack_and_fill_width() {
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="width:300px;">
+                <div style="display:contents;">
+                    <div id="a" style="height:50px;"></div>
+                    <div id="b" style="height:70px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let a = doc.query_selector("#a").unwrap().expect("#a not found");
+    let b = doc.query_selector("#b").unwrap().expect("#b not found");
+    let la = doc.get_node(a).unwrap().final_layout;
+    let lb = doc.get_node(b).unwrap().final_layout;
+    assert_eq!(
+        (la.size.width, la.size.height),
+        (300.0, 50.0),
+        "first hoisted block child must fill the grandparent width"
+    );
+    assert_eq!(
+        (lb.size.width, lb.size.height),
+        (300.0, 70.0),
+        "second hoisted block child must fill the grandparent width"
+    );
+    assert_eq!(
+        lb.location.y - la.location.y,
+        50.0,
+        "hoisted block children must stack vertically"
+    );
+}
+
+#[test]
+fn scroller_wrapping_contents_gets_full_scroll_size() {
+    // The kopuz route-shell shape: a scroll container whose only child is a
+    // display:contents wrapper holding tall content.
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="height:200px; overflow-y:auto;">
+                <div style="display:contents;">
+                    <div id="tall" style="height:1000px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let scroller = doc
+        .query_selector("#scroller")
+        .unwrap()
+        .expect("#scroller not found");
+    let tall = doc.query_selector("#tall").unwrap().expect("#tall not found");
+    let ls = doc.get_node(scroller).unwrap().final_layout;
+    let lt = doc.get_node(tall).unwrap().final_layout;
+    assert_eq!(
+        (lt.size.width, lt.size.height),
+        (800.0, 1000.0),
+        "content inside the contents wrapper must size normally"
+    );
+    assert_eq!(
+        ls.content_size.height, 1000.0,
+        "the scroller's scrollable content size must include the hoisted content"
+    );
+}
+
+#[test]
+fn contents_in_flex_container_hoists_children_as_flex_items() {
+    // The kopuz showcase shape: flex rows whose direct children are
+    // display:contents wrappers (keyed row wrappers).
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="display:flex; flex-direction:column; width:300px;">
+                <div style="display:contents;">
+                    <div id="x" style="height:40px;"></div>
+                    <div id="y" style="height:40px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let x = doc.query_selector("#x").unwrap().expect("#x not found");
+    let y = doc.query_selector("#y").unwrap().expect("#y not found");
+    let lx = doc.get_node(x).unwrap().final_layout;
+    let ly = doc.get_node(y).unwrap().final_layout;
+    assert_eq!(
+        (lx.size.width, lx.size.height),
+        (300.0, 40.0),
+        "hoisted flex item must stretch to the flex container width"
+    );
+    assert_eq!(
+        ly.location.y - lx.location.y,
+        40.0,
+        "hoisted flex items must stack in the column"
+    );
+}
+

--- a/packages/blitz-html/tests/display_contents.rs
+++ b/packages/blitz-html/tests/display_contents.rs
@@ -113,3 +113,29 @@ fn contents_in_flex_container_hoists_children_as_flex_items() {
     );
 }
 
+
+#[test]
+fn abspos_child_hoisted_through_contents_stretches() {
+    // The kopuz route-shell chain: scroll container > display:contents shell
+    // > absolute inset:0 page (plus a comment placeholder sibling). The page
+    // must stretch to the scroll container's padding box.
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:300px; height:200px; overflow-y:auto;">
+                <!-- placeholder -->
+                <div style="display:contents;">
+                    <div id="page" style="position:absolute; inset:0;">
+                        <div style="height:5000px;"></div>
+                    </div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let page = doc.query_selector("#page").unwrap().expect("#page not found");
+    let layout = doc.get_node(page).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (300.0, 200.0),
+        "abspos hoisted through display:contents must stretch to the containing block"
+    );
+}

--- a/packages/blitz-html/tests/display_contents.rs
+++ b/packages/blitz-html/tests/display_contents.rs
@@ -69,7 +69,10 @@ fn scroller_wrapping_contents_gets_full_scroll_size() {
         .query_selector("#scroller")
         .unwrap()
         .expect("#scroller not found");
-    let tall = doc.query_selector("#tall").unwrap().expect("#tall not found");
+    let tall = doc
+        .query_selector("#tall")
+        .unwrap()
+        .expect("#tall not found");
     let ls = doc.get_node(scroller).unwrap().final_layout;
     let lt = doc.get_node(tall).unwrap().final_layout;
     assert_eq!(
@@ -113,7 +116,6 @@ fn contents_in_flex_container_hoists_children_as_flex_items() {
     );
 }
 
-
 #[test]
 fn abspos_child_hoisted_through_contents_stretches() {
     // The kopuz route-shell chain: scroll container > display:contents shell
@@ -131,7 +133,10 @@ fn abspos_child_hoisted_through_contents_stretches() {
             </div>
         </body></html>"#,
     );
-    let page = doc.query_selector("#page").unwrap().expect("#page not found");
+    let page = doc
+        .query_selector("#page")
+        .unwrap()
+        .expect("#page not found");
     let layout = doc.get_node(page).unwrap().final_layout;
     assert_eq!(
         (layout.size.width, layout.size.height),


### PR DESCRIPTION
Stacked on #452 (contains its commit; will rebase once it lands).

`display: contents` is transparent for box generation, but three places in `collect_layout_children` treated the contents element as opaque. Together they made a common Dioxus/Tailwind structure (a `class="contents"` shell between a scroll container and absolutely-positioned pages) lay out as zero-size or content-size boxes. Each fix is covered by a test in `packages/blitz-html/tests/display_contents.rs`:

1. **Classification didn't recurse into contents children.** A container whose in-flow children were all contents wrappers classified as `all_inline` (the existing `TODO: make "all_inline" detection work in the presence of display:contents`) and became an inline root, embedding hoisted *block* children as zero-width inline boxes. The scan now recurses through contents children; the contents node itself casts no vote — including not clearing `all_out_of_flow`, so a container whose only box-generating descendants are out-of-flow takes the out-of-flow path instead of becoming an inline root.

2. **The `DisplayInside::Contents` arm hoisted the wrong generation.** It called `collect_layout_children` on each child, which pushes the child's *layout children* — so leaf children contributed nothing and vanished from the layout tree. Extracted `push_hoisted_children_and_pseudos`, which pushes the children themselves and recurses only through nested contents nodes; the arm also gains `::before`/`::after` support. The same helper now serves the `all_out_of_flow` early-return, which previously pushed the container's direct children — a contents node holding the out-of-flow elements was itself pushed as a layout box, and an `absolute inset:0` child then sized against it instead of the real containing block (content-sized: a real-app page measured 1745x50517 inside a 1004x1251 scroller, leaving nothing scrollable).

3. **Whitespace-only anonymous-block cleanup corrupted the child list.** It removed the anon block with `layout_children.pop()`, assuming it was the most recent entry. Hoisted contents children can land after it, so `pop()` dropped a real child and left the removed anon block's stale id in the list — a slab `invalid key` panic in `resolve_layout_children`. Removal is now by identity.

WPT `css/css-grid` + `css/css-flexbox`: 1154 tests pass before and after.
