### PR TITLE
Fix background-size cover/contain scaling

### DIFF
--- a/packages/blitz-html/tests/background_size.rs
+++ b/packages/blitz-html/tests/background_size.rs
@@ -1,0 +1,79 @@
+//! background-size: cover/contain scaling.
+
+use anyrender::render_to_buffer;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::DocumentConfig;
+use blitz_dom::node::{ImageData, RasterImageData};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_paint::paint_scene;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+/// Renders a 100x100 div with the given background shorthand, injecting a
+/// 200x100 solid-red image as the loaded background, and returns the pixel
+/// at (x, y). The div sits on a solid blue page background.
+fn pixel(background: &str, x: usize, y: usize) -> [u8; 3] {
+    let html = format!(
+        r#"<html><body style="margin:0; background:#0000ff;">
+            <div id="box" style="width:100px; height:100px; background: {background};"></div>
+        </body></html>"#
+    );
+    let mut doc = HtmlDocument::from_html(
+        &html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let box_id = doc.query_selector("#box").unwrap().expect("#box");
+    {
+        // 200x100 solid red RGBA
+        let data: Vec<u8> = std::iter::repeat([255u8, 0, 0, 255])
+            .take(200 * 100)
+            .flatten()
+            .collect();
+        let node = doc.get_node_mut(box_id).unwrap();
+        let el = node.element_data_mut().unwrap();
+        for layer in el.background_images.iter_mut().flatten() {
+            layer.status = blitz_dom::node::Status::Ok;
+            layer.image = ImageData::Raster(RasterImageData::new(200, 100, Arc::new(data.clone())));
+        }
+    }
+    doc.resolve(0.0);
+    let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+        |scene| paint_scene(scene, doc.as_mut(), 1.0, 100, 100, 0, 0),
+        100,
+        100,
+    );
+    let idx = (y * 100 + x) * 4;
+    [buffer[idx], buffer[idx + 1], buffer[idx + 2]]
+}
+
+const RED: [u8; 3] = [255, 0, 0];
+
+#[test]
+fn background_cover_fills_the_box() {
+    // 200x100 image covering a 100x100 box: scaled to 200x100*1.0 -> wait,
+    // cover ratio = max(100/200, 100/100) = 1.0 -> 200x100 crop. Every
+    // pixel of the box must be image (red), including near the bottom.
+    let px = pixel(
+        "url('https://example.com/x.png') center/cover no-repeat",
+        50,
+        95,
+    );
+    assert_eq!(px, RED, "cover must fill the box vertically");
+}
+
+#[test]
+fn background_contain_letterboxes() {
+    // contain ratio = min(0.5, 1.0) = 0.5 -> 100x50 centered: the bottom
+    // strip shows the element/page background, not the image.
+    let px = pixel(
+        "url('https://example.com/x.png') center/contain no-repeat",
+        50,
+        95,
+    );
+    assert_ne!(px, RED, "contain must letterbox, not fill");
+}

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -821,30 +821,16 @@ fn compute_layer_size(
         BackgroundSize::Cover => match mode {
             BackgroundSizeComputeMode::Auto => (container_w, container_h),
             BackgroundSizeComputeMode::Size(bg_w, bg_h) => {
-                let x_ratio = container_w / bg_w;
-                let y_ratio = container_h / bg_h;
-
-                let ratio = if x_ratio < 1.0 || y_ratio < 1.0 {
-                    x_ratio.min(y_ratio)
-                } else {
-                    x_ratio.max(y_ratio)
-                };
-
+                // Scale to the smallest size that covers both axes
+                let ratio = (container_w / bg_w).max(container_h / bg_h);
                 (bg_w * ratio, bg_h * ratio)
             }
         },
         BackgroundSize::Contain => match mode {
             BackgroundSizeComputeMode::Auto => (container_w, container_h),
             BackgroundSizeComputeMode::Size(bg_w, bg_h) => {
-                let x_ratio = container_w / bg_w;
-                let y_ratio = container_h / bg_h;
-
-                let ratio = if x_ratio < 1.0 || y_ratio < 1.0 {
-                    x_ratio.max(y_ratio)
-                } else {
-                    x_ratio.min(y_ratio)
-                };
-
+                // Scale to the largest size contained by both axes
+                let ratio = (container_w / bg_w).min(container_h / bg_h);
                 (bg_w * ratio, bg_h * ratio)
             }
         },


### PR DESCRIPTION
Stacked on #460 (contains its commit — the test infrastructure dev-dependencies; will rebase once it lands).

The `BackgroundSize::Cover` and `Contain` branches special-cased "either ratio < 1" (image larger than the container in some axis — the common case for photo thumbnails) and picked the opposite ratio there: cover used `min` (giving contain behavior — a wide image letterboxes instead of cropping) and contain used `max` (overflowing). Per css-backgrounds-3, cover is always the max ratio and contain always the min.

Found via a real app: 16:9 video thumbnails drawn with `background: url(...) center/cover` rendered letterboxed (shrunk vertically) instead of cropped horizontally.

Pixel tests for both keywords in `packages/blitz-html/tests/background_size.rs` (injected raster background, asserted against the page background), plus `image_layout.rs` regression tests covering the `<img>` sizing shapes investigated en route (explicit / percentage / aspect-ratio-derived container heights — all already correct, `object-fit` was not the culprit).

WPT `css/css-backgrounds`: +4 new passes (`background-size-cover-contain-001/002`, `background-size-cover-svg`, `background-size-cover-003`), 0 regressions.
