### PR TITLE
UA stylesheet: vertically center button content

### DIFF
--- a/packages/blitz-dom/assets/default.css
+++ b/packages/blitz-dom/assets/default.css
@@ -87,6 +87,9 @@ input[type="button"] {
     color: black;
     background-color: #EFEFEF;
     text-align: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 input[type="file"] {


### PR DESCRIPTION
Follow-up to #454, which centered button text horizontally.

The button UA rule only sets `text-align: center`, so on fixed-height buttons the content sits at the top instead of being centered vertically. Browsers center button content on both axes.

This centers content on the cross axis too. It changes button `display` from `inline-block` to `inline-flex` — there's no block-level way to vertically center content without flex/grid/table — and adds `align-items: center; justify-content: center;`.

Verified by rendering a fixed-height button to a texture and checking the glyph's vertical band: before, an `A` in an 80px button rendered with its center at y≈17 (top); after, center y≈40 (centered), matching an explicit `align-items: center` reference.
