### PR TITLE
Make overlay scrollbar thumbs draggable, with hover/active styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,10 @@ dependencies = [
 name = "blitz-html"
 version = "0.3.0-alpha.4"
 dependencies = [
+ "anyrender",
+ "anyrender_vello_cpu",
  "blitz-dom",
+ "blitz-paint",
  "blitz-traits",
  "html5ever",
  "tracing",

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -241,6 +241,9 @@ pub struct BaseDocument {
     pub(crate) click_count: u16,
     /// Whether we're currently in a text selection drag (moved 2px+ from mousedown)
     pub(crate) drag_mode: DragMode,
+    /// The scrollbar thumb (scroll container id, is-horizontal) currently
+    /// under the pointer, if any
+    pub(crate) hovered_scrollbar: Option<(usize, bool)>,
     /// Whether and what kind of scroll animation is currently in progress
     pub(crate) scroll_animation: ScrollAnimationState,
 
@@ -453,6 +456,7 @@ impl BaseDocument {
             mousedown_position: taffy::Point::ZERO,
             click_count: 0,
             drag_mode: DragMode::None,
+            hovered_scrollbar: None,
             scroll_animation: ScrollAnimationState::None,
             text_selection: TextSelection::default(),
         };
@@ -1285,6 +1289,21 @@ impl BaseDocument {
         }
 
         true
+    }
+
+    /// The scrollbar thumb (scroll container id, is-horizontal) currently
+    /// under the pointer, if any.
+    pub fn hovered_scrollbar(&self) -> Option<(usize, bool)> {
+        self.hovered_scrollbar
+    }
+
+    /// The scrollbar thumb (scroll container id, is-horizontal) currently
+    /// being dragged, if any.
+    pub fn scrollbar_drag_target(&self) -> Option<(usize, bool)> {
+        match &self.drag_mode {
+            DragMode::ScrollbarDrag(state) => Some((state.node_id, state.horizontal)),
+            _ => None,
+        }
     }
 
     pub fn set_hover_to(&mut self, x: f32, y: f32) -> bool {

--- a/packages/blitz-dom/src/events/mod.rs
+++ b/packages/blitz-dom/src/events/mod.rs
@@ -164,6 +164,7 @@ pub(crate) fn handle_dom_event<F: FnMut(DomEvent)>(
                 target_node_id,
                 event.page_x(),
                 event.page_y(),
+                event.button,
                 event.mods,
                 &mut dispatch_event,
             );

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -46,6 +46,15 @@ pub(crate) struct PanSample {
     pub(crate) dy: f32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ScrollbarDragState {
+    /// The scroll container whose thumb is being dragged
+    pub(crate) node_id: usize,
+    pub(crate) horizontal: bool,
+    /// Last pointer position along the drag axis, in page coordinates
+    pub(crate) last_pos: f32,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum DragMode {
     /// We are not currently dragging
@@ -54,6 +63,8 @@ pub(crate) enum DragMode {
     Selecting,
     /// We are currently panning the document with a drag (probably touch)
     Panning(PanState),
+    /// We are currently dragging a scrollbar thumb
+    ScrollbarDrag(ScrollbarDragState),
 }
 
 impl DragMode {
@@ -138,6 +149,41 @@ impl PanState {
     }
 }
 
+/// Find the scrollbar thumb under the given page position: walks the layout
+/// ancestor chain of the hit node (the hit test returns the content under
+/// the overlay thumb) looking for a scroll container whose thumb contains
+/// the pointer. Returns (scroll container id, is-horizontal).
+pub(crate) fn scrollbar_thumb_at(
+    doc: &BaseDocument,
+    x: f32,
+    y: f32,
+) -> Option<(usize, bool)> {
+    let hit = doc.hit(x, y)?;
+    let mut cursor = Some(hit.node_id);
+    while let Some(node_id) = cursor {
+        let node = &doc.nodes[node_id];
+        for horizontal in [false, true] {
+            if !node.wants_scrollbar(horizontal) {
+                continue;
+            }
+            let Some(thumb) = node.scrollbar_thumb(horizontal) else {
+                continue;
+            };
+            // absolute_position subtracts the node's own scroll offset
+            // (it maps content coordinates); compensate to get the
+            // border-box origin.
+            let origin = node.absolute_position(0.0, 0.0);
+            let local_x = (x - origin.x) as f64 - node.scroll_offset.x;
+            let local_y = (y - origin.y) as f64 - node.scroll_offset.y;
+            if thumb.contains(local_x, local_y) {
+                return Some((node_id, horizontal));
+            }
+        }
+        cursor = node.layout_parent.get();
+    }
+    None
+}
+
 pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
     doc: &mut BaseDocument,
     target: usize,
@@ -202,6 +248,32 @@ pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
 
         let has_changed = doc.scroll_by(Some(target), dx, dy, &mut dispatch_event);
         return has_changed;
+    }
+
+    if let DragMode::ScrollbarDrag(state) = &mut doc.drag_mode {
+        let pos = if state.horizontal { x } else { y };
+        let delta_px = (pos - state.last_pos) as f64;
+        state.last_pos = pos;
+        let (node_id, horizontal) = (state.node_id, state.horizontal);
+
+        // Thumb px -> content px. scroll_by uses wheel-delta semantics
+        // (positive delta decreases the offset), so negate.
+        let ratio = doc.nodes[node_id].scrollbar_drag_ratio(horizontal);
+        let (dx, dy) = if horizontal {
+            (-delta_px * ratio, 0.0)
+        } else {
+            (0.0, -delta_px * ratio)
+        };
+        let has_changed = doc.scroll_by(Some(node_id), dx, dy, &mut dispatch_event);
+        return has_changed;
+    }
+
+    // Track which scrollbar thumb the pointer is over (for hover styling);
+    // repaint when it changes.
+    let hovered_scrollbar = scrollbar_thumb_at(doc, x, y);
+    if hovered_scrollbar != doc.hovered_scrollbar {
+        doc.hovered_scrollbar = hovered_scrollbar;
+        changed = true;
     }
 
     let Some(hit) = doc.hit(x, y) else {
@@ -279,6 +351,7 @@ pub(crate) fn handle_pointerdown(
     _target: usize,
     x: f32,
     y: f32,
+    button: MouseEventButton,
     mods: Modifiers,
     dispatch_event: &mut dyn FnMut(DomEvent),
 ) {
@@ -308,6 +381,20 @@ pub(crate) fn handle_pointerdown(
         doc.clear_text_selection();
         return;
     };
+
+    // Scrollbar thumb drags take precedence over content interactions and
+    // are not dispatched to the page (matching native scrollbars).
+    if button == MouseEventButton::Main {
+        if let Some((node_id, horizontal)) = scrollbar_thumb_at(doc, x, y) {
+            doc.drag_mode = DragMode::ScrollbarDrag(ScrollbarDragState {
+                node_id,
+                horizontal,
+                last_pos: if horizontal { x } else { y },
+            });
+            doc.shell_provider.request_redraw();
+            return;
+        }
+    }
 
     // Use hit.node_id for determining the actual clicked element.
     // This may differ from `target` for anonymous blocks (which are layout children
@@ -428,6 +515,11 @@ pub(crate) fn handle_pointerup<F: FnMut(DomEvent)>(
     // Don't dispatch click if we were doing a text selection drag or panning
     // the document with a touch
     let do_click = drag_mode == DragMode::None;
+
+    // Repaint so a dragged scrollbar thumb drops its active styling
+    if matches!(drag_mode, DragMode::ScrollbarDrag(_)) {
+        doc.shell_provider.request_redraw();
+    }
 
     let time_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -549,7 +549,9 @@ impl BaseDocument {
                 let z_index = style.clone_z_index().integer_or(0);
 
                 // TODO: more complete hoisting detection
-                if position != Position::Static && z_index != 0 {
+                // z-index applies to static flex/grid items too
+                // (css-flexbox-1 §painting, css-grid-1 §z-order).
+                if z_index != 0 && (position != Position::Static || is_flex_or_grid) {
                     stacking_context.children.push(HoistedPaintChild {
                         node_id: child_id,
                         z_index,
@@ -593,8 +595,11 @@ impl BaseDocument {
 #[inline(always)]
 fn position_to_order(pos: Position) -> i32 {
     match pos {
-        Position::Static | Position::Relative | Position::Sticky => 0,
-        Position::Absolute | Position::Fixed => 2,
+        Position::Static => 0,
+        // All positioned descendants with z-index: auto share one paint
+        // level (CSS 2.1 Appendix E step 8); the stable sort keeps them in
+        // tree order among themselves, above in-flow content and floats.
+        Position::Relative | Position::Sticky | Position::Absolute | Position::Fixed => 2,
     }
 }
 #[inline(always)]
@@ -605,17 +610,25 @@ fn float_to_order(pos: Float) -> i32 {
     }
 }
 
+/// Paint sort key: (paint level, order-modified position). Positioned
+/// (z-index: auto) descendants paint above in-flow content (CSS 2.1
+/// Appendix E step 8); within a level the stable sort preserves
+/// (order-modified) document order.
 #[inline(always)]
-fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> i32 {
+fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> (i32, i32) {
     let Some(style) = node.primary_styles() else {
-        return 0;
+        return (0, 0);
     };
+    let position = style.clone_position();
     if is_flex_or_grid {
-        match style.clone_position() {
-            Position::Static | Position::Relative | Position::Sticky => style.clone_order(),
-            Position::Absolute | Position::Fixed => 0,
+        match position {
+            Position::Static => (0, style.clone_order()),
+            Position::Relative | Position::Sticky => (2, style.clone_order()),
+            // Out-of-flow children are not flex/grid items: `order` does
+            // not apply; tree order does.
+            Position::Absolute | Position::Fixed => (2, 0),
         }
     } else {
-        position_to_order(style.clone_position()) + float_to_order(style.clone_float())
+        (position_to_order(position) + float_to_order(style.clone_float()), 0)
     }
 }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -494,6 +494,22 @@ pub enum NodeKind {
     Comment,
 }
 
+/// Geometry of an overlay scrollbar thumb, in (unscaled) CSS px relative to
+/// the owning node's border-box origin.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScrollbarThumb {
+    pub x0: f64,
+    pub y0: f64,
+    pub x1: f64,
+    pub y1: f64,
+}
+
+impl ScrollbarThumb {
+    pub fn contains(&self, x: f64, y: f64) -> bool {
+        x >= self.x0 && x <= self.x1 && y >= self.y0 && y <= self.y1
+    }
+}
+
 /// The different kinds of nodes in the DOM.
 #[derive(Debug, Clone)]
 pub enum NodeData {
@@ -1093,6 +1109,110 @@ impl Node {
         };
 
         Some(offset)
+    }
+
+    /// Whether the node shows an overlay scrollbar in the given axis:
+    /// always for `overflow: scroll`, only when the content overflows for
+    /// `overflow: auto`, never otherwise.
+    pub fn wants_scrollbar(&self, horizontal: bool) -> bool {
+        use style::values::computed::Overflow;
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+        let (overflow, scroll_extent) = if horizontal {
+            (
+                style.clone_overflow_x(),
+                self.final_layout.scroll_width() as f64,
+            )
+        } else {
+            (
+                style.clone_overflow_y(),
+                self.final_layout.scroll_height() as f64,
+            )
+        };
+        match overflow {
+            Overflow::Scroll => true,
+            Overflow::Auto => scroll_extent > 0.5,
+            _ => false,
+        }
+    }
+
+    /// Geometry of the overlay scrollbar thumb for the given axis, in
+    /// (unscaled) CSS px relative to the node's border-box origin. `None`
+    /// if there is no scrollable overflow in that axis.
+    pub fn scrollbar_thumb(&self, horizontal: bool) -> Option<ScrollbarThumb> {
+        const THUMB_THICKNESS: f64 = 6.0;
+        const THUMB_MARGIN: f64 = 2.0;
+        const MIN_THUMB_LENGTH: f64 = 16.0;
+
+        let layout = &self.final_layout;
+        let scroll_extent = if horizontal {
+            layout.scroll_width() as f64
+        } else {
+            layout.scroll_height() as f64
+        };
+        if scroll_extent <= 0.5 {
+            return None;
+        }
+
+        // The scrollport is the padding box.
+        let x0 = layout.border.left as f64;
+        let y0 = layout.border.top as f64;
+        let x1 = layout.size.width as f64 - layout.border.right as f64;
+        let y1 = layout.size.height as f64 - layout.border.bottom as f64;
+
+        let (viewport_len, scroll_offset) = if horizontal {
+            (x1 - x0, self.scroll_offset.x)
+        } else {
+            (y1 - y0, self.scroll_offset.y)
+        };
+        let thumb_len = (viewport_len * viewport_len / (viewport_len + scroll_extent))
+            .max(MIN_THUMB_LENGTH)
+            .min(viewport_len);
+        let progress = (scroll_offset / scroll_extent).clamp(0.0, 1.0);
+        let thumb_start = progress * (viewport_len - thumb_len);
+
+        Some(if horizontal {
+            ScrollbarThumb {
+                x0: x0 + thumb_start,
+                y0: y1 - THUMB_MARGIN - THUMB_THICKNESS,
+                x1: x0 + thumb_start + thumb_len,
+                y1: y1 - THUMB_MARGIN,
+            }
+        } else {
+            ScrollbarThumb {
+                x0: x1 - THUMB_MARGIN - THUMB_THICKNESS,
+                y0: y0 + thumb_start,
+                x1: x1 - THUMB_MARGIN,
+                y1: y0 + thumb_start + thumb_len,
+            }
+        })
+    }
+
+    /// Content px scrolled per thumb px dragged, for the given axis.
+    pub fn scrollbar_drag_ratio(&self, horizontal: bool) -> f64 {
+        let Some(thumb) = self.scrollbar_thumb(horizontal) else {
+            return 0.0;
+        };
+        let layout = &self.final_layout;
+        let (scroll_extent, viewport_len, thumb_len) = if horizontal {
+            (
+                layout.scroll_width() as f64,
+                layout.size.width as f64 - layout.border.left as f64 - layout.border.right as f64,
+                thumb.x1 - thumb.x0,
+            )
+        } else {
+            (
+                layout.scroll_height() as f64,
+                layout.size.height as f64 - layout.border.top as f64 - layout.border.bottom as f64,
+                thumb.y1 - thumb.y0,
+            )
+        };
+        let track_play = viewport_len - thumb_len;
+        if track_play <= 0.0 {
+            return 0.0;
+        }
+        scroll_extent / track_play
     }
 
     /// Computes the Document-relative coordinates of the `Node`

--- a/packages/blitz-html/Cargo.toml
+++ b/packages/blitz-html/Cargo.toml
@@ -23,3 +23,8 @@ html5ever = { workspace = true }
 xml5ever = { workspace = true }
 
 tracing = { workspace = true, optional = true }
+
+[dev-dependencies]
+blitz-paint = { workspace = true }
+anyrender = { workspace = true }
+anyrender_vello_cpu = { workspace = true }

--- a/packages/blitz-html/tests/paint_order.rs
+++ b/packages/blitz-html/tests/paint_order.rs
@@ -1,0 +1,78 @@
+//! CSS 2.1 Appendix E: all positioned descendants with z-index: auto share
+//! one paint level (step 8) and paint in tree order among themselves.
+
+use anyrender::render_to_buffer;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_paint::paint_scene;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn center_pixel(html: &str) -> [u8; 3] {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+        |scene| paint_scene(scene, &mut doc, 1.0, 100, 100, 0, 0),
+        100,
+        100,
+    );
+    let idx = (50 * 100 + 50) * 4;
+    [buffer[idx], buffer[idx + 1], buffer[idx + 2]]
+}
+
+#[test]
+fn later_relative_sibling_paints_above_earlier_abspos() {
+    let px = center_pixel(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:100px; height:100px;">
+                <div style="position:absolute; inset:0; background:#0000ff;"></div>
+                <div style="position:relative; width:100px; height:100px; background:#ff0000;"></div>
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(
+        px,
+        [255, 0, 0],
+        "later positioned (z-index auto) sibling must paint above earlier abspos sibling"
+    );
+}
+
+#[test]
+fn abspos_paints_above_earlier_static_sibling() {
+    let px = center_pixel(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:100px; height:100px;">
+                <div style="width:100px; height:100px; background:#0000ff;"></div>
+                <div style="position:absolute; inset:0; background:#ff0000;"></div>
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(px, [255, 0, 0], "abspos must paint above in-flow content");
+}
+
+#[test]
+fn earlier_abspos_stays_below_static_when_later_in_tree_order_is_static() {
+    // In-flow content paints below positioned content even when the
+    // positioned element comes first in tree order.
+    let px = center_pixel(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:100px; height:100px;">
+                <div style="position:absolute; inset:0; background:#ff0000;"></div>
+                <div style="width:100px; height:100px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(
+        px,
+        [255, 0, 0],
+        "positioned content paints above in-flow content regardless of tree order"
+    );
+}

--- a/packages/blitz-html/tests/scrollbar_drag.rs
+++ b/packages/blitz-html/tests/scrollbar_drag.rs
@@ -1,0 +1,157 @@
+//! Dragging an overlay scrollbar thumb scrolls the container.
+
+use blitz_dom::{DocumentConfig, EventDriver, NoopEventHandler};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::events::{
+    BlitzPointerEvent, BlitzPointerId, MouseEventButton, MouseEventButtons, PointerCoords,
+    PointerDetails, UiEvent,
+};
+use blitz_traits::shell::{ColorScheme, Viewport};
+
+use std::sync::Arc;
+
+fn pointer_event(x: f32, y: f32, buttons: MouseEventButtons) -> BlitzPointerEvent {
+    BlitzPointerEvent {
+        id: BlitzPointerId::Mouse,
+        is_primary: true,
+        coords: PointerCoords {
+            page_x: x,
+            page_y: y,
+            screen_x: x,
+            screen_y: y,
+            client_x: x,
+            client_y: y,
+        },
+        button: MouseEventButton::Main,
+        buttons,
+        mods: Default::default(),
+        details: PointerDetails::default(),
+    }
+}
+
+fn drag(doc: &mut HtmlDocument, from: (f32, f32), to: (f32, f32)) {
+    let mut driver = EventDriver::new(doc, NoopEventHandler);
+    driver.handle_ui_event(UiEvent::PointerDown(pointer_event(
+        from.0,
+        from.1,
+        MouseEventButtons::Primary,
+    )));
+    driver.handle_ui_event(UiEvent::PointerMove(pointer_event(
+        to.0,
+        to.1,
+        MouseEventButtons::Primary,
+    )));
+    driver.handle_ui_event(UiEvent::PointerUp(pointer_event(
+        to.0,
+        to.1,
+        MouseEventButtons::None,
+    )));
+}
+
+fn scroller_doc() -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:auto;">
+                <div style="height:1000px;"></div>
+            </div>
+        </body></html>"#,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+#[test]
+fn dragging_the_thumb_scrolls_the_container() {
+    let mut doc = scroller_doc();
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+
+    // Thumb starts at the top right (16px long, 6px wide, 2px margin).
+    drag(&mut doc, (97.0, 8.0), (97.0, 50.0));
+
+    let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
+    // 42 thumb px * (900 scroll range / 84 track play) = 450 content px
+    assert!(
+        (offset - 450.0).abs() < 1.0,
+        "expected scroll offset ~450 after dragging the thumb 42px, got {offset}"
+    );
+}
+
+#[test]
+fn dragging_content_does_not_scroll() {
+    let mut doc = scroller_doc();
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+
+    // Same drag, but starting in the content area, left of the thumb.
+    drag(&mut doc, (50.0, 8.0), (50.0, 50.0));
+
+    let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
+    assert_eq!(offset, 0.0, "content drags must not move the scrollbar");
+}
+
+#[test]
+fn drag_clamps_at_the_end_of_the_track() {
+    let mut doc = scroller_doc();
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+
+    drag(&mut doc, (97.0, 8.0), (97.0, 500.0));
+
+    let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
+    assert!(
+        (offset - 900.0).abs() < 1.0,
+        "expected scroll offset clamped to 900, got {offset}"
+    );
+}
+
+
+#[test]
+fn thumb_brightens_on_hover_and_drag() {
+    use anyrender::render_to_buffer;
+    use anyrender_vello_cpu::VelloCpuImageRenderer;
+    use blitz_paint::paint_scene;
+
+    fn thumb_pixel(doc: &mut HtmlDocument) -> [u8; 4] {
+        let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+            |scene| paint_scene(scene, doc.as_mut(), 1.0, 100, 100, 0, 0),
+            100,
+            100,
+        );
+        // Scrolled by 50 -> thumb sits around y=8; sample inside it.
+        let idx = (8 * 100 + 95) * 4;
+        [buffer[idx], buffer[idx + 1], buffer[idx + 2], buffer[idx + 3]]
+    }
+
+    let mut doc = scroller_doc();
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+    doc.get_node_mut(scroller).unwrap().scroll_offset.y = 50.0;
+
+    let base = thumb_pixel(&mut doc);
+
+    // Hover the thumb
+    {
+        let mut driver = EventDriver::new(&mut doc, NoopEventHandler);
+        driver.handle_ui_event(UiEvent::PointerMove(pointer_event(
+            95.0,
+            8.0,
+            MouseEventButtons::None,
+        )));
+    }
+    let hovered = thumb_pixel(&mut doc);
+    assert_ne!(base, hovered, "thumb must change appearance on hover");
+
+    // Start dragging the thumb
+    {
+        let mut driver = EventDriver::new(&mut doc, NoopEventHandler);
+        driver.handle_ui_event(UiEvent::PointerDown(pointer_event(
+            95.0,
+            8.0,
+            MouseEventButtons::Primary,
+        )));
+    }
+    let active = thumb_pixel(&mut doc);
+    assert_ne!(hovered, active, "thumb must change appearance while dragged");
+}

--- a/packages/blitz-html/tests/scrollbars.rs
+++ b/packages/blitz-html/tests/scrollbars.rs
@@ -1,0 +1,90 @@
+//! Scroll containers paint overlay scrollbars while hovered or scrolled:
+//! always for overflow: scroll, only when overflowing for overflow: auto,
+//! never for overflow: hidden. At rest (unhovered, unscrolled) nothing is
+//! painted, like other overlay scrollbar UIs.
+
+use anyrender::render_to_buffer;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_paint::paint_scene;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+const BLUE: [u8; 3] = [0, 0, 255];
+
+/// Renders `html`, scrolling the `#scroller` element by (dx, dy) first,
+/// and returns the pixel at (x, y).
+fn pixel(html: &str, scroll: (f64, f64), x: usize, y: usize) -> [u8; 3] {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let scroller = doc.query_selector("#scroller").unwrap().expect("#scroller");
+    let node = doc.get_node_mut(scroller).unwrap();
+    node.scroll_offset.x = scroll.0;
+    node.scroll_offset.y = scroll.1;
+    let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+        |scene| paint_scene(scene, &mut doc, 1.0, 100, 100, 0, 0),
+        100,
+        100,
+    );
+    let idx = (y * 100 + x) * 4;
+    [buffer[idx], buffer[idx + 1], buffer[idx + 2]]
+}
+
+fn scroller(overflow: &str, child_height: u32) -> String {
+    format!(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:{overflow};">
+                <div style="height:{child_height}px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#
+    )
+}
+
+#[test]
+fn scrolled_auto_scroller_paints_a_thumb() {
+    let px = pixel(&scroller("auto", 1000), (0.0, 50.0), 97, 10);
+    assert_ne!(px, BLUE, "expected a scrollbar thumb over the content");
+}
+
+#[test]
+fn unscrolled_unhovered_scroller_paints_no_thumb() {
+    let px = pixel(&scroller("auto", 1000), (0.0, 0.0), 97, 4);
+    assert_eq!(px, BLUE, "overlay scrollbars are hidden at rest");
+}
+
+#[test]
+fn non_overflowing_auto_scroller_paints_no_thumb() {
+    // Even with a (stale) scroll offset, a non-overflowing auto container
+    // has no scroll range and paints no thumb.
+    let px = pixel(&scroller("auto", 100), (0.0, 10.0), 97, 4);
+    assert_eq!(px, BLUE, "no scrollbar for non-overflowing overflow:auto");
+}
+
+#[test]
+fn hidden_scroller_paints_no_thumb() {
+    let px = pixel(&scroller("hidden", 1000), (0.0, 50.0), 97, 10);
+    assert_eq!(px, BLUE, "overflow:hidden must not paint scrollbars");
+}
+
+#[test]
+fn horizontal_scroller_paints_a_thumb() {
+    let px = pixel(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-x:auto; overflow-y:hidden;">
+                <div style="width:1000px; height:100px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+        (50.0, 0.0),
+        10,
+        97,
+    );
+    assert_ne!(px, BLUE, "expected a horizontal scrollbar thumb");
+}

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -539,75 +539,65 @@ impl ElementCx<'_, '_> {
     /// scrollbar UIs, thumbs only appear while the scroll container is
     /// hovered or scrolled away from the origin; this also keeps them out
     /// of (static, unhovered) reftest screenshots.
+    ///
+    /// Geometry comes from [`Node::scrollbar_thumb`], shared with the
+    /// thumb-drag hit testing in blitz-dom.
     fn draw_scrollbars(
         &self,
         scene: &mut impl PaintScene,
-        overflow_x: Overflow,
-        overflow_y: Overflow,
+        _overflow_x: Overflow,
+        _overflow_y: Overflow,
     ) {
+        let drag_target = self.context.dom.scrollbar_drag_target();
+        let hovered_thumb = self.context.dom.hovered_scrollbar();
+
+        let node_id = self.node.id;
+        let is_drag_target =
+            matches!(drag_target, Some((target_id, _)) if target_id == node_id);
         if !self.node.is_hovered()
+            && !is_drag_target
             && self.node.scroll_offset.x == 0.0
             && self.node.scroll_offset.y == 0.0
         {
             return;
         }
-        const THUMB_THICKNESS: f64 = 6.0;
-        const THUMB_MARGIN: f64 = 2.0;
-        const MIN_THUMB_LENGTH: f64 = 16.0;
+
         const THUMB_COLOR: Color = Color::from_rgba8(128, 128, 128, 178);
+        const THUMB_HOVER_COLOR: Color = Color::from_rgba8(152, 152, 152, 222);
+        const THUMB_ACTIVE_COLOR: Color = Color::from_rgba8(170, 170, 170, 255);
 
-        let layout = &self.node.final_layout;
-        let padding_box = self.frame.padding_box;
-
-        let mut draw_thumb = |scroll_extent: f64, scroll_offset: f64, horizontal: bool| {
-            if scroll_extent <= 0.5 {
-                return;
+        for horizontal in [false, true] {
+            if !self.node.wants_scrollbar(horizontal) {
+                continue;
             }
-            let viewport_len = if horizontal {
-                padding_box.width()
-            } else {
-                padding_box.height()
+            let Some(thumb) = self.node.scrollbar_thumb(horizontal) else {
+                continue;
             };
-            let max_scroll = scroll_extent * self.scale;
-            let thumb_len = (viewport_len * viewport_len / (viewport_len + max_scroll))
-                .max(MIN_THUMB_LENGTH * self.scale)
-                .min(viewport_len);
-            let progress = (scroll_offset * self.scale / max_scroll).clamp(0.0, 1.0);
-            let thumb_start = progress * (viewport_len - thumb_len);
-            let thickness = THUMB_THICKNESS * self.scale;
-            let margin = THUMB_MARGIN * self.scale;
-            let rect = if horizontal {
-                Rect::new(
-                    padding_box.x0 + thumb_start,
-                    padding_box.y1 - margin - thickness,
-                    padding_box.x0 + thumb_start + thumb_len,
-                    padding_box.y1 - margin,
-                )
+            let color = if drag_target == Some((node_id, horizontal)) {
+                THUMB_ACTIVE_COLOR
+            } else if hovered_thumb == Some((node_id, horizontal)) {
+                THUMB_HOVER_COLOR
             } else {
-                Rect::new(
-                    padding_box.x1 - margin - thickness,
-                    padding_box.y0 + thumb_start,
-                    padding_box.x1 - margin,
-                    padding_box.y0 + thumb_start + thumb_len,
-                )
+                THUMB_COLOR
             };
-            let thumb = rect.to_rounded_rect(thickness / 2.0);
-            scene.fill(Fill::NonZero, self.transform, THUMB_COLOR, None, &thumb);
-        };
-
-        let wants_bar = |overflow: Overflow, scroll_extent: f64| match overflow {
-            Overflow::Scroll => true,
-            Overflow::Auto => scroll_extent > 0.5,
-            _ => false,
-        };
-
-        let scroll_height = layout.scroll_height() as f64;
-        if wants_bar(overflow_y, scroll_height) {
-            draw_thumb(scroll_height, self.node.scroll_offset.y, false);
-        }
-        let scroll_width = layout.scroll_width() as f64;
-        if wants_bar(overflow_x, scroll_width) {
-            draw_thumb(scroll_width, self.node.scroll_offset.x, true);
+            let rect = Rect::new(
+                thumb.x0 * self.scale,
+                thumb.y0 * self.scale,
+                thumb.x1 * self.scale,
+                thumb.y1 * self.scale,
+            );
+            let radius = if horizontal {
+                rect.height() / 2.0
+            } else {
+                rect.width() / 2.0
+            };
+            scene.fill(
+                Fill::NonZero,
+                self.transform,
+                color,
+                None,
+                &rect.to_rounded_rect(radius),
+            );
         }
     }
 

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -401,6 +401,11 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                                 cx.draw_children(scene, cx.transform);
                             },
                         );
+
+                        // Overlay scrollbars, drawn unscrolled above the
+                        // clipped content.
+                        cx.transform = unscrolled_transform;
+                        cx.draw_scrollbars(scene, overflow_x, overflow_y);
                     },
                 );
 
@@ -528,6 +533,84 @@ fn convert_rect(rect: &parley::BoundingBox) -> kurbo::Rect {
 }
 
 impl ElementCx<'_, '_> {
+    /// Paint overlay scrollbar thumbs for scroll containers (`overflow:
+    /// scroll`, or `auto` when the content overflows — never `hidden`/
+    /// `clip`, which scroll only programmatically). Like other overlay
+    /// scrollbar UIs, thumbs only appear while the scroll container is
+    /// hovered or scrolled away from the origin; this also keeps them out
+    /// of (static, unhovered) reftest screenshots.
+    fn draw_scrollbars(
+        &self,
+        scene: &mut impl PaintScene,
+        overflow_x: Overflow,
+        overflow_y: Overflow,
+    ) {
+        if !self.node.is_hovered()
+            && self.node.scroll_offset.x == 0.0
+            && self.node.scroll_offset.y == 0.0
+        {
+            return;
+        }
+        const THUMB_THICKNESS: f64 = 6.0;
+        const THUMB_MARGIN: f64 = 2.0;
+        const MIN_THUMB_LENGTH: f64 = 16.0;
+        const THUMB_COLOR: Color = Color::from_rgba8(128, 128, 128, 178);
+
+        let layout = &self.node.final_layout;
+        let padding_box = self.frame.padding_box;
+
+        let mut draw_thumb = |scroll_extent: f64, scroll_offset: f64, horizontal: bool| {
+            if scroll_extent <= 0.5 {
+                return;
+            }
+            let viewport_len = if horizontal {
+                padding_box.width()
+            } else {
+                padding_box.height()
+            };
+            let max_scroll = scroll_extent * self.scale;
+            let thumb_len = (viewport_len * viewport_len / (viewport_len + max_scroll))
+                .max(MIN_THUMB_LENGTH * self.scale)
+                .min(viewport_len);
+            let progress = (scroll_offset * self.scale / max_scroll).clamp(0.0, 1.0);
+            let thumb_start = progress * (viewport_len - thumb_len);
+            let thickness = THUMB_THICKNESS * self.scale;
+            let margin = THUMB_MARGIN * self.scale;
+            let rect = if horizontal {
+                Rect::new(
+                    padding_box.x0 + thumb_start,
+                    padding_box.y1 - margin - thickness,
+                    padding_box.x0 + thumb_start + thumb_len,
+                    padding_box.y1 - margin,
+                )
+            } else {
+                Rect::new(
+                    padding_box.x1 - margin - thickness,
+                    padding_box.y0 + thumb_start,
+                    padding_box.x1 - margin,
+                    padding_box.y0 + thumb_start + thumb_len,
+                )
+            };
+            let thumb = rect.to_rounded_rect(thickness / 2.0);
+            scene.fill(Fill::NonZero, self.transform, THUMB_COLOR, None, &thumb);
+        };
+
+        let wants_bar = |overflow: Overflow, scroll_extent: f64| match overflow {
+            Overflow::Scroll => true,
+            Overflow::Auto => scroll_extent > 0.5,
+            _ => false,
+        };
+
+        let scroll_height = layout.scroll_height() as f64;
+        if wants_bar(overflow_y, scroll_height) {
+            draw_thumb(scroll_height, self.node.scroll_offset.y, false);
+        }
+        let scroll_width = layout.scroll_width() as f64;
+        if wants_bar(overflow_x, scroll_width) {
+            draw_thumb(scroll_width, self.node.scroll_offset.x, true);
+        }
+    }
+
     fn draw_inline_layout(&self, scene: &mut impl PaintScene, pos: Point) {
         if self.node.flags.is_inline_root() {
             let text_layout = self.element


### PR DESCRIPTION
Stacked on #461 (contains its commit; will rebase once it lands).

Makes the overlay scrollbar thumbs from #461 interactive:

- Thumb geometry moves from blitz-paint into a shared helper on `Node` (`scrollbar_thumb` / `wants_scrollbar` / `scrollbar_drag_ratio`) so painting and hit testing cannot drift; blitz-paint consumes it.
- Pointer handling gains a `DragMode::ScrollbarDrag` state: on pointerdown the layout ancestor chain of the hit node is walked for a scroll container whose thumb contains the pointer (the hit test returns the content under the overlay thumb; the helper is shared with hover tracking). While dragging, pointer movement maps thumb px to content px via the track ratio and scrolls through the existing clamped `scroll_by` path. Scrollbar drags are not dispatched to the page, and the existing `DragMode` handling suppresses the synthetic click on release.
- The document tracks which thumb the pointer is over (`hovered_scrollbar`, repainting on change), and the painter renders three thumb states: normal, hovered, dragged — a dragged thumb also stays visible if the pointer leaves the container mid-drag.

Tests in `packages/blitz-html/tests/scrollbar_drag.rs` drive the `EventDriver` with synthetic pointer events: thumb drags scroll proportionally and clamp at the track end; content drags don't scroll; hover and drag visibly restyle the thumb.
