### PR TITLE
Skip pointer-events:none elements in hit-testing

### DIFF
--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -909,6 +909,7 @@ impl Node {
     /// TODO: z-index
     /// (If multiple children are positioned at the position then a random one will be recursed into)
     pub fn hit(&self, x: f32, y: f32, scale: f64) -> Option<HitResult> {
+        use style::computed_values::pointer_events::T as PointerEvents;
         use style::computed_values::visibility::T as Visibility;
 
         // Don't hit on visbility:hidden elements
@@ -920,6 +921,12 @@ impl Node {
                 return None;
             }
         }
+
+        // pointer-events:none makes this element transparent to hits, but its
+        // descendants are still tested (one may restore pointer-events:auto).
+        let pointer_events_none = self
+            .primary_styles()
+            .is_some_and(|style| style.clone_pointer_events() == PointerEvents::None);
 
         let mut x = x - self.final_layout.location.x + self.scroll_offset.x as f32;
         let mut y = y - self.final_layout.location.y + self.scroll_offset.y as f32;
@@ -1018,18 +1025,24 @@ impl Node {
                 {
                     let style_index = cluster.glyphs().next()?.style_index();
                     let node_id = layout.styles()[style_index].brush.id;
-                    return Some(HitResult {
-                        node_id,
-                        x,
-                        y,
-                        is_text: true,
-                    });
+                    let text_pointer_events_none = self
+                        .with(node_id)
+                        .primary_styles()
+                        .is_some_and(|style| style.clone_pointer_events() == PointerEvents::None);
+                    if !text_pointer_events_none {
+                        return Some(HitResult {
+                            node_id,
+                            x,
+                            y,
+                            is_text: true,
+                        });
+                    }
                 }
             }
         }
 
         // Self (this node)
-        if matches_self {
+        if matches_self && !pointer_events_none {
             return Some(HitResult {
                 node_id: self.id,
                 x,

--- a/packages/blitz-html/tests/pointer_events.rs
+++ b/packages/blitz-html/tests/pointer_events.rs
@@ -1,0 +1,101 @@
+//! `pointer-events: none` removes an element as a hit-test target: pointer
+//! events pass through to whatever is underneath. Descendants are skipped via
+//! inheritance, but a descendant that restores `pointer-events: auto` is
+//! targetable again (css-ui-4).
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn doc(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(200, 200, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+fn hit_id(doc: &HtmlDocument, x: f32, y: f32) -> usize {
+    doc.hit(x, y).expect("hit should land somewhere").node_id
+}
+
+fn node_id(doc: &HtmlDocument, selector: &str) -> usize {
+    doc.query_selector(selector).unwrap().expect(selector)
+}
+
+#[test]
+fn overlay_with_pointer_events_none_passes_through_to_button() {
+    // The titlebar shape: an in-flow button row with a full-size positioned
+    // overlay (paints and hit-tests above in-flow content) that sets
+    // pointer-events: none.
+    let doc = doc(r#"<html><body style="margin:0">
+        <div style="position:relative; width:200px; height:36px;">
+            <button id="btn" style="position:static; width:44px; height:36px; margin-left:156px; display:block;">x</button>
+            <div id="overlay" style="position:absolute; left:0; top:0; right:0; bottom:0; pointer-events:none;">
+                <span>Kopuz</span>
+            </div>
+        </div>
+    </body></html>"#);
+
+    let btn = node_id(&doc, "#btn");
+    let hit = hit_id(&doc, 178.0, 18.0);
+    // The hit may be the button itself or its text child; resolve via ancestors
+    let hit_or_ancestor = std::iter::successors(Some(hit), |&id| {
+        doc.get_node(id).and_then(|n| n.parent)
+    })
+    .any(|id| id == btn);
+    assert!(
+        hit_or_ancestor,
+        "expected hit on #btn (node {btn}) but hit node {hit}"
+    );
+}
+
+#[test]
+fn element_with_pointer_events_none_is_not_a_target() {
+    let doc = doc(r#"<html><body style="margin:0">
+        <div id="under" style="width:100px; height:100px;">
+            <div id="blocker" style="width:100px; height:100px; pointer-events:none;"></div>
+        </div>
+    </body></html>"#);
+
+    let blocker = node_id(&doc, "#blocker");
+    let under = node_id(&doc, "#under");
+    let hit = hit_id(&doc, 50.0, 50.0);
+    assert_ne!(hit, blocker, "pointer-events:none element must not be hit");
+    assert_eq!(hit, under, "the event should fall through to the parent");
+}
+
+#[test]
+fn descendant_restoring_pointer_events_auto_is_targetable() {
+    let doc = doc(r#"<html><body style="margin:0">
+        <div style="pointer-events:none; width:200px; height:100px;">
+            <div id="inner" style="pointer-events:auto; width:50px; height:50px;"></div>
+        </div>
+    </body></html>"#);
+
+    let inner = node_id(&doc, "#inner");
+    assert_eq!(hit_id(&doc, 25.0, 25.0), inner);
+}
+
+#[test]
+fn text_inside_pointer_events_none_overlay_is_not_a_target() {
+    let doc = doc(r#"<html><body style="margin:0">
+        <div id="under" style="position:relative; width:200px; height:36px;">
+            <div id="overlay" style="position:absolute; left:0; top:0; right:0; bottom:0; pointer-events:none;">
+                <span id="label" style="font-size:20px;">KOPUZKOPUZKOPUZ</span>
+            </div>
+        </div>
+    </body></html>"#);
+
+    let overlay = node_id(&doc, "#overlay");
+    let label = node_id(&doc, "#label");
+    let hit = hit_id(&doc, 30.0, 14.0);
+    assert_ne!(hit, overlay);
+    assert_ne!(hit, label, "text in a pointer-events:none subtree must not be hit");
+}

--- a/packages/blitz-html/tests/pointer_events.rs
+++ b/packages/blitz-html/tests/pointer_events.rs
@@ -46,10 +46,9 @@ fn overlay_with_pointer_events_none_passes_through_to_button() {
     let btn = node_id(&doc, "#btn");
     let hit = hit_id(&doc, 178.0, 18.0);
     // The hit may be the button itself or its text child; resolve via ancestors
-    let hit_or_ancestor = std::iter::successors(Some(hit), |&id| {
-        doc.get_node(id).and_then(|n| n.parent)
-    })
-    .any(|id| id == btn);
+    let hit_or_ancestor =
+        std::iter::successors(Some(hit), |&id| doc.get_node(id).and_then(|n| n.parent))
+            .any(|id| id == btn);
     assert!(
         hit_or_ancestor,
         "expected hit on #btn (node {btn}) but hit node {hit}"
@@ -97,5 +96,8 @@ fn text_inside_pointer_events_none_overlay_is_not_a_target() {
     let label = node_id(&doc, "#label");
     let hit = hit_id(&doc, 30.0, 14.0);
     assert_ne!(hit, overlay);
-    assert_ne!(hit, label, "text in a pointer-events:none subtree must not be hit");
+    assert_ne!(
+        hit, label,
+        "text in a pointer-events:none subtree must not be hit"
+    );
 }


### PR DESCRIPTION
## Problem

`Node::hit()` never consulted the `pointer-events` property, so an element with `pointer-events: none` still absorbed pointer hits. This is most visible when a decorative positioned overlay sits above interactive content: per CSS painting order the positioned overlay hit-tests above in-flow siblings, so it swallowed every click and hover meant for the controls beneath it — even though authors set `pointer-events: none` on it precisely to let events through.

## Fix

`hit()` now reads computed `pointer-events`. A `none` element is no longer returned as the hit target itself — neither as a block box nor as the inline text cluster it owns — but its descendants are still tested, so a child that restores `pointer-events: auto` remains hittable (per css-ui-4 inheritance semantics).

## Tests

`packages/blitz-html/tests/pointer_events.rs`:
- a `pointer-events: none` overlay over a button passes the hit through to the button,
- a `none` element falls through to its parent,
- text inside a `none` subtree is not a target,
- a descendant restoring `auto` is targetable.
