### PR TITLE
Paint overlay scrollbars for scroll containers (feature-gated, default off)

### DIFF
--- a/packages/blitz-html/Cargo.toml
+++ b/packages/blitz-html/Cargo.toml
@@ -25,6 +25,6 @@ xml5ever = { workspace = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
-blitz-paint = { workspace = true }
+blitz-paint = { workspace = true, features = ["scrollbars"] }
 anyrender = { workspace = true }
 anyrender_vello_cpu = { workspace = true }

--- a/packages/blitz-html/tests/scrollbars.rs
+++ b/packages/blitz-html/tests/scrollbars.rs
@@ -1,0 +1,90 @@
+//! Scroll containers paint overlay scrollbars while hovered or scrolled:
+//! always for overflow: scroll, only when overflowing for overflow: auto,
+//! never for overflow: hidden. At rest (unhovered, unscrolled) nothing is
+//! painted, like other overlay scrollbar UIs.
+
+use anyrender::render_to_buffer;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_paint::paint_scene;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+const BLUE: [u8; 3] = [0, 0, 255];
+
+/// Renders `html`, scrolling the `#scroller` element by (dx, dy) first,
+/// and returns the pixel at (x, y).
+fn pixel(html: &str, scroll: (f64, f64), x: usize, y: usize) -> [u8; 3] {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let scroller = doc.query_selector("#scroller").unwrap().expect("#scroller");
+    let node = doc.get_node_mut(scroller).unwrap();
+    node.scroll_offset.x = scroll.0;
+    node.scroll_offset.y = scroll.1;
+    let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+        |scene| paint_scene(scene, &mut doc, 1.0, 100, 100, 0, 0),
+        100,
+        100,
+    );
+    let idx = (y * 100 + x) * 4;
+    [buffer[idx], buffer[idx + 1], buffer[idx + 2]]
+}
+
+fn scroller(overflow: &str, child_height: u32) -> String {
+    format!(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:{overflow};">
+                <div style="height:{child_height}px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#
+    )
+}
+
+#[test]
+fn scrolled_auto_scroller_paints_a_thumb() {
+    let px = pixel(&scroller("auto", 1000), (0.0, 50.0), 97, 10);
+    assert_ne!(px, BLUE, "expected a scrollbar thumb over the content");
+}
+
+#[test]
+fn unscrolled_unhovered_scroller_paints_no_thumb() {
+    let px = pixel(&scroller("auto", 1000), (0.0, 0.0), 97, 4);
+    assert_eq!(px, BLUE, "overlay scrollbars are hidden at rest");
+}
+
+#[test]
+fn non_overflowing_auto_scroller_paints_no_thumb() {
+    // Even with a (stale) scroll offset, a non-overflowing auto container
+    // has no scroll range and paints no thumb.
+    let px = pixel(&scroller("auto", 100), (0.0, 10.0), 97, 4);
+    assert_eq!(px, BLUE, "no scrollbar for non-overflowing overflow:auto");
+}
+
+#[test]
+fn hidden_scroller_paints_no_thumb() {
+    let px = pixel(&scroller("hidden", 1000), (0.0, 50.0), 97, 10);
+    assert_eq!(px, BLUE, "overflow:hidden must not paint scrollbars");
+}
+
+#[test]
+fn horizontal_scroller_paints_a_thumb() {
+    let px = pixel(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-x:auto; overflow-y:hidden;">
+                <div style="width:1000px; height:100px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+        (50.0, 0.0),
+        10,
+        97,
+    );
+    assert_ne!(px, BLUE, "expected a horizontal scrollbar thumb");
+}

--- a/packages/blitz-paint/Cargo.toml
+++ b/packages/blitz-paint/Cargo.toml
@@ -17,6 +17,9 @@ svg = ["dep:anyrender_svg", "dep:usvg", "blitz-dom/svg"]
 custom-widget = ["blitz-dom/custom-widget"]
 font-embolden = []
 apple-font-embolden = []
+# Paint overlay scrollbar thumbs on scroll containers (off by default while
+# the feature matures).
+scrollbars = []
 
 [dependencies]
 # Blitz dependencies

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -401,6 +401,11 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                                 cx.draw_children(scene, cx.transform);
                             },
                         );
+
+                        // Overlay scrollbars, drawn unscrolled above the
+                        // clipped content.
+                        cx.transform = unscrolled_transform;
+                        cx.draw_scrollbars(scene, overflow_x, overflow_y);
                     },
                 );
 
@@ -528,6 +533,84 @@ fn convert_rect(rect: &parley::BoundingBox) -> kurbo::Rect {
 }
 
 impl ElementCx<'_, '_> {
+    /// Paint overlay scrollbar thumbs for scroll containers (`overflow:
+    /// scroll`, or `auto` when the content overflows — never `hidden`/
+    /// `clip`, which scroll only programmatically). Like other overlay
+    /// scrollbar UIs, thumbs only appear while the scroll container is
+    /// hovered or scrolled away from the origin; this also keeps them out
+    /// of (static, unhovered) reftest screenshots.
+    fn draw_scrollbars(
+        &self,
+        scene: &mut impl PaintScene,
+        overflow_x: Overflow,
+        overflow_y: Overflow,
+    ) {
+        if !self.node.is_hovered()
+            && self.node.scroll_offset.x == 0.0
+            && self.node.scroll_offset.y == 0.0
+        {
+            return;
+        }
+        const THUMB_THICKNESS: f64 = 6.0;
+        const THUMB_MARGIN: f64 = 2.0;
+        const MIN_THUMB_LENGTH: f64 = 16.0;
+        const THUMB_COLOR: Color = Color::from_rgba8(128, 128, 128, 178);
+
+        let layout = &self.node.final_layout;
+        let padding_box = self.frame.padding_box;
+
+        let mut draw_thumb = |scroll_extent: f64, scroll_offset: f64, horizontal: bool| {
+            if scroll_extent <= 0.5 {
+                return;
+            }
+            let viewport_len = if horizontal {
+                padding_box.width()
+            } else {
+                padding_box.height()
+            };
+            let max_scroll = scroll_extent * self.scale;
+            let thumb_len = (viewport_len * viewport_len / (viewport_len + max_scroll))
+                .max(MIN_THUMB_LENGTH * self.scale)
+                .min(viewport_len);
+            let progress = (scroll_offset * self.scale / max_scroll).clamp(0.0, 1.0);
+            let thumb_start = progress * (viewport_len - thumb_len);
+            let thickness = THUMB_THICKNESS * self.scale;
+            let margin = THUMB_MARGIN * self.scale;
+            let rect = if horizontal {
+                Rect::new(
+                    padding_box.x0 + thumb_start,
+                    padding_box.y1 - margin - thickness,
+                    padding_box.x0 + thumb_start + thumb_len,
+                    padding_box.y1 - margin,
+                )
+            } else {
+                Rect::new(
+                    padding_box.x1 - margin - thickness,
+                    padding_box.y0 + thumb_start,
+                    padding_box.x1 - margin,
+                    padding_box.y0 + thumb_start + thumb_len,
+                )
+            };
+            let thumb = rect.to_rounded_rect(thickness / 2.0);
+            scene.fill(Fill::NonZero, self.transform, THUMB_COLOR, None, &thumb);
+        };
+
+        let wants_bar = |overflow: Overflow, scroll_extent: f64| match overflow {
+            Overflow::Scroll => true,
+            Overflow::Auto => scroll_extent > 0.5,
+            _ => false,
+        };
+
+        let scroll_height = layout.scroll_height() as f64;
+        if wants_bar(overflow_y, scroll_height) {
+            draw_thumb(scroll_height, self.node.scroll_offset.y, false);
+        }
+        let scroll_width = layout.scroll_width() as f64;
+        if wants_bar(overflow_x, scroll_width) {
+            draw_thumb(scroll_width, self.node.scroll_offset.x, true);
+        }
+    }
+
     fn draw_inline_layout(&self, scene: &mut impl PaintScene, pos: Point) {
         if self.node.flags.is_inline_root() {
             let text_layout = self.element

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -404,8 +404,11 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
 
                         // Overlay scrollbars, drawn unscrolled above the
                         // clipped content.
-                        cx.transform = unscrolled_transform;
-                        cx.draw_scrollbars(scene, overflow_x, overflow_y);
+                        #[cfg(feature = "scrollbars")]
+                        {
+                            cx.transform = unscrolled_transform;
+                            cx.draw_scrollbars(scene, overflow_x, overflow_y);
+                        }
                     },
                 );
 
@@ -539,27 +542,40 @@ impl ElementCx<'_, '_> {
     /// scrollbar UIs, thumbs only appear while the scroll container is
     /// hovered or scrolled away from the origin; this also keeps them out
     /// of (static, unhovered) reftest screenshots.
+    #[cfg(feature = "scrollbars")]
     fn draw_scrollbars(
         &self,
         scene: &mut impl PaintScene,
         overflow_x: Overflow,
         overflow_y: Overflow,
     ) {
-        if !self.node.is_hovered()
-            && self.node.scroll_offset.x == 0.0
-            && self.node.scroll_offset.y == 0.0
-        {
-            return;
+        /// Whether an axis shows a bar: always for `scroll`, only when the
+        /// content actually overflows for `auto`, never for anything else.
+        fn wants_bar(overflow: Overflow, scroll_extent: f64) -> bool {
+            match overflow {
+                Overflow::Scroll => true,
+                Overflow::Auto => scroll_extent > 0.5,
+                _ => false,
+            }
         }
-        const THUMB_THICKNESS: f64 = 6.0;
-        const THUMB_MARGIN: f64 = 2.0;
-        const MIN_THUMB_LENGTH: f64 = 16.0;
-        const THUMB_COLOR: Color = Color::from_rgba8(128, 128, 128, 178);
 
-        let layout = &self.node.final_layout;
-        let padding_box = self.frame.padding_box;
+        /// Fill one axis' thumb: length proportional to the visible fraction
+        /// (clamped to a minimum), positioned by scroll progress, inset from
+        /// the padding-box edge. All lengths in scaled device pixels.
+        fn draw_thumb(
+            scene: &mut impl PaintScene,
+            transform: Affine,
+            scale: f64,
+            padding_box: Rect,
+            scroll_extent: f64,
+            scroll_offset: f64,
+            horizontal: bool,
+        ) {
+            const THUMB_THICKNESS: f64 = 6.0;
+            const THUMB_MARGIN: f64 = 2.0;
+            const MIN_THUMB_LENGTH: f64 = 16.0;
+            const THUMB_COLOR: Color = Color::from_rgba8(128, 128, 128, 178);
 
-        let mut draw_thumb = |scroll_extent: f64, scroll_offset: f64, horizontal: bool| {
             if scroll_extent <= 0.5 {
                 return;
             }
@@ -568,14 +584,14 @@ impl ElementCx<'_, '_> {
             } else {
                 padding_box.height()
             };
-            let max_scroll = scroll_extent * self.scale;
+            let max_scroll = scroll_extent * scale;
             let thumb_len = (viewport_len * viewport_len / (viewport_len + max_scroll))
-                .max(MIN_THUMB_LENGTH * self.scale)
+                .max(MIN_THUMB_LENGTH * scale)
                 .min(viewport_len);
-            let progress = (scroll_offset * self.scale / max_scroll).clamp(0.0, 1.0);
+            let progress = (scroll_offset * scale / max_scroll).clamp(0.0, 1.0);
             let thumb_start = progress * (viewport_len - thumb_len);
-            let thickness = THUMB_THICKNESS * self.scale;
-            let margin = THUMB_MARGIN * self.scale;
+            let thickness = THUMB_THICKNESS * scale;
+            let margin = THUMB_MARGIN * scale;
             let rect = if horizontal {
                 Rect::new(
                     padding_box.x0 + thumb_start,
@@ -592,22 +608,42 @@ impl ElementCx<'_, '_> {
                 )
             };
             let thumb = rect.to_rounded_rect(thickness / 2.0);
-            scene.fill(Fill::NonZero, self.transform, THUMB_COLOR, None, &thumb);
-        };
+            scene.fill(Fill::NonZero, transform, THUMB_COLOR, None, &thumb);
+        }
 
-        let wants_bar = |overflow: Overflow, scroll_extent: f64| match overflow {
-            Overflow::Scroll => true,
-            Overflow::Auto => scroll_extent > 0.5,
-            _ => false,
-        };
+        if !self.node.is_hovered()
+            && self.node.scroll_offset.x == 0.0
+            && self.node.scroll_offset.y == 0.0
+        {
+            return;
+        }
+
+        let layout = &self.node.final_layout;
+        let padding_box = self.frame.padding_box;
 
         let scroll_height = layout.scroll_height() as f64;
         if wants_bar(overflow_y, scroll_height) {
-            draw_thumb(scroll_height, self.node.scroll_offset.y, false);
+            draw_thumb(
+                scene,
+                self.transform,
+                self.scale,
+                padding_box,
+                scroll_height,
+                self.node.scroll_offset.y,
+                false,
+            );
         }
         let scroll_width = layout.scroll_width() as f64;
         if wants_bar(overflow_x, scroll_width) {
-            draw_thumb(scroll_width, self.node.scroll_offset.x, true);
+            draw_thumb(
+                scene,
+                self.transform,
+                self.scale,
+                padding_box,
+                scroll_width,
+                self.node.scroll_offset.x,
+                true,
+            );
         }
     }
 

--- a/packages/blitz/Cargo.toml
+++ b/packages/blitz/Cargo.toml
@@ -15,6 +15,7 @@ default = ["net", "accessibility", "tracing"]
 net = ["dep:tokio", "dep:url", "dep:blitz-net"]
 accessibility = ["blitz-shell/accessibility"]
 tracing = ["dep:tracing", "blitz-shell/tracing", "blitz-html/tracing", "blitz-net/tracing"]
+scrollbars = ["blitz-paint/scrollbars"]
 
 [dependencies]
 # Blitz dependencies

--- a/packages/dioxus-native/Cargo.toml
+++ b/packages/dioxus-native/Cargo.toml
@@ -41,6 +41,7 @@ vello-cpu-base = ["dep:anyrender_vello_cpu"]
 
 font-embolden = ["blitz-paint/font-embolden"]
 apple-font-embolden = ["blitz-paint/apple-font-embolden"]
+scrollbars = ["blitz-paint/scrollbars"]
 
 # Other features
 # No-op on wasm32 (blitz_net::Provider needs tokio's threaded runtime); launch_cfg


### PR DESCRIPTION
blitz previously never painted scrollbars: an `overflow: auto`/`scroll` container gave no visual indication that it scrolls or where within the content the viewport sits.

**Scope correction from the original description:** this PR is **painting only** — the thumb drag/interaction work described earlier was never pushed here (it exists locally and will come as a stacked follow-up PR). Apologies for the confusion; the review was right that the scrollbars in this PR are purely visual.

## What this does

Paints an overlay thumb (no reserved gutter, so no layout change) per overflowing axis: always for `overflow: scroll`, only when the content overflows for `overflow: auto`, never for `hidden`/`clip` (programmatic-only scrolling). Geometry derives from `Layout::scroll_width`/`scroll_height` and `node.scroll_offset`; the thumb is drawn unscrolled, above the clipped content, inside the opacity/filter layer.

Like other overlay scrollbar UIs (macOS, Firefox on Linux), thumbs only appear while the scroll container is hovered or scrolled away from the origin — beyond matching platform conventions, this keeps thumbs out of static reftest screenshots: an always-visible variant regressed 10 WPT overflow reftests (whose reference pages cannot scroll); the hover/scroll rule regresses none.

## Review changes

- **Feature-gated, default off** (as requested): painting sits behind a `scrollbars` cargo feature on `blitz-paint`, mirrored in the `blitz` and `dioxus-native` umbrella crates like the other paint features. Zero code and zero behavior change unless enabled.
- **Closures → functions**: `draw_thumb` / `wants_bar` are now regular (nested) functions with explicit parameters.

## Tests

Pixel-level paint tests in `packages/blitz-html/tests/scrollbars.rs` (render via `anyrender_vello_cpu`, assert pixels); they enable the feature through the dev-dependency.

## Follow-ups (in order)

1. Thumb hit-testing/dragging with hover/active styling (implemented locally; next PR, stacked on this one).
2. css-scrollbars-1 (`scrollbar-color`/`scrollbar-width`) — implemented locally but blocked on enabling those two properties for the servo engine in stylo (their `engine = "gecko"` gate in the property definitions); stylo PR in progress, blitz consumption lands after a stylo release includes it.
3. Track click-to-page, show/hide fade animations.