### PR TITLE
Inline roots: apply aspect-ratio to known dimensions at final layout

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -203,25 +203,44 @@ pub(crate) fn collect_layout_children(
             // Take children array from node to avoid borrow checker issues.
             let children = std::mem::take(&mut doc.nodes[container_node_id].children);
 
+            // display:contents is transparent for box generation: hoist the
+            // children THEMSELVES (not their layout children) into the
+            // parent, recursing only through nested contents nodes.
             for child_id in children.iter().copied() {
-                collect_layout_children(doc, child_id, layout_children, anonymous_block_id)
+                let child = &doc.nodes[child_id];
+                if child.data.kind() == NodeKind::Comment || child.is_whitespace_node() {
+                    continue;
+                }
+                let child_display = child.display_style().unwrap_or(Display::inline());
+                if matches!(child_display.inside(), DisplayInside::Contents) {
+                    collect_layout_children(doc, child_id, layout_children, anonymous_block_id);
+                } else {
+                    layout_children.push(child_id);
+                }
             }
 
             // Put children array back
             doc.nodes[container_node_id].children = children;
         }
         DisplayInside::Flow | DisplayInside::FlowRoot | DisplayInside::TableCell => {
-            // TODO: make "all_inline" detection work in the presence of display:contents nodes
             let mut all_block = true;
             let mut all_inline = true;
             let mut all_out_of_flow = true;
             let mut has_contents = false;
-            for child in doc.nodes[container_node_id]
+            // display:contents children are transparent for box generation:
+            // their children participate in this container's formatting
+            // context, so classification must recurse into them. Work-stack
+            // in place of plain iteration (reversed so order is preserved,
+            // though classification is order-independent).
+            let mut classify_stack: Vec<usize> = doc.nodes[container_node_id]
                 .children
                 .iter()
                 .copied()
-                .map(|child_id| &doc.nodes[child_id])
-            {
+                .rev()
+                .collect();
+            while let Some(child_id) = classify_stack.pop() {
+                let child = &doc.nodes[child_id];
+
                 // Comment nodes generate no boxes and must not affect the
                 // inline-vs-block classification: an unstyled comment would
                 // default to display:inline below and force an inline
@@ -241,6 +260,7 @@ pub(crate) fn collect_layout_children(
                 if matches!(display.inside(), DisplayInside::Contents) {
                     has_contents = true;
                     all_out_of_flow = false;
+                    classify_stack.extend(child.children.iter().copied().rev());
                 } else {
                     let position = style
                         .map(|s| s.clone_position())
@@ -596,7 +616,11 @@ fn collect_complex_layout_children(
             // If anonymous block node only contains whitespace then delete it
             if let Some(anon_id) = *anonymous_block_id {
                 if block_is_only_whitespace(doc, anon_id) {
-                    layout_children.pop();
+                    // Remove by identity, not pop(): hoisted display:contents
+                    // children may have been pushed after the anon block.
+                    if let Some(pos) = layout_children.iter().rposition(|id| *id == anon_id) {
+                        layout_children.remove(pos);
+                    }
                     doc.nodes.remove(anon_id);
                 }
             }
@@ -609,7 +633,9 @@ fn collect_complex_layout_children(
     // If anonymous block node only contains whitespace then delete it
     if let Some(anon_id) = *anonymous_block_id {
         if block_is_only_whitespace(doc, anon_id) {
-            layout_children.pop();
+            if let Some(pos) = layout_children.iter().rposition(|id| *id == anon_id) {
+                layout_children.remove(pos);
+            }
             doc.nodes.remove(anon_id);
             *anonymous_block_id = None;
         }

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -65,6 +65,38 @@ fn push_children_and_pseudos(layout_children: &mut Vec<usize>, node: &Node) {
     }
 }
 
+/// Push the container's children (and ::before/::after pseudos) as layout
+/// children, hoisting transparently through display:contents nodes and
+/// filtering out comments and whitespace.
+fn push_hoisted_children_and_pseudos(
+    doc: &mut BaseDocument,
+    container_node_id: usize,
+    layout_children: &mut Vec<usize>,
+    anonymous_block_id: &mut Option<usize>,
+) {
+    if let Some(before) = doc.nodes[container_node_id].before {
+        layout_children.push(before);
+    }
+    // Take children array from node to avoid borrow checker issues.
+    let children = std::mem::take(&mut doc.nodes[container_node_id].children);
+    for child_id in children.iter().copied() {
+        let child = &doc.nodes[child_id];
+        if child.data.kind() == NodeKind::Comment || child.is_whitespace_node() {
+            continue;
+        }
+        let child_display = child.display_style().unwrap_or(Display::inline());
+        if matches!(child_display.inside(), DisplayInside::Contents) {
+            collect_layout_children(doc, child_id, layout_children, anonymous_block_id);
+        } else {
+            layout_children.push(child_id);
+        }
+    }
+    doc.nodes[container_node_id].children = children;
+    if let Some(after) = doc.nodes[container_node_id].after {
+        layout_children.push(after);
+    }
+}
+
 fn push_non_whitespace_children_and_pseudos(layout_children: &mut Vec<usize>, node: &Node) {
     if let Some(before) = node.before {
         layout_children.push(before);
@@ -200,27 +232,15 @@ pub(crate) fn collect_layout_children(
         DisplayInside::Contents => {
             doc.nodes[container_node_id]
                 .remove_damage(CONSTRUCT_BOX | CONSTRUCT_DESCENDENT | CONSTRUCT_FC);
-            // Take children array from node to avoid borrow checker issues.
-            let children = std::mem::take(&mut doc.nodes[container_node_id].children);
-
             // display:contents is transparent for box generation: hoist the
             // children THEMSELVES (not their layout children) into the
             // parent, recursing only through nested contents nodes.
-            for child_id in children.iter().copied() {
-                let child = &doc.nodes[child_id];
-                if child.data.kind() == NodeKind::Comment || child.is_whitespace_node() {
-                    continue;
-                }
-                let child_display = child.display_style().unwrap_or(Display::inline());
-                if matches!(child_display.inside(), DisplayInside::Contents) {
-                    collect_layout_children(doc, child_id, layout_children, anonymous_block_id);
-                } else {
-                    layout_children.push(child_id);
-                }
-            }
-
-            // Put children array back
-            doc.nodes[container_node_id].children = children;
+            push_hoisted_children_and_pseudos(
+                doc,
+                container_node_id,
+                layout_children,
+                anonymous_block_id,
+            );
         }
         DisplayInside::Flow | DisplayInside::FlowRoot | DisplayInside::TableCell => {
             let mut all_block = true;
@@ -229,9 +249,7 @@ pub(crate) fn collect_layout_children(
             let mut has_contents = false;
             // display:contents children are transparent for box generation:
             // their children participate in this container's formatting
-            // context, so classification must recurse into them. Work-stack
-            // in place of plain iteration (reversed so order is preserved,
-            // though classification is order-independent).
+            // context, so classification must recurse into them.
             let mut classify_stack: Vec<usize> = doc.nodes[container_node_id]
                 .children
                 .iter()
@@ -258,8 +276,9 @@ pub(crate) fn collect_layout_children(
                     .map(|s| s.clone_display())
                     .unwrap_or(Display::inline());
                 if matches!(display.inside(), DisplayInside::Contents) {
+                    // Transparent for box generation: the contents node casts
+                    // no vote itself — its children decide.
                     has_contents = true;
-                    all_out_of_flow = false;
                     classify_stack.extend(child.children.iter().copied().rev());
                 } else {
                     let position = style
@@ -302,9 +321,14 @@ pub(crate) fn collect_layout_children(
             }
 
             if all_out_of_flow {
-                return push_non_whitespace_children_and_pseudos(
+                // Contents-transparent: a display:contents child may be
+                // holding the out-of-flow elements (otherwise the contents
+                // node itself would be pushed as a layout box).
+                return push_hoisted_children_and_pseudos(
+                    doc,
+                    container_node_id,
                     layout_children,
-                    &doc.nodes[container_node_id],
+                    anonymous_block_id,
                 );
             }
 

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -48,7 +48,7 @@ impl BaseDocument {
 
         // Resolve node's preferred/min/max sizes (width/heights) against the available space (percentages resolve to pixel values)
         // For ContentSize mode, we pretend that the node has no size styles as these should be ignored.
-        let (clamped_style_size, min_size, max_size, _aspect_ratio) = match inputs.sizing_mode {
+        let (clamped_style_size, min_size, max_size, aspect_ratio) = match inputs.sizing_mode {
             SizingMode::ContentSize => {
                 let node_size = known_dimensions;
                 let node_min_size = Size::NONE;
@@ -84,9 +84,18 @@ impl BaseDocument {
             _ => None,
         });
 
+        // An aspect-ratio with one definite axis makes the other definite
+        // (css-sizing-4), e.g. aspect-ratio: 1 with a stretched width.
+        // Final-layout only: widths in measure passes are tentative and
+        // must not transfer through the ratio (stale-width).
+        let layout_aspect_ratio = match run_mode {
+            RunMode::PerformLayout => aspect_ratio,
+            _ => None,
+        };
         let styled_based_known_dimensions = known_dimensions
             .or(min_max_definite_size)
             .or(clamped_style_size)
+            .maybe_apply_aspect_ratio(layout_aspect_ratio)
             .maybe_max(padding_border_size);
 
         // Short-circuit layout if the container's size is fully determined by the container's size and the run mode

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -84,18 +84,25 @@ impl BaseDocument {
             _ => None,
         });
 
-        // An aspect-ratio with one definite axis makes the other definite
-        // (css-sizing-4), e.g. aspect-ratio: 1 with a stretched width.
-        // Final-layout only: widths in measure passes are tentative and
-        // must not transfer through the ratio (stale-width).
-        let layout_aspect_ratio = match run_mode {
-            RunMode::PerformLayout => aspect_ratio,
-            _ => None,
+        // css-sizing-4: a definite axis (e.g. a stretched width passed in via
+        // known_dimensions) transfers through the ratio to make the other
+        // definite. This self-gates — blitz's block parent is taffy, which fills
+        // known_dimensions only as a real constraint and leaves it None while
+        // probing intrinsic sizes — so there is no run-mode special case and
+        // measure passes stay content-based. Only a newly-derived axis is
+        // adopted; an incoming known size is left as the parent resolved it.
+        let known_dimensions = {
+            let derived = known_dimensions
+                .maybe_apply_aspect_ratio(aspect_ratio)
+                .maybe_clamp(min_size, max_size);
+            Size {
+                width: known_dimensions.width.or(derived.width),
+                height: known_dimensions.height.or(derived.height),
+            }
         };
         let styled_based_known_dimensions = known_dimensions
             .or(min_max_definite_size)
             .or(clamped_style_size)
-            .maybe_apply_aspect_ratio(layout_aspect_ratio)
             .maybe_max(padding_border_size);
 
         // Short-circuit layout if the container's size is fully determined by the container's size and the run mode

--- a/packages/blitz-html/tests/comment_layout.rs
+++ b/packages/blitz-html/tests/comment_layout.rs
@@ -65,3 +65,49 @@ fn comment_sibling_does_not_inline_block_child() {
         "block child must fill its parent's width even with a comment sibling"
     );
 }
+
+#[test]
+fn abspos_inset_child_of_scroll_container_sizes_to_padding_box() {
+    // An absolute inset:0 child of a relative scroll container must size to
+    // the container's padding box, not to its scrollable content area.
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:300px; height:200px; overflow-y:auto;">
+                <div id="abs" style="position:absolute; inset:0;">
+                    <div style="height:5000px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let abs_id = doc.query_selector("#abs").unwrap().expect("#abs not found");
+    let layout = doc.get_node(abs_id).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (300.0, 200.0),
+        "absolute inset:0 child of a scroll container must match the padding box"
+    );
+}
+
+#[test]
+fn abspos_calc_var_inset_stretches() {
+    // Tailwind v4 emits `inset: calc(var(--spacing) * 0)` for inset-0.
+    let doc = layout_doc(
+        r#"<html><head><style>
+            :root { --spacing: 0.25rem; }
+            .inset-0 { inset: calc(var(--spacing) * 0); }
+        </style></head><body style="margin:0">
+            <div style="position:relative; width:300px; height:200px; overflow-y:auto;">
+                <div id="abs" class="inset-0" style="position:absolute;">
+                    <div style="height:5000px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let abs_id = doc.query_selector("#abs").unwrap().expect("#abs not found");
+    let layout = doc.get_node(abs_id).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (300.0, 200.0),
+        "calc(var()*0) insets must stretch the abspos child to its containing block"
+    );
+}

--- a/packages/blitz-html/tests/display_contents.rs
+++ b/packages/blitz-html/tests/display_contents.rs
@@ -1,0 +1,115 @@
+//! display:contents — children must lay out as if they were children of the
+//! contents element's parent.
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn layout_doc(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+#[test]
+fn contents_block_children_stack_and_fill_width() {
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="width:300px;">
+                <div style="display:contents;">
+                    <div id="a" style="height:50px;"></div>
+                    <div id="b" style="height:70px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let a = doc.query_selector("#a").unwrap().expect("#a not found");
+    let b = doc.query_selector("#b").unwrap().expect("#b not found");
+    let la = doc.get_node(a).unwrap().final_layout;
+    let lb = doc.get_node(b).unwrap().final_layout;
+    assert_eq!(
+        (la.size.width, la.size.height),
+        (300.0, 50.0),
+        "first hoisted block child must fill the grandparent width"
+    );
+    assert_eq!(
+        (lb.size.width, lb.size.height),
+        (300.0, 70.0),
+        "second hoisted block child must fill the grandparent width"
+    );
+    assert_eq!(
+        lb.location.y - la.location.y,
+        50.0,
+        "hoisted block children must stack vertically"
+    );
+}
+
+#[test]
+fn scroller_wrapping_contents_gets_full_scroll_size() {
+    // The kopuz route-shell shape: a scroll container whose only child is a
+    // display:contents wrapper holding tall content.
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="height:200px; overflow-y:auto;">
+                <div style="display:contents;">
+                    <div id="tall" style="height:1000px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let scroller = doc
+        .query_selector("#scroller")
+        .unwrap()
+        .expect("#scroller not found");
+    let tall = doc.query_selector("#tall").unwrap().expect("#tall not found");
+    let ls = doc.get_node(scroller).unwrap().final_layout;
+    let lt = doc.get_node(tall).unwrap().final_layout;
+    assert_eq!(
+        (lt.size.width, lt.size.height),
+        (800.0, 1000.0),
+        "content inside the contents wrapper must size normally"
+    );
+    assert_eq!(
+        ls.content_size.height, 1000.0,
+        "the scroller's scrollable content size must include the hoisted content"
+    );
+}
+
+#[test]
+fn contents_in_flex_container_hoists_children_as_flex_items() {
+    // The kopuz showcase shape: flex rows whose direct children are
+    // display:contents wrappers (keyed row wrappers).
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="display:flex; flex-direction:column; width:300px;">
+                <div style="display:contents;">
+                    <div id="x" style="height:40px;"></div>
+                    <div id="y" style="height:40px;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let x = doc.query_selector("#x").unwrap().expect("#x not found");
+    let y = doc.query_selector("#y").unwrap().expect("#y not found");
+    let lx = doc.get_node(x).unwrap().final_layout;
+    let ly = doc.get_node(y).unwrap().final_layout;
+    assert_eq!(
+        (lx.size.width, lx.size.height),
+        (300.0, 40.0),
+        "hoisted flex item must stretch to the flex container width"
+    );
+    assert_eq!(
+        ly.location.y - lx.location.y,
+        40.0,
+        "hoisted flex items must stack in the column"
+    );
+}
+

--- a/packages/blitz-html/tests/display_contents.rs
+++ b/packages/blitz-html/tests/display_contents.rs
@@ -113,3 +113,29 @@ fn contents_in_flex_container_hoists_children_as_flex_items() {
     );
 }
 
+
+#[test]
+fn abspos_child_hoisted_through_contents_stretches() {
+    // The kopuz route-shell chain: scroll container > display:contents shell
+    // > absolute inset:0 page (plus a comment placeholder sibling). The page
+    // must stretch to the scroll container's padding box.
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:300px; height:200px; overflow-y:auto;">
+                <!-- placeholder -->
+                <div style="display:contents;">
+                    <div id="page" style="position:absolute; inset:0;">
+                        <div style="height:5000px;"></div>
+                    </div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let page = doc.query_selector("#page").unwrap().expect("#page not found");
+    let layout = doc.get_node(page).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (300.0, 200.0),
+        "abspos hoisted through display:contents must stretch to the containing block"
+    );
+}

--- a/packages/blitz-html/tests/display_contents.rs
+++ b/packages/blitz-html/tests/display_contents.rs
@@ -69,7 +69,10 @@ fn scroller_wrapping_contents_gets_full_scroll_size() {
         .query_selector("#scroller")
         .unwrap()
         .expect("#scroller not found");
-    let tall = doc.query_selector("#tall").unwrap().expect("#tall not found");
+    let tall = doc
+        .query_selector("#tall")
+        .unwrap()
+        .expect("#tall not found");
     let ls = doc.get_node(scroller).unwrap().final_layout;
     let lt = doc.get_node(tall).unwrap().final_layout;
     assert_eq!(
@@ -113,7 +116,6 @@ fn contents_in_flex_container_hoists_children_as_flex_items() {
     );
 }
 
-
 #[test]
 fn abspos_child_hoisted_through_contents_stretches() {
     // The kopuz route-shell chain: scroll container > display:contents shell
@@ -131,7 +133,10 @@ fn abspos_child_hoisted_through_contents_stretches() {
             </div>
         </body></html>"#,
     );
-    let page = doc.query_selector("#page").unwrap().expect("#page not found");
+    let page = doc
+        .query_selector("#page")
+        .unwrap()
+        .expect("#page not found");
     let layout = doc.get_node(page).unwrap().final_layout;
     assert_eq!(
         (layout.size.width, layout.size.height),

--- a/packages/blitz-html/tests/image_layout.rs
+++ b/packages/blitz-html/tests/image_layout.rs
@@ -28,9 +28,12 @@ fn doc_with_wide_image(img_style: &str) -> (HtmlDocument, usize) {
     // Inject a 200x100 (2:1 wide) image as if it had loaded.
     {
         let node = doc.get_node_mut(img).unwrap();
-        node.element_data_mut().unwrap().special_data = SpecialElementData::Image(Box::new(
-            ImageData::Raster(RasterImageData::new(200, 100, Arc::new(vec![0u8; 200 * 100 * 4]))),
-        ));
+        node.element_data_mut().unwrap().special_data =
+            SpecialElementData::Image(Box::new(ImageData::Raster(RasterImageData::new(
+                200,
+                100,
+                Arc::new(vec![0u8; 200 * 100 * 4]),
+            ))));
         node.cache.clear();
     }
     doc.resolve(0.0);
@@ -80,9 +83,12 @@ fn wide_image_fills_aspect_ratio_sized_parent() {
     let img = doc.query_selector("#img").unwrap().expect("#img");
     {
         let node = doc.get_node_mut(img).unwrap();
-        node.element_data_mut().unwrap().special_data = SpecialElementData::Image(Box::new(
-            ImageData::Raster(RasterImageData::new(200, 100, Arc::new(vec![0u8; 200 * 100 * 4]))),
-        ));
+        node.element_data_mut().unwrap().special_data =
+            SpecialElementData::Image(Box::new(ImageData::Raster(RasterImageData::new(
+                200,
+                100,
+                Arc::new(vec![0u8; 200 * 100 * 4]),
+            ))));
         node.cache.clear();
     }
     doc.resolve(0.0);
@@ -119,9 +125,12 @@ fn wide_image_in_flex_shelf_card() {
     let img = doc.query_selector("#img").unwrap().expect("#img");
     {
         let node = doc.get_node_mut(img).unwrap();
-        node.element_data_mut().unwrap().special_data = SpecialElementData::Image(Box::new(
-            ImageData::Raster(RasterImageData::new(320, 180, Arc::new(vec![0u8; 320 * 180 * 4]))),
-        ));
+        node.element_data_mut().unwrap().special_data =
+            SpecialElementData::Image(Box::new(ImageData::Raster(RasterImageData::new(
+                320,
+                180,
+                Arc::new(vec![0u8; 320 * 180 * 4]),
+            ))));
         node.cache.clear();
     }
     doc.resolve(0.0);
@@ -132,4 +141,3 @@ fn wide_image_in_flex_shelf_card() {
         "cover img must fill the square card"
     );
 }
-

--- a/packages/blitz-html/tests/image_layout.rs
+++ b/packages/blitz-html/tests/image_layout.rs
@@ -1,0 +1,135 @@
+//! An <img> with explicit/percentage width AND height must use them — its
+//! intrinsic aspect ratio only matters when a dimension is auto.
+
+use blitz_dom::DocumentConfig;
+use blitz_dom::node::{ImageData, RasterImageData, SpecialElementData};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn doc_with_wide_image(img_style: &str) -> (HtmlDocument, usize) {
+    let html = format!(
+        r#"<html><body style="margin:0">
+            <div style="width:100px; height:100px; overflow:hidden; position:relative;">
+                <img id="img" style="{img_style}" src="https://example.com/x.png">
+            </div>
+        </body></html>"#
+    );
+    let mut doc = HtmlDocument::from_html(
+        &html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let img = doc.query_selector("#img").unwrap().expect("#img");
+    // Inject a 200x100 (2:1 wide) image as if it had loaded.
+    {
+        let node = doc.get_node_mut(img).unwrap();
+        node.element_data_mut().unwrap().special_data = SpecialElementData::Image(Box::new(
+            ImageData::Raster(RasterImageData::new(200, 100, Arc::new(vec![0u8; 200 * 100 * 4]))),
+        ));
+        node.cache.clear();
+    }
+    doc.resolve(0.0);
+    (doc, img)
+}
+
+#[test]
+fn wide_image_with_full_width_and_height_fills_the_box() {
+    let (doc, img) = doc_with_wide_image("width:100%; height:100%; object-fit:cover;");
+    let layout = doc.get_node(img).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (100.0, 100.0),
+        "img with width:100% and height:100% must fill its container"
+    );
+}
+
+#[test]
+fn wide_image_with_auto_height_uses_aspect_ratio() {
+    let (doc, img) = doc_with_wide_image("width:100%;");
+    let layout = doc.get_node(img).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (100.0, 50.0),
+        "img with auto height must derive it from the intrinsic aspect ratio"
+    );
+}
+
+#[test]
+fn wide_image_fills_aspect_ratio_sized_parent() {
+    // The cover-card shape: parent height comes from aspect-ratio, and the
+    // image resolves its percentage height against it.
+    let html = r#"<html><body style="margin:0">
+        <div style="width:100px; aspect-ratio:1/1; overflow:hidden; position:relative;">
+            <img id="img" style="width:100%; height:100%; object-fit:cover;" src="https://example.com/x.png">
+        </div>
+    </body></html>"#;
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let img = doc.query_selector("#img").unwrap().expect("#img");
+    {
+        let node = doc.get_node_mut(img).unwrap();
+        node.element_data_mut().unwrap().special_data = SpecialElementData::Image(Box::new(
+            ImageData::Raster(RasterImageData::new(200, 100, Arc::new(vec![0u8; 200 * 100 * 4]))),
+        ));
+        node.cache.clear();
+    }
+    doc.resolve(0.0);
+    let layout = doc.get_node(img).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (100.0, 100.0),
+        "img must fill the aspect-ratio-sized parent"
+    );
+}
+
+#[test]
+fn wide_image_in_flex_shelf_card() {
+    // The Continue Listening card shape: flex row shelf > fixed-width flex
+    // item > aspect-ratio square (implicit width) > img 100%/100% cover.
+    let html = r#"<html><body style="margin:0">
+        <div style="display:flex; overflow-x:auto; gap:20px; width:600px;">
+            <div style="flex:none; width:176px;">
+                <div style="aspect-ratio:1/1; overflow:hidden; position:relative; border-radius:12px;">
+                    <img id="img" style="width:100%; height:100%; object-fit:cover;" src="https://example.com/x.png">
+                </div>
+            </div>
+        </div>
+    </body></html>"#;
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let img = doc.query_selector("#img").unwrap().expect("#img");
+    {
+        let node = doc.get_node_mut(img).unwrap();
+        node.element_data_mut().unwrap().special_data = SpecialElementData::Image(Box::new(
+            ImageData::Raster(RasterImageData::new(320, 180, Arc::new(vec![0u8; 320 * 180 * 4]))),
+        ));
+        node.cache.clear();
+    }
+    doc.resolve(0.0);
+    let layout = doc.get_node(img).unwrap().final_layout;
+    assert_eq!(
+        (layout.size.width, layout.size.height),
+        (176.0, 176.0),
+        "cover img must fill the square card"
+    );
+}
+


### PR DESCRIPTION
Stacked on #453 (contains its commits). The included layout tests additionally require DioxusLabs/taffy#965 (block aspect-ratio definite height) to pass — draft until both land.

An inline root with `aspect-ratio` and a stretched (known) width never derived its height from the ratio, so e.g. an aspect-square cover containing only inline content sized itself from that content instead. Paired with taffy#965 (the block-layout half of the same gap) and gated to `RunMode::PerformLayout` for the same reason: measure-pass widths are tentative and must not transfer through the ratio.

Layout tests in `packages/blitz-html/tests/image_layout.rs` cover the `<img>` sizing shapes: explicit, percentage, and aspect-ratio-derived container heights, the flex-shelf card shape, and a full-fidelity Tailwind card (where preflight's `img { display: block }` routes through taffy block layout rather than this inline path — both halves are needed).
