### PR TITLE
Paint positioned z-index:auto descendants above in-flow content, in tree order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,10 @@ dependencies = [
 name = "blitz-html"
 version = "0.3.0-alpha.5"
 dependencies = [
+ "anyrender",
+ "anyrender_vello_cpu",
  "blitz-dom",
+ "blitz-paint",
  "blitz-traits",
  "html5ever",
  "tracing",

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -549,7 +549,9 @@ impl BaseDocument {
                 let z_index = style.clone_z_index().integer_or(0);
 
                 // TODO: more complete hoisting detection
-                if position != Position::Static && z_index != 0 {
+                // z-index applies to static flex/grid items too
+                // (css-flexbox-1 §painting, css-grid-1 §z-order).
+                if z_index != 0 && (position != Position::Static || is_flex_or_grid) {
                     stacking_context.children.push(HoistedPaintChild {
                         node_id: child_id,
                         z_index,
@@ -593,8 +595,11 @@ impl BaseDocument {
 #[inline(always)]
 fn position_to_order(pos: Position) -> i32 {
     match pos {
-        Position::Static | Position::Relative | Position::Sticky => 0,
-        Position::Absolute | Position::Fixed => 2,
+        Position::Static => 0,
+        // All positioned descendants with z-index: auto share one paint
+        // level (CSS 2.1 Appendix E step 8); the stable sort keeps them in
+        // tree order among themselves, above in-flow content and floats.
+        Position::Relative | Position::Sticky | Position::Absolute | Position::Fixed => 2,
     }
 }
 #[inline(always)]
@@ -605,17 +610,25 @@ fn float_to_order(pos: Float) -> i32 {
     }
 }
 
+/// Paint sort key: (paint level, order-modified position). Positioned
+/// (z-index: auto) descendants paint above in-flow content (CSS 2.1
+/// Appendix E step 8); within a level the stable sort preserves
+/// (order-modified) document order.
 #[inline(always)]
-fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> i32 {
+fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> (i32, i32) {
     let Some(style) = node.primary_styles() else {
-        return 0;
+        return (0, 0);
     };
+    let position = style.clone_position();
     if is_flex_or_grid {
-        match style.clone_position() {
-            Position::Static | Position::Relative | Position::Sticky => style.clone_order(),
-            Position::Absolute | Position::Fixed => 0,
+        match position {
+            Position::Static => (0, style.clone_order()),
+            Position::Relative | Position::Sticky => (2, style.clone_order()),
+            // Out-of-flow children are not flex/grid items: `order` does
+            // not apply; tree order does.
+            Position::Absolute | Position::Fixed => (2, 0),
         }
     } else {
-        position_to_order(style.clone_position()) + float_to_order(style.clone_float())
+        (position_to_order(position) + float_to_order(style.clone_float()), 0)
     }
 }

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -629,6 +629,9 @@ fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> (i32, i32) {
             Position::Absolute | Position::Fixed => (2, 0),
         }
     } else {
-        (position_to_order(position) + float_to_order(style.clone_float()), 0)
+        (
+            position_to_order(position) + float_to_order(style.clone_float()),
+            0,
+        )
     }
 }

--- a/packages/blitz-html/Cargo.toml
+++ b/packages/blitz-html/Cargo.toml
@@ -23,3 +23,8 @@ html5ever = { workspace = true }
 xml5ever = { workspace = true }
 
 tracing = { workspace = true, optional = true }
+
+[dev-dependencies]
+blitz-paint = { workspace = true }
+anyrender = { workspace = true }
+anyrender_vello_cpu = { workspace = true }

--- a/packages/blitz-html/tests/paint_order.rs
+++ b/packages/blitz-html/tests/paint_order.rs
@@ -1,0 +1,78 @@
+//! CSS 2.1 Appendix E: all positioned descendants with z-index: auto share
+//! one paint level (step 8) and paint in tree order among themselves.
+
+use anyrender::render_to_buffer;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_paint::paint_scene;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn center_pixel(html: &str) -> [u8; 3] {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+        |scene| paint_scene(scene, &mut doc, 1.0, 100, 100, 0, 0),
+        100,
+        100,
+    );
+    let idx = (50 * 100 + 50) * 4;
+    [buffer[idx], buffer[idx + 1], buffer[idx + 2]]
+}
+
+#[test]
+fn later_relative_sibling_paints_above_earlier_abspos() {
+    let px = center_pixel(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:100px; height:100px;">
+                <div style="position:absolute; inset:0; background:#0000ff;"></div>
+                <div style="position:relative; width:100px; height:100px; background:#ff0000;"></div>
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(
+        px,
+        [255, 0, 0],
+        "later positioned (z-index auto) sibling must paint above earlier abspos sibling"
+    );
+}
+
+#[test]
+fn abspos_paints_above_earlier_static_sibling() {
+    let px = center_pixel(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:100px; height:100px;">
+                <div style="width:100px; height:100px; background:#0000ff;"></div>
+                <div style="position:absolute; inset:0; background:#ff0000;"></div>
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(px, [255, 0, 0], "abspos must paint above in-flow content");
+}
+
+#[test]
+fn earlier_abspos_stays_below_static_when_later_in_tree_order_is_static() {
+    // In-flow content paints below positioned content even when the
+    // positioned element comes first in tree order.
+    let px = center_pixel(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:100px; height:100px;">
+                <div style="position:absolute; inset:0; background:#ff0000;"></div>
+                <div style="width:100px; height:100px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(
+        px,
+        [255, 0, 0],
+        "positioned content paints above in-flow content regardless of tree order"
+    );
+}


### PR DESCRIPTION
Fixes #458.

Two paint-order fixes in `flush_styles_to_layout`'s `paint_children` sort:

1. `position_to_order` put relative/sticky at the in-flow level (0) and absolute/fixed above it (2), so an earlier abspos sibling painted above a later relative sibling. Per CSS 2.1 Appendix E step 8, all positioned descendants with `z-index: auto` share one paint level and paint in tree order among themselves, above in-flow content. The hero-banner pattern (`absolute inset-0` image layer + relative content overlay) rendered only the image.

2. Flex/grid items ignored `position` entirely (the sort key was just `order`), and z-index was only honored for non-static children — but z-index applies to static flex/grid items too (css-flexbox-1 §painting, css-grid-1 §z-order). The sort key is now (paint level, order-modified position), and static flex/grid items with z-index are hoisted into the stacking context.

Pixel-level regression tests in `packages/blitz-html/tests/paint_order.rs` (render via `anyrender_vello_cpu`, assert the center pixel — adds those as dev-dependencies to blitz-html).

WPT `css/css-grid` + `css/css-flexbox`: **0 regressions**, new passes: `flexbox-items-as-stacking-contexts-002` (its *reference page* depends on fix 1 — it previously "passed" because both pages rendered identically wrong), `flex-item-z-ordering-001/002`, `grid-z-axis-ordering-001/002/003`, `positioned-grid-items-020/021`, `positioned-grid-items-negative-indices-003`.
