### PR TITLE
Workaround notched rendering of borders in Vello by rendering a stroke

### DIFF
--- a/packages/blitz-paint/src/kurbo_css/css_box.rs
+++ b/packages/blitz-paint/src/kurbo_css/css_box.rs
@@ -239,7 +239,10 @@ impl CssBox {
     /// path (see [`Self::is_uniform_corner_border`]); this catches the true ellipses
     /// (unequal axes) that a rounded rect can't represent.
     pub fn is_elliptical_border(&self) -> bool {
-        let (rx, ry) = (self.border_box.width() / 2.0, self.border_box.height() / 2.0);
+        let (rx, ry) = (
+            self.border_box.width() / 2.0,
+            self.border_box.height() / 2.0,
+        );
         let is_half = |c: Vec2| (c.x - rx).abs() < 0.01 && (c.y - ry).abs() < 0.01;
         let radii = &self.border_radii;
         is_half(radii.top_left)

--- a/packages/blitz-paint/src/kurbo_css/css_box.rs
+++ b/packages/blitz-paint/src/kurbo_css/css_box.rs
@@ -230,6 +230,42 @@ impl CssBox {
         path
     }
 
+    /// Whether the border box is a full ellipse (which includes a circle): every
+    /// corner radius equals half the box in that axis, i.e. `border-radius: 50%`.
+    /// Such a border is a single continuous curve with no straight edges; it is best
+    /// drawn as a stroked ellipse rather than a filled two-contour annulus
+    /// (see `draw_border`), which otherwise leaves seam notches on a thin ring where
+    /// the quarter-arcs meet. Circles are already covered by the stroked-rounded-rect
+    /// path (see [`Self::is_uniform_corner_border`]); this catches the true ellipses
+    /// (unequal axes) that a rounded rect can't represent.
+    pub fn is_elliptical_border(&self) -> bool {
+        let (rx, ry) = (self.border_box.width() / 2.0, self.border_box.height() / 2.0);
+        let is_half = |c: Vec2| (c.x - rx).abs() < 0.01 && (c.y - ry).abs() < 0.01;
+        let radii = &self.border_radii;
+        is_half(radii.top_left)
+            && is_half(radii.top_right)
+            && is_half(radii.bottom_right)
+            && is_half(radii.bottom_left)
+    }
+
+    /// Whether every corner has an equal x and y radius, i.e. each corner is a
+    /// circular (not elliptical) arc. Corners may still differ from one another, so
+    /// this also covers plain rectangles (radius 0) and ordinary rounded rectangles,
+    /// not just circles. Such a border can be drawn as a single stroked
+    /// `kurbo::RoundedRect` rather than the filled per-edge annulus in
+    /// `draw_border` — simpler and faster, since it avoids building and filling a
+    /// separate path per edge. (`draw_border` additionally requires uniform border
+    /// width/color and each radius to be 0 or ≥ the border width for the stroke to
+    /// reproduce the CSS shape exactly.)
+    pub fn is_uniform_corner_border(&self) -> bool {
+        let is_circular = |c: Vec2| (c.x - c.y).abs() < 0.01;
+        let radii = &self.border_radii;
+        is_circular(radii.top_left)
+            && is_circular(radii.top_right)
+            && is_circular(radii.bottom_right)
+            && is_circular(radii.bottom_left)
+    }
+
     fn shape(&self, path: &mut BezPath, line: CssBoxKind, direction: Direction) {
         use Corner::*;
 
@@ -733,4 +769,76 @@ mod tests {
             }
         }
     }
+}
+
+#[test]
+fn detects_elliptical_border() {
+    let corners = |x: f64, y: f64| NonUniformRoundedRectRadii {
+        top_left: Vec2::new(x, y),
+        top_right: Vec2::new(x, y),
+        bottom_right: Vec2::new(x, y),
+        bottom_left: Vec2::new(x, y),
+    };
+    let css_box = |w: f64, h: f64, radii: NonUniformRoundedRectRadii| {
+        CssBox::new(
+            Rect::new(0.0, 0.0, w, h),
+            Insets::uniform(1.0),
+            Insets::ZERO,
+            0.0,
+            radii,
+        )
+    };
+
+    // Circle: square box, every radius == half the side.
+    assert!(css_box(44.0, 44.0, corners(22.0, 22.0)).is_elliptical_border());
+    // Ellipse: non-square box, radii == half each axis.
+    assert!(css_box(120.0, 64.0, corners(60.0, 32.0)).is_elliptical_border());
+    // Rounded rectangle: radius smaller than half → has straight edges.
+    assert!(!css_box(44.0, 44.0, corners(10.0, 10.0)).is_elliptical_border());
+    // Sharp rectangle: no rounding.
+    assert!(!css_box(44.0, 44.0, corners(0.0, 0.0)).is_elliptical_border());
+}
+
+#[test]
+fn detects_uniform_corner_border() {
+    let corners = |x: f64, y: f64| NonUniformRoundedRectRadii {
+        top_left: Vec2::new(x, y),
+        top_right: Vec2::new(x, y),
+        bottom_right: Vec2::new(x, y),
+        bottom_left: Vec2::new(x, y),
+    };
+    let css_box = |w: f64, h: f64, radii: NonUniformRoundedRectRadii| {
+        CssBox::new(
+            Rect::new(0.0, 0.0, w, h),
+            Insets::uniform(1.0),
+            Insets::ZERO,
+            0.0,
+            radii,
+        )
+    };
+
+    // Sharp rectangle: no rounding, still trivially "uniform" (0 == 0).
+    assert!(css_box(44.0, 44.0, corners(0.0, 0.0)).is_uniform_corner_border());
+    // Ordinary rounded rectangle: each corner is a circular arc.
+    assert!(css_box(44.0, 44.0, corners(10.0, 10.0)).is_uniform_corner_border());
+    // Circle: square box, every radius == half the side.
+    assert!(css_box(44.0, 44.0, corners(22.0, 22.0)).is_uniform_corner_border());
+    // Ellipse: non-square box, radii == half each axis → corners aren't circular.
+    assert!(!css_box(120.0, 64.0, corners(60.0, 32.0)).is_uniform_corner_border());
+    // Per-corner elliptical radius (rx != ry) anywhere disqualifies the box, even
+    // if it isn't a full border-radius: 50% ellipse.
+    let mixed = NonUniformRoundedRectRadii {
+        top_left: Vec2::new(10.0, 5.0),
+        ..corners(10.0, 10.0)
+    };
+    assert!(!css_box(44.0, 44.0, mixed).is_uniform_corner_border());
+
+    // Corners may differ in radius from each other, as long as each is circular.
+    let differing = NonUniformRoundedRectRadii {
+        top_left: Vec2::new(10.0, 10.0),
+        top_right: Vec2::new(5.0, 5.0),
+        bottom_right: Vec2::new(8.0, 8.0),
+        bottom_left: Vec2::new(2.0, 2.0),
+    };
+    assert!(css_box(44.0, 44.0, differing).is_uniform_corner_border());
 }

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -1,6 +1,6 @@
 use anyrender::PaintScene;
 use blitz_dom::node::SpecialElementData;
-use kurbo::{BezPath, Cap, Circle, PathEl, Point, Rect, Shape as _, Stroke};
+use kurbo::{BezPath, Cap, Circle, Insets, Join, PathEl, Point, Rect, Shape as _, Stroke, Vec2};
 use peniko::{Color, Fill};
 use smallvec::SmallVec;
 use style::{
@@ -156,6 +156,81 @@ impl ElementCx<'_, '_> {
         let style = &*self.style;
         let border = style.get_border();
         let current_color = style.clone_color();
+
+        // Fast path: a uniform-width, single-color solid border whose corners are
+        // all circular arcs (equal x and y radius — sharp rectangles, ordinary
+        // rounded rectangles and circles all qualify) can be drawn as a single
+        // stroke along its center-line instead of a fill per edge. Besides being
+        // faster, this works around Vello seam artifacts at the quarter-arc joins
+        // when a thin circular/elliptical border is drawn as the
+        // border-box/padding-box annulus.
+        //
+        // A full ellipse (`border-radius: 50%` on a non-square box) has the same
+        // seam problem but no rounded-rect representation, so it is stroked as an
+        // ellipse.
+        let all_solid = border.border_top_style == BorderStyle::Solid
+            && border.border_right_style == BorderStyle::Solid
+            && border.border_bottom_style == BorderStyle::Solid
+            && border.border_left_style == BorderStyle::Solid;
+        if all_solid {
+            let color = border
+                .border_top_color
+                .resolve_to_absolute(&current_color)
+                .as_srgb_color();
+            let same_color = [
+                &border.border_right_color,
+                &border.border_bottom_color,
+                &border.border_left_color,
+            ]
+            .iter()
+            .all(|c| c.resolve_to_absolute(&current_color).as_srgb_color() == color);
+            let bw = self.frame.border_width;
+            let uniform_width = bw.x0 == bw.y0 && bw.x0 == bw.x1 && bw.x0 == bw.y1 && bw.x0 > 0.0;
+            if same_color && uniform_width && color.components[3] > 0.0 {
+                let bb = self.frame.border_box;
+                let pb = self.frame.padding_box;
+                let width = (bb.width() - pb.width()) / 2.0;
+                // Miter join keeps sharp corners square. It has no effect on rounded
+                // corners, whose arcs meet the straight edges tangentially.
+                let stroke = Stroke::new(width).with_join(Join::Miter);
+
+                if self.frame.is_uniform_corner_border() {
+                    let radii = self.frame.border_radii;
+                    // The stroke matches the CSS border shape only when each corner is
+                    // sharp or its radius is at least the border width (outer radius
+                    // `r`, inner radius `r - width`, concentric). For 0 < r < width CSS
+                    // draws a rounded outer edge against a sharp inner corner, which a
+                    // stroke can't represent — leave those to the per-edge fill.
+                    let is_exact = |r: Vec2| r.x == 0.0 || r.x >= width;
+                    let stroke_is_exact = is_exact(radii.top_left)
+                        && is_exact(radii.top_right)
+                        && is_exact(radii.bottom_right)
+                        && is_exact(radii.bottom_left);
+                    if stroke_is_exact {
+                        let half_width = width / 2.0;
+                        // Center-line rect, and corner radii shrunk to match.
+                        let centerline_box = bb - Insets::uniform(half_width);
+                        let centerline_radius = |r: Vec2| (r.x - half_width).max(0.0);
+                        let radii = kurbo::RoundedRectRadii::new(
+                            centerline_radius(radii.top_left),
+                            centerline_radius(radii.top_right),
+                            centerline_radius(radii.bottom_right),
+                            centerline_radius(radii.bottom_left),
+                        );
+                        let rr = kurbo::RoundedRect::from_rect(centerline_box, radii);
+                        scene.stroke(&stroke, self.transform, color, None, &rr);
+                        return;
+                    }
+                } else if self.frame.is_elliptical_border() {
+                    // Center-line radii, straight from the boxes.
+                    let rx = (bb.width() + pb.width()) / 4.0;
+                    let ry = (bb.height() + pb.height()) / 4.0;
+                    let e = kurbo::Ellipse::new(bb.center(), (rx, ry), 0.0);
+                    scene.stroke(&stroke, self.transform, color, None, &e);
+                    return;
+                }
+            }
+        }
 
         // (colour, path) pairs to be filled. Several entries may share a colour;
         // they are grouped before filling so that adjacent same-coloured regions


### PR DESCRIPTION

# Reproducer
```html
<!DOCTYPE html>
<!--
  Minimal reproducer: a small `border-radius:50%` element with a thin solid border
  renders with visible seams/notches in the border ring (most clearly at ~9 and
  ~6 o'clock) and an uneven ring width. The same element with no border (a filled
  circle) is smooth, so the artifact is in the BORDER ring construction.

  Render at devicePixelRatio = 2.0 (the artifact is scale-sensitive — see README).
  Drop this into Blitz's `screenshot`/`himg` example, or any blitz-html + Vello path.
-->
<html>
  <head>
    <style>
      html, body { margin: 0; }
      body { background: #9aa0a6; padding: 24px; display: inline-block; }

      /* The disc under test — a board-game stat badge: 44px, thin 1.5px ring. */
      .ring {
        width: 44px;
        height: 44px;
        border-radius: 50%;
        box-sizing: border-box;
        border: 1.5px solid #231b13;
        background: #d64a86;
      }
      /* Control: identical disc with NO border — renders as a smooth circle. */
      .fill {
        width: 44px;
        height: 44px;
        border-radius: 50%;
        background: #d64a86;
      }
    </style>
  </head>
  <body>
    <div class="ring"></div>
    <div class="fill"></div>
  </body>
</html>
```