### PR TITLE
UA stylesheet: center button text

### DIFF
--- a/packages/blitz-dom/assets/default.css
+++ b/packages/blitz-dom/assets/default.css
@@ -86,6 +86,7 @@ input[type="button"] {
     padding: 1px 6px;
     color: black;
     background-color: #EFEFEF;
+    text-align: center;
 }
 
 input[type="file"] {


### PR DESCRIPTION
Every major browser's UA sheet applies `text-align: center` to `<button>`; blitz's `default.css` styled buttons but left their text left-aligned. One line + a centering test (the probe is an inline-block embedded box, since plain inline spans don't get a box assigned).
