### PR TITLE
Integrate Taffy's and Parley's baseline support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "anyrender",
  "image",
  "peniko",
- "read-fonts",
+ "read-fonts 0.39.2",
  "serde",
  "serde_json",
  "sha2",
@@ -855,7 +855,7 @@ dependencies = [
  "percent-encoding",
  "rayon",
  "selectors",
- "skrifa",
+ "skrifa 0.42.1",
  "slab",
  "smallvec",
  "stylo",
@@ -2806,6 +2806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "font-types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bf886368962a7d8456f136073ed33ed1b0770c690d2063731bb6a776e99f33"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,9 +2839,8 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
+version = "0.11.0"
+source = "git+https://github.com/linebender/parley?rev=a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838#a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -2842,7 +2850,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts",
+ "read-fonts 0.40.2",
  "roxmltree 0.21.1",
  "smallvec",
  "windows",
@@ -3146,7 +3154,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "peniko",
- "skrifa",
+ "skrifa 0.42.1",
  "smallvec",
  "vello_common",
 ]
@@ -3330,13 +3338,13 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
+checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.40.2",
  "smallvec",
 ]
 
@@ -4772,7 +4780,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc8f19a1c361e5fb1a57e487b993ff8b3c44321b50ca86c9e2b235e57dc94008"
 dependencies = [
- "font-types",
+ "font-types 0.11.3",
 ]
 
 [[package]]
@@ -5249,32 +5257,40 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+source = "git+https://github.com/linebender/parley?rev=a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838#a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838"
 
 [[package]]
 name = "parley"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
+version = "0.11.0"
+source = "git+https://github.com/linebender/parley?rev=a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838#a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838"
 dependencies = [
  "fontique",
  "harfrust",
  "hashbrown 0.17.1",
  "icu_normalizer",
  "icu_properties",
- "icu_segmenter",
  "linebender_resource_handle",
  "parlance",
+ "parley_core",
+ "skrifa 0.43.2",
+]
+
+[[package]]
+name = "parley_core"
+version = "0.11.0"
+source = "git+https://github.com/linebender/parley?rev=a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838#a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
+ "parlance",
  "parley_data",
- "skrifa",
 ]
 
 [[package]]
 name = "parley_data"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
+version = "0.11.0"
+source = "git+https://github.com/linebender/parley?rev=a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838#a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838"
 dependencies = [
  "icu_properties",
 ]
@@ -5884,7 +5900,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
- "font-types",
+ "font-types 0.11.3",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
+dependencies = [
+ "bytemuck",
+ "font-types 0.12.0",
+ "once_cell",
 ]
 
 [[package]]
@@ -6580,7 +6607,7 @@ checksum = "caad12d9a3f75948b725a643cd60aea6de9d20cb03d3e35221e7a8a31c549409"
 dependencies = [
  "fnv",
  "hashbrown 0.17.1",
- "skrifa",
+ "skrifa 0.42.1",
  "thiserror 2.0.18",
  "write-fonts",
 ]
@@ -6619,7 +6646,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.39.2",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.40.2",
 ]
 
 [[package]]
@@ -7951,7 +7988,7 @@ dependencies = [
  "log",
  "peniko",
  "png 0.18.1",
- "skrifa",
+ "skrifa 0.42.1",
  "static_assertions",
  "thiserror 2.0.18",
  "vello_encoding",
@@ -8001,7 +8038,7 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko",
- "skrifa",
+ "skrifa 0.42.1",
  "smallvec",
 ]
 
@@ -9279,11 +9316,11 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb731d4c4d93eacc69a1ad2f270f905788a98e4a3438267bcafbe08d3431c8d8"
 dependencies = [
- "font-types",
+ "font-types 0.11.3",
  "indexmap",
  "kurbo",
  "log",
- "read-fonts",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ taffy = { version = "0.12.1", default-features = false, features = [
     "calc",
     "detailed_layout_info",
 ] }
-parley = { version = "0.10", default-features = false, features = ["std"] }
+parley = { git = "https://github.com/linebender/parley", rev = "a5ea9a77abfe34e3d3ac742e9e8bbbed0d023838", default-features = false, features = ["std"] }
 skrifa = { version = "0.42", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -1074,6 +1074,7 @@ pub(crate) fn build_inline_layout_into(
                                 kind: box_kind,
                                 // Overridden by push_inline_box method
                                 index: 0,
+                                baseline: None,
                                 // Width and height are set during layout
                                 width: 0.0,
                                 height: 0.0,
@@ -1154,6 +1155,7 @@ pub(crate) fn build_inline_layout_into(
                             kind: box_kind,
                             // Overridden by push_inline_box method
                             index: 0,
+                            baseline: None,
                             // Width and height are set during layout
                             width: 0.0,
                             height: 0.0,

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -300,6 +300,7 @@ impl BaseDocument {
                 ibox.height = 0.0;
             } else {
                 let output = self.compute_child_layout(NodeId::from(ibox.id), child_inputs);
+                ibox.baseline = output.first_baselines.y;
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
                 // Vertical margins adjust the space the box reserves in the line, but the
                 // reserved space cannot be negative.
@@ -571,7 +572,7 @@ impl BaseDocument {
                         // dbg!(&layout.size);
                         // dbg!(&layout.location);
 
-                        state.append_inline_box_to_line(box_break_data.advance, 0.0);
+                        state.append_inline_box_to_line(box_break_data.advance, 0.0, 0.0);
 
                         // if float.is_floated() {
                         //     println!("INLINE FLOATED BOX ({}) {:?}", ibox.id, float);
@@ -724,6 +725,11 @@ impl BaseDocument {
         // println!("known_dimensions: w: {:?} h: {:?}", inputs.known_dimensions.width, inputs.known_dimensions.height);
         // println!("\n");
 
+        let first_baseline = inline_layout
+            .layout
+            .first_baseline()
+            .map(|baseline| baseline + content_box_inset.top);
+
         // Put layout back
         self.nodes[node_id]
             .data
@@ -734,7 +740,10 @@ impl BaseDocument {
         LayoutOutput {
             size: final_size,
             content_size: measured_size + padding.sum_axes(),
-            first_baselines: Point::NONE,
+            first_baselines: Point {
+                x: None,
+                y: first_baseline,
+            },
             top_margin: CollapsibleMarginSet::ZERO,
             bottom_margin: CollapsibleMarginSet::ZERO,
             margins_can_collapse_through: !has_styles_preventing_being_collapsed_through

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1123,7 +1123,7 @@ impl Node {
                 if let Some((cluster, _side)) =
                     Cluster::from_point_exact(layout, x * scale, y * scale)
                 {
-                    let style_index = cluster.glyphs().next()?.style_index();
+                    let style_index = cluster.style_index() as usize;
                     let node_id = layout.styles()[style_index].brush.id;
                     let text_pointer_events_none = self
                         .with(node_id)


### PR DESCRIPTION
Depends on an upstream Parley PR to add baseline support for inline boxes:

- https://github.com/linebender/parley/pull/639

<!-- wpt-results-start -->
## WPT results

**31** newly passing, **69** newly failing (net -38).

<details>
<summary>Full diff (100 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/bidi-text/bidi-001.xht
- Pass => Fail css/CSS2/floats-clear/float-003.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-006.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-008.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-009.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-left-overflow.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-left-table.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-right-overflow.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-right-table.xht
- Pass => Fail css/CSS2/floats/new-fc-relayout.html
- Pass => Fail css/CSS2/fonts/font-family-applies-to-005.xht
- Pass => Fail css/CSS2/linebox/baseline-block-with-overflow-001.html
- Pass => Fail css/CSS2/linebox/inline-formatting-context-013.xht
- Pass => Fail css/CSS2/margin-padding-clear/margin-collapse-014.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-replaced-width-001.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-replaced-width-003.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-width-001.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-width-003.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-036.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-047.xht
- Pass => Fail css/CSS2/normal-flow/max-width-percentage-001.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-036.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-047.xht
- Pass => Fail css/CSS2/normal-flow/min-width-percentage-001.xht
- Pass => Fail css/CSS2/normal-flow/width-percentage-001.xht
- Pass => Fail css/CSS2/normal-flow/width-percentage-002.xht
- Pass => Fail css/CSS2/positioning/absolute-non-replaced-height-008.xht
- Pass => Fail css/CSS2/positioning/absolute-non-replaced-max-height-008.xht
+ Fail => Pass css/CSS2/visudet/content-height-001.html
+ Fail => Pass css/CSS2/visudet/content-height-002.html
+ Fail => Pass css/CSS2/visudet/content-height-003.html
- Pass => Fail css/css-align/baseline-of-scrollable-1a.html
- Pass => Fail css/css-align/baseline-of-scrollable-2.html
- Pass => Fail css/css-align/baseline-rules/inline-table-inline-block-baseline-vert-rl.html
- Pass => Fail css/css-align/baseline-rules/inline-table-inline-block-baseline.html
- Pass => Fail css/css-backgrounds/background-size-027.html
- Pass => Fail css/css-backgrounds/background-size-028.html
- Pass => Fail css/css-backgrounds/background-size-030.html
- Pass => Fail css/css-backgrounds/background-size-031.html
+ Fail => Pass css/css-break/flexbox/multi-line-row-flex-fragmentation-081a-print.html
+ Fail => Pass css/css-break/flexbox/multi-line-row-flex-fragmentation-081b-print.html
+ Fail => Pass css/css-break/flexbox/multi-line-row-flex-fragmentation-081c-print.html
+ Fail => Pass css/css-break/flexbox/multi-line-row-flex-fragmentation-081d-print.html
- Pass => Fail css/css-break/ruby-003.html
- Pass => Fail css/css-contain/contain-layout-baseline-001.html
- Pass => Fail css/css-contain/contain-layout-baseline-002.html
- Pass => Fail css/css-contain/contain-layout-baseline-003.html
+ Fail => Pass css/css-contain/contain-paint-022.html
+ Fail => Pass css/css-flexbox/align-items-004.htm
+ Fail => Pass css/css-flexbox/flex-direction-row-reverse.html
+ Fail => Pass css/css-flexbox/flexbox-align-self-baseline-horiz-004.xhtml
+ Fail => Pass css/css-flexbox/flexbox-align-self-baseline-horiz-005.xhtml
+ Fail => Pass css/css-flexbox/flexbox-align-self-vert-003.xhtml
- Pass => Fail css/css-flexbox/flexbox-baseline-multi-line-horiz-003.html
- Pass => Fail css/css-flexbox/flexbox-baseline-multi-line-vert-002.html
- Pass => Fail css/css-flexbox/flexbox-baseline-single-item-001a.html
- Pass => Fail css/css-flexbox/flexbox-baseline-single-item-001b.html
+ Fail => Pass css/css-flexbox/flexbox-basic-img-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-textarea-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox_align-items-baseline.html
- Pass => Fail css/css-flexbox/percentage-size-subitems-001.html
- Pass => Fail css/css-grid/alignment/grid-baseline-001.html
- Pass => Fail css/css-grid/alignment/grid-inline-baseline.html
- Pass => Fail css/css-grid/alignment/grid-item-aspect-ratio-stretch-1.html
- Pass => Fail css/css-grid/alignment/grid-item-aspect-ratio-stretch-2.html
- Pass => Fail css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-2.html
- Pass => Fail css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-3.html
- Pass => Fail css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-4.html
- Pass => Fail css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-5.html
- Pass => Fail css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-6.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-001.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-002.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-003.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-004.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-005.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-006.html
- Pass => Fail css/css-grid/grid-items/grid-inline-items-002.html
- Pass => Fail css/css-grid/grid-items/percentage-size-replaced-subitems-001.html
- Pass => Fail css/css-grid/grid-items/percentage-size-subitems-001.html
- Pass => Fail css/css-grid/subgrid/scrollbar-gutter-001.html
- Pass => Fail css/css-grid/subgrid/scrollbar-gutter-002.html
- Pass => Fail css/css-images/object-view-box-fit-contain-img.html
- Pass => Fail css/css-images/object-view-box-fit-contain-svg.html
- Pass => Fail css/css-images/object-view-box-fit-none-img.html
- Pass => Fail css/css-images/object-view-box-fit-none-svg.html
+ Fail => Pass css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html
- Pass => Fail css/css-lists/list-and-block-in-inline.html
- Pass => Fail css/css-lists/list-and-flex-001.html
- Pass => Fail css/css-multicol/baseline-001.html
- Pass => Fail css/css-multicol/baseline-002.html
- Pass => Fail css/css-position/position-relative-014.html
- Pass => Fail css/css-ruby/br-clear-all-000.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/circle/shape-outside-circle-041.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/ellipse/shape-outside-ellipse-044.html
- Pass => Fail css/css-tables/absolute-tables-013.html
- Pass => Fail css/css-tables/absolute-tables-014.html
- Pass => Fail css/css-tables/absolute-tables-015.html
+ Fail => Pass css/css-text/line-breaking/line-breaking-atomic-009.html
+ Fail => Pass css/css-writing-modes/text-combine-upright-shadow.html
+ Fail => Pass css/filter-effects/effect-reference-after-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30129562984).</sub>
<!-- wpt-results-end -->
