### PR TITLE
Touch action

### DIFF
--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -12,7 +12,7 @@ use blitz_traits::{
 };
 use keyboard_types::Modifiers;
 use markup5ever::local_name;
-use style::values::computed::UserSelect;
+use style::values::computed::{TouchAction, UserSelect};
 use taffy::AbsoluteAxis;
 
 use crate::{
@@ -28,6 +28,10 @@ pub(crate) struct PanState {
     pub(crate) target: NodeId,
     pub(crate) last_x: f32,
     pub(crate) last_y: f32,
+    /// Whether horizontal panning is permitted by the `touch-action` property.
+    pub(crate) allow_x: bool,
+    /// Whether vertical panning is permitted by the `touch-action` property.
+    pub(crate) allow_y: bool,
     pub(crate) samples: VecDeque<PanSample>,
 }
 
@@ -66,8 +70,18 @@ impl DragMode {
 
 impl PanState {
     fn update(&mut self, time_ms: u64, screen_x: f32, screen_y: f32) -> (f64, f64) {
-        let dx = (screen_x - self.last_x) as f64;
-        let dy = (screen_y - self.last_y) as f64;
+        // Constrain panning to the axes permitted by the `touch-action` property. Positions are
+        // still tracked on both axes so that deltas remain correct after a disallowed movement.
+        let dx = if self.allow_x {
+            (screen_x - self.last_x) as f64
+        } else {
+            0.0
+        };
+        let dy = if self.allow_y {
+            (screen_y - self.last_y) as f64
+        } else {
+            0.0
+        };
         self.last_x = screen_x;
         self.last_y = screen_y;
 
@@ -140,6 +154,36 @@ impl PanState {
     }
 }
 
+/// Compute which axes a touch pan gesture starting on `node_id` is allowed to scroll, according to
+/// the `touch-action` property.
+///
+/// Per spec the effective behaviour is the intersection of the `touch-action` values of the target
+/// and all of its ancestors, so we walk up the tree combining the permitted axes. `touch-action:
+/// none` blocks panning entirely, `pan-x`/`pan-y` restrict it to a single axis, and `auto` /
+/// `manipulation` permit both.
+fn touch_action_pan_axes(doc: &BaseDocument, node_id: usize) -> (bool, bool) {
+    let pan_x_flags = TouchAction::AUTO | TouchAction::MANIPULATION | TouchAction::PAN_X;
+    let pan_y_flags = TouchAction::AUTO | TouchAction::MANIPULATION | TouchAction::PAN_Y;
+
+    let mut allow_x = true;
+    let mut allow_y = true;
+    let mut current = Some(node_id);
+    while let Some(id) = current {
+        let node = &doc.nodes[id];
+        if let Some(style) = node.primary_styles() {
+            let touch_action = style.clone_touch_action();
+            allow_x &= touch_action.intersects(pan_x_flags);
+            allow_y &= touch_action.intersects(pan_y_flags);
+            if !allow_x && !allow_y {
+                break;
+            }
+        }
+        current = node.parent;
+    }
+
+    (allow_x, allow_y)
+}
+
 pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
     doc: &mut BaseDocument,
     target: NodeId,
@@ -182,12 +226,19 @@ pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
                     }
                 }
                 BlitzPointerId::Finger(_) => {
-                    doc.drag_mode = DragMode::Panning(PanState {
-                        target,
-                        last_x: event.screen_x(),
-                        last_y: event.screen_y(),
-                        samples: VecDeque::with_capacity(200),
-                    });
+                    let (allow_x, allow_y) = touch_action_pan_axes(doc, target);
+                    // If `touch-action` forbids panning on both axes (e.g. `touch-action: none`)
+                    // there is nothing to scroll, so don't enter the panning drag mode.
+                    if allow_x || allow_y {
+                        doc.drag_mode = DragMode::Panning(PanState {
+                            target,
+                            last_x: event.screen_x(),
+                            last_y: event.screen_y(),
+                            allow_x,
+                            allow_y,
+                            samples: VecDeque::with_capacity(200),
+                        });
+                    }
                 }
             }
         }

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -161,7 +161,7 @@ impl PanState {
 /// and all of its ancestors, so we walk up the tree combining the permitted axes. `touch-action:
 /// none` blocks panning entirely, `pan-x`/`pan-y` restrict it to a single axis, and `auto` /
 /// `manipulation` permit both.
-fn touch_action_pan_axes(doc: &BaseDocument, node_id: usize) -> (bool, bool) {
+fn touch_action_pan_axes(doc: &BaseDocument, node_id: NodeId) -> (bool, bool) {
     let pan_x_flags = TouchAction::AUTO | TouchAction::MANIPULATION | TouchAction::PAN_X;
     let pan_y_flags = TouchAction::AUTO | TouchAction::MANIPULATION | TouchAction::PAN_Y;
 

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -11,7 +11,7 @@ use blitz_traits::{
 };
 use keyboard_types::Modifiers;
 use markup5ever::local_name;
-use style::values::computed::UserSelect;
+use style::values::computed::{TouchAction, UserSelect};
 use taffy::AbsoluteAxis;
 
 use crate::{
@@ -40,6 +40,10 @@ pub(crate) struct PanState {
     pub(crate) target: usize,
     pub(crate) last_x: f32,
     pub(crate) last_y: f32,
+    /// Whether horizontal panning is permitted by the `touch-action` property.
+    pub(crate) allow_x: bool,
+    /// Whether vertical panning is permitted by the `touch-action` property.
+    pub(crate) allow_y: bool,
     pub(crate) samples: VecDeque<PanSample>,
 }
 
@@ -78,8 +82,18 @@ impl DragMode {
 
 impl PanState {
     fn update(&mut self, time_ms: u64, screen_x: f32, screen_y: f32) -> (f64, f64) {
-        let dx = (screen_x - self.last_x) as f64;
-        let dy = (screen_y - self.last_y) as f64;
+        // Constrain panning to the axes permitted by the `touch-action` property. Positions are
+        // still tracked on both axes so that deltas remain correct after a disallowed movement.
+        let dx = if self.allow_x {
+            (screen_x - self.last_x) as f64
+        } else {
+            0.0
+        };
+        let dy = if self.allow_y {
+            (screen_y - self.last_y) as f64
+        } else {
+            0.0
+        };
         self.last_x = screen_x;
         self.last_y = screen_y;
 
@@ -152,6 +166,36 @@ impl PanState {
     }
 }
 
+/// Compute which axes a touch pan gesture starting on `node_id` is allowed to scroll, according to
+/// the `touch-action` property.
+///
+/// Per spec the effective behaviour is the intersection of the `touch-action` values of the target
+/// and all of its ancestors, so we walk up the tree combining the permitted axes. `touch-action:
+/// none` blocks panning entirely, `pan-x`/`pan-y` restrict it to a single axis, and `auto` /
+/// `manipulation` permit both.
+fn touch_action_pan_axes(doc: &BaseDocument, node_id: usize) -> (bool, bool) {
+    let pan_x_flags = TouchAction::AUTO | TouchAction::MANIPULATION | TouchAction::PAN_X;
+    let pan_y_flags = TouchAction::AUTO | TouchAction::MANIPULATION | TouchAction::PAN_Y;
+
+    let mut allow_x = true;
+    let mut allow_y = true;
+    let mut current = Some(node_id);
+    while let Some(id) = current {
+        let node = &doc.nodes[id];
+        if let Some(style) = node.primary_styles() {
+            let touch_action = style.clone_touch_action();
+            allow_x &= touch_action.intersects(pan_x_flags);
+            allow_y &= touch_action.intersects(pan_y_flags);
+            if !allow_x && !allow_y {
+                break;
+            }
+        }
+        current = node.parent;
+    }
+
+    (allow_x, allow_y)
+}
+
 pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
     doc: &mut BaseDocument,
     target: usize,
@@ -194,12 +238,19 @@ pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
                     }
                 }
                 BlitzPointerId::Finger(_) => {
-                    doc.drag_mode = DragMode::Panning(PanState {
-                        target,
-                        last_x: event.screen_x(),
-                        last_y: event.screen_y(),
-                        samples: VecDeque::with_capacity(200),
-                    });
+                    let (allow_x, allow_y) = touch_action_pan_axes(doc, target);
+                    // If `touch-action` forbids panning on both axes (e.g. `touch-action: none`)
+                    // there is nothing to scroll, so don't enter the panning drag mode.
+                    if allow_x || allow_y {
+                        doc.drag_mode = DragMode::Panning(PanState {
+                            target,
+                            last_x: event.screen_x(),
+                            last_y: event.screen_y(),
+                            allow_x,
+                            allow_y,
+                            samples: VecDeque::with_capacity(200),
+                        });
+                    }
                 }
             }
         }

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -12,7 +12,7 @@ use blitz_traits::{
 };
 use keyboard_types::Modifiers;
 use markup5ever::local_name;
-use style::values::computed::{TouchAction, UserSelect};
+use style::values::computed::{Overflow, TouchAction, UserSelect};
 use taffy::AbsoluteAxis;
 
 use crate::{
@@ -157,24 +157,42 @@ impl PanState {
 /// Compute which axes a touch pan gesture starting on `node_id` is allowed to scroll, according to
 /// the `touch-action` property.
 ///
-/// Per spec the effective behaviour is the intersection of the `touch-action` values of the target
-/// and all of its ancestors, so we walk up the tree combining the permitted axes. `touch-action:
-/// none` blocks panning entirely, `pan-x`/`pan-y` restrict it to a single axis, and `auto` /
-/// `manipulation` permit both.
+/// Per the Pointer Events spec the effective behaviour is the intersection of the `touch-action`
+/// values of the target and its ancestors up to and including the nearest ancestor that implements
+/// the pan (the nearest scroll container which can actually scroll on that axis), so the walk stops
+/// per-axis at that scroller: `touch-action` values on elements *above* it do not restrict pans it
+/// handles. `touch-action: none` blocks panning entirely, `pan-x`/`pan-y` restrict it to a single
+/// axis, and `auto` / `manipulation` permit both.
 fn touch_action_pan_axes(doc: &BaseDocument, node_id: NodeId) -> (bool, bool) {
     let pan_x_flags = TouchAction::AUTO | TouchAction::MANIPULATION | TouchAction::PAN_X;
     let pan_y_flags = TouchAction::AUTO | TouchAction::MANIPULATION | TouchAction::PAN_Y;
 
     let mut allow_x = true;
     let mut allow_y = true;
+    // Whether the nearest scroller for the axis has been reached (its own `touch-action` counts,
+    // but its ancestors' do not).
+    let mut done_x = false;
+    let mut done_y = false;
     let mut current = Some(node_id);
     while let Some(id) = current {
         let node = &doc.nodes[id];
         if let Some(style) = node.primary_styles() {
             let touch_action = style.clone_touch_action();
-            allow_x &= touch_action.intersects(pan_x_flags);
-            allow_y &= touch_action.intersects(pan_y_flags);
-            if !allow_x && !allow_y {
+            if !done_x {
+                allow_x &= touch_action.intersects(pan_x_flags);
+            }
+            if !done_y {
+                allow_y &= touch_action.intersects(pan_y_flags);
+            }
+
+            let scrolls_x = matches!(style.clone_overflow_x(), Overflow::Scroll | Overflow::Auto)
+                && node.final_layout().scroll_width() > 0.0;
+            let scrolls_y = matches!(style.clone_overflow_y(), Overflow::Scroll | Overflow::Auto)
+                && node.final_layout().scroll_height() > 0.0;
+            done_x |= scrolls_x;
+            done_y |= scrolls_y;
+
+            if (done_x || !allow_x) && (done_y || !allow_y) {
                 break;
             }
         }

--- a/packages/blitz-html/tests/touch_action.rs
+++ b/packages/blitz-html/tests/touch_action.rs
@@ -1,0 +1,151 @@
+//! The `touch-action` CSS property controls whether touch (finger) input may pan/scroll an
+//! element. `none` blocks panning on both axes, `pan-x`/`pan-y` restrict it to a single axis, and
+//! `auto`/`manipulation` permit panning on both axes. Mouse input is unaffected.
+
+use blitz_dom::{Document, DocumentConfig};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::{
+    events::{
+        BlitzPointerEvent, BlitzPointerId, MouseEventButton, MouseEventButtons, Point,
+        PointerCoords, PointerDetails, UiEvent,
+    },
+    shell::{ColorScheme, Viewport},
+};
+use std::sync::Arc;
+
+fn doc(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(200, 200, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+fn finger_event(x: f32, y: f32) -> BlitzPointerEvent {
+    BlitzPointerEvent {
+        id: BlitzPointerId::Finger(0),
+        is_primary: true,
+        coords: PointerCoords {
+            page_x: x,
+            page_y: y,
+            screen_x: x,
+            screen_y: y,
+            client_x: x,
+            client_y: y,
+        },
+        button: MouseEventButton::Main,
+        buttons: MouseEventButtons::from(MouseEventButton::Main),
+        mods: Default::default(),
+        details: PointerDetails::default(),
+        element: Point::default(),
+        active_pointers: Default::default(),
+    }
+}
+
+/// Perform a finger pan gesture from `(x0, y0)` moving by `(dx, dy)` and return the resulting
+/// scroll offset of the `#scroller` element.
+///
+/// The gesture uses three moves: the first crosses the drag threshold and starts the pan (its
+/// delta is not applied), and the following moves produce the actual scroll delta.
+fn pan(doc: &mut HtmlDocument, dx: f32, dy: f32) -> (f64, f64) {
+    let (x0, y0) = (100.0f32, 100.0f32);
+    doc.handle_ui_event(UiEvent::PointerDown(finger_event(x0, y0)));
+    // Cross the 2px threshold to begin panning (this move applies no scroll delta).
+    doc.handle_ui_event(UiEvent::PointerMove(finger_event(x0 + dx, y0 + dy)));
+    // Move back to the origin, producing a scroll delta of (dx, dy).
+    doc.handle_ui_event(UiEvent::PointerMove(finger_event(x0, y0)));
+    doc.handle_ui_event(UiEvent::PointerUp(finger_event(x0, y0)));
+
+    let scroller = doc.query_selector("#scroller").unwrap().expect("#scroller");
+    let offset = doc.get_node(scroller).unwrap().scroll_offset;
+    (offset.x, offset.y)
+}
+
+fn scroller_doc(touch_action: &str) -> HtmlDocument {
+    doc(&format!(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="overflow:scroll; width:200px; height:200px; touch-action:{touch_action};">
+                <div style="width:400px; height:400px;"></div>
+            </div>
+        </body></html>"#
+    ))
+}
+
+#[test]
+fn auto_allows_panning_on_both_axes() {
+    let mut doc = scroller_doc("auto");
+    let (x, _) = pan(&mut doc, 60.0, 0.0);
+    assert!(x > 0.0, "touch-action:auto should allow horizontal panning");
+
+    let mut doc = scroller_doc("auto");
+    let (_, y) = pan(&mut doc, 0.0, 60.0);
+    assert!(y > 0.0, "touch-action:auto should allow vertical panning");
+}
+
+#[test]
+fn none_blocks_panning() {
+    let mut doc = scroller_doc("none");
+    let (x, y) = pan(&mut doc, 60.0, 0.0);
+    assert_eq!(
+        (x, y),
+        (0.0, 0.0),
+        "touch-action:none should block horizontal panning"
+    );
+
+    let mut doc = scroller_doc("none");
+    let (x, y) = pan(&mut doc, 0.0, 60.0);
+    assert_eq!(
+        (x, y),
+        (0.0, 0.0),
+        "touch-action:none should block vertical panning"
+    );
+}
+
+#[test]
+fn pan_x_allows_only_horizontal() {
+    let mut doc = scroller_doc("pan-x");
+    let (x, y) = pan(&mut doc, 60.0, 0.0);
+    assert!(
+        x > 0.0,
+        "touch-action:pan-x should allow horizontal panning"
+    );
+    assert_eq!(y, 0.0, "horizontal pan must not scroll vertically");
+
+    let mut doc = scroller_doc("pan-x");
+    let (_, y) = pan(&mut doc, 0.0, 60.0);
+    assert_eq!(y, 0.0, "touch-action:pan-x should block vertical panning");
+}
+
+#[test]
+fn pan_y_allows_only_vertical() {
+    let mut doc = scroller_doc("pan-y");
+    let (x, y) = pan(&mut doc, 0.0, 60.0);
+    assert!(y > 0.0, "touch-action:pan-y should allow vertical panning");
+    assert_eq!(x, 0.0, "vertical pan must not scroll horizontally");
+
+    let mut doc = scroller_doc("pan-y");
+    let (x, _) = pan(&mut doc, 60.0, 0.0);
+    assert_eq!(x, 0.0, "touch-action:pan-y should block horizontal panning");
+}
+
+#[test]
+fn manipulation_allows_panning_on_both_axes() {
+    let mut doc = scroller_doc("manipulation");
+    let (x, _) = pan(&mut doc, 60.0, 0.0);
+    assert!(
+        x > 0.0,
+        "touch-action:manipulation should allow horizontal panning"
+    );
+
+    let mut doc = scroller_doc("manipulation");
+    let (_, y) = pan(&mut doc, 0.0, 60.0);
+    assert!(
+        y > 0.0,
+        "touch-action:manipulation should allow vertical panning"
+    );
+}

--- a/tests/blitz-tests/tests/touch_action.rs
+++ b/tests/blitz-tests/tests/touch_action.rs
@@ -1,0 +1,151 @@
+//! The `touch-action` CSS property controls whether touch (finger) input may pan/scroll an
+//! element. `none` blocks panning on both axes, `pan-x`/`pan-y` restrict it to a single axis, and
+//! `auto`/`manipulation` permit panning on both axes. Mouse input is unaffected.
+
+use blitz_dom::{Document, DocumentConfig};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::{
+    events::{
+        BlitzPointerEvent, BlitzPointerId, MouseEventButton, MouseEventButtons, Point,
+        PointerCoords, PointerDetails, UiEvent,
+    },
+    shell::{ColorScheme, Viewport},
+};
+use std::sync::Arc;
+
+fn doc(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(200, 200, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+fn finger_event(x: f32, y: f32) -> BlitzPointerEvent {
+    BlitzPointerEvent {
+        id: BlitzPointerId::Finger(0),
+        is_primary: true,
+        coords: PointerCoords {
+            page_x: x,
+            page_y: y,
+            screen_x: x,
+            screen_y: y,
+            client_x: x,
+            client_y: y,
+        },
+        button: MouseEventButton::Main,
+        buttons: MouseEventButtons::from(MouseEventButton::Main),
+        mods: Default::default(),
+        details: PointerDetails::default(),
+        element: Point::default(),
+        active_pointers: Default::default(),
+    }
+}
+
+/// Perform a finger pan gesture from `(x0, y0)` moving by `(dx, dy)` and return the resulting
+/// scroll offset of the `#scroller` element.
+///
+/// The gesture uses three moves: the first crosses the drag threshold and starts the pan (its
+/// delta is not applied), and the following moves produce the actual scroll delta.
+fn pan(doc: &mut HtmlDocument, dx: f32, dy: f32) -> (f64, f64) {
+    let (x0, y0) = (100.0f32, 100.0f32);
+    doc.handle_ui_event(UiEvent::PointerDown(finger_event(x0, y0)));
+    // Cross the 2px threshold to begin panning (this move applies no scroll delta).
+    doc.handle_ui_event(UiEvent::PointerMove(finger_event(x0 + dx, y0 + dy)));
+    // Move back to the origin, producing a scroll delta of (dx, dy).
+    doc.handle_ui_event(UiEvent::PointerMove(finger_event(x0, y0)));
+    doc.handle_ui_event(UiEvent::PointerUp(finger_event(x0, y0)));
+
+    let scroller = doc.query_selector("#scroller").unwrap().expect("#scroller");
+    let offset = doc.get_node(scroller).unwrap().scroll_offset;
+    (offset.x, offset.y)
+}
+
+fn scroller_doc(touch_action: &str) -> HtmlDocument {
+    doc(&format!(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="overflow:scroll; width:200px; height:200px; touch-action:{touch_action};">
+                <div style="width:400px; height:400px;"></div>
+            </div>
+        </body></html>"#
+    ))
+}
+
+#[test]
+fn auto_allows_panning_on_both_axes() {
+    let mut doc = scroller_doc("auto");
+    let (x, _) = pan(&mut doc, 60.0, 0.0);
+    assert!(x > 0.0, "touch-action:auto should allow horizontal panning");
+
+    let mut doc = scroller_doc("auto");
+    let (_, y) = pan(&mut doc, 0.0, 60.0);
+    assert!(y > 0.0, "touch-action:auto should allow vertical panning");
+}
+
+#[test]
+fn none_blocks_panning() {
+    let mut doc = scroller_doc("none");
+    let (x, y) = pan(&mut doc, 60.0, 0.0);
+    assert_eq!(
+        (x, y),
+        (0.0, 0.0),
+        "touch-action:none should block horizontal panning"
+    );
+
+    let mut doc = scroller_doc("none");
+    let (x, y) = pan(&mut doc, 0.0, 60.0);
+    assert_eq!(
+        (x, y),
+        (0.0, 0.0),
+        "touch-action:none should block vertical panning"
+    );
+}
+
+#[test]
+fn pan_x_allows_only_horizontal() {
+    let mut doc = scroller_doc("pan-x");
+    let (x, y) = pan(&mut doc, 60.0, 0.0);
+    assert!(
+        x > 0.0,
+        "touch-action:pan-x should allow horizontal panning"
+    );
+    assert_eq!(y, 0.0, "horizontal pan must not scroll vertically");
+
+    let mut doc = scroller_doc("pan-x");
+    let (_, y) = pan(&mut doc, 0.0, 60.0);
+    assert_eq!(y, 0.0, "touch-action:pan-x should block vertical panning");
+}
+
+#[test]
+fn pan_y_allows_only_vertical() {
+    let mut doc = scroller_doc("pan-y");
+    let (x, y) = pan(&mut doc, 0.0, 60.0);
+    assert!(y > 0.0, "touch-action:pan-y should allow vertical panning");
+    assert_eq!(x, 0.0, "vertical pan must not scroll horizontally");
+
+    let mut doc = scroller_doc("pan-y");
+    let (x, _) = pan(&mut doc, 60.0, 0.0);
+    assert_eq!(x, 0.0, "touch-action:pan-y should block horizontal panning");
+}
+
+#[test]
+fn manipulation_allows_panning_on_both_axes() {
+    let mut doc = scroller_doc("manipulation");
+    let (x, _) = pan(&mut doc, 60.0, 0.0);
+    assert!(
+        x > 0.0,
+        "touch-action:manipulation should allow horizontal panning"
+    );
+
+    let mut doc = scroller_doc("manipulation");
+    let (_, y) = pan(&mut doc, 0.0, 60.0);
+    assert!(
+        y > 0.0,
+        "touch-action:manipulation should allow vertical panning"
+    );
+}

--- a/tests/blitz-tests/tests/touch_action.rs
+++ b/tests/blitz-tests/tests/touch_action.rs
@@ -133,6 +133,35 @@ fn pan_y_allows_only_vertical() {
     assert_eq!(x, 0.0, "touch-action:pan-y should block horizontal panning");
 }
 
+/// `touch-action` restrictions on ancestors *above* the scroll container which handles the pan
+/// must not apply: the ancestor walk stops at the nearest scroller for the axis.
+#[test]
+fn ancestor_restriction_stops_at_scroll_container() {
+    // An outer `pan-y` restriction must not block horizontal panning of a nested scroller.
+    let mut outer_restricted = doc(r#"<html><body style="margin:0; touch-action:pan-y;">
+            <div id="scroller" style="overflow:scroll; width:200px; height:200px;">
+                <div style="width:400px; height:400px;"></div>
+            </div>
+        </body></html>"#);
+    let (x, _) = pan(&mut outer_restricted, 60.0, 0.0);
+    assert!(
+        x > 0.0,
+        "outer touch-action:pan-y should not block horizontal panning of a nested scroller"
+    );
+
+    // But a restriction on the scroll container itself (or its descendants) still applies.
+    let mut scroller_restricted = doc(r#"<html><body style="margin:0;">
+            <div id="scroller" style="overflow:scroll; width:200px; height:200px; touch-action:pan-y;">
+                <div style="width:400px; height:400px;"></div>
+            </div>
+        </body></html>"#);
+    let (x, _) = pan(&mut scroller_restricted, 60.0, 0.0);
+    assert_eq!(
+        x, 0.0,
+        "touch-action:pan-y on the scroller itself should block horizontal panning"
+    );
+}
+
 #[test]
 fn manipulation_allows_panning_on_both_axes() {
     let mut doc = scroller_doc("manipulation");

--- a/tests/blitz-tests/tests/touch_action.rs
+++ b/tests/blitz-tests/tests/touch_action.rs
@@ -62,7 +62,7 @@ fn pan(doc: &mut HtmlDocument, dx: f32, dy: f32) -> (f64, f64) {
     doc.handle_ui_event(UiEvent::PointerUp(finger_event(x0, y0)));
 
     let scroller = doc.query_selector("#scroller").unwrap().expect("#scroller");
-    let offset = doc.get_node(scroller).unwrap().scroll_offset;
+    let offset = doc.get_node(scroller).unwrap().scroll_offset();
     (offset.x, offset.y)
 }
 


### PR DESCRIPTION
Implemented for the touch functionality we support, but blocked on enabling the property in Stylo
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🕐 Outdated | [`a4d5571`](https://github.com/DioxusLabs/blitz/pull/485/commits/a4d5571af8cf24af4eda051cde84c66acc9ff1df) (HEAD is `5b5f249`) |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/485?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32255475942).</sub>
<!-- wpt-results-end -->
