### PR TITLE
Implement `border-style`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,7 @@ dependencies = [
  "kurbo",
  "parley",
  "peniko",
+ "smallvec",
  "stylo",
  "taffy",
  "tracing",

--- a/packages/blitz-paint/Cargo.toml
+++ b/packages/blitz-paint/Cargo.toml
@@ -40,4 +40,5 @@ kurbo = { workspace = true }
 usvg = { workspace = true, optional = true }
 
 # Other dependencies
+smallvec = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/packages/blitz-paint/src/kurbo_css/css_box.rs
+++ b/packages/blitz-paint/src/kurbo_css/css_box.rs
@@ -139,6 +139,14 @@ impl CssBox {
         path
     }
 
+    /// Whether any corner of this box has a non-zero border radius.
+    pub fn has_border_radius(&self) -> bool {
+        let r = &self.border_radii;
+        [r.top_left, r.top_right, r.bottom_right, r.bottom_left]
+            .iter()
+            .any(|radius| radius.x > 0.0 || radius.y > 0.0)
+    }
+
     /// Construct a new [`CssBox`] representing a "slice" of this box's border,
     /// running from `start_frac` to `end_frac` of the border width (measured as
     /// a fraction from the outer border-box edge inwards).

--- a/packages/blitz-paint/src/kurbo_css/css_box.rs
+++ b/packages/blitz-paint/src/kurbo_css/css_box.rs
@@ -139,6 +139,54 @@ impl CssBox {
         path
     }
 
+    /// Construct a new [`CssBox`] representing a "slice" of this box's border,
+    /// running from `start_frac` to `end_frac` of the border width (measured as
+    /// a fraction from the outer border-box edge inwards).
+    ///
+    /// The returned box's border region is exactly the requested slice, so
+    /// [`CssBox::border_edge_shape`] can then be used to render it. This is used
+    /// to draw the two lines of a `double` border.
+    pub fn border_slice(&self, start_frac: f64, end_frac: f64) -> CssBox {
+        use Corner::*;
+
+        let scale_insets = |frac: f64| Insets {
+            x0: self.border_width.x0 * frac,
+            y0: self.border_width.y0 * frac,
+            x1: self.border_width.x1 * frac,
+            y1: self.border_width.y1 * frac,
+        };
+
+        let start_insets = scale_insets(start_frac);
+        let slice_border = scale_insets(end_frac - start_frac);
+
+        // Move the outer edge of the box inwards to the start of the slice.
+        let slice_border_box = self.border_box - start_insets;
+
+        // Border radii shrink as we move inwards through the border, matching the
+        // model used when computing inner (padding/content) box radii.
+        let reduce = |radius: Vec2, corner: Corner| {
+            let inset = get_corner_insets(start_insets, corner);
+            Vec2 {
+                x: (radius.x - inset.x).max(0.0),
+                y: (radius.y - inset.y).max(0.0),
+            }
+        };
+        let slice_radii = NonUniformRoundedRectRadii {
+            top_left: reduce(self.border_radii.top_left, TopLeft),
+            top_right: reduce(self.border_radii.top_right, TopRight),
+            bottom_right: reduce(self.border_radii.bottom_right, BottomRight),
+            bottom_left: reduce(self.border_radii.bottom_left, BottomLeft),
+        };
+
+        CssBox::new(
+            slice_border_box,
+            slice_border,
+            Insets::ZERO,
+            0.0,
+            slice_radii,
+        )
+    }
+
     /// Construct a bezpath drawing the outline
     pub fn outline(&self) -> BezPath {
         let mut path = BezPath::new();

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -10,26 +10,13 @@ use style::{
 
 use crate::{color::ToColorColor as _, kurbo_css::Edge, render::ElementCx};
 
-/// The WCAG relative luminance of a colour (weighted sum of the linearised sRGB
-/// components), matching Chrome's `color_utils::GetRelativeLuminance4f`. Alpha is
-/// ignored.
-fn relative_luminance(color: Color) -> f32 {
-    fn linearize(c: f32) -> f32 {
-        if c <= 0.04045 {
-            c / 12.92
-        } else {
-            ((c + 0.055) / 1.055).powf(2.4)
-        }
-    }
-    let [r, g, b, _] = color.components;
-    0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
-}
-
 /// The WCAG contrast ratio (>= 1) between two colours, matching Chrome's
 /// `color_utils::GetContrastRatio`.
 fn contrast_ratio(a: Color, b: Color) -> f32 {
-    let la = relative_luminance(a) + 0.05;
-    let lb = relative_luminance(b) + 0.05;
+    // `relative_luminance` is defined on `OpaqueColor`; discard the alpha (which
+    // it ignores anyway) with `split`.
+    let la = a.split().0.relative_luminance() + 0.05;
+    let lb = b.split().0.relative_luminance() + 0.05;
     if la > lb { la / lb } else { lb / la }
 }
 

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -25,6 +25,14 @@ fn relative_luminance(color: Color) -> f32 {
     0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
 }
 
+/// The WCAG contrast ratio (>= 1) between two colours, matching Chrome's
+/// `color_utils::GetContrastRatio`.
+fn contrast_ratio(a: Color, b: Color) -> f32 {
+    let la = relative_luminance(a) + 0.05;
+    let lb = relative_luminance(b) + 0.05;
+    if la > lb { la / lb } else { lb / la }
+}
+
 /// A darker version of a colour (mirrors WebKit/Blink's `Color::Dark`): the
 /// brightest channel is reduced by a fixed amount and the others scaled to match,
 /// preserving hue.
@@ -58,33 +66,34 @@ fn lighten(color: Color) -> Color {
 /// the bottom/right edges the "darker" shade (`inset` is the reverse). The exact
 /// shading matches Chrome's `CalculateInsetOutsetColor`:
 ///
-/// * Very dark colours are lightened on both edges (once on the darker edge,
-///   twice on the lighter edge) to keep enough contrast to read as 3D.
-/// * Otherwise the darker edge is darkened, and the lighter edge is lightened
-///   unless the colour is already very light (in which case it's left unchanged).
+/// * The darker edge is always darkened.
+/// * The lighter edge keeps the base colour unchanged, *except* for colours dark
+///   enough that the darkened edge wouldn't have enough contrast against the base
+///   colour, which are lightened instead so the bevel stays visible.
 fn beveled_edge_color(color: Color, edge: Edge, inset: bool) -> Color {
-    // Luminance thresholds from Chrome: rgb(32, 32, 32) and rgb(235, 235, 235).
-    const BASE_DARK_LUMINANCE: f32 = 0.014443844;
-    const BASE_LIGHT_LUMINANCE: f32 = 0.83077;
-
     let top_or_left = matches!(edge, Edge::Top | Edge::Left);
     let should_darken = top_or_left == inset;
 
-    let luminance = relative_luminance(color);
-    if luminance <= BASE_DARK_LUMINANCE {
-        // Special-case very dark colours to give them extra contrast.
-        if should_darken {
-            lighten(color)
-        } else {
-            lighten(lighten(color))
-        }
-    } else if should_darken {
-        darken(color)
-    } else if luminance > BASE_LIGHT_LUMINANCE {
-        // Lightening a very light colour is invisible, so leave it unchanged.
-        color
-    } else {
+    let dark_color = darken(color);
+    if should_darken {
+        return dark_color;
+    }
+
+    // Lighter edge. Chrome uses the base colour as-is unless the colour is dark
+    // enough that the darkened edge lacks contrast against it. The red/green
+    // shortcut mirrors Chrome: for those colours the contrast is always
+    // sufficient, so the base colour is used without a contrast check.
+    let [r, g, _, _] = color.components;
+    if r >= 150.0 / 255.0 || g >= 92.0 / 255.0 {
+        return color;
+    }
+
+    // Lighten only when the darkened edge would be too low-contrast to read.
+    const MIN_CONTRAST_RATIO: f32 = 1.75;
+    if contrast_ratio(color, dark_color) < MIN_CONTRAST_RATIO {
         lighten(color)
+    } else {
+        color
     }
 }
 

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -224,17 +224,25 @@ impl ElementCx<'_, '_> {
         let mut path = BezPath::new();
 
         if dotted {
-            // Dots are circles whose diameter equals the border thickness. They
-            // are distributed evenly, each centred within an equally sized cell so
-            // that the gaps at either end of the edge are symmetrical.
+            // Dots are circles whose diameter equals the border thickness. A dot is
+            // anchored in each corner (both ends of the edge, inset by the radius so
+            // the dot sits snugly in the corner) and the remaining dots are spread
+            // evenly between them, so the corners always contain a dot.
             let radius = thickness / 2.0;
-            let cell_count = (length / (2.0 * thickness)).round().max(1.0);
-            let cell = length / cell_count;
-            let mut k = 0.0;
-            while k < cell_count {
-                let center = dot_center((k + 0.5) * cell);
+            let span = length - thickness;
+            if span <= 0.0 {
+                // Edge too short to fit two dots; place a single centred dot.
+                let center = dot_center(length / 2.0);
                 path.extend(Circle::new(center, radius).path_elements(0.1));
-                k += 1.0;
+            } else {
+                // Aim for a centre-to-centre spacing of about two dot diameters,
+                // then adjust it so the first and last dots land in the corners.
+                let gaps = (span / (2.0 * thickness)).round().max(1.0) as usize;
+                let spacing = span / gaps as f64;
+                for i in 0..=gaps {
+                    let center = dot_center(radius + i as f64 * spacing);
+                    path.extend(Circle::new(center, radius).path_elements(0.1));
+                }
             }
         } else {
             // Dashes are rectangles. They are distributed so that the edge both

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -47,10 +47,43 @@ impl ElementCx<'_, '_> {
                 BorderStyle::Dotted => self.draw_dashed_border_edge(scene, edge, color, true),
                 BorderStyle::Dashed => self.draw_dashed_border_edge(scene, edge, color, false),
 
-                // Solid (and, for now, the unimplemented 3D/double styles) are
-                // rendered as a solid fill of the edge's region.
+                // A double border is two solid lines separated by a gap, splitting
+                // the border width into three equal parts (outer line / gap / inner
+                // line). Both lines share a color, so both rings are placed into a
+                // single path and batched together with the other solid edges.
+                BorderStyle::Double => {
+                    let edge_width = match edge {
+                        Edge::Top => self.frame.border_width.y0,
+                        Edge::Bottom => self.frame.border_width.y1,
+                        Edge::Left => self.frame.border_width.x0,
+                        Edge::Right => self.frame.border_width.x1,
+                    };
+
+                    // Needs at least 3px (one device pixel per line and per gap) to
+                    // render as two lines; thinner borders fall back to a solid
+                    // fill, matching browser behaviour.
+                    let path = if edge_width < 3.0 * self.scale {
+                        self.frame.border_edge_shape(edge)
+                    } else {
+                        let mut path = self
+                            .frame
+                            .border_slice(0.0, 1.0 / 3.0)
+                            .border_edge_shape(edge);
+                        path.extend(
+                            &self
+                                .frame
+                                .border_slice(2.0 / 3.0, 1.0)
+                                .border_edge_shape(edge),
+                        );
+                        path
+                    };
+                    borders[count] = (color, Some(path));
+                    count += 1;
+                }
+
+                // Solid (and, for now, the unimplemented 3D styles) are rendered as
+                // a solid fill of the edge's region.
                 BorderStyle::Solid
-                | BorderStyle::Double
                 | BorderStyle::Groove
                 | BorderStyle::Ridge
                 | BorderStyle::Inset

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -9,6 +9,37 @@ use style::{
 
 use crate::{color::ToColorColor as _, kurbo_css::Edge, render::ElementCx};
 
+/// Darken a colour by halving its (sRGB) RGB components. Used to derive the
+/// shaded edges of the 3D border styles (`inset`/`outset`/`groove`/`ridge`).
+fn darken(color: Color) -> Color {
+    let [r, g, b, a] = color.components;
+    Color::new([r * 0.5, g * 0.5, b * 0.5, a])
+}
+
+/// The colour of a single edge of an `inset`/`outset` border.
+///
+/// An `outset` border is raised: it keeps the base colour on the top/left edges
+/// and darkens the bottom/right edges. `inset` is the reverse (sunken).
+fn beveled_edge_color(color: Color, edge: Edge, inset: bool) -> Color {
+    let top_or_left = matches!(edge, Edge::Top | Edge::Left);
+    if top_or_left ^ inset {
+        color
+    } else {
+        darken(color)
+    }
+}
+
+/// The (outer half, inner half) colours of a single edge of a `groove`/`ridge`
+/// border.
+///
+/// A `groove` looks carved into the page: its outer half is shaded like `inset`
+/// and its inner half like `outset`. `ridge` is the reverse (raised).
+fn grooved_edge_colors(color: Color, edge: Edge, ridge: bool) -> (Color, Color) {
+    let outer = beveled_edge_color(color, edge, !ridge);
+    let inner = beveled_edge_color(color, edge, ridge);
+    (outer, inner)
+}
+
 impl ElementCx<'_, '_> {
     /// Draw all borders for a node
     pub(crate) fn draw_border(&self, scene: &mut impl PaintScene) {
@@ -16,13 +47,10 @@ impl ElementCx<'_, '_> {
         let border = style.get_border();
         let current_color = style.clone_color();
 
-        let mut borders: [(Color, Option<BezPath>); 4] = [
-            (Color::TRANSPARENT, None),
-            (Color::TRANSPARENT, None),
-            (Color::TRANSPARENT, None),
-            (Color::TRANSPARENT, None),
-        ];
-        let mut count = 0;
+        // (colour, path) pairs to be filled. Several entries may share a colour;
+        // they are grouped before filling so that adjacent same-coloured regions
+        // are drawn together, avoiding anti-aliasing seams between them.
+        let mut borders: Vec<(Color, BezPath)> = Vec::new();
 
         for &edge in &[Edge::Top, Edge::Right, Edge::Bottom, Edge::Left] {
             let (color, edge_style) = match edge {
@@ -50,19 +78,12 @@ impl ElementCx<'_, '_> {
                 // A double border is two solid lines separated by a gap, splitting
                 // the border width into three equal parts (outer line / gap / inner
                 // line). Both lines share a color, so both rings are placed into a
-                // single path and batched together with the other solid edges.
+                // single path.
                 BorderStyle::Double => {
-                    let edge_width = match edge {
-                        Edge::Top => self.frame.border_width.y0,
-                        Edge::Bottom => self.frame.border_width.y1,
-                        Edge::Left => self.frame.border_width.x0,
-                        Edge::Right => self.frame.border_width.x1,
-                    };
-
                     // Needs at least 3px (one device pixel per line and per gap) to
                     // render as two lines; thinner borders fall back to a solid
                     // fill, matching browser behaviour.
-                    let path = if edge_width < 3.0 * self.scale {
+                    let path = if self.edge_width(edge) < 3.0 * self.scale {
                         self.frame.border_edge_shape(edge)
                     } else {
                         let mut path = self
@@ -77,58 +98,73 @@ impl ElementCx<'_, '_> {
                         );
                         path
                     };
-                    borders[count] = (color, Some(path));
-                    count += 1;
+                    borders.push((color, path));
                 }
 
-                // Solid (and, for now, the unimplemented 3D styles) are rendered as
-                // a solid fill of the edge's region.
-                BorderStyle::Solid
-                | BorderStyle::Groove
-                | BorderStyle::Ridge
-                | BorderStyle::Inset
-                | BorderStyle::Outset => {
-                    borders[count] = (color, Some(self.frame.border_edge_shape(edge)));
-                    count += 1;
+                // `inset`/`outset` are solid, but each edge is shaded lighter or
+                // darker to give a bevelled (3D) appearance.
+                BorderStyle::Inset | BorderStyle::Outset => {
+                    let inset = edge_style == BorderStyle::Inset;
+                    let shade = beveled_edge_color(color, edge, inset);
+                    borders.push((shade, self.frame.border_edge_shape(edge)));
+                }
+
+                // `groove`/`ridge` split each edge into an outer and an inner half,
+                // each shaded as if it were `inset`/`outset`, producing a carved or
+                // raised ridge.
+                BorderStyle::Groove | BorderStyle::Ridge => {
+                    let ridge = edge_style == BorderStyle::Ridge;
+                    let (outer, inner) = grooved_edge_colors(color, edge, ridge);
+                    borders.push((
+                        outer,
+                        self.frame.border_slice(0.0, 0.5).border_edge_shape(edge),
+                    ));
+                    borders.push((
+                        inner,
+                        self.frame.border_slice(0.5, 1.0).border_edge_shape(edge),
+                    ));
+                }
+
+                // Solid fills the whole edge region with the border colour.
+                BorderStyle::Solid => {
+                    borders.push((color, self.frame.border_edge_shape(edge)));
                 }
             }
         }
 
-        if count == 0 {
+        if borders.is_empty() {
             return;
         }
 
-        // Group together identical colors by sorting.
-        let active_slice = &mut borders[0..count];
-        active_slice.sort_unstable_by(|a, b| {
+        // Group together identical colors by sorting, then fill each group as a
+        // single path.
+        borders.sort_unstable_by(|a, b| {
             a.0.components
                 .partial_cmp(&b.0.components)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
-        let mut start_border_index = 0;
-        while start_border_index < count {
-            let color = borders[start_border_index].0;
-            let mut next_border_index = start_border_index + 1;
-            let has_multiple_edges =
-                next_border_index < count && borders[next_border_index].0 == color;
-            if has_multiple_edges {
-                let mut border_path = borders[start_border_index].1.take().unwrap();
-                while next_border_index < count && borders[next_border_index].0 == color {
-                    border_path.extend(&borders[next_border_index].1.take().unwrap());
-                    next_border_index += 1;
-                }
-                scene.fill(Fill::NonZero, self.transform, color, None, &border_path);
-            } else {
-                scene.fill(
-                    Fill::NonZero,
-                    self.transform,
-                    color,
-                    None,
-                    borders[start_border_index].1.as_ref().unwrap(),
-                );
+        let mut start = 0;
+        while start < borders.len() {
+            let color = borders[start].0;
+            let mut path = std::mem::take(&mut borders[start].1);
+            let mut next = start + 1;
+            while next < borders.len() && borders[next].0 == color {
+                path.extend(&borders[next].1);
+                next += 1;
             }
-            start_border_index = next_border_index;
+            scene.fill(Fill::NonZero, self.transform, color, None, &path);
+            start = next;
+        }
+    }
+
+    /// The border width (in device pixels) of a single edge.
+    fn edge_width(&self, edge: Edge) -> f64 {
+        match edge {
+            Edge::Top => self.frame.border_width.y0,
+            Edge::Bottom => self.frame.border_width.y1,
+            Edge::Left => self.frame.border_width.x0,
+            Edge::Right => self.frame.border_width.x1,
         }
     }
 

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -10,23 +10,63 @@ use style::{
 
 use crate::{color::ToColorColor as _, kurbo_css::Edge, render::ElementCx};
 
-/// Darken a colour by halving its (sRGB) RGB components. Used to derive the
-/// shaded edges of the 3D border styles (`inset`/`outset`/`groove`/`ridge`).
+/// Whether a colour is closer to black than to white (Euclidean distance in
+/// gamma-encoded sRGB), i.e. a "dark" colour.
+fn is_dark(color: Color) -> bool {
+    let [r, g, b, _] = color.components;
+    let to_black = r * r + g * g + b * b;
+    let to_white = (1.0 - r).powi(2) + (1.0 - g).powi(2) + (1.0 - b).powi(2);
+    to_black < to_white
+}
+
+/// A darker version of a colour (mirrors WebKit/Blink's `Color::Dark`): the
+/// brightest channel is reduced by a fixed amount and the others scaled to match,
+/// preserving hue.
 fn darken(color: Color) -> Color {
     let [r, g, b, a] = color.components;
-    Color::new([r * 0.5, g * 0.5, b * 0.5, a])
+    let v = r.max(g).max(b);
+    if v == 0.0 {
+        return color;
+    }
+    let multiplier = ((v - 0.33) / v).max(0.0);
+    Color::new([r * multiplier, g * multiplier, b * multiplier, a])
+}
+
+/// A lighter version of a colour (mirrors WebKit/Blink's `Color::Light`): the
+/// brightest channel is increased by a fixed amount and the others scaled to
+/// match, preserving hue.
+fn lighten(color: Color) -> Color {
+    let [r, g, b, a] = color.components;
+    let v = r.max(g).max(b);
+    if v == 0.0 {
+        // Pure black: WebKit uses a fixed dark grey (0x545454).
+        return Color::new([0.33, 0.33, 0.33, a]);
+    }
+    let multiplier = (v + 0.33).min(1.0) / v;
+    Color::new([r * multiplier, g * multiplier, b * multiplier, a])
 }
 
 /// The colour of a single edge of an `inset`/`outset` border.
 ///
-/// An `outset` border is raised: it keeps the base colour on the top/left edges
-/// and darkens the bottom/right edges. `inset` is the reverse (sunken).
+/// An `outset` border is raised: the top/left edges use the "lighter" shade and
+/// the bottom/right edges the "darker" shade (`inset` is the reverse). To keep a
+/// visible 3D effect the base colour is only darkened when it's light enough, and
+/// only lightened when it's dark enough (matching WebKit/Blink); otherwise the
+/// base colour is used unchanged.
 fn beveled_edge_color(color: Color, edge: Edge, inset: bool) -> Color {
     let top_or_left = matches!(edge, Edge::Top | Edge::Left);
-    if top_or_left ^ inset {
-        color
+    let should_darken = top_or_left == inset;
+
+    if should_darken {
+        // Darkening a dark colour is invisible, so only darken lighter colours.
+        if is_dark(color) { color } else { darken(color) }
     } else {
-        darken(color)
+        // Lightening a light colour is invisible, so only lighten darker colours.
+        if is_dark(color) {
+            lighten(color)
+        } else {
+            color
+        }
     }
 }
 

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -127,8 +127,8 @@ impl ElementCx<'_, '_> {
 
                 // Dashed and dotted edges are drawn immediately as their own
                 // (clipped) shapes rather than being batched with the solid edges.
-                BorderStyle::Dotted => self.draw_dashed_border_edge(scene, edge, color, true),
-                BorderStyle::Dashed => self.draw_dashed_border_edge(scene, edge, color, false),
+                BorderStyle::Dotted => self.draw_dotted_border_edge(scene, edge, color),
+                BorderStyle::Dashed => self.draw_dashed_border_edge(scene, edge, color),
 
                 // A double border is two solid lines separated by a gap, splitting
                 // the border width into three equal parts (outer line / gap / inner
@@ -223,75 +223,142 @@ impl ElementCx<'_, '_> {
         }
     }
 
-    /// Draw a single `dashed` or `dotted` border edge.
+    /// Draw a single `dashed` border edge.
     ///
-    /// The dashes/dots are generated as filled shapes running along the centre of
-    /// the edge and are drawn clipped to the edge's region (the same trapezoid
-    /// used by the solid path). Clipping means the corners are mitred correctly,
-    /// adjacent edges of different styles/colors don't overlap, and any
+    /// The dashes are produced by stroking the centre line of the border with a
+    /// dash pattern (butt caps give them flat, square ends). Everything is clipped
+    /// to the edge's region (the same trapezoid used by the solid path) so corners
+    /// are mitred, adjacent edges of different colors don't overlap, and any
     /// border-radius is respected.
-    fn draw_dashed_border_edge(
-        &self,
-        scene: &mut impl PaintScene,
-        edge: Edge,
-        color: Color,
-        dotted: bool,
-    ) {
-        let bb = self.frame.border_box;
-        let bw = self.frame.border_width;
-
-        // `thickness` is the width of this border side, `length` is the distance
-        // the dashes run along the edge (measured along the outer border box).
-        let (thickness, length): (f64, f64) = match edge {
-            Edge::Top => (bw.y0, bb.width()),
-            Edge::Bottom => (bw.y1, bb.width()),
-            Edge::Left => (bw.x0, bb.height()),
-            Edge::Right => (bw.x1, bb.height()),
-        };
-
-        if thickness <= 0.0 || length <= 0.0 {
+    fn draw_dashed_border_edge(&self, scene: &mut impl PaintScene, edge: Edge, color: Color) {
+        let thickness = self.edge_width(edge);
+        if thickness <= 0.0 {
             return;
         }
 
-        // When the box has rounded corners the dashes/dots must follow the curve,
-        // so they're stroked/placed along the rounded centre line of the border
-        // instead of along straight per-edge lines.
-        if self.frame.has_border_radius() {
-            self.draw_rounded_dashed_border_edge(scene, edge, color, dotted, thickness);
-            return;
-        }
+        let (dash_ratio, gap_ratio) = dashed_ratios(thickness, self.scale);
 
-        // Build a rectangle for a dash spanning `[start, end]` along the run,
-        // covering the full thickness of the border on the cross axis.
-        let dash_rect = |start: f64, end: f64| -> Rect {
-            match edge {
-                Edge::Top => Rect::new(bb.x0 + start, bb.y0, bb.x0 + end, bb.y0 + thickness),
-                Edge::Bottom => Rect::new(bb.x0 + start, bb.y1 - thickness, bb.x0 + end, bb.y1),
-                Edge::Left => Rect::new(bb.x0, bb.y0 + start, bb.x0 + thickness, bb.y0 + end),
-                Edge::Right => Rect::new(bb.x1 - thickness, bb.y0 + start, bb.x1, bb.y0 + end),
+        // Work out the centre line to stroke and the dash/gap lengths along it.
+        let (centerline, dash, gap) = if self.frame.has_border_radius() {
+            // Rounded corners: stroke the rounded centre line running through the
+            // whole perimeter. Every edge uses the same centre line and pattern, so
+            // dashes stay continuous and aligned as they wrap around each corner.
+            // Dash and gap keep their ratio, sized so a whole number of periods fit
+            // exactly around the perimeter (kurbo merges the dash across the seam).
+            let mut centerline = self.frame.border_slice(0.0, 0.5).padding_box_path();
+            centerline.close_path();
+            let perimeter = centerline.perimeter(0.1);
+            if perimeter <= 0.0 {
+                return;
             }
-        };
-
-        // Centre point of a dot placed `along` the run (on the centre line of the
-        // border thickness).
-        let dot_center = |along: f64| -> Point {
+            let period0 = (dash_ratio + gap_ratio) * thickness;
+            let count = (perimeter / period0).round().max(1.0);
+            let period = perimeter / count;
+            let dash = period * dash_ratio / (dash_ratio + gap_ratio);
+            (centerline, dash, period - dash)
+        } else {
+            // Square corners: stroke a straight line through the middle of the edge,
+            // corner to corner. Dash and gap keep their ratio but are scaled so the
+            // edge both starts and ends with a dash (covering the corners).
+            let bb = self.frame.border_box;
             let half = thickness / 2.0;
-            match edge {
-                Edge::Top => Point::new(bb.x0 + along, bb.y0 + half),
-                Edge::Bottom => Point::new(bb.x0 + along, bb.y1 - half),
-                Edge::Left => Point::new(bb.x0 + half, bb.y0 + along),
-                Edge::Right => Point::new(bb.x1 - half, bb.y0 + along),
+            let (start, end, length) = match edge {
+                Edge::Top => (
+                    Point::new(bb.x0, bb.y0 + half),
+                    Point::new(bb.x1, bb.y0 + half),
+                    bb.width(),
+                ),
+                Edge::Bottom => (
+                    Point::new(bb.x0, bb.y1 - half),
+                    Point::new(bb.x1, bb.y1 - half),
+                    bb.width(),
+                ),
+                Edge::Left => (
+                    Point::new(bb.x0 + half, bb.y0),
+                    Point::new(bb.x0 + half, bb.y1),
+                    bb.height(),
+                ),
+                Edge::Right => (
+                    Point::new(bb.x1 - half, bb.y0),
+                    Point::new(bb.x1 - half, bb.y1),
+                    bb.height(),
+                ),
+            };
+            if length <= 0.0 {
+                return;
             }
+            let dash0 = dash_ratio * thickness;
+            let gap0 = gap_ratio * thickness;
+            // `count` dashes with `count - 1` gaps between them.
+            let count = ((length + gap0) / (dash0 + gap0)).round().max(1.0);
+            let r = dash_ratio / gap_ratio;
+            let gap = length / (count * r + count - 1.0);
+
+            let mut line = BezPath::new();
+            line.move_to(start);
+            line.line_to(end);
+            (line, r * gap, gap)
         };
+
+        let stroke = Stroke::new(thickness)
+            .with_caps(Cap::Butt)
+            .with_dashes(0.0, [dash, gap]);
+        let clip = self.frame.border_edge_shape(edge);
+        scene.push_clip_layer(self.transform, &clip);
+        scene.stroke(&stroke, self.transform, color, None, &centerline);
+        scene.pop_layer();
+    }
+
+    /// Draw a single `dotted` border edge.
+    ///
+    /// Dots are filled circles (diameter == border thickness). Unlike dashes they
+    /// can't be produced by stroking, because kurbo doesn't emit zero-length dashes
+    /// (so a round-capped dash pattern would render nothing); drawing them
+    /// explicitly also lets us anchor a dot in each square corner. Everything is
+    /// clipped to the edge's region, as for the other styles.
+    fn draw_dotted_border_edge(&self, scene: &mut impl PaintScene, edge: Edge, color: Color) {
+        let thickness = self.edge_width(edge);
+        if thickness <= 0.0 {
+            return;
+        }
+        let radius = thickness / 2.0;
 
         let mut path = BezPath::new();
+        if self.frame.has_border_radius() {
+            // Rounded corners: dots spaced evenly around the rounded centre line so
+            // the ring wraps seamlessly around the corners.
+            let mut centerline = self.frame.border_slice(0.0, 0.5).padding_box_path();
+            centerline.close_path();
+            let perimeter = centerline.perimeter(0.1);
+            if perimeter <= 0.0 {
+                return;
+            }
+            let count = (perimeter / (2.0 * thickness)).round().max(1.0);
+            let spacing = perimeter / count;
+            for center in sample_points_along_path(&centerline, spacing, count as usize) {
+                path.extend(Circle::new(center, radius).path_elements(0.1));
+            }
+        } else {
+            // Square corners: a dot is anchored in each corner (both ends of the
+            // edge, inset by the radius so it sits snugly in the corner) and the
+            // rest are spread evenly between them.
+            let bb = self.frame.border_box;
+            let length = match edge {
+                Edge::Top | Edge::Bottom => bb.width(),
+                Edge::Left | Edge::Right => bb.height(),
+            };
+            if length <= 0.0 {
+                return;
+            }
+            let dot_center = |along: f64| -> Point {
+                match edge {
+                    Edge::Top => Point::new(bb.x0 + along, bb.y0 + radius),
+                    Edge::Bottom => Point::new(bb.x0 + along, bb.y1 - radius),
+                    Edge::Left => Point::new(bb.x0 + radius, bb.y0 + along),
+                    Edge::Right => Point::new(bb.x1 - radius, bb.y0 + along),
+                }
+            };
 
-        if dotted {
-            // Dots are circles whose diameter equals the border thickness. A dot is
-            // anchored in each corner (both ends of the edge, inset by the radius so
-            // the dot sits snugly in the corner) and the remaining dots are spread
-            // evenly between them, so the corners always contain a dot.
-            let radius = thickness / 2.0;
             let span = length - thickness;
             if span <= 0.0 {
                 // Edge too short to fit two dots; place a single centred dot.
@@ -307,91 +374,11 @@ impl ElementCx<'_, '_> {
                     path.extend(Circle::new(center, radius).path_elements(0.1));
                 }
             }
-        } else {
-            // Dashes are rectangles distributed so the edge both starts and ends
-            // with a dash (covering the corners). The dash and gap lengths keep a
-            // fixed ratio (matching Chrome) but are scaled to fit the edge exactly.
-            let (dash_ratio, gap_ratio) = dashed_ratios(thickness, self.scale);
-            let dash0 = dash_ratio * thickness;
-            let gap0 = gap_ratio * thickness;
-
-            // `count` dashes with `count - 1` gaps between them.
-            let count = ((length + gap0) / (dash0 + gap0)).round().max(1.0);
-            let r = dash_ratio / gap_ratio;
-            let gap = length / (count * r + count - 1.0);
-            let dash = r * gap;
-
-            let mut i = 0.0;
-            while i < count {
-                let start = i * (dash + gap);
-                path.extend(dash_rect(start, start + dash).path_elements(0.1));
-                i += 1.0;
-            }
         }
 
         let clip = self.frame.border_edge_shape(edge);
         scene.push_clip_layer(self.transform, &clip);
         scene.fill(Fill::NonZero, self.transform, color, None, &path);
-        scene.pop_layer();
-    }
-
-    /// Draw the `dashed`/`dotted` portion of a single edge when the box has a
-    /// border-radius, so that the dashes/dots follow the rounded corners.
-    ///
-    /// The dashes are stroked (and the dots placed) along the border's rounded
-    /// centre line, which runs through the whole perimeter. Each edge clips the
-    /// result to its own region (as in the straight case), but because every edge
-    /// uses the same centre line and pattern the dashes/dots stay continuous and
-    /// aligned as they wrap around each corner.
-    fn draw_rounded_dashed_border_edge(
-        &self,
-        scene: &mut impl PaintScene,
-        edge: Edge,
-        color: Color,
-        dotted: bool,
-        thickness: f64,
-    ) {
-        // Rounded rectangle running through the middle of the border.
-        let mut centerline = self.frame.border_slice(0.0, 0.5).padding_box_path();
-        centerline.close_path();
-
-        let perimeter = centerline.perimeter(0.1);
-        if perimeter <= 0.0 {
-            return;
-        }
-
-        let clip = self.frame.border_edge_shape(edge);
-        scene.push_clip_layer(self.transform, &clip);
-
-        if dotted {
-            // Dots are circles (diameter == border thickness) spaced evenly around
-            // the perimeter. Even spacing means the ring of dots wraps seamlessly.
-            let count = (perimeter / (2.0 * thickness)).round().max(1.0);
-            let spacing = perimeter / count;
-            let radius = thickness / 2.0;
-
-            let mut path = BezPath::new();
-            for center in sample_points_along_path(&centerline, spacing, count as usize) {
-                path.extend(Circle::new(center, radius).path_elements(0.1));
-            }
-            scene.fill(Fill::NonZero, self.transform, color, None, &path);
-        } else {
-            // Dash and gap keep a fixed ratio (matching Chrome), sized so a whole
-            // number of dash+gap periods fit exactly around the perimeter (kurbo
-            // merges the dash across the seam). Butt caps give the dashes flat,
-            // square ends rather than the rounded ends of the default cap.
-            let (dash_ratio, gap_ratio) = dashed_ratios(thickness, self.scale);
-            let period0 = (dash_ratio + gap_ratio) * thickness;
-            let count = (perimeter / period0).round().max(1.0);
-            let period = perimeter / count;
-            let dash = period * dash_ratio / (dash_ratio + gap_ratio);
-            let gap = period - dash;
-            let stroke = Stroke::new(thickness)
-                .with_caps(Cap::Butt)
-                .with_dashes(0.0, [dash, gap]);
-            scene.stroke(&stroke, self.transform, color, None, &centerline);
-        }
-
         scene.pop_layer();
     }
 

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -40,6 +40,21 @@ fn grooved_edge_colors(color: Color, edge: Edge, ridge: bool) -> (Color, Color) 
     (outer, inner)
 }
 
+/// The `(dash, gap)` lengths of a dashed border, as multiples of the border
+/// thickness.
+///
+/// Matches Chrome: borders that are at least 3px use a 2:1 dash-to-gap ratio,
+/// while thinner borders use longer dashes and gaps (3:2) so they still read as
+/// dashes rather than dots or a solid line. `thickness` and `scale` are in device
+/// pixels; the 3px threshold is applied in CSS pixels.
+fn dashed_ratios(thickness: f64, scale: f64) -> (f64, f64) {
+    if thickness >= 3.0 * scale {
+        (2.0, 1.0)
+    } else {
+        (3.0, 2.0)
+    }
+}
+
 /// Return `count` points spaced `spacing` apart (by arc length) along `path`,
 /// starting at its beginning. Used to place dots along a rounded border.
 fn sample_points_along_path(path: &BezPath, spacing: f64, count: usize) -> Vec<Point> {
@@ -293,17 +308,24 @@ impl ElementCx<'_, '_> {
                 }
             }
         } else {
-            // Dashes are rectangles. They are distributed so that the edge both
-            // starts and ends with a dash (covering the corners), with the dashes
-            // and gaps all the same length.
-            let nominal = 2.0 * thickness;
-            let dash_count = ((length / nominal + 1.0) / 2.0).round().max(1.0);
-            let segment = length / (2.0 * dash_count - 1.0);
-            let mut k = 0.0;
-            while k < dash_count {
-                let start = 2.0 * k * segment;
-                path.extend(dash_rect(start, start + segment).path_elements(0.1));
-                k += 1.0;
+            // Dashes are rectangles distributed so the edge both starts and ends
+            // with a dash (covering the corners). The dash and gap lengths keep a
+            // fixed ratio (matching Chrome) but are scaled to fit the edge exactly.
+            let (dash_ratio, gap_ratio) = dashed_ratios(thickness, self.scale);
+            let dash0 = dash_ratio * thickness;
+            let gap0 = gap_ratio * thickness;
+
+            // `count` dashes with `count - 1` gaps between them.
+            let count = ((length + gap0) / (dash0 + gap0)).round().max(1.0);
+            let r = dash_ratio / gap_ratio;
+            let gap = length / (count * r + count - 1.0);
+            let dash = r * gap;
+
+            let mut i = 0.0;
+            while i < count {
+                let start = i * (dash + gap);
+                path.extend(dash_rect(start, start + dash).path_elements(0.1));
+                i += 1.0;
             }
         }
 
@@ -354,16 +376,19 @@ impl ElementCx<'_, '_> {
             }
             scene.fill(Fill::NonZero, self.transform, color, None, &path);
         } else {
-            // Dashes and gaps of equal length, sized so a whole number of them fit
-            // exactly around the perimeter (kurbo merges the dash across the seam).
-            // Butt caps give the dashes flat, square ends (like the straight-corner
-            // dashes) rather than the rounded ends of the default cap.
-            let nominal = 4.0 * thickness;
-            let count = (perimeter / nominal).round().max(1.0);
-            let dash = perimeter / count / 2.0;
+            // Dash and gap keep a fixed ratio (matching Chrome), sized so a whole
+            // number of dash+gap periods fit exactly around the perimeter (kurbo
+            // merges the dash across the seam). Butt caps give the dashes flat,
+            // square ends rather than the rounded ends of the default cap.
+            let (dash_ratio, gap_ratio) = dashed_ratios(thickness, self.scale);
+            let period0 = (dash_ratio + gap_ratio) * thickness;
+            let count = (perimeter / period0).round().max(1.0);
+            let period = perimeter / count;
+            let dash = period * dash_ratio / (dash_ratio + gap_ratio);
+            let gap = period - dash;
             let stroke = Stroke::new(thickness)
                 .with_caps(Cap::Butt)
-                .with_dashes(0.0, [dash, dash]);
+                .with_dashes(0.0, [dash, gap]);
             scene.stroke(&stroke, self.transform, color, None, &centerline);
         }
 

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -1,6 +1,6 @@
 use anyrender::PaintScene;
 use blitz_dom::node::SpecialElementData;
-use kurbo::{BezPath, Circle, Point, Rect, Shape as _};
+use kurbo::{BezPath, Cap, Circle, PathEl, Point, Rect, Shape as _, Stroke};
 use peniko::{Color, Fill};
 use style::{
     computed_values::border_collapse::T as BorderCollapse,
@@ -38,6 +38,46 @@ fn grooved_edge_colors(color: Color, edge: Edge, ridge: bool) -> (Color, Color) 
     let outer = beveled_edge_color(color, edge, !ridge);
     let inner = beveled_edge_color(color, edge, ridge);
     (outer, inner)
+}
+
+/// Return `count` points spaced `spacing` apart (by arc length) along `path`,
+/// starting at its beginning. Used to place dots along a rounded border.
+fn sample_points_along_path(path: &BezPath, spacing: f64, count: usize) -> Vec<Point> {
+    // Flatten to a polyline so we can walk it by arc length.
+    let mut poly: Vec<Point> = Vec::new();
+    kurbo::flatten(path.iter(), 0.1, |el| match el {
+        PathEl::MoveTo(p) | PathEl::LineTo(p) => poly.push(p),
+        PathEl::ClosePath => {
+            if let Some(&first) = poly.first() {
+                poly.push(first);
+            }
+        }
+        _ => {}
+    });
+
+    let mut points = Vec::with_capacity(count);
+    if poly.len() < 2 {
+        return points;
+    }
+
+    let mut seg = 0;
+    let mut seg_start = 0.0;
+    let mut seg_len = (poly[1] - poly[0]).hypot();
+    for i in 0..count {
+        let target = i as f64 * spacing;
+        while seg + 2 < poly.len() && target > seg_start + seg_len {
+            seg_start += seg_len;
+            seg += 1;
+            seg_len = (poly[seg + 1] - poly[seg]).hypot();
+        }
+        let t = if seg_len > 0.0 {
+            ((target - seg_start) / seg_len).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        points.push(poly[seg].lerp(poly[seg + 1], t));
+    }
+    points
 }
 
 impl ElementCx<'_, '_> {
@@ -198,6 +238,14 @@ impl ElementCx<'_, '_> {
             return;
         }
 
+        // When the box has rounded corners the dashes/dots must follow the curve,
+        // so they're stroked/placed along the rounded centre line of the border
+        // instead of along straight per-edge lines.
+        if self.frame.has_border_radius() {
+            self.draw_rounded_dashed_border_edge(scene, edge, color, dotted, thickness);
+            return;
+        }
+
         // Build a rectangle for a dash spanning `[start, end]` along the run,
         // covering the full thickness of the border on the cross axis.
         let dash_rect = |start: f64, end: f64| -> Rect {
@@ -262,6 +310,63 @@ impl ElementCx<'_, '_> {
         let clip = self.frame.border_edge_shape(edge);
         scene.push_clip_layer(self.transform, &clip);
         scene.fill(Fill::NonZero, self.transform, color, None, &path);
+        scene.pop_layer();
+    }
+
+    /// Draw the `dashed`/`dotted` portion of a single edge when the box has a
+    /// border-radius, so that the dashes/dots follow the rounded corners.
+    ///
+    /// The dashes are stroked (and the dots placed) along the border's rounded
+    /// centre line, which runs through the whole perimeter. Each edge clips the
+    /// result to its own region (as in the straight case), but because every edge
+    /// uses the same centre line and pattern the dashes/dots stay continuous and
+    /// aligned as they wrap around each corner.
+    fn draw_rounded_dashed_border_edge(
+        &self,
+        scene: &mut impl PaintScene,
+        edge: Edge,
+        color: Color,
+        dotted: bool,
+        thickness: f64,
+    ) {
+        // Rounded rectangle running through the middle of the border.
+        let mut centerline = self.frame.border_slice(0.0, 0.5).padding_box_path();
+        centerline.close_path();
+
+        let perimeter = centerline.perimeter(0.1);
+        if perimeter <= 0.0 {
+            return;
+        }
+
+        let clip = self.frame.border_edge_shape(edge);
+        scene.push_clip_layer(self.transform, &clip);
+
+        if dotted {
+            // Dots are circles (diameter == border thickness) spaced evenly around
+            // the perimeter. Even spacing means the ring of dots wraps seamlessly.
+            let count = (perimeter / (2.0 * thickness)).round().max(1.0);
+            let spacing = perimeter / count;
+            let radius = thickness / 2.0;
+
+            let mut path = BezPath::new();
+            for center in sample_points_along_path(&centerline, spacing, count as usize) {
+                path.extend(Circle::new(center, radius).path_elements(0.1));
+            }
+            scene.fill(Fill::NonZero, self.transform, color, None, &path);
+        } else {
+            // Dashes and gaps of equal length, sized so a whole number of them fit
+            // exactly around the perimeter (kurbo merges the dash across the seam).
+            // Butt caps give the dashes flat, square ends (like the straight-corner
+            // dashes) rather than the rounded ends of the default cap.
+            let nominal = 6.0 * thickness;
+            let count = (perimeter / nominal).round().max(1.0);
+            let dash = perimeter / count / 2.0;
+            let stroke = Stroke::new(thickness)
+                .with_caps(Cap::Butt)
+                .with_dashes(0.0, [dash, dash]);
+            scene.stroke(&stroke, self.transform, color, None, &centerline);
+        }
+
         scene.pop_layer();
     }
 

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -10,13 +10,19 @@ use style::{
 
 use crate::{color::ToColorColor as _, kurbo_css::Edge, render::ElementCx};
 
-/// Whether a colour is closer to black than to white (Euclidean distance in
-/// gamma-encoded sRGB), i.e. a "dark" colour.
-fn is_dark(color: Color) -> bool {
+/// The WCAG relative luminance of a colour (weighted sum of the linearised sRGB
+/// components), matching Chrome's `color_utils::GetRelativeLuminance4f`. Alpha is
+/// ignored.
+fn relative_luminance(color: Color) -> f32 {
+    fn linearize(c: f32) -> f32 {
+        if c <= 0.04045 {
+            c / 12.92
+        } else {
+            ((c + 0.055) / 1.055).powf(2.4)
+        }
+    }
     let [r, g, b, _] = color.components;
-    let to_black = r * r + g * g + b * b;
-    let to_white = (1.0 - r).powi(2) + (1.0 - g).powi(2) + (1.0 - b).powi(2);
-    to_black < to_white
+    0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
 }
 
 /// A darker version of a colour (mirrors WebKit/Blink's `Color::Dark`): the
@@ -49,24 +55,36 @@ fn lighten(color: Color) -> Color {
 /// The colour of a single edge of an `inset`/`outset` border.
 ///
 /// An `outset` border is raised: the top/left edges use the "lighter" shade and
-/// the bottom/right edges the "darker" shade (`inset` is the reverse). To keep a
-/// visible 3D effect the base colour is only darkened when it's light enough, and
-/// only lightened when it's dark enough (matching WebKit/Blink); otherwise the
-/// base colour is used unchanged.
+/// the bottom/right edges the "darker" shade (`inset` is the reverse). The exact
+/// shading matches Chrome's `CalculateInsetOutsetColor`:
+///
+/// * Very dark colours are lightened on both edges (once on the darker edge,
+///   twice on the lighter edge) to keep enough contrast to read as 3D.
+/// * Otherwise the darker edge is darkened, and the lighter edge is lightened
+///   unless the colour is already very light (in which case it's left unchanged).
 fn beveled_edge_color(color: Color, edge: Edge, inset: bool) -> Color {
+    // Luminance thresholds from Chrome: rgb(32, 32, 32) and rgb(235, 235, 235).
+    const BASE_DARK_LUMINANCE: f32 = 0.014443844;
+    const BASE_LIGHT_LUMINANCE: f32 = 0.83077;
+
     let top_or_left = matches!(edge, Edge::Top | Edge::Left);
     let should_darken = top_or_left == inset;
 
-    if should_darken {
-        // Darkening a dark colour is invisible, so only darken lighter colours.
-        if is_dark(color) { color } else { darken(color) }
-    } else {
-        // Lightening a light colour is invisible, so only lighten darker colours.
-        if is_dark(color) {
+    let luminance = relative_luminance(color);
+    if luminance <= BASE_DARK_LUMINANCE {
+        // Special-case very dark colours to give them extra contrast.
+        if should_darken {
             lighten(color)
         } else {
-            color
+            lighten(lighten(color))
         }
+    } else if should_darken {
+        darken(color)
+    } else if luminance > BASE_LIGHT_LUMINANCE {
+        // Lightening a very light colour is invisible, so leave it unchanged.
+        color
+    } else {
+        lighten(color)
     }
 }
 

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -2,6 +2,7 @@ use anyrender::PaintScene;
 use blitz_dom::node::SpecialElementData;
 use kurbo::{BezPath, Cap, Circle, PathEl, Point, Rect, Shape as _, Stroke};
 use peniko::{Color, Fill};
+use smallvec::SmallVec;
 use style::{
     computed_values::border_collapse::T as BorderCollapse,
     values::computed::{BorderStyle, OutlineStyle},
@@ -105,7 +106,10 @@ impl ElementCx<'_, '_> {
         // (colour, path) pairs to be filled. Several entries may share a colour;
         // they are grouped before filling so that adjacent same-coloured regions
         // are drawn together, avoiding anti-aliasing seams between them.
-        let mut borders: Vec<(Color, BezPath)> = Vec::new();
+        //
+        // At most 8 entries: 4 edges, each of which can contribute 2 (the outer
+        // and inner halves of a `groove`/`ridge`).
+        let mut borders: SmallVec<[(Color, BezPath); 8]> = SmallVec::new();
 
         for &edge in &[Edge::Top, Edge::Right, Edge::Bottom, Edge::Left] {
             let (color, edge_style) = match edge {

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -296,7 +296,7 @@ impl ElementCx<'_, '_> {
             // Dashes are rectangles. They are distributed so that the edge both
             // starts and ends with a dash (covering the corners), with the dashes
             // and gaps all the same length.
-            let nominal = 3.0 * thickness;
+            let nominal = 2.0 * thickness;
             let dash_count = ((length / nominal + 1.0) / 2.0).round().max(1.0);
             let segment = length / (2.0 * dash_count - 1.0);
             let mut k = 0.0;
@@ -358,7 +358,7 @@ impl ElementCx<'_, '_> {
             // exactly around the perimeter (kurbo merges the dash across the seam).
             // Butt caps give the dashes flat, square ends (like the straight-corner
             // dashes) rather than the rounded ends of the default cap.
-            let nominal = 6.0 * thickness;
+            let nominal = 4.0 * thickness;
             let count = (perimeter / nominal).round().max(1.0);
             let dash = perimeter / count / 2.0;
             let stroke = Stroke::new(thickness)

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -1,6 +1,6 @@
 use anyrender::PaintScene;
 use blitz_dom::node::SpecialElementData;
-use kurbo::{BezPath, Rect};
+use kurbo::{BezPath, Circle, Point, Rect, Shape as _};
 use peniko::{Color, Fill};
 use style::{
     computed_values::border_collapse::T as BorderCollapse,
@@ -25,18 +25,39 @@ impl ElementCx<'_, '_> {
         let mut count = 0;
 
         for &edge in &[Edge::Top, Edge::Right, Edge::Bottom, Edge::Left] {
-            let color = match edge {
-                Edge::Top => &border.border_top_color,
-                Edge::Right => &border.border_right_color,
-                Edge::Bottom => &border.border_bottom_color,
-                Edge::Left => &border.border_left_color,
-            }
-            .resolve_to_absolute(&current_color)
-            .as_srgb_color();
+            let (color, edge_style) = match edge {
+                Edge::Top => (&border.border_top_color, border.border_top_style),
+                Edge::Right => (&border.border_right_color, border.border_right_style),
+                Edge::Bottom => (&border.border_bottom_color, border.border_bottom_style),
+                Edge::Left => (&border.border_left_color, border.border_left_style),
+            };
+            let color = color.resolve_to_absolute(&current_color).as_srgb_color();
 
-            if color.components[3] > 0.0 {
-                borders[count] = (color, Some(self.frame.border_edge_shape(edge)));
-                count += 1;
+            if color.components[3] <= 0.0 {
+                continue;
+            }
+
+            match edge_style {
+                // `none`/`hidden` produce a zero-width border during layout, but
+                // guard against drawing them anyway.
+                BorderStyle::None | BorderStyle::Hidden => {}
+
+                // Dashed and dotted edges are drawn immediately as their own
+                // (clipped) shapes rather than being batched with the solid edges.
+                BorderStyle::Dotted => self.draw_dashed_border_edge(scene, edge, color, true),
+                BorderStyle::Dashed => self.draw_dashed_border_edge(scene, edge, color, false),
+
+                // Solid (and, for now, the unimplemented 3D/double styles) are
+                // rendered as a solid fill of the edge's region.
+                BorderStyle::Solid
+                | BorderStyle::Double
+                | BorderStyle::Groove
+                | BorderStyle::Ridge
+                | BorderStyle::Inset
+                | BorderStyle::Outset => {
+                    borders[count] = (color, Some(self.frame.border_edge_shape(edge)));
+                    count += 1;
+                }
             }
         }
 
@@ -76,6 +97,95 @@ impl ElementCx<'_, '_> {
             }
             start_border_index = next_border_index;
         }
+    }
+
+    /// Draw a single `dashed` or `dotted` border edge.
+    ///
+    /// The dashes/dots are generated as filled shapes running along the centre of
+    /// the edge and are drawn clipped to the edge's region (the same trapezoid
+    /// used by the solid path). Clipping means the corners are mitred correctly,
+    /// adjacent edges of different styles/colors don't overlap, and any
+    /// border-radius is respected.
+    fn draw_dashed_border_edge(
+        &self,
+        scene: &mut impl PaintScene,
+        edge: Edge,
+        color: Color,
+        dotted: bool,
+    ) {
+        let bb = self.frame.border_box;
+        let bw = self.frame.border_width;
+
+        // `thickness` is the width of this border side, `length` is the distance
+        // the dashes run along the edge (measured along the outer border box).
+        let (thickness, length): (f64, f64) = match edge {
+            Edge::Top => (bw.y0, bb.width()),
+            Edge::Bottom => (bw.y1, bb.width()),
+            Edge::Left => (bw.x0, bb.height()),
+            Edge::Right => (bw.x1, bb.height()),
+        };
+
+        if thickness <= 0.0 || length <= 0.0 {
+            return;
+        }
+
+        // Build a rectangle for a dash spanning `[start, end]` along the run,
+        // covering the full thickness of the border on the cross axis.
+        let dash_rect = |start: f64, end: f64| -> Rect {
+            match edge {
+                Edge::Top => Rect::new(bb.x0 + start, bb.y0, bb.x0 + end, bb.y0 + thickness),
+                Edge::Bottom => Rect::new(bb.x0 + start, bb.y1 - thickness, bb.x0 + end, bb.y1),
+                Edge::Left => Rect::new(bb.x0, bb.y0 + start, bb.x0 + thickness, bb.y0 + end),
+                Edge::Right => Rect::new(bb.x1 - thickness, bb.y0 + start, bb.x1, bb.y0 + end),
+            }
+        };
+
+        // Centre point of a dot placed `along` the run (on the centre line of the
+        // border thickness).
+        let dot_center = |along: f64| -> Point {
+            let half = thickness / 2.0;
+            match edge {
+                Edge::Top => Point::new(bb.x0 + along, bb.y0 + half),
+                Edge::Bottom => Point::new(bb.x0 + along, bb.y1 - half),
+                Edge::Left => Point::new(bb.x0 + half, bb.y0 + along),
+                Edge::Right => Point::new(bb.x1 - half, bb.y0 + along),
+            }
+        };
+
+        let mut path = BezPath::new();
+
+        if dotted {
+            // Dots are circles whose diameter equals the border thickness. They
+            // are distributed evenly, each centred within an equally sized cell so
+            // that the gaps at either end of the edge are symmetrical.
+            let radius = thickness / 2.0;
+            let cell_count = (length / (2.0 * thickness)).round().max(1.0);
+            let cell = length / cell_count;
+            let mut k = 0.0;
+            while k < cell_count {
+                let center = dot_center((k + 0.5) * cell);
+                path.extend(Circle::new(center, radius).path_elements(0.1));
+                k += 1.0;
+            }
+        } else {
+            // Dashes are rectangles. They are distributed so that the edge both
+            // starts and ends with a dash (covering the corners), with the dashes
+            // and gaps all the same length.
+            let nominal = 3.0 * thickness;
+            let dash_count = ((length / nominal + 1.0) / 2.0).round().max(1.0);
+            let segment = length / (2.0 * dash_count - 1.0);
+            let mut k = 0.0;
+            while k < dash_count {
+                let start = 2.0 * k * segment;
+                path.extend(dash_rect(start, start + segment).path_elements(0.1));
+                k += 1.0;
+            }
+        }
+
+        let clip = self.frame.border_edge_shape(edge);
+        scene.push_clip_layer(self.transform, &clip);
+        scene.fill(Fill::NonZero, self.transform, color, None, &path);
+        scene.pop_layer();
     }
 
     pub(crate) fn draw_table_borders(&self, scene: &mut impl PaintScene) {


### PR DESCRIPTION
Adds support for the remaining border styles: `dotted`, `dashed`, `double`, `inset`, `outset`, `groove`, and `ridge` (`solid`, `none`, and `hidden` were already implemented).