### PR TITLE
Implement scrollbars end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6173,7 +6173,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6896,7 +6896,8 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "git+https://github.com/UMCEKO/stylo?rev=b620178ec7dbe1bc4245610ced415360caacd5ce#b620178ec7dbe1bc4245610ced415360caacd5ce"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8656272f7483cdce91f1c55d60810ba6e7c2bac1b5940b2be60a2b12575ddb93"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7198,7 +7199,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8656,7 +8657,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -284,7 +284,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2396,7 +2396,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2656,7 +2656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4654,7 +4654,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6173,7 +6173,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6751,7 +6751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6896,8 +6896,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8656272f7483cdce91f1c55d60810ba6e7c2bac1b5940b2be60a2b12575ddb93"
+source = "git+https://github.com/UMCEKO/stylo?rev=b620178ec7dbe1bc4245610ced415360caacd5ce#b620178ec7dbe1bc4245610ced415360caacd5ce"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7199,7 +7198,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7760,7 +7759,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8657,7 +8656,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,3 +295,9 @@ tracing-subscriber = "0.3"
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
+# TEMPORARY (draft only — drop before merge): stylo 0.18.0 with the
+# css-scrollbars-1 properties enabled for the servo engine behind the
+# layout.unimplemented pref (which blitz sets), mirroring servo/stylo#413.
+# Replace with a plain version bump once a release ships it.
+[patch.crates-io]
+stylo = { git = "https://github.com/UMCEKO/stylo", rev = "b620178ec7dbe1bc4245610ced415360caacd5ce" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,9 +295,3 @@ tracing-subscriber = "0.3"
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
-# TEMPORARY (draft only — drop before merge): stylo 0.18.0 with the
-# css-scrollbars-1 properties enabled for the servo engine behind the
-# layout.unimplemented pref (which blitz sets), mirroring servo/stylo#413.
-# Replace with a plain version bump once a release ships it.
-[patch.crates-io]
-stylo = { git = "https://github.com/UMCEKO/stylo", rev = "b620178ec7dbe1bc4245610ced415360caacd5ce" }

--- a/packages/blitz-dom/Cargo.toml
+++ b/packages/blitz-dom/Cargo.toml
@@ -31,6 +31,9 @@ complex-scripts = ["parley/complex-scripts"]
 autofocus = []
 floats = ["taffy/float_layout", "stylo_taffy/floats"]
 file-input = []
+# Overlay-scrollbar thumb interaction (drag + hover tracking). Normally
+# enabled through `blitz-paint/scrollbars`, which paints the thumbs.
+scrollbars = []
 incremental = []
 parallel-construct = []
 log-phase-times = ["debug_timer/enable"]

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -249,6 +249,9 @@ pub struct BaseDocument {
     pub(crate) drag_mode: DragMode,
     /// The scrollbar thumb currently under the pointer, if any
     pub(crate) hovered_scrollbar: Option<crate::node::ScrollbarRef>,
+    /// When each scroll container's overlay scrollbars were last shown
+    /// (scrolled, or the pointer left the thumb); drives their fade-out
+    pub(crate) scrollbar_activity: HashMap<usize, Instant>,
     /// Whether and what kind of scroll animation is currently in progress
     pub(crate) scroll_animation: ScrollAnimationState,
 
@@ -463,6 +466,7 @@ impl BaseDocument {
             click_count: 0,
             drag_mode: DragMode::None,
             hovered_scrollbar: None,
+            scrollbar_activity: HashMap::new(),
             scroll_animation: ScrollAnimationState::None,
             text_selection: TextSelection::default(),
         };
@@ -1339,6 +1343,42 @@ impl BaseDocument {
         }
     }
 
+    /// The current opacity of `node_id`'s overlay scrollbars. They show at
+    /// full opacity on scroll and fade out after a delay (Chromium's overlay
+    /// timings); the pointer resting on a thumb, or dragging it, holds them
+    /// visible.
+    pub fn scrollbar_opacity(&self, node_id: usize) -> f32 {
+        let interacting = |scrollbar: &crate::node::ScrollbarRef| scrollbar.node_id == node_id;
+        if self.hovered_scrollbar.as_ref().is_some_and(interacting)
+            || self
+                .scrollbar_drag_target()
+                .as_ref()
+                .is_some_and(interacting)
+        {
+            return 1.0;
+        }
+        self.scrollbar_activity.get(&node_id).map_or(0.0, |last| {
+            crate::node::scrollbar::opacity_at(last.elapsed())
+        })
+    }
+
+    /// Show `node_id`'s overlay scrollbars at full opacity and restart their
+    /// fade-out delay.
+    pub(crate) fn show_scrollbars(&mut self, node_id: usize) {
+        if cfg!(feature = "scrollbars") {
+            self.scrollbar_activity.insert(node_id, Instant::now());
+        }
+    }
+
+    /// Whether any overlay scrollbars are awaiting or animating their
+    /// fade-out (so frames must keep rendering until they finish).
+    fn scrollbars_animating(&self) -> bool {
+        use crate::node::scrollbar::{FADE_DELAY, FADE_DURATION};
+        self.scrollbar_activity
+            .values()
+            .any(|last| last.elapsed() < FADE_DELAY + FADE_DURATION)
+    }
+
     /// [`hit`](Self::hit), also resolving the innermost overlay scrollbar
     /// thumb under the point (shares the traversal, so it costs nothing
     /// extra).
@@ -1364,10 +1404,24 @@ impl BaseDocument {
 
     pub fn set_hover_to(&mut self, x: f32, y: f32) -> bool {
         let (hit, hovered_scrollbar) = self.hit_with_scrollbar(x, y);
+        // A faded-out thumb is not interactive: pointer moves never fade
+        // overlay scrollbars back in (only scrolling shows them).
+        let hovered_scrollbar =
+            hovered_scrollbar.filter(|scrollbar| self.scrollbar_opacity(scrollbar.node_id) > 0.0);
         // Scrollbar-thumb hover is part of hover state: track it here so a
         // pointer crossing a thumb restyles it even when the hit node (the
         // content under the overlay thumb) is unchanged.
         let scrollbar_changed = hovered_scrollbar != self.hovered_scrollbar;
+        if scrollbar_changed {
+            // Entering a thumb restores full opacity mid-fade; leaving one
+            // restarts the fade-out delay.
+            for scrollbar in [self.hovered_scrollbar, hovered_scrollbar]
+                .into_iter()
+                .flatten()
+            {
+                self.show_scrollbars(scrollbar.node_id);
+            }
+        }
         self.hovered_scrollbar = hovered_scrollbar;
         let hover_node_id = hit.map(|hit| hit.node_id);
         let new_is_text = hit.map(|hit| hit.is_text).unwrap_or(false);
@@ -1530,6 +1584,7 @@ impl BaseDocument {
             | self.subdoc_is_animating
             | has_custom_widgets
             | (self.scroll_animation != ScrollAnimationState::None)
+            | self.scrollbars_animating()
     }
 
     /// Update the device and reset the stylist to process the new size
@@ -1777,8 +1832,13 @@ impl BaseDocument {
             dispatch_event(DomEvent::new(node_id, DomEventData::Scroll(event)));
         }
 
+        let parent = node.parent;
+        if has_changed {
+            self.show_scrollbars(node_id);
+        }
+
         if bubble_x != 0.0 || bubble_y != 0.0 {
-            if let Some(parent) = node.parent {
+            if let Some(parent) = parent {
                 return self.scroll_node_by_has_changed(parent, bubble_x, bubble_y, dispatch_event)
                     | has_changed;
             } else {

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -247,9 +247,8 @@ pub struct BaseDocument {
     pub(crate) click_count: u16,
     /// Whether we're currently in a text selection drag (moved 2px+ from mousedown)
     pub(crate) drag_mode: DragMode,
-    /// The scrollbar thumb (scroll container id, is-horizontal) currently
-    /// under the pointer, if any
-    pub(crate) hovered_scrollbar: Option<(usize, bool)>,
+    /// The scrollbar thumb currently under the pointer, if any
+    pub(crate) hovered_scrollbar: Option<crate::node::ScrollbarRef>,
     /// Whether and what kind of scroll animation is currently in progress
     pub(crate) scroll_animation: ScrollAnimationState,
 
@@ -1245,16 +1244,7 @@ impl BaseDocument {
 
     // Takes (x, y) co-ordinates (relative to the )
     pub fn hit(&self, x: f32, y: f32) -> Option<HitResult> {
-        if TDocument::as_node(&&self.nodes[0])
-            .first_element_child()
-            .is_none()
-        {
-            #[cfg(feature = "tracing")]
-            tracing::warn!("No DOM - not resolving hit test");
-            return None;
-        }
-
-        self.root_element().hit(x, y, self.viewport().scale_f64())
+        self.hit_with_scrollbar(x, y).0
     }
 
     pub fn focus_next_node(&mut self) -> Option<usize> {
@@ -1336,29 +1326,55 @@ impl BaseDocument {
         true
     }
 
-    /// The scrollbar thumb (scroll container id, is-horizontal) currently
-    /// under the pointer, if any.
-    pub fn hovered_scrollbar(&self) -> Option<(usize, bool)> {
+    /// The scrollbar thumb currently under the pointer, if any.
+    pub fn hovered_scrollbar(&self) -> Option<crate::node::ScrollbarRef> {
         self.hovered_scrollbar
     }
 
-    /// The scrollbar thumb (scroll container id, is-horizontal) currently
-    /// being dragged, if any.
-    pub fn scrollbar_drag_target(&self) -> Option<(usize, bool)> {
+    /// The scrollbar thumb currently being dragged, if any.
+    pub fn scrollbar_drag_target(&self) -> Option<crate::node::ScrollbarRef> {
         match &self.drag_mode {
-            DragMode::ScrollbarDrag(state) => Some((state.node_id, state.horizontal)),
+            DragMode::ScrollbarDrag(state) => Some(state.scrollbar),
             _ => None,
         }
     }
 
+    /// [`hit`](Self::hit), also resolving the innermost overlay scrollbar
+    /// thumb under the point (shares the traversal, so it costs nothing
+    /// extra).
+    pub(crate) fn hit_with_scrollbar(
+        &self,
+        x: f32,
+        y: f32,
+    ) -> (Option<HitResult>, Option<crate::node::ScrollbarRef>) {
+        if TDocument::as_node(&&self.nodes[0])
+            .first_element_child()
+            .is_none()
+        {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("No DOM - not resolving hit test");
+            return (None, None);
+        }
+        let mut scrollbar = None;
+        let hit = self
+            .root_element()
+            .hit_inner(x, y, self.viewport().scale_f64(), &mut scrollbar);
+        (hit, scrollbar)
+    }
+
     pub fn set_hover_to(&mut self, x: f32, y: f32) -> bool {
-        let hit = self.hit(x, y);
+        let (hit, hovered_scrollbar) = self.hit_with_scrollbar(x, y);
+        // Scrollbar-thumb hover is part of hover state: track it here so a
+        // pointer crossing a thumb restyles it even when the hit node (the
+        // content under the overlay thumb) is unchanged.
+        let scrollbar_changed = hovered_scrollbar != self.hovered_scrollbar;
+        self.hovered_scrollbar = hovered_scrollbar;
         let hover_node_id = hit.map(|hit| hit.node_id);
         let new_is_text = hit.map(|hit| hit.is_text).unwrap_or(false);
 
         // Return early if the new node is the same as the already-hovered node
         if hover_node_id == self.hover_node_id {
-            return false;
+            return scrollbar_changed;
         }
 
         let old_node_path = self.maybe_node_layout_ancestors(self.hover_node_id);

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -247,6 +247,9 @@ pub struct BaseDocument {
     pub(crate) click_count: u16,
     /// Whether we're currently in a text selection drag (moved 2px+ from mousedown)
     pub(crate) drag_mode: DragMode,
+    /// The scrollbar thumb (scroll container id, is-horizontal) currently
+    /// under the pointer, if any
+    pub(crate) hovered_scrollbar: Option<(usize, bool)>,
     /// Whether and what kind of scroll animation is currently in progress
     pub(crate) scroll_animation: ScrollAnimationState,
 
@@ -460,6 +463,7 @@ impl BaseDocument {
             mousedown_position: taffy::Point::ZERO,
             click_count: 0,
             drag_mode: DragMode::None,
+            hovered_scrollbar: None,
             scroll_animation: ScrollAnimationState::None,
             text_selection: TextSelection::default(),
         };
@@ -1330,6 +1334,21 @@ impl BaseDocument {
         }
 
         true
+    }
+
+    /// The scrollbar thumb (scroll container id, is-horizontal) currently
+    /// under the pointer, if any.
+    pub fn hovered_scrollbar(&self) -> Option<(usize, bool)> {
+        self.hovered_scrollbar
+    }
+
+    /// The scrollbar thumb (scroll container id, is-horizontal) currently
+    /// being dragged, if any.
+    pub fn scrollbar_drag_target(&self) -> Option<(usize, bool)> {
+        match &self.drag_mode {
+            DragMode::ScrollbarDrag(state) => Some((state.node_id, state.horizontal)),
+            _ => None,
+        }
     }
 
     pub fn set_hover_to(&mut self, x: f32, y: f32) -> bool {

--- a/packages/blitz-dom/src/events/mod.rs
+++ b/packages/blitz-dom/src/events/mod.rs
@@ -188,6 +188,7 @@ pub(crate) fn handle_dom_event<F: FnMut(DomEvent)>(
                 target_node_id,
                 event.page_x(),
                 event.page_y(),
+                event.button,
                 event.mods,
                 &mut dispatch_event,
             );

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -12,8 +12,12 @@ use blitz_traits::{
 use keyboard_types::Modifiers;
 use markup5ever::local_name;
 use style::values::computed::UserSelect;
+use taffy::AbsoluteAxis;
 
-use crate::{BaseDocument, node::SpecialElementData};
+use crate::{
+    BaseDocument,
+    node::{ScrollbarRef, SpecialElementData},
+};
 
 use super::focus::generate_focus_events;
 
@@ -48,9 +52,8 @@ pub(crate) struct PanSample {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct ScrollbarDragState {
-    /// The scroll container whose thumb is being dragged
-    pub(crate) node_id: usize,
-    pub(crate) horizontal: bool,
+    /// The thumb being dragged
+    pub(crate) scrollbar: ScrollbarRef,
     /// Last pointer position along the drag axis, in page coordinates
     pub(crate) last_pos: f32,
 }
@@ -149,48 +152,6 @@ impl PanState {
     }
 }
 
-/// Find the scrollbar thumb under the given page position: walks the layout
-/// ancestor chain of the hit node (the hit test returns the content under
-/// the overlay thumb) looking for a scroll container whose thumb contains
-/// the pointer. Returns (scroll container id, is-horizontal).
-///
-/// Also the `scrollbars` feature's single behavioral gate: returning `None`
-/// keeps unpainted thumbs from ever claiming pointer events.
-pub(crate) fn scrollbar_thumb_at(doc: &BaseDocument, x: f32, y: f32) -> Option<(usize, bool)> {
-    if !cfg!(feature = "scrollbars") {
-        return None;
-    }
-    let hit = doc.hit(x, y)?;
-    let mut cursor = Some(hit.node_id);
-    while let Some(node_id) = cursor {
-        let node = &doc.nodes[node_id];
-        for horizontal in [false, true] {
-            if !node.wants_scrollbar(horizontal) {
-                continue;
-            }
-            let Some(thumb) = node.scrollbar_thumb(horizontal) else {
-                continue;
-            };
-            // absolute_position subtracts the node's own scroll offset
-            // (it maps content coordinates); compensate to get the
-            // border-box origin.
-            //
-            // FIXME: absolute_position ignores CSS transforms, so the hit
-            // region is wrong inside transformed ancestors (as is blitz's
-            // other pointer math). Wants a shared transform-aware
-            // page->local conversion, not a scrollbar-local fix.
-            let origin = node.absolute_position(0.0, 0.0);
-            let local_x = (x - origin.x) as f64 - node.scroll_offset.x;
-            let local_y = (y - origin.y) as f64 - node.scroll_offset.y;
-            if thumb.contains(kurbo::Point::new(local_x, local_y)) {
-                return Some((node_id, horizontal));
-            }
-        }
-        cursor = node.layout_parent.get();
-    }
-    None
-}
-
 pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
     doc: &mut BaseDocument,
     target: usize,
@@ -258,29 +219,23 @@ pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
     }
 
     if let DragMode::ScrollbarDrag(state) = &mut doc.drag_mode {
-        let pos = if state.horizontal { x } else { y };
+        let ScrollbarRef { node_id, axis } = state.scrollbar;
+        let pos = match axis {
+            AbsoluteAxis::Horizontal => x,
+            AbsoluteAxis::Vertical => y,
+        };
         let delta_px = (pos - state.last_pos) as f64;
         state.last_pos = pos;
-        let (node_id, horizontal) = (state.node_id, state.horizontal);
 
         // Thumb px -> content px. scroll_by uses wheel-delta semantics
         // (positive delta decreases the offset), so negate.
-        let ratio = doc.nodes[node_id].scrollbar_drag_ratio(horizontal);
-        let (dx, dy) = if horizontal {
-            (-delta_px * ratio, 0.0)
-        } else {
-            (0.0, -delta_px * ratio)
+        let ratio = doc.nodes[node_id].scrollbar_drag_ratio(axis);
+        let (dx, dy) = match axis {
+            AbsoluteAxis::Horizontal => (-delta_px * ratio, 0.0),
+            AbsoluteAxis::Vertical => (0.0, -delta_px * ratio),
         };
         let has_changed = doc.scroll_by(Some(node_id), dx, dy, &mut dispatch_event);
         return has_changed;
-    }
-
-    // Track which scrollbar thumb the pointer is over (for hover styling);
-    // repaint when it changes.
-    let hovered_scrollbar = scrollbar_thumb_at(doc, x, y);
-    if hovered_scrollbar != doc.hovered_scrollbar {
-        doc.hovered_scrollbar = hovered_scrollbar;
-        changed = true;
     }
 
     let Some(hit) = doc.hit(x, y) else {
@@ -401,11 +356,13 @@ pub(crate) fn handle_pointerdown(
     // Scrollbar thumb drags take precedence over content interactions and
     // are not dispatched to the page (matching native scrollbars).
     if button == MouseEventButton::Main {
-        if let Some((node_id, horizontal)) = scrollbar_thumb_at(doc, x, y) {
+        if let (_, Some(scrollbar)) = doc.hit_with_scrollbar(x, y) {
             doc.drag_mode = DragMode::ScrollbarDrag(ScrollbarDragState {
-                node_id,
-                horizontal,
-                last_pos: if horizontal { x } else { y },
+                scrollbar,
+                last_pos: match scrollbar.axis {
+                    AbsoluteAxis::Horizontal => x,
+                    AbsoluteAxis::Vertical => y,
+                },
             });
             doc.shell_provider.request_redraw();
             return;

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -354,9 +354,12 @@ pub(crate) fn handle_pointerdown(
     };
 
     // Scrollbar thumb drags take precedence over content interactions and
-    // are not dispatched to the page (matching native scrollbars).
+    // are not dispatched to the page (matching native scrollbars). A
+    // faded-out thumb doesn't capture: the click goes to the content.
     if button == MouseEventButton::Main {
-        if let (_, Some(scrollbar)) = doc.hit_with_scrollbar(x, y) {
+        if let (_, Some(scrollbar)) = doc.hit_with_scrollbar(x, y)
+            && doc.scrollbar_opacity(scrollbar.node_id) > 0.0
+        {
             doc.drag_mode = DragMode::ScrollbarDrag(ScrollbarDragState {
                 scrollbar,
                 last_pos: match scrollbar.axis {
@@ -512,8 +515,10 @@ pub(crate) fn handle_pointerup<F: FnMut(DomEvent)>(
     // the document with a touch
     let do_click = drag_mode == DragMode::None;
 
-    // Repaint so a dragged scrollbar thumb drops its active styling
-    if matches!(drag_mode, DragMode::ScrollbarDrag(_)) {
+    // Repaint so a dragged scrollbar thumb drops its active styling, and
+    // restart its fade-out delay now that the drag no longer holds it shown
+    if let DragMode::ScrollbarDrag(state) = &drag_mode {
+        doc.show_scrollbars(state.scrollbar.node_id);
         doc.shell_provider.request_redraw();
     }
 

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -154,10 +154,8 @@ impl PanState {
 /// the overlay thumb) looking for a scroll container whose thumb contains
 /// the pointer. Returns (scroll container id, is-horizontal).
 ///
-/// This is the single behavioral gate for the `scrollbars` feature: both the
-/// drag entry (pointerdown) and hover tracking (pointermove) resolve thumbs
-/// through here, so returning `None` keeps the whole interaction inert —
-/// nothing may grab pointer events for thumbs that are never painted.
+/// Also the `scrollbars` feature's single behavioral gate: returning `None`
+/// keeps unpainted thumbs from ever claiming pointer events.
 pub(crate) fn scrollbar_thumb_at(doc: &BaseDocument, x: f32, y: f32) -> Option<(usize, bool)> {
     if !cfg!(feature = "scrollbars") {
         return None;
@@ -176,10 +174,15 @@ pub(crate) fn scrollbar_thumb_at(doc: &BaseDocument, x: f32, y: f32) -> Option<(
             // absolute_position subtracts the node's own scroll offset
             // (it maps content coordinates); compensate to get the
             // border-box origin.
+            //
+            // FIXME: absolute_position ignores CSS transforms, so the hit
+            // region is wrong inside transformed ancestors (as is blitz's
+            // other pointer math). Wants a shared transform-aware
+            // page->local conversion, not a scrollbar-local fix.
             let origin = node.absolute_position(0.0, 0.0);
             let local_x = (x - origin.x) as f64 - node.scroll_offset.x;
             let local_y = (y - origin.y) as f64 - node.scroll_offset.y;
-            if thumb.contains(local_x, local_y) {
+            if thumb.contains(kurbo::Point::new(local_x, local_y)) {
                 return Some((node_id, horizontal));
             }
         }

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -46,6 +46,15 @@ pub(crate) struct PanSample {
     pub(crate) dy: f32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ScrollbarDragState {
+    /// The scroll container whose thumb is being dragged
+    pub(crate) node_id: usize,
+    pub(crate) horizontal: bool,
+    /// Last pointer position along the drag axis, in page coordinates
+    pub(crate) last_pos: f32,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum DragMode {
     /// We are not currently dragging
@@ -54,6 +63,8 @@ pub(crate) enum DragMode {
     Selecting,
     /// We are currently panning the document with a drag (probably touch)
     Panning(PanState),
+    /// We are currently dragging a scrollbar thumb
+    ScrollbarDrag(ScrollbarDragState),
 }
 
 impl DragMode {
@@ -138,6 +149,45 @@ impl PanState {
     }
 }
 
+/// Find the scrollbar thumb under the given page position: walks the layout
+/// ancestor chain of the hit node (the hit test returns the content under
+/// the overlay thumb) looking for a scroll container whose thumb contains
+/// the pointer. Returns (scroll container id, is-horizontal).
+///
+/// This is the single behavioral gate for the `scrollbars` feature: both the
+/// drag entry (pointerdown) and hover tracking (pointermove) resolve thumbs
+/// through here, so returning `None` keeps the whole interaction inert —
+/// nothing may grab pointer events for thumbs that are never painted.
+pub(crate) fn scrollbar_thumb_at(doc: &BaseDocument, x: f32, y: f32) -> Option<(usize, bool)> {
+    if !cfg!(feature = "scrollbars") {
+        return None;
+    }
+    let hit = doc.hit(x, y)?;
+    let mut cursor = Some(hit.node_id);
+    while let Some(node_id) = cursor {
+        let node = &doc.nodes[node_id];
+        for horizontal in [false, true] {
+            if !node.wants_scrollbar(horizontal) {
+                continue;
+            }
+            let Some(thumb) = node.scrollbar_thumb(horizontal) else {
+                continue;
+            };
+            // absolute_position subtracts the node's own scroll offset
+            // (it maps content coordinates); compensate to get the
+            // border-box origin.
+            let origin = node.absolute_position(0.0, 0.0);
+            let local_x = (x - origin.x) as f64 - node.scroll_offset.x;
+            let local_y = (y - origin.y) as f64 - node.scroll_offset.y;
+            if thumb.contains(local_x, local_y) {
+                return Some((node_id, horizontal));
+            }
+        }
+        cursor = node.layout_parent.get();
+    }
+    None
+}
+
 pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
     doc: &mut BaseDocument,
     target: usize,
@@ -202,6 +252,32 @@ pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
 
         let has_changed = doc.scroll_by(Some(target), dx, dy, &mut dispatch_event);
         return has_changed;
+    }
+
+    if let DragMode::ScrollbarDrag(state) = &mut doc.drag_mode {
+        let pos = if state.horizontal { x } else { y };
+        let delta_px = (pos - state.last_pos) as f64;
+        state.last_pos = pos;
+        let (node_id, horizontal) = (state.node_id, state.horizontal);
+
+        // Thumb px -> content px. scroll_by uses wheel-delta semantics
+        // (positive delta decreases the offset), so negate.
+        let ratio = doc.nodes[node_id].scrollbar_drag_ratio(horizontal);
+        let (dx, dy) = if horizontal {
+            (-delta_px * ratio, 0.0)
+        } else {
+            (0.0, -delta_px * ratio)
+        };
+        let has_changed = doc.scroll_by(Some(node_id), dx, dy, &mut dispatch_event);
+        return has_changed;
+    }
+
+    // Track which scrollbar thumb the pointer is over (for hover styling);
+    // repaint when it changes.
+    let hovered_scrollbar = scrollbar_thumb_at(doc, x, y);
+    if hovered_scrollbar != doc.hovered_scrollbar {
+        doc.hovered_scrollbar = hovered_scrollbar;
+        changed = true;
     }
 
     let Some(hit) = doc.hit(x, y) else {
@@ -288,6 +364,7 @@ pub(crate) fn handle_pointerdown(
     _target: usize,
     x: f32,
     y: f32,
+    button: MouseEventButton,
     mods: Modifiers,
     dispatch_event: &mut dyn FnMut(DomEvent),
 ) {
@@ -317,6 +394,20 @@ pub(crate) fn handle_pointerdown(
         doc.clear_text_selection();
         return;
     };
+
+    // Scrollbar thumb drags take precedence over content interactions and
+    // are not dispatched to the page (matching native scrollbars).
+    if button == MouseEventButton::Main {
+        if let Some((node_id, horizontal)) = scrollbar_thumb_at(doc, x, y) {
+            doc.drag_mode = DragMode::ScrollbarDrag(ScrollbarDragState {
+                node_id,
+                horizontal,
+                last_pos: if horizontal { x } else { y },
+            });
+            doc.shell_provider.request_redraw();
+            return;
+        }
+    }
 
     // Use hit.node_id for determining the actual clicked element.
     // This may differ from `target` for anonymous blocks (which are layout children
@@ -460,6 +551,11 @@ pub(crate) fn handle_pointerup<F: FnMut(DomEvent)>(
     // Don't dispatch click if we were doing a text selection drag or panning
     // the document with a touch
     let do_click = drag_mode == DragMode::None;
+
+    // Repaint so a dragged scrollbar thumb drops its active styling
+    if matches!(drag_mode, DragMode::ScrollbarDrag(_)) {
+        doc.shell_provider.request_redraw();
+    }
 
     let time_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/packages/blitz-dom/src/node/mod.rs
+++ b/packages/blitz-dom/src/node/mod.rs
@@ -5,7 +5,7 @@ mod attributes;
 mod custom_widget;
 mod element;
 mod node;
-mod scrollbar;
+pub(crate) mod scrollbar;
 mod stylo_data;
 mod text;
 

--- a/packages/blitz-dom/src/node/mod.rs
+++ b/packages/blitz-dom/src/node/mod.rs
@@ -5,6 +5,7 @@ mod attributes;
 mod custom_widget;
 mod element;
 mod node;
+mod scrollbar;
 mod stylo_data;
 mod text;
 
@@ -18,4 +19,5 @@ pub use element::{
     Marker, RasterImageData, SpecialElementData, SpecialElementType, Status,
 };
 pub use node::*;
+pub use scrollbar::{ScrollbarColor, ScrollbarRef, ScrollbarWidth};
 pub use text::{GeneratedTextInputEvent, TextBrush, TextInputData, TextLayout};

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1128,12 +1128,18 @@ impl Node {
 
     /// Whether the node shows an overlay scrollbar in the given axis:
     /// always for `overflow: scroll`, only when the content overflows for
-    /// `overflow: auto`, never otherwise.
+    /// `overflow: auto`, never otherwise — and never when
+    /// `scrollbar-width: none`.
     pub fn wants_scrollbar(&self, horizontal: bool) -> bool {
         use style::values::computed::Overflow;
         let Some(style) = self.primary_styles() else {
             return false;
         };
+        if style.clone_scrollbar_width()
+            == style::properties::longhands::scrollbar_width::computed_value::T::None
+        {
+            return false;
+        }
         let (overflow, scroll_extent) = if horizontal {
             (
                 style.clone_overflow_x(),
@@ -1157,6 +1163,7 @@ impl Node {
     /// if there is no scrollable overflow in that axis.
     pub fn scrollbar_thumb(&self, horizontal: bool) -> Option<ScrollbarThumb> {
         const THUMB_THICKNESS: f64 = 6.0;
+        const THIN_THUMB_THICKNESS: f64 = 4.0;
         const THUMB_MARGIN: f64 = 2.0;
         const MIN_THUMB_LENGTH: f64 = 16.0;
 
@@ -1169,6 +1176,13 @@ impl Node {
         if scroll_extent <= 0.5 {
             return None;
         }
+
+        let thickness = match self.primary_styles().map(|s| s.clone_scrollbar_width()) {
+            Some(style::properties::longhands::scrollbar_width::computed_value::T::Thin) => {
+                THIN_THUMB_THICKNESS
+            }
+            _ => THUMB_THICKNESS,
+        };
 
         // The scrollport is the padding box.
         let x0 = layout.border.left as f64;
@@ -1190,13 +1204,13 @@ impl Node {
         Some(if horizontal {
             ScrollbarThumb {
                 x0: x0 + thumb_start,
-                y0: y1 - THUMB_MARGIN - THUMB_THICKNESS,
+                y0: y1 - THUMB_MARGIN - thickness,
                 x1: x0 + thumb_start + thumb_len,
                 y1: y1 - THUMB_MARGIN,
             }
         } else {
             ScrollbarThumb {
-                x0: x1 - THUMB_MARGIN - THUMB_THICKNESS,
+                x0: x1 - THUMB_MARGIN - thickness,
                 y0: y0 + thumb_start,
                 x1: x1 - THUMB_MARGIN,
                 y1: y0 + thumb_start + thumb_len,

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -494,30 +494,6 @@ pub enum NodeKind {
     Comment,
 }
 
-/// The computed value of `scrollbar-width` (css-scrollbars-1). A local
-/// mirror of the stylo type, which isn't exposed to the servo engine yet
-/// (servo/stylo#413).
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum ScrollbarWidth {
-    #[default]
-    Auto,
-    Thin,
-    None,
-}
-
-/// The computed value of `scrollbar-color` (css-scrollbars-1). A local
-/// mirror of the stylo type, which isn't exposed to the servo engine yet
-/// (servo/stylo#413). Colors are fully resolved (no `currentColor`).
-#[derive(Clone, Debug, Default, PartialEq)]
-pub enum ScrollbarColor {
-    #[default]
-    Auto,
-    Colors {
-        thumb: style::color::AbsoluteColor,
-        track: style::color::AbsoluteColor,
-    },
-}
-
 /// The different kinds of nodes in the DOM.
 #[derive(Debug, Clone)]
 pub enum NodeData {
@@ -933,6 +909,20 @@ impl Node {
     /// TODO: z-index
     /// (If multiple children are positioned at the position then a random one will be recursed into)
     pub fn hit(&self, x: f32, y: f32, scale: f64) -> Option<HitResult> {
+        self.hit_inner(x, y, scale, &mut None)
+    }
+
+    /// [`hit`](Self::hit), also resolving the innermost overlay scrollbar
+    /// thumb under the point into `scrollbar` during the same descent (so
+    /// thumb hit-testing shares the exact coordinate handling — transforms
+    /// included — of every other hit test).
+    pub(crate) fn hit_inner(
+        &self,
+        x: f32,
+        y: f32,
+        scale: f64,
+        scrollbar: &mut Option<crate::node::ScrollbarRef>,
+    ) -> Option<HitResult> {
         use style::computed_values::pointer_events::T as PointerEvents;
         use style::computed_values::visibility::T as Visibility;
 
@@ -997,6 +987,17 @@ impl Node {
             return None;
         }
 
+        // Descendants overwrite, so the innermost scroll container's thumb
+        // wins. Thumb coords are border-box relative (unscrolled).
+        if matches_self
+            && let Some(sb) = self.scrollbar_at_local(
+                (x - self.scroll_offset.x as f32) as f64,
+                (y - self.scroll_offset.y as f32) as f64,
+            )
+        {
+            *scrollbar = Some(sb);
+        }
+
         if self.flags.is_inline_root() {
             let content_box_offset = taffy::Point {
                 x: self.final_layout.padding.left + self.final_layout.border.left,
@@ -1012,7 +1013,10 @@ impl Node {
                 for hoisted_child in hoisted.pos_z_hoisted_children().rev() {
                     let x = x - hoisted_child.position.x;
                     let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self.with(hoisted_child.node_id).hit(x, y, scale) {
+                    if let Some(hit) = self
+                        .with(hoisted_child.node_id)
+                        .hit_inner(x, y, scale, scrollbar)
+                    {
                         return Some(hit);
                     }
                 }
@@ -1021,7 +1025,7 @@ impl Node {
 
         // Call `.hit()` on each child in turn. If any return `Some` then return that value. Else return `Some(self.id).
         for child_id in self.paint_children.borrow().iter().flatten().rev() {
-            if let Some(hit) = self.with(*child_id).hit(x, y, scale) {
+            if let Some(hit) = self.with(*child_id).hit_inner(x, y, scale, scrollbar) {
                 return Some(hit);
             }
         }
@@ -1032,7 +1036,10 @@ impl Node {
                 for hoisted_child in hoisted.neg_z_hoisted_children().rev() {
                     let x = x - hoisted_child.position.x;
                     let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self.with(hoisted_child.node_id).hit(x, y, scale) {
+                    if let Some(hit) = self
+                        .with(hoisted_child.node_id)
+                        .hit_inner(x, y, scale, scrollbar)
+                    {
                         return Some(hit);
                     }
                 }
@@ -1132,151 +1139,6 @@ impl Node {
         };
 
         Some(offset)
-    }
-
-    /// The node's used `scrollbar-width`.
-    pub fn scrollbar_width(&self) -> ScrollbarWidth {
-        // TODO: read the computed style once stylo exposes scrollbar-width
-        // to the servo engine (servo/stylo#413):
-        // match self.primary_styles().map(|s| s.clone_scrollbar_width()) { .. }
-        ScrollbarWidth::Auto
-    }
-
-    /// The node's used `scrollbar-color`.
-    pub fn scrollbar_color(&self) -> ScrollbarColor {
-        // TODO: read the computed style once stylo exposes scrollbar-color
-        // to the servo engine (servo/stylo#413), resolving the colors
-        // against the element's `color`:
-        // self.primary_styles().map(|s| s.clone_scrollbar_color()) { .. }
-        ScrollbarColor::Auto
-    }
-
-    /// Whether the node shows an overlay scrollbar in the given axis:
-    /// always for `overflow: scroll`, only when the content overflows for
-    /// `overflow: auto`, never otherwise — and never when
-    /// `scrollbar-width: none`.
-    pub fn wants_scrollbar(&self, horizontal: bool) -> bool {
-        use style::values::computed::Overflow;
-        let Some(style) = self.primary_styles() else {
-            return false;
-        };
-        if self.scrollbar_width() == ScrollbarWidth::None {
-            return false;
-        }
-        let (overflow, scroll_extent) = if horizontal {
-            (
-                style.clone_overflow_x(),
-                self.final_layout.scroll_width() as f64,
-            )
-        } else {
-            (
-                style.clone_overflow_y(),
-                self.final_layout.scroll_height() as f64,
-            )
-        };
-        match overflow {
-            Overflow::Scroll => true,
-            Overflow::Auto => scroll_extent > 0.5,
-            _ => false,
-        }
-    }
-
-    /// The scrollport (padding box) in (unscaled) CSS px relative to the
-    /// node's border-box origin. Taffy has content-box helpers but none for
-    /// the padding box.
-    fn scrollport(&self) -> KurboRect {
-        let layout = &self.final_layout;
-        KurboRect::new(
-            layout.border.left as f64,
-            layout.border.top as f64,
-            layout.size.width as f64 - layout.border.right as f64,
-            layout.size.height as f64 - layout.border.bottom as f64,
-        )
-    }
-
-    /// Geometry of the overlay scrollbar thumb for the given axis, in
-    /// (unscaled) CSS px relative to the node's border-box origin. `None`
-    /// if there is no scrollable overflow in that axis.
-    pub fn scrollbar_thumb(&self, horizontal: bool) -> Option<KurboRect> {
-        // Matches Chromium's overlay thumb in its interactive state.
-        const THUMB_THICKNESS: f64 = 10.0;
-        const THIN_THUMB_THICKNESS: f64 = 6.0;
-        const THUMB_MARGIN: f64 = 2.0;
-        const MIN_THUMB_LENGTH: f64 = 32.0;
-
-        let layout = &self.final_layout;
-        let scroll_extent = if horizontal {
-            layout.scroll_width() as f64
-        } else {
-            layout.scroll_height() as f64
-        };
-        if scroll_extent <= 0.5 {
-            return None;
-        }
-
-        let thickness = match self.scrollbar_width() {
-            ScrollbarWidth::Thin => THIN_THUMB_THICKNESS,
-            _ => THUMB_THICKNESS,
-        };
-
-        let port = self.scrollport();
-        let (viewport_len, scroll_offset) = if horizontal {
-            (port.width(), self.scroll_offset.x)
-        } else {
-            (port.height(), self.scroll_offset.y)
-        };
-        let thumb_len = (viewport_len * viewport_len / (viewport_len + scroll_extent))
-            .max(MIN_THUMB_LENGTH)
-            .min(viewport_len);
-        let progress = (scroll_offset / scroll_extent).clamp(0.0, 1.0);
-        // Round a sub-pixel displacement up to a whole pixel so any nonzero
-        // scroll visibly moves the thumb off the origin.
-        let thumb_start = match progress * (viewport_len - thumb_len) {
-            start if start > 0.0 && start < 1.0 => 1.0,
-            start => start,
-        };
-
-        Some(if horizontal {
-            KurboRect::new(
-                port.x0 + thumb_start,
-                port.y1 - THUMB_MARGIN - thickness,
-                port.x0 + thumb_start + thumb_len,
-                port.y1 - THUMB_MARGIN,
-            )
-        } else {
-            KurboRect::new(
-                port.x1 - THUMB_MARGIN - thickness,
-                port.y0 + thumb_start,
-                port.x1 - THUMB_MARGIN,
-                port.y0 + thumb_start + thumb_len,
-            )
-        })
-    }
-
-    /// Content px scrolled per thumb px dragged, for the given axis.
-    pub fn scrollbar_drag_ratio(&self, horizontal: bool) -> f64 {
-        let Some(thumb) = self.scrollbar_thumb(horizontal) else {
-            return 0.0;
-        };
-        let port = self.scrollport();
-        let (scroll_extent, viewport_len, thumb_len) = if horizontal {
-            (
-                self.final_layout.scroll_width() as f64,
-                port.width(),
-                thumb.width(),
-            )
-        } else {
-            (
-                self.final_layout.scroll_height() as f64,
-                port.height(),
-                thumb.height(),
-            )
-        };
-        let track_play = viewport_len - thumb_len;
-        if track_play <= 0.0 {
-            return 0.0;
-        }
-        scroll_extent / track_play
     }
 
     /// Computes the Document-relative coordinates of the `Node`

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -494,6 +494,30 @@ pub enum NodeKind {
     Comment,
 }
 
+/// The computed value of `scrollbar-width` (css-scrollbars-1). A local
+/// mirror of the stylo type, which isn't exposed to the servo engine yet
+/// (servo/stylo#413).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ScrollbarWidth {
+    #[default]
+    Auto,
+    Thin,
+    None,
+}
+
+/// The computed value of `scrollbar-color` (css-scrollbars-1). A local
+/// mirror of the stylo type, which isn't exposed to the servo engine yet
+/// (servo/stylo#413). Colors are fully resolved (no `currentColor`).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum ScrollbarColor {
+    #[default]
+    Auto,
+    Colors {
+        thumb: style::color::AbsoluteColor,
+        track: style::color::AbsoluteColor,
+    },
+}
+
 /// The different kinds of nodes in the DOM.
 #[derive(Debug, Clone)]
 pub enum NodeData {
@@ -1110,6 +1134,23 @@ impl Node {
         Some(offset)
     }
 
+    /// The node's used `scrollbar-width`.
+    pub fn scrollbar_width(&self) -> ScrollbarWidth {
+        // TODO: read the computed style once stylo exposes scrollbar-width
+        // to the servo engine (servo/stylo#413):
+        // match self.primary_styles().map(|s| s.clone_scrollbar_width()) { .. }
+        ScrollbarWidth::Auto
+    }
+
+    /// The node's used `scrollbar-color`.
+    pub fn scrollbar_color(&self) -> ScrollbarColor {
+        // TODO: read the computed style once stylo exposes scrollbar-color
+        // to the servo engine (servo/stylo#413), resolving the colors
+        // against the element's `color`:
+        // self.primary_styles().map(|s| s.clone_scrollbar_color()) { .. }
+        ScrollbarColor::Auto
+    }
+
     /// Whether the node shows an overlay scrollbar in the given axis:
     /// always for `overflow: scroll`, only when the content overflows for
     /// `overflow: auto`, never otherwise — and never when
@@ -1119,9 +1160,7 @@ impl Node {
         let Some(style) = self.primary_styles() else {
             return false;
         };
-        if style.clone_scrollbar_width()
-            == style::properties::longhands::scrollbar_width::computed_value::T::None
-        {
+        if self.scrollbar_width() == ScrollbarWidth::None {
             return false;
         }
         let (overflow, scroll_extent) = if horizontal {
@@ -1175,10 +1214,8 @@ impl Node {
             return None;
         }
 
-        let thickness = match self.primary_styles().map(|s| s.clone_scrollbar_width()) {
-            Some(style::properties::longhands::scrollbar_width::computed_value::T::Thin) => {
-                THIN_THUMB_THICKNESS
-            }
+        let thickness = match self.scrollbar_width() {
+            ScrollbarWidth::Thin => THIN_THUMB_THICKNESS,
             _ => THUMB_THICKNESS,
         };
 

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -494,6 +494,22 @@ pub enum NodeKind {
     Comment,
 }
 
+/// Geometry of an overlay scrollbar thumb, in (unscaled) CSS px relative to
+/// the owning node's border-box origin.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScrollbarThumb {
+    pub x0: f64,
+    pub y0: f64,
+    pub x1: f64,
+    pub y1: f64,
+}
+
+impl ScrollbarThumb {
+    pub fn contains(&self, x: f64, y: f64) -> bool {
+        x >= self.x0 && x <= self.x1 && y >= self.y0 && y <= self.y1
+    }
+}
+
 /// The different kinds of nodes in the DOM.
 #[derive(Debug, Clone)]
 pub enum NodeData {
@@ -1108,6 +1124,110 @@ impl Node {
         };
 
         Some(offset)
+    }
+
+    /// Whether the node shows an overlay scrollbar in the given axis:
+    /// always for `overflow: scroll`, only when the content overflows for
+    /// `overflow: auto`, never otherwise.
+    pub fn wants_scrollbar(&self, horizontal: bool) -> bool {
+        use style::values::computed::Overflow;
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+        let (overflow, scroll_extent) = if horizontal {
+            (
+                style.clone_overflow_x(),
+                self.final_layout.scroll_width() as f64,
+            )
+        } else {
+            (
+                style.clone_overflow_y(),
+                self.final_layout.scroll_height() as f64,
+            )
+        };
+        match overflow {
+            Overflow::Scroll => true,
+            Overflow::Auto => scroll_extent > 0.5,
+            _ => false,
+        }
+    }
+
+    /// Geometry of the overlay scrollbar thumb for the given axis, in
+    /// (unscaled) CSS px relative to the node's border-box origin. `None`
+    /// if there is no scrollable overflow in that axis.
+    pub fn scrollbar_thumb(&self, horizontal: bool) -> Option<ScrollbarThumb> {
+        const THUMB_THICKNESS: f64 = 6.0;
+        const THUMB_MARGIN: f64 = 2.0;
+        const MIN_THUMB_LENGTH: f64 = 16.0;
+
+        let layout = &self.final_layout;
+        let scroll_extent = if horizontal {
+            layout.scroll_width() as f64
+        } else {
+            layout.scroll_height() as f64
+        };
+        if scroll_extent <= 0.5 {
+            return None;
+        }
+
+        // The scrollport is the padding box.
+        let x0 = layout.border.left as f64;
+        let y0 = layout.border.top as f64;
+        let x1 = layout.size.width as f64 - layout.border.right as f64;
+        let y1 = layout.size.height as f64 - layout.border.bottom as f64;
+
+        let (viewport_len, scroll_offset) = if horizontal {
+            (x1 - x0, self.scroll_offset.x)
+        } else {
+            (y1 - y0, self.scroll_offset.y)
+        };
+        let thumb_len = (viewport_len * viewport_len / (viewport_len + scroll_extent))
+            .max(MIN_THUMB_LENGTH)
+            .min(viewport_len);
+        let progress = (scroll_offset / scroll_extent).clamp(0.0, 1.0);
+        let thumb_start = progress * (viewport_len - thumb_len);
+
+        Some(if horizontal {
+            ScrollbarThumb {
+                x0: x0 + thumb_start,
+                y0: y1 - THUMB_MARGIN - THUMB_THICKNESS,
+                x1: x0 + thumb_start + thumb_len,
+                y1: y1 - THUMB_MARGIN,
+            }
+        } else {
+            ScrollbarThumb {
+                x0: x1 - THUMB_MARGIN - THUMB_THICKNESS,
+                y0: y0 + thumb_start,
+                x1: x1 - THUMB_MARGIN,
+                y1: y0 + thumb_start + thumb_len,
+            }
+        })
+    }
+
+    /// Content px scrolled per thumb px dragged, for the given axis.
+    pub fn scrollbar_drag_ratio(&self, horizontal: bool) -> f64 {
+        let Some(thumb) = self.scrollbar_thumb(horizontal) else {
+            return 0.0;
+        };
+        let layout = &self.final_layout;
+        let (scroll_extent, viewport_len, thumb_len) = if horizontal {
+            (
+                layout.scroll_width() as f64,
+                layout.size.width as f64 - layout.border.left as f64 - layout.border.right as f64,
+                thumb.x1 - thumb.x0,
+            )
+        } else {
+            (
+                layout.scroll_height() as f64,
+                layout.size.height as f64 - layout.border.top as f64 - layout.border.bottom as f64,
+                thumb.y1 - thumb.y0,
+            )
+        };
+        let track_play = viewport_len - thumb_len;
+        if track_play <= 0.0 {
+            return 0.0;
+        }
+        scroll_extent / track_play
     }
 
     /// Computes the Document-relative coordinates of the `Node`

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1159,10 +1159,11 @@ impl Node {
     /// (unscaled) CSS px relative to the node's border-box origin. `None`
     /// if there is no scrollable overflow in that axis.
     pub fn scrollbar_thumb(&self, horizontal: bool) -> Option<KurboRect> {
-        const THUMB_THICKNESS: f64 = 6.0;
-        const THIN_THUMB_THICKNESS: f64 = 4.0;
+        // Matches Chromium's overlay thumb in its interactive state.
+        const THUMB_THICKNESS: f64 = 10.0;
+        const THIN_THUMB_THICKNESS: f64 = 6.0;
         const THUMB_MARGIN: f64 = 2.0;
-        const MIN_THUMB_LENGTH: f64 = 16.0;
+        const MIN_THUMB_LENGTH: f64 = 32.0;
 
         let layout = &self.final_layout;
         let scroll_extent = if horizontal {

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -494,22 +494,6 @@ pub enum NodeKind {
     Comment,
 }
 
-/// Geometry of an overlay scrollbar thumb, in (unscaled) CSS px relative to
-/// the owning node's border-box origin.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ScrollbarThumb {
-    pub x0: f64,
-    pub y0: f64,
-    pub x1: f64,
-    pub y1: f64,
-}
-
-impl ScrollbarThumb {
-    pub fn contains(&self, x: f64, y: f64) -> bool {
-        x >= self.x0 && x <= self.x1 && y >= self.y0 && y <= self.y1
-    }
-}
-
 /// The different kinds of nodes in the DOM.
 #[derive(Debug, Clone)]
 pub enum NodeData {
@@ -1158,10 +1142,23 @@ impl Node {
         }
     }
 
+    /// The scrollport (padding box) in (unscaled) CSS px relative to the
+    /// node's border-box origin. Taffy has content-box helpers but none for
+    /// the padding box.
+    fn scrollport(&self) -> KurboRect {
+        let layout = &self.final_layout;
+        KurboRect::new(
+            layout.border.left as f64,
+            layout.border.top as f64,
+            layout.size.width as f64 - layout.border.right as f64,
+            layout.size.height as f64 - layout.border.bottom as f64,
+        )
+    }
+
     /// Geometry of the overlay scrollbar thumb for the given axis, in
     /// (unscaled) CSS px relative to the node's border-box origin. `None`
     /// if there is no scrollable overflow in that axis.
-    pub fn scrollbar_thumb(&self, horizontal: bool) -> Option<ScrollbarThumb> {
+    pub fn scrollbar_thumb(&self, horizontal: bool) -> Option<KurboRect> {
         const THUMB_THICKNESS: f64 = 6.0;
         const THIN_THUMB_THICKNESS: f64 = 4.0;
         const THUMB_MARGIN: f64 = 2.0;
@@ -1184,37 +1181,37 @@ impl Node {
             _ => THUMB_THICKNESS,
         };
 
-        // The scrollport is the padding box.
-        let x0 = layout.border.left as f64;
-        let y0 = layout.border.top as f64;
-        let x1 = layout.size.width as f64 - layout.border.right as f64;
-        let y1 = layout.size.height as f64 - layout.border.bottom as f64;
-
+        let port = self.scrollport();
         let (viewport_len, scroll_offset) = if horizontal {
-            (x1 - x0, self.scroll_offset.x)
+            (port.width(), self.scroll_offset.x)
         } else {
-            (y1 - y0, self.scroll_offset.y)
+            (port.height(), self.scroll_offset.y)
         };
         let thumb_len = (viewport_len * viewport_len / (viewport_len + scroll_extent))
             .max(MIN_THUMB_LENGTH)
             .min(viewport_len);
         let progress = (scroll_offset / scroll_extent).clamp(0.0, 1.0);
-        let thumb_start = progress * (viewport_len - thumb_len);
+        // Round a sub-pixel displacement up to a whole pixel so any nonzero
+        // scroll visibly moves the thumb off the origin.
+        let thumb_start = match progress * (viewport_len - thumb_len) {
+            start if start > 0.0 && start < 1.0 => 1.0,
+            start => start,
+        };
 
         Some(if horizontal {
-            ScrollbarThumb {
-                x0: x0 + thumb_start,
-                y0: y1 - THUMB_MARGIN - thickness,
-                x1: x0 + thumb_start + thumb_len,
-                y1: y1 - THUMB_MARGIN,
-            }
+            KurboRect::new(
+                port.x0 + thumb_start,
+                port.y1 - THUMB_MARGIN - thickness,
+                port.x0 + thumb_start + thumb_len,
+                port.y1 - THUMB_MARGIN,
+            )
         } else {
-            ScrollbarThumb {
-                x0: x1 - THUMB_MARGIN - thickness,
-                y0: y0 + thumb_start,
-                x1: x1 - THUMB_MARGIN,
-                y1: y0 + thumb_start + thumb_len,
-            }
+            KurboRect::new(
+                port.x1 - THUMB_MARGIN - thickness,
+                port.y0 + thumb_start,
+                port.x1 - THUMB_MARGIN,
+                port.y0 + thumb_start + thumb_len,
+            )
         })
     }
 
@@ -1223,18 +1220,18 @@ impl Node {
         let Some(thumb) = self.scrollbar_thumb(horizontal) else {
             return 0.0;
         };
-        let layout = &self.final_layout;
+        let port = self.scrollport();
         let (scroll_extent, viewport_len, thumb_len) = if horizontal {
             (
-                layout.scroll_width() as f64,
-                layout.size.width as f64 - layout.border.left as f64 - layout.border.right as f64,
-                thumb.x1 - thumb.x0,
+                self.final_layout.scroll_width() as f64,
+                port.width(),
+                thumb.width(),
             )
         } else {
             (
-                layout.scroll_height() as f64,
-                layout.size.height as f64 - layout.border.top as f64 - layout.border.bottom as f64,
-                thumb.y1 - thumb.y0,
+                self.final_layout.scroll_height() as f64,
+                port.height(),
+                thumb.height(),
             )
         };
         let track_play = viewport_len - thumb_len;

--- a/packages/blitz-dom/src/node/scrollbar.rs
+++ b/packages/blitz-dom/src/node/scrollbar.rs
@@ -4,8 +4,25 @@
 
 use kurbo::Rect as KurboRect;
 use taffy::AbsoluteAxis;
+use web_time::Duration;
 
 use super::Node;
+
+/// How long overlay scrollbars stay fully opaque after their last activity
+/// (a scroll, or the pointer leaving the thumb), and how long the fade-out
+/// takes. Chromium's overlay values.
+pub(crate) const FADE_DELAY: Duration = Duration::from_millis(500);
+pub(crate) const FADE_DURATION: Duration = Duration::from_millis(200);
+
+/// Overlay scrollbar opacity as a function of time since the scroll
+/// container's last scrollbar activity: fully opaque through the fade
+/// delay, then fading linearly to hidden.
+pub(crate) fn opacity_at(elapsed: Duration) -> f32 {
+    match elapsed.checked_sub(FADE_DELAY) {
+        None => 1.0,
+        Some(fading) => 1.0 - (fading.as_secs_f32() / FADE_DURATION.as_secs_f32()).min(1.0),
+    }
+}
 
 /// A specific scrollbar: one axis of one scroll container.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -201,5 +218,20 @@ impl Node {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opacity_holds_through_the_fade_delay_then_fades_out() {
+        assert_eq!(opacity_at(Duration::ZERO), 1.0);
+        assert_eq!(opacity_at(FADE_DELAY), 1.0);
+        let mid_fade = opacity_at(FADE_DELAY + FADE_DURATION / 2);
+        assert!((mid_fade - 0.5).abs() < 0.01, "got {mid_fade}");
+        assert_eq!(opacity_at(FADE_DELAY + FADE_DURATION), 0.0);
+        assert_eq!(opacity_at(Duration::from_secs(3600)), 0.0);
     }
 }

--- a/packages/blitz-dom/src/node/scrollbar.rs
+++ b/packages/blitz-dom/src/node/scrollbar.rs
@@ -1,0 +1,205 @@
+//! Overlay scrollbar geometry and css-scrollbars-1 style accessors for
+//! [`Node`]. Geometry is shared between painting (blitz-paint) and thumb
+//! hit-testing so the two cannot drift.
+
+use kurbo::Rect as KurboRect;
+use taffy::AbsoluteAxis;
+
+use super::Node;
+
+/// A specific scrollbar: one axis of one scroll container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrollbarRef {
+    pub node_id: usize,
+    pub axis: AbsoluteAxis,
+}
+
+/// The computed value of `scrollbar-width` (css-scrollbars-1). A local
+/// mirror of the stylo type, which isn't exposed to the servo engine yet
+/// (servo/stylo#413).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ScrollbarWidth {
+    #[default]
+    Auto,
+    Thin,
+    None,
+}
+
+/// The computed value of `scrollbar-color` (css-scrollbars-1). A local
+/// mirror of the stylo type, which isn't exposed to the servo engine yet
+/// (servo/stylo#413). Colors are fully resolved (no `currentColor`).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum ScrollbarColor {
+    #[default]
+    Auto,
+    Colors {
+        thumb: style::color::AbsoluteColor,
+        track: style::color::AbsoluteColor,
+    },
+}
+
+impl Node {
+    /// The node's used `scrollbar-width`.
+    pub fn scrollbar_width(&self) -> ScrollbarWidth {
+        // TODO: read the computed style once stylo exposes scrollbar-width
+        // to the servo engine (servo/stylo#413):
+        // match self.primary_styles().map(|s| s.clone_scrollbar_width()) { .. }
+        ScrollbarWidth::Auto
+    }
+
+    /// The node's used `scrollbar-color`.
+    pub fn scrollbar_color(&self) -> ScrollbarColor {
+        // TODO: read the computed style once stylo exposes scrollbar-color
+        // to the servo engine (servo/stylo#413), resolving the colors
+        // against the element's `color`:
+        // self.primary_styles().map(|s| s.clone_scrollbar_color()) { .. }
+        ScrollbarColor::Auto
+    }
+
+    /// Whether the node shows an overlay scrollbar in the given axis:
+    /// always for `overflow: scroll`, only when the content overflows for
+    /// `overflow: auto`, never otherwise — and never when
+    /// `scrollbar-width: none`.
+    pub fn wants_scrollbar(&self, axis: AbsoluteAxis) -> bool {
+        use style::values::computed::Overflow;
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+        if self.scrollbar_width() == ScrollbarWidth::None {
+            return false;
+        }
+        let (overflow, scroll_extent) = match axis {
+            AbsoluteAxis::Horizontal => (
+                style.clone_overflow_x(),
+                self.final_layout.scroll_width() as f64,
+            ),
+            AbsoluteAxis::Vertical => (
+                style.clone_overflow_y(),
+                self.final_layout.scroll_height() as f64,
+            ),
+        };
+        match overflow {
+            Overflow::Scroll => true,
+            Overflow::Auto => scroll_extent > 0.5,
+            _ => false,
+        }
+    }
+
+    /// The scrollport (padding box) in (unscaled) CSS px relative to the
+    /// node's border-box origin. Taffy has content-box helpers but none for
+    /// the padding box.
+    fn scrollport(&self) -> KurboRect {
+        let layout = &self.final_layout;
+        KurboRect::new(
+            layout.border.left as f64,
+            layout.border.top as f64,
+            layout.size.width as f64 - layout.border.right as f64,
+            layout.size.height as f64 - layout.border.bottom as f64,
+        )
+    }
+
+    /// Geometry of the overlay scrollbar thumb for the given axis, in
+    /// (unscaled) CSS px relative to the node's border-box origin. `None`
+    /// if there is no scrollable overflow in that axis.
+    pub fn scrollbar_thumb(&self, axis: AbsoluteAxis) -> Option<KurboRect> {
+        // Matches Chromium's overlay thumb in its interactive state.
+        const THUMB_THICKNESS: f64 = 10.0;
+        const THIN_THUMB_THICKNESS: f64 = 6.0;
+        const THUMB_MARGIN: f64 = 2.0;
+        const MIN_THUMB_LENGTH: f64 = 32.0;
+
+        let layout = &self.final_layout;
+        let scroll_extent = match axis {
+            AbsoluteAxis::Horizontal => layout.scroll_width() as f64,
+            AbsoluteAxis::Vertical => layout.scroll_height() as f64,
+        };
+        if scroll_extent <= 0.5 {
+            return None;
+        }
+
+        let thickness = match self.scrollbar_width() {
+            ScrollbarWidth::Thin => THIN_THUMB_THICKNESS,
+            _ => THUMB_THICKNESS,
+        };
+
+        let port = self.scrollport();
+        let (viewport_len, scroll_offset) = match axis {
+            AbsoluteAxis::Horizontal => (port.width(), self.scroll_offset.x),
+            AbsoluteAxis::Vertical => (port.height(), self.scroll_offset.y),
+        };
+        let thumb_len = (viewport_len * viewport_len / (viewport_len + scroll_extent))
+            .max(MIN_THUMB_LENGTH)
+            .min(viewport_len);
+        let progress = (scroll_offset / scroll_extent).clamp(0.0, 1.0);
+        // Round a sub-pixel displacement up to a whole pixel so any nonzero
+        // scroll visibly moves the thumb off the origin.
+        let thumb_start = match progress * (viewport_len - thumb_len) {
+            start if start > 0.0 && start < 1.0 => 1.0,
+            start => start,
+        };
+
+        Some(match axis {
+            AbsoluteAxis::Horizontal => KurboRect::new(
+                port.x0 + thumb_start,
+                port.y1 - THUMB_MARGIN - thickness,
+                port.x0 + thumb_start + thumb_len,
+                port.y1 - THUMB_MARGIN,
+            ),
+            AbsoluteAxis::Vertical => KurboRect::new(
+                port.x1 - THUMB_MARGIN - thickness,
+                port.y0 + thumb_start,
+                port.x1 - THUMB_MARGIN,
+                port.y0 + thumb_start + thumb_len,
+            ),
+        })
+    }
+
+    /// Content px scrolled per thumb px dragged, for the given axis.
+    pub fn scrollbar_drag_ratio(&self, axis: AbsoluteAxis) -> f64 {
+        let Some(thumb) = self.scrollbar_thumb(axis) else {
+            return 0.0;
+        };
+        let port = self.scrollport();
+        let (scroll_extent, viewport_len, thumb_len) = match axis {
+            AbsoluteAxis::Horizontal => (
+                self.final_layout.scroll_width() as f64,
+                port.width(),
+                thumb.width(),
+            ),
+            AbsoluteAxis::Vertical => (
+                self.final_layout.scroll_height() as f64,
+                port.height(),
+                thumb.height(),
+            ),
+        };
+        let track_play = viewport_len - thumb_len;
+        if track_play <= 0.0 {
+            return 0.0;
+        }
+        scroll_extent / track_play
+    }
+
+    /// The scrollbar thumb containing the given point (in this node's
+    /// border-box coordinates), if any. The `scrollbars` feature's single
+    /// behavioral gate: returning `None` keeps unpainted thumbs from ever
+    /// claiming pointer events.
+    pub(crate) fn scrollbar_at_local(&self, x: f64, y: f64) -> Option<ScrollbarRef> {
+        if !cfg!(feature = "scrollbars") {
+            return None;
+        }
+        for axis in [AbsoluteAxis::Vertical, AbsoluteAxis::Horizontal] {
+            if !self.wants_scrollbar(axis) {
+                continue;
+            }
+            if let Some(thumb) = self.scrollbar_thumb(axis)
+                && thumb.contains(kurbo::Point::new(x, y))
+            {
+                return Some(ScrollbarRef {
+                    node_id: self.id,
+                    axis,
+                });
+            }
+        }
+        None
+    }
+}

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -54,6 +54,14 @@ impl BaseDocument {
 
         self.resolve_scroll_animation();
 
+        // Drop scrollbar-activity entries whose fade-out has finished (also
+        // sheds entries for removed nodes).
+        {
+            use crate::node::scrollbar::{FADE_DELAY, FADE_DURATION};
+            self.scrollbar_activity
+                .retain(|_, last| last.elapsed() < FADE_DELAY + FADE_DURATION);
+        }
+
         let root_node_id = self.root_element().id;
         debug_timer!(timer, feature = "log-phase-times");
 

--- a/packages/blitz-html/Cargo.toml
+++ b/packages/blitz-html/Cargo.toml
@@ -26,6 +26,6 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 markup5ever = { workspace = true }
-blitz-paint = { workspace = true }
+blitz-paint = { workspace = true, features = ["scrollbars"] }
 anyrender = { workspace = true }
 anyrender_vello_cpu = { workspace = true }

--- a/packages/blitz-html/tests/scrollbar_drag.rs
+++ b/packages/blitz-html/tests/scrollbar_drag.rs
@@ -67,19 +67,28 @@ fn scroller_doc() -> HtmlDocument {
     doc
 }
 
+/// Scrolls `scroller` down by `dy` content px through the scroll API, which
+/// also shows its overlay scrollbars (thumbs are only interactive while
+/// visible).
+fn scroll_down(doc: &mut HtmlDocument, scroller: usize, dy: f64) {
+    doc.scroll_by(Some(scroller), 0.0, -dy, &mut |_| {});
+}
+
 #[test]
 fn dragging_the_thumb_scrolls_the_container() {
     let mut doc = scroller_doc();
     let scroller = doc.query_selector("#scroller").unwrap().unwrap();
 
-    // Thumb starts at the top right (32px long, 10px wide, 2px margin).
-    drag(&mut doc, (97.0, 8.0), (97.0, 42.0));
+    // Scrolled to 450 (of 900), the 32px thumb sits 34px down its 68px of
+    // track play: y in [36, 68] (2px margin).
+    scroll_down(&mut doc, scroller, 450.0);
+    drag(&mut doc, (97.0, 50.0), (97.0, 16.0));
 
     let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
-    // 34 thumb px * (900 scroll range / 68 track play) = 450 content px
+    // -34 thumb px * (900 scroll range / 68 track play) = -450 content px
     assert!(
-        (offset - 450.0).abs() < 1.0,
-        "expected scroll offset ~450 after dragging the thumb 34px, got {offset}"
+        offset.abs() < 1.0,
+        "expected scroll offset ~0 after dragging the thumb up 34px, got {offset}"
     );
 }
 
@@ -89,10 +98,11 @@ fn dragging_content_does_not_scroll() {
     let scroller = doc.query_selector("#scroller").unwrap().unwrap();
 
     // Same drag, but starting in the content area, left of the thumb.
-    drag(&mut doc, (50.0, 8.0), (50.0, 50.0));
+    scroll_down(&mut doc, scroller, 450.0);
+    drag(&mut doc, (50.0, 50.0), (50.0, 16.0));
 
     let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
-    assert_eq!(offset, 0.0, "content drags must not move the scrollbar");
+    assert_eq!(offset, 450.0, "content drags must not move the scrollbar");
 }
 
 #[test]
@@ -100,13 +110,59 @@ fn drag_clamps_at_the_end_of_the_track() {
     let mut doc = scroller_doc();
     let scroller = doc.query_selector("#scroller").unwrap().unwrap();
 
-    drag(&mut doc, (97.0, 8.0), (97.0, 500.0));
+    scroll_down(&mut doc, scroller, 450.0);
+    drag(&mut doc, (97.0, 50.0), (97.0, 500.0));
 
     let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
     assert!(
         (offset - 900.0).abs() < 1.0,
         "expected scroll offset clamped to 900, got {offset}"
     );
+}
+
+#[test]
+fn faded_out_thumb_does_not_capture_drags() {
+    let mut doc = scroller_doc();
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+
+    // Never scrolled, so the scrollbars are hidden: a drag across where the
+    // thumb would be must fall through to the content.
+    drag(&mut doc, (97.0, 8.0), (97.0, 42.0));
+
+    let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
+    assert_eq!(offset, 0.0, "hidden thumbs must not capture pointer events");
+}
+
+#[test]
+fn pointer_hover_does_not_summon_hidden_scrollbars() {
+    use anyrender::render_to_buffer;
+    use anyrender_vello_cpu::VelloCpuImageRenderer;
+    use blitz_paint::paint_scene;
+
+    fn render(doc: &mut HtmlDocument) -> Vec<u8> {
+        render_to_buffer::<VelloCpuImageRenderer, _>(
+            |scene| paint_scene(scene, doc.as_mut(), 1.0, 100, 100, 0, 0),
+            100,
+            100,
+        )
+    }
+
+    let mut doc = scroller_doc();
+    let at_rest = render(&mut doc);
+
+    // Only scrolling shows overlay scrollbars: hovering where the thumb
+    // would be must not fade them in.
+    {
+        let mut driver = EventDriver::new(&mut doc, NoopEventHandler);
+        driver.handle_ui_event(UiEvent::PointerMove(pointer_event(
+            95.0,
+            8.0,
+            MouseEventButtons::None,
+        )));
+    }
+    let hovered = render(&mut doc);
+
+    assert_eq!(at_rest, hovered, "hovering must not paint a thumb");
 }
 
 #[test]
@@ -133,7 +189,7 @@ fn thumb_brightens_on_hover_and_drag() {
 
     let mut doc = scroller_doc();
     let scroller = doc.query_selector("#scroller").unwrap().unwrap();
-    doc.get_node_mut(scroller).unwrap().scroll_offset.y = 50.0;
+    scroll_down(&mut doc, scroller, 50.0);
 
     let base = thumb_pixel(&mut doc);
 
@@ -203,7 +259,7 @@ fn white_author_thumb_still_signals_hover_and_drag() {
     );
     doc.resolve(0.0);
     let scroller = doc.query_selector("#scroller").unwrap().unwrap();
-    doc.get_node_mut(scroller).unwrap().scroll_offset.y = 50.0;
+    scroll_down(&mut doc, scroller, 50.0);
 
     let base = thumb_pixel(&mut doc);
 

--- a/packages/blitz-html/tests/scrollbar_drag.rs
+++ b/packages/blitz-html/tests/scrollbar_drag.rs
@@ -1,0 +1,166 @@
+//! Dragging an overlay scrollbar thumb scrolls the container.
+
+use blitz_dom::{DocumentConfig, EventDriver, NoopEventHandler};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::events::{
+    BlitzPointerEvent, BlitzPointerId, MouseEventButton, MouseEventButtons, Point, PointerCoords,
+    PointerDetails, UiEvent,
+};
+use blitz_traits::shell::{ColorScheme, Viewport};
+
+use std::sync::Arc;
+
+fn pointer_event(x: f32, y: f32, buttons: MouseEventButtons) -> BlitzPointerEvent {
+    BlitzPointerEvent {
+        id: BlitzPointerId::Mouse,
+        is_primary: true,
+        coords: PointerCoords {
+            page_x: x,
+            page_y: y,
+            screen_x: x,
+            screen_y: y,
+            client_x: x,
+            client_y: y,
+        },
+        button: MouseEventButton::Main,
+        buttons,
+        mods: Default::default(),
+        details: PointerDetails::default(),
+        element: Point::default(),
+        active_pointers: Default::default(),
+    }
+}
+
+fn drag(doc: &mut HtmlDocument, from: (f32, f32), to: (f32, f32)) {
+    let mut driver = EventDriver::new(doc, NoopEventHandler);
+    driver.handle_ui_event(UiEvent::PointerDown(pointer_event(
+        from.0,
+        from.1,
+        MouseEventButtons::Primary,
+    )));
+    driver.handle_ui_event(UiEvent::PointerMove(pointer_event(
+        to.0,
+        to.1,
+        MouseEventButtons::Primary,
+    )));
+    driver.handle_ui_event(UiEvent::PointerUp(pointer_event(
+        to.0,
+        to.1,
+        MouseEventButtons::None,
+    )));
+}
+
+fn scroller_doc() -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:auto;">
+                <div style="height:1000px;"></div>
+            </div>
+        </body></html>"#,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+#[test]
+fn dragging_the_thumb_scrolls_the_container() {
+    let mut doc = scroller_doc();
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+
+    // Thumb starts at the top right (16px long, 6px wide, 2px margin).
+    drag(&mut doc, (97.0, 8.0), (97.0, 50.0));
+
+    let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
+    // 42 thumb px * (900 scroll range / 84 track play) = 450 content px
+    assert!(
+        (offset - 450.0).abs() < 1.0,
+        "expected scroll offset ~450 after dragging the thumb 42px, got {offset}"
+    );
+}
+
+#[test]
+fn dragging_content_does_not_scroll() {
+    let mut doc = scroller_doc();
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+
+    // Same drag, but starting in the content area, left of the thumb.
+    drag(&mut doc, (50.0, 8.0), (50.0, 50.0));
+
+    let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
+    assert_eq!(offset, 0.0, "content drags must not move the scrollbar");
+}
+
+#[test]
+fn drag_clamps_at_the_end_of_the_track() {
+    let mut doc = scroller_doc();
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+
+    drag(&mut doc, (97.0, 8.0), (97.0, 500.0));
+
+    let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
+    assert!(
+        (offset - 900.0).abs() < 1.0,
+        "expected scroll offset clamped to 900, got {offset}"
+    );
+}
+
+#[test]
+fn thumb_brightens_on_hover_and_drag() {
+    use anyrender::render_to_buffer;
+    use anyrender_vello_cpu::VelloCpuImageRenderer;
+    use blitz_paint::paint_scene;
+
+    fn thumb_pixel(doc: &mut HtmlDocument) -> [u8; 4] {
+        let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+            |scene| paint_scene(scene, doc.as_mut(), 1.0, 100, 100, 0, 0),
+            100,
+            100,
+        );
+        // Scrolled by 50 -> thumb sits around y=8; sample inside it.
+        let idx = (8 * 100 + 95) * 4;
+        [
+            buffer[idx],
+            buffer[idx + 1],
+            buffer[idx + 2],
+            buffer[idx + 3],
+        ]
+    }
+
+    let mut doc = scroller_doc();
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+    doc.get_node_mut(scroller).unwrap().scroll_offset.y = 50.0;
+
+    let base = thumb_pixel(&mut doc);
+
+    // Hover the thumb
+    {
+        let mut driver = EventDriver::new(&mut doc, NoopEventHandler);
+        driver.handle_ui_event(UiEvent::PointerMove(pointer_event(
+            95.0,
+            8.0,
+            MouseEventButtons::None,
+        )));
+    }
+    let hovered = thumb_pixel(&mut doc);
+    assert_ne!(base, hovered, "thumb must change appearance on hover");
+
+    // Start dragging the thumb
+    {
+        let mut driver = EventDriver::new(&mut doc, NoopEventHandler);
+        driver.handle_ui_event(UiEvent::PointerDown(pointer_event(
+            95.0,
+            8.0,
+            MouseEventButtons::Primary,
+        )));
+    }
+    let active = thumb_pixel(&mut doc);
+    assert_ne!(
+        hovered, active,
+        "thumb must change appearance while dragged"
+    );
+}

--- a/packages/blitz-html/tests/scrollbar_drag.rs
+++ b/packages/blitz-html/tests/scrollbar_drag.rs
@@ -164,3 +164,73 @@ fn thumb_brightens_on_hover_and_drag() {
         "thumb must change appearance while dragged"
     );
 }
+
+#[test]
+fn white_author_thumb_still_signals_hover_and_drag() {
+    // A near-white `scrollbar-color` thumb can't get lighter: hover/drag
+    // feedback must blend towards the pole with contrast headroom (darken).
+    use anyrender::render_to_buffer;
+    use anyrender_vello_cpu::VelloCpuImageRenderer;
+    use blitz_paint::paint_scene;
+
+    fn thumb_pixel(doc: &mut HtmlDocument) -> [u8; 4] {
+        let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+            |scene| paint_scene(scene, doc.as_mut(), 1.0, 100, 100, 0, 0),
+            100,
+            100,
+        );
+        let idx = (8 * 100 + 95) * 4;
+        [
+            buffer[idx],
+            buffer[idx + 1],
+            buffer[idx + 2],
+            buffer[idx + 3],
+        ]
+    }
+
+    let mut doc = HtmlDocument::from_html(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:auto; scrollbar-color:#ffffff transparent;">
+                <div style="height:1000px;"></div>
+            </div>
+        </body></html>"#,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let scroller = doc.query_selector("#scroller").unwrap().unwrap();
+    doc.get_node_mut(scroller).unwrap().scroll_offset.y = 50.0;
+
+    let base = thumb_pixel(&mut doc);
+
+    {
+        let mut driver = EventDriver::new(&mut doc, NoopEventHandler);
+        driver.handle_ui_event(UiEvent::PointerMove(pointer_event(
+            95.0,
+            8.0,
+            MouseEventButtons::None,
+        )));
+    }
+    let hovered = thumb_pixel(&mut doc);
+    assert_ne!(
+        base, hovered,
+        "a white author thumb must still visibly change on hover"
+    );
+
+    {
+        let mut driver = EventDriver::new(&mut doc, NoopEventHandler);
+        driver.handle_ui_event(UiEvent::PointerDown(pointer_event(
+            95.0,
+            8.0,
+            MouseEventButtons::Primary,
+        )));
+    }
+    let active = thumb_pixel(&mut doc);
+    assert_ne!(
+        hovered, active,
+        "a white author thumb must still visibly change while dragged"
+    );
+}

--- a/packages/blitz-html/tests/scrollbar_drag.rs
+++ b/packages/blitz-html/tests/scrollbar_drag.rs
@@ -166,6 +166,7 @@ fn thumb_brightens_on_hover_and_drag() {
 }
 
 #[test]
+#[ignore = "scrollbar-color is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn white_author_thumb_still_signals_hover_and_drag() {
     // A near-white `scrollbar-color` thumb can't get lighter: hover/drag
     // feedback must blend towards the pole with contrast headroom (darken).

--- a/packages/blitz-html/tests/scrollbar_drag.rs
+++ b/packages/blitz-html/tests/scrollbar_drag.rs
@@ -72,14 +72,14 @@ fn dragging_the_thumb_scrolls_the_container() {
     let mut doc = scroller_doc();
     let scroller = doc.query_selector("#scroller").unwrap().unwrap();
 
-    // Thumb starts at the top right (16px long, 6px wide, 2px margin).
-    drag(&mut doc, (97.0, 8.0), (97.0, 50.0));
+    // Thumb starts at the top right (32px long, 10px wide, 2px margin).
+    drag(&mut doc, (97.0, 8.0), (97.0, 42.0));
 
     let offset = doc.get_node(scroller).unwrap().scroll_offset.y;
-    // 42 thumb px * (900 scroll range / 84 track play) = 450 content px
+    // 34 thumb px * (900 scroll range / 68 track play) = 450 content px
     assert!(
         (offset - 450.0).abs() < 1.0,
-        "expected scroll offset ~450 after dragging the thumb 42px, got {offset}"
+        "expected scroll offset ~450 after dragging the thumb 34px, got {offset}"
     );
 }
 

--- a/packages/blitz-html/tests/scrollbars.rs
+++ b/packages/blitz-html/tests/scrollbars.rs
@@ -1,0 +1,90 @@
+//! Scroll containers paint overlay scrollbars while hovered or scrolled:
+//! always for overflow: scroll, only when overflowing for overflow: auto,
+//! never for overflow: hidden. At rest (unhovered, unscrolled) nothing is
+//! painted, like other overlay scrollbar UIs.
+
+use anyrender::render_to_buffer;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_paint::paint_scene;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+const BLUE: [u8; 3] = [0, 0, 255];
+
+/// Renders `html`, scrolling the `#scroller` element by (dx, dy) first,
+/// and returns the pixel at (x, y).
+fn pixel(html: &str, scroll: (f64, f64), x: usize, y: usize) -> [u8; 3] {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let scroller = doc.query_selector("#scroller").unwrap().expect("#scroller");
+    let node = doc.get_node_mut(scroller).unwrap();
+    node.scroll_offset.x = scroll.0;
+    node.scroll_offset.y = scroll.1;
+    let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+        |scene| paint_scene(scene, &mut doc, 1.0, 100, 100, 0, 0),
+        100,
+        100,
+    );
+    let idx = (y * 100 + x) * 4;
+    [buffer[idx], buffer[idx + 1], buffer[idx + 2]]
+}
+
+fn scroller(overflow: &str, child_height: u32) -> String {
+    format!(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:{overflow};">
+                <div style="height:{child_height}px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#
+    )
+}
+
+#[test]
+fn scrolled_auto_scroller_paints_a_thumb() {
+    let px = pixel(&scroller("auto", 1000), (0.0, 50.0), 97, 10);
+    assert_ne!(px, BLUE, "expected a scrollbar thumb over the content");
+}
+
+#[test]
+fn unscrolled_unhovered_scroller_paints_no_thumb() {
+    let px = pixel(&scroller("auto", 1000), (0.0, 0.0), 97, 4);
+    assert_eq!(px, BLUE, "overlay scrollbars are hidden at rest");
+}
+
+#[test]
+fn non_overflowing_auto_scroller_paints_no_thumb() {
+    // Even with a (stale) scroll offset, a non-overflowing auto container
+    // has no scroll range and paints no thumb.
+    let px = pixel(&scroller("auto", 100), (0.0, 10.0), 97, 4);
+    assert_eq!(px, BLUE, "no scrollbar for non-overflowing overflow:auto");
+}
+
+#[test]
+fn hidden_scroller_paints_no_thumb() {
+    let px = pixel(&scroller("hidden", 1000), (0.0, 50.0), 97, 10);
+    assert_eq!(px, BLUE, "overflow:hidden must not paint scrollbars");
+}
+
+#[test]
+fn horizontal_scroller_paints_a_thumb() {
+    let px = pixel(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-x:auto; overflow-y:hidden;">
+                <div style="width:1000px; height:100px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+        (50.0, 0.0),
+        10,
+        97,
+    );
+    assert_ne!(px, BLUE, "expected a horizontal scrollbar thumb");
+}

--- a/packages/blitz-html/tests/scrollbars.rs
+++ b/packages/blitz-html/tests/scrollbars.rs
@@ -88,3 +88,73 @@ fn horizontal_scroller_paints_a_thumb() {
     );
     assert_ne!(px, BLUE, "expected a horizontal scrollbar thumb");
 }
+
+#[test]
+fn scrollbar_color_styles_the_thumb() {
+    // Scrolled so the thumb is visible without hover.
+    let px = pixel(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:auto; scrollbar-color:#ff0000 transparent;">
+                <div style="height:1000px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+        (0.0, 50.0),
+        97,
+        10,
+    );
+    assert!(
+        px[0] > 200 && px[2] < 100,
+        "thumb should be the author's red, got {px:?}"
+    );
+}
+
+#[test]
+fn scrollbar_color_styles_the_track() {
+    let px = pixel(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:auto; scrollbar-color:#ff0000 #00ff00;">
+                <div style="height:1000px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+        (0.0, 50.0),
+        97,
+        90,
+    );
+    assert!(
+        px[1] > 200 && px[2] < 100,
+        "track should be the author's green, got {px:?}"
+    );
+}
+
+#[test]
+fn scrollbar_width_none_hides_the_scrollbar() {
+    let px = pixel(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:auto; scrollbar-width:none;">
+                <div style="height:1000px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+        (0.0, 50.0),
+        97,
+        10,
+    );
+    assert_eq!(px, BLUE, "scrollbar-width:none must paint no scrollbar");
+}
+
+#[test]
+fn author_styled_scrollbar_still_hides_at_rest() {
+    // scrollbar-color colors the scrollbar; it does not change overlay
+    // visibility behavior (persistence is UA policy, not author styling —
+    // matching Firefox/WebKit rendering of the property).
+    let px = pixel(
+        r#"<html><body style="margin:0">
+            <div id="scroller" style="width:100px; height:100px; overflow-y:auto; scrollbar-color:#ff0000 transparent;">
+                <div style="height:1000px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+        (0.0, 0.0),
+        97,
+        4,
+    );
+    assert_eq!(px, BLUE, "styled overlay scrollbars still hide at rest");
+}

--- a/packages/blitz-html/tests/scrollbars.rs
+++ b/packages/blitz-html/tests/scrollbars.rs
@@ -1,7 +1,7 @@
-//! Scroll containers paint overlay scrollbars while hovered or scrolled:
-//! always for overflow: scroll, only when overflowing for overflow: auto,
-//! never for overflow: hidden. At rest (unhovered, unscrolled) nothing is
-//! painted, like other overlay scrollbar UIs.
+//! Scroll containers paint overlay scrollbars when scrolled, fading them
+//! out after a delay: for overflow: scroll and overflowing overflow: auto,
+//! never for overflow: hidden. At rest nothing is painted, like other
+//! overlay scrollbar UIs.
 
 use anyrender::render_to_buffer;
 use anyrender_vello_cpu::VelloCpuImageRenderer;
@@ -31,9 +31,9 @@ fn pixel_in(html: &str, scroll: (f64, f64), x: usize, y: usize, scheme: ColorSch
     );
     doc.resolve(0.0);
     let scroller = doc.query_selector("#scroller").unwrap().expect("#scroller");
-    let node = doc.get_node_mut(scroller).unwrap();
-    node.scroll_offset.x = scroll.0;
-    node.scroll_offset.y = scroll.1;
+    // Scroll through the scroll API (wheel-delta semantics: negated), so the
+    // scroll registers as scrollbar activity like a real user scroll.
+    doc.scroll_by(Some(scroller), -scroll.0, -scroll.1, &mut |_| {});
     let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
         |scene| paint_scene(scene, &mut doc, 1.0, 100, 100, 0, 0),
         100,
@@ -67,16 +67,44 @@ fn unscrolled_unhovered_scroller_paints_no_thumb() {
 
 #[test]
 fn non_overflowing_auto_scroller_paints_no_thumb() {
-    // Even with a (stale) scroll offset, a non-overflowing auto container
-    // has no scroll range and paints no thumb.
+    // A non-overflowing auto container has no scroll range: the scroll
+    // doesn't move it and must not summon a thumb.
     let px = pixel(&scroller("auto", 100), (0.0, 10.0), 97, 4);
     assert_eq!(px, BLUE, "no scrollbar for non-overflowing overflow:auto");
 }
 
 #[test]
 fn hidden_scroller_paints_no_thumb() {
+    // overflow:hidden ignores user scrolls entirely.
     let px = pixel(&scroller("hidden", 1000), (0.0, 50.0), 97, 10);
     assert_eq!(px, BLUE, "overflow:hidden must not paint scrollbars");
+}
+
+#[test]
+fn stale_scroll_offset_alone_paints_no_thumb() {
+    // Overlay scrollbar visibility follows scroll *activity*, not scroll
+    // position: an offset applied outside the scroll API (no activity)
+    // paints nothing, like a scrolled-then-idle container after its
+    // scrollbars have faded out.
+    let mut doc = HtmlDocument::from_html(
+        &scroller("auto", 1000),
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let scroller = doc.query_selector("#scroller").unwrap().expect("#scroller");
+    doc.get_node_mut(scroller).unwrap().scroll_offset.y = 50.0;
+    let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+        |scene| paint_scene(scene, &mut doc, 1.0, 100, 100, 0, 0),
+        100,
+        100,
+    );
+    let idx = (10 * 100 + 97) * 4;
+    let px = [buffer[idx], buffer[idx + 1], buffer[idx + 2]];
+    assert_eq!(px, BLUE, "no scrollbar without scroll activity");
 }
 
 #[test]

--- a/packages/blitz-html/tests/scrollbars.rs
+++ b/packages/blitz-html/tests/scrollbars.rs
@@ -166,10 +166,10 @@ fn author_styled_scrollbar_still_hides_at_rest() {
 #[test]
 fn default_thumb_has_a_contrast_stroke() {
     // Default thumbs paint as fill + a thin contrast stroke. The thumb spans
-    // x in [92, 98]: x=92 lands on the stroke, x=95 on the fill.
+    // x in [88, 98]: x=88 lands on the stroke, x=93 on the fill.
     let html = scroller("auto", 1000);
-    let edge = pixel(&html, (0.0, 50.0), 92, 12);
-    let fill = pixel(&html, (0.0, 50.0), 95, 12);
+    let edge = pixel(&html, (0.0, 50.0), 88, 12);
+    let fill = pixel(&html, (0.0, 50.0), 93, 12);
     assert_ne!(edge, fill, "thumb edge should carry a contrast stroke");
 }
 

--- a/packages/blitz-html/tests/scrollbars.rs
+++ b/packages/blitz-html/tests/scrollbars.rs
@@ -95,6 +95,7 @@ fn horizontal_scroller_paints_a_thumb() {
 }
 
 #[test]
+#[ignore = "scrollbar-color is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn scrollbar_color_styles_the_thumb() {
     // Scrolled so the thumb is visible without hover.
     let px = pixel(
@@ -114,6 +115,7 @@ fn scrollbar_color_styles_the_thumb() {
 }
 
 #[test]
+#[ignore = "scrollbar-color is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn scrollbar_color_styles_the_track() {
     let px = pixel(
         r#"<html><body style="margin:0">
@@ -132,6 +134,7 @@ fn scrollbar_color_styles_the_track() {
 }
 
 #[test]
+#[ignore = "scrollbar-width is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn scrollbar_width_none_hides_the_scrollbar() {
     let px = pixel(
         r#"<html><body style="margin:0">
@@ -147,6 +150,7 @@ fn scrollbar_width_none_hides_the_scrollbar() {
 }
 
 #[test]
+#[ignore = "scrollbar-color is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn author_styled_scrollbar_still_hides_at_rest() {
     // scrollbar-color doesn't affect overlay visibility (matches how
     // Firefox/WebKit render the property).

--- a/packages/blitz-html/tests/scrollbars.rs
+++ b/packages/blitz-html/tests/scrollbars.rs
@@ -16,10 +16,15 @@ const BLUE: [u8; 3] = [0, 0, 255];
 /// Renders `html`, scrolling the `#scroller` element by (dx, dy) first,
 /// and returns the pixel at (x, y).
 fn pixel(html: &str, scroll: (f64, f64), x: usize, y: usize) -> [u8; 3] {
+    pixel_in(html, scroll, x, y, ColorScheme::Light)
+}
+
+/// [`pixel`], with the viewport's color scheme chosen by the caller.
+fn pixel_in(html: &str, scroll: (f64, f64), x: usize, y: usize, scheme: ColorScheme) -> [u8; 3] {
     let mut doc = HtmlDocument::from_html(
         html,
         DocumentConfig {
-            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            viewport: Some(Viewport::new(100, 100, 1.0, scheme)),
             html_parser_provider: Some(Arc::new(HtmlProvider) as _),
             ..Default::default()
         },
@@ -143,9 +148,8 @@ fn scrollbar_width_none_hides_the_scrollbar() {
 
 #[test]
 fn author_styled_scrollbar_still_hides_at_rest() {
-    // scrollbar-color colors the scrollbar; it does not change overlay
-    // visibility behavior (persistence is UA policy, not author styling —
-    // matching Firefox/WebKit rendering of the property).
+    // scrollbar-color doesn't affect overlay visibility (matches how
+    // Firefox/WebKit render the property).
     let px = pixel(
         r#"<html><body style="margin:0">
             <div id="scroller" style="width:100px; height:100px; overflow-y:auto; scrollbar-color:#ff0000 transparent;">
@@ -157,4 +161,23 @@ fn author_styled_scrollbar_still_hides_at_rest() {
         4,
     );
     assert_eq!(px, BLUE, "styled overlay scrollbars still hide at rest");
+}
+
+#[test]
+fn default_thumb_has_a_contrast_stroke() {
+    // Default thumbs paint as fill + a thin contrast stroke. The thumb spans
+    // x in [92, 98]: x=92 lands on the stroke, x=95 on the fill.
+    let html = scroller("auto", 1000);
+    let edge = pixel(&html, (0.0, 50.0), 92, 12);
+    let fill = pixel(&html, (0.0, 50.0), 95, 12);
+    assert_ne!(edge, fill, "thumb edge should carry a contrast stroke");
+}
+
+#[test]
+fn dark_scheme_uses_a_distinct_thumb() {
+    // The default palette follows the viewport color scheme.
+    let html = scroller("auto", 1000);
+    let light = pixel_in(&html, (0.0, 50.0), 95, 12, ColorScheme::Light);
+    let dark = pixel_in(&html, (0.0, 50.0), 95, 12, ColorScheme::Dark);
+    assert_ne!(light, dark, "thumb fill should follow the color scheme");
 }

--- a/packages/blitz-paint/Cargo.toml
+++ b/packages/blitz-paint/Cargo.toml
@@ -17,9 +17,10 @@ svg = ["dep:anyrender_svg", "dep:usvg", "blitz-dom/svg"]
 custom-widget = ["blitz-dom/custom-widget"]
 font-embolden = []
 apple-font-embolden = []
-# Paint overlay scrollbar thumbs on scroll containers (off by default while
-# the feature matures).
-scrollbars = []
+# Paint overlay scrollbar thumbs on scroll containers, and enable their
+# drag/hover interaction in blitz-dom (off by default while the feature
+# matures).
+scrollbars = ["blitz-dom/scrollbars"]
 
 [dependencies]
 # Blitz dependencies

--- a/packages/blitz-paint/Cargo.toml
+++ b/packages/blitz-paint/Cargo.toml
@@ -17,6 +17,9 @@ svg = ["dep:anyrender_svg", "dep:usvg", "blitz-dom/svg"]
 custom-widget = ["blitz-dom/custom-widget"]
 font-embolden = []
 apple-font-embolden = []
+# Paint overlay scrollbar thumbs on scroll containers (off by default while
+# the feature matures).
+scrollbars = []
 
 [dependencies]
 # Blitz dependencies

--- a/packages/blitz-paint/src/color.rs
+++ b/packages/blitz-paint/src/color.rs
@@ -23,3 +23,44 @@ impl ToColorColor for AbsoluteColor {
         DynamicColor::from_alpha_color(self.as_srgb_color())
     }
 }
+
+/// The WCAG contrast ratio (>= 1) between two colours, matching Chrome's
+/// `color_utils::GetContrastRatio`.
+pub(crate) fn contrast_ratio(a: Color, b: Color) -> f32 {
+    // `relative_luminance` is defined on `OpaqueColor`; discard the alpha (which
+    // it ignores anyway) with `split`.
+    let la = a.split().0.relative_luminance() + 0.05;
+    let lb = b.split().0.relative_luminance() + 0.05;
+    if la > lb { la / lb } else { lb / la }
+}
+
+/// Blend `color` towards black or white (whichever has contrast headroom)
+/// just far enough to reach `target` contrast with the original, so the
+/// result is visibly distinct for any input. Transparent colours pass
+/// through unchanged; alpha is preserved.
+#[cfg(feature = "scrollbars")]
+pub(crate) fn blend_for_contrast(color: Color, target: f32) -> Color {
+    let alpha = color.components[3];
+    if alpha == 0.0 {
+        return color;
+    }
+    let white = Color::new([1.0, 1.0, 1.0, alpha]);
+    let black = Color::new([0.0, 0.0, 0.0, alpha]);
+    let pole = if contrast_ratio(color, white) >= contrast_ratio(color, black) {
+        white
+    } else {
+        black
+    };
+    // Contrast grows monotonically towards the pole: bisect the blend
+    // fraction to land just past the target ratio.
+    let (mut lo, mut hi) = (0.0_f32, 1.0_f32);
+    for _ in 0..8 {
+        let mid = (lo + hi) / 2.0;
+        if contrast_ratio(color, color.lerp_rect(pole, mid)) < target {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    color.lerp_rect(pole, hi)
+}

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -582,14 +582,12 @@ impl ElementCx<'_, '_> {
     #[cfg(feature = "scrollbars")]
     fn draw_scrollbars(&self, scene: &mut impl PaintScene) {
         // css-scrollbars-1 scrollbar-color: author thumb/track colors
-        use style::values::generics::ui::ScrollbarColor as StyloScrollbarColor;
-        let current_color = self.style.clone_color();
-        let (custom_thumb, custom_track) = match &self.style.clone_scrollbar_color() {
-            StyloScrollbarColor::Auto => (None, None),
-            StyloScrollbarColor::Colors { thumb, track } => (
-                Some(thumb.resolve_to_absolute(&current_color).as_srgb_color()),
-                Some(track.resolve_to_absolute(&current_color).as_srgb_color()),
-            ),
+        use blitz_dom::node::ScrollbarColor;
+        let (custom_thumb, custom_track) = match self.node.scrollbar_color() {
+            ScrollbarColor::Auto => (None, None),
+            ScrollbarColor::Colors { thumb, track } => {
+                (Some(thumb.as_srgb_color()), Some(track.as_srgb_color()))
+            }
         };
 
         let drag_target = self.context.dom.scrollbar_drag_target();

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -441,7 +441,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                         #[cfg(feature = "scrollbars")]
                         {
                             cx.transform = unscrolled_transform;
-                            cx.draw_scrollbars(scene, overflow_x, overflow_y);
+                            cx.draw_scrollbars(scene);
                         }
                     },
                 );
@@ -577,107 +577,59 @@ impl ElementCx<'_, '_> {
     /// scrollbar UIs, thumbs only appear while the scroll container is
     /// hovered or scrolled away from the origin; this also keeps them out
     /// of (static, unhovered) reftest screenshots.
+    ///
+    /// Geometry comes from [`Node::scrollbar_thumb`], shared with the
+    /// thumb-drag hit testing in blitz-dom.
     #[cfg(feature = "scrollbars")]
-    fn draw_scrollbars(
-        &self,
-        scene: &mut impl PaintScene,
-        overflow_x: Overflow,
-        overflow_y: Overflow,
-    ) {
-        /// Whether an axis shows a bar: always for `scroll`, only when the
-        /// content actually overflows for `auto`, never for anything else.
-        fn wants_bar(overflow: Overflow, scroll_extent: f64) -> bool {
-            match overflow {
-                Overflow::Scroll => true,
-                Overflow::Auto => scroll_extent > 0.5,
-                _ => false,
-            }
-        }
+    fn draw_scrollbars(&self, scene: &mut impl PaintScene) {
+        let drag_target = self.context.dom.scrollbar_drag_target();
+        let hovered_thumb = self.context.dom.hovered_scrollbar();
 
-        /// Fill one axis' thumb: length proportional to the visible fraction
-        /// (clamped to a minimum), positioned by scroll progress, inset from
-        /// the padding-box edge. All lengths in scaled device pixels.
-        fn draw_thumb(
-            scene: &mut impl PaintScene,
-            transform: Affine,
-            scale: f64,
-            padding_box: Rect,
-            scroll_extent: f64,
-            scroll_offset: f64,
-            horizontal: bool,
-        ) {
-            const THUMB_THICKNESS: f64 = 6.0;
-            const THUMB_MARGIN: f64 = 2.0;
-            const MIN_THUMB_LENGTH: f64 = 16.0;
-            const THUMB_COLOR: Color = Color::from_rgba8(128, 128, 128, 178);
-
-            if scroll_extent <= 0.5 {
-                return;
-            }
-            let viewport_len = if horizontal {
-                padding_box.width()
-            } else {
-                padding_box.height()
-            };
-            let max_scroll = scroll_extent * scale;
-            let thumb_len = (viewport_len * viewport_len / (viewport_len + max_scroll))
-                .max(MIN_THUMB_LENGTH * scale)
-                .min(viewport_len);
-            let progress = (scroll_offset * scale / max_scroll).clamp(0.0, 1.0);
-            let thumb_start = progress * (viewport_len - thumb_len);
-            let thickness = THUMB_THICKNESS * scale;
-            let margin = THUMB_MARGIN * scale;
-            let rect = if horizontal {
-                Rect::new(
-                    padding_box.x0 + thumb_start,
-                    padding_box.y1 - margin - thickness,
-                    padding_box.x0 + thumb_start + thumb_len,
-                    padding_box.y1 - margin,
-                )
-            } else {
-                Rect::new(
-                    padding_box.x1 - margin - thickness,
-                    padding_box.y0 + thumb_start,
-                    padding_box.x1 - margin,
-                    padding_box.y0 + thumb_start + thumb_len,
-                )
-            };
-            let thumb = rect.to_rounded_rect(thickness / 2.0);
-            scene.fill(Fill::NonZero, transform, THUMB_COLOR, None, &thumb);
-        }
-
+        let node_id = self.node.id;
+        let is_drag_target = matches!(drag_target, Some((target_id, _)) if target_id == node_id);
         if !self.node.is_hovered()
+            && !is_drag_target
             && self.node.scroll_offset.x == 0.0
             && self.node.scroll_offset.y == 0.0
         {
             return;
         }
 
-        let layout = &self.node.final_layout;
-        let padding_box = self.frame.padding_box;
+        const THUMB_COLOR: Color = Color::from_rgba8(128, 128, 128, 178);
+        const THUMB_HOVER_COLOR: Color = Color::from_rgba8(152, 152, 152, 222);
+        const THUMB_ACTIVE_COLOR: Color = Color::from_rgba8(170, 170, 170, 255);
 
-        let scroll_height = layout.scroll_height() as f64;
-        if wants_bar(overflow_y, scroll_height) {
-            draw_thumb(
-                scene,
-                self.transform,
-                self.scale,
-                padding_box,
-                scroll_height,
-                self.node.scroll_offset.y,
-                false,
+        for horizontal in [false, true] {
+            if !self.node.wants_scrollbar(horizontal) {
+                continue;
+            }
+            let Some(thumb) = self.node.scrollbar_thumb(horizontal) else {
+                continue;
+            };
+            let color = if drag_target == Some((node_id, horizontal)) {
+                THUMB_ACTIVE_COLOR
+            } else if hovered_thumb == Some((node_id, horizontal)) {
+                THUMB_HOVER_COLOR
+            } else {
+                THUMB_COLOR
+            };
+            let rect = Rect::new(
+                thumb.x0 * self.scale,
+                thumb.y0 * self.scale,
+                thumb.x1 * self.scale,
+                thumb.y1 * self.scale,
             );
-        }
-        let scroll_width = layout.scroll_width() as f64;
-        if wants_bar(overflow_x, scroll_width) {
-            draw_thumb(
-                scene,
+            let radius = if horizontal {
+                rect.height() / 2.0
+            } else {
+                rect.width() / 2.0
+            };
+            scene.fill(
+                Fill::NonZero,
                 self.transform,
-                self.scale,
-                padding_box,
-                scroll_width,
-                self.node.scroll_offset.x,
-                true,
+                color,
+                None,
+                &rect.to_rounded_rect(radius),
             );
         }
     }

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -582,9 +582,10 @@ fn convert_rect(rect: &parley::BoundingBox) -> kurbo::Rect {
 impl ElementCx<'_, '_> {
     /// Paint overlay scrollbar thumbs for scroll containers: `overflow:
     /// scroll`, or `auto` when the content overflows (never `hidden`/`clip`,
-    /// which scroll only programmatically). Thumbs only appear while the
-    /// container is hovered or scrolled away from the origin, which also
-    /// keeps them out of static reftest screenshots.
+    /// which scroll only programmatically). Thumbs appear on scroll and fade
+    /// out after a delay ([`BaseDocument::scrollbar_opacity`]); never-scrolled
+    /// containers paint nothing, keeping thumbs out of static reftest
+    /// screenshots.
     ///
     /// Geometry comes from [`Node::scrollbar_thumb`], shared with the
     /// thumb-drag hit testing in blitz-dom.
@@ -606,12 +607,8 @@ impl ElementCx<'_, '_> {
         // scrollbar-color doesn't affect overlay visibility: persistence is
         // UA policy, not author styling.
         let node_id = self.node.id;
-        let is_drag_target = drag_target.is_some_and(|s| s.node_id == node_id);
-        if !self.node.is_hovered()
-            && !is_drag_target
-            && self.node.scroll_offset.x == 0.0
-            && self.node.scroll_offset.y == 0.0
-        {
+        let opacity = self.context.dom.scrollbar_opacity(node_id);
+        if opacity == 0.0 {
             return;
         }
 
@@ -664,7 +661,7 @@ impl ElementCx<'_, '_> {
                 scene.fill(
                     Fill::NonZero,
                     self.transform,
-                    track_color,
+                    track_color.multiply_alpha(opacity),
                     None,
                     &track_rect,
                 );
@@ -688,7 +685,7 @@ impl ElementCx<'_, '_> {
             scene.fill(
                 Fill::NonZero,
                 self.transform,
-                color,
+                color.multiply_alpha(opacity),
                 None,
                 &rect.to_rounded_rect(radius),
             );
@@ -700,7 +697,7 @@ impl ElementCx<'_, '_> {
                 scene.stroke(
                     &Stroke::new(stroke_width),
                     self.transform,
-                    stroke_color,
+                    stroke_color.multiply_alpha(opacity),
                     None,
                     &stroke_rect.to_rounded_rect(radius - stroke_width / 2.0),
                 );

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -582,9 +582,23 @@ impl ElementCx<'_, '_> {
     /// thumb-drag hit testing in blitz-dom.
     #[cfg(feature = "scrollbars")]
     fn draw_scrollbars(&self, scene: &mut impl PaintScene) {
+        // css-scrollbars-1 scrollbar-color: author thumb/track colors
+        use style::values::generics::ui::ScrollbarColor as StyloScrollbarColor;
+        let current_color = self.style.clone_color();
+        let (custom_thumb, custom_track) = match &self.style.clone_scrollbar_color() {
+            StyloScrollbarColor::Auto => (None, None),
+            StyloScrollbarColor::Colors { thumb, track } => (
+                Some(thumb.resolve_to_absolute(&current_color).as_srgb_color()),
+                Some(track.resolve_to_absolute(&current_color).as_srgb_color()),
+            ),
+        };
+
         let drag_target = self.context.dom.scrollbar_drag_target();
         let hovered_thumb = self.context.dom.hovered_scrollbar();
 
+        // scrollbar-color colors the scrollbar; it does not change overlay
+        // visibility behavior (matching Firefox/WebKit rendering of the
+        // property — persistence is UA policy, not author styling).
         let node_id = self.node.id;
         let is_drag_target = matches!(drag_target, Some((target_id, _)) if target_id == node_id);
         if !self.node.is_hovered()
@@ -599,6 +613,18 @@ impl ElementCx<'_, '_> {
         const THUMB_HOVER_COLOR: Color = Color::from_rgba8(152, 152, 152, 222);
         const THUMB_ACTIVE_COLOR: Color = Color::from_rgba8(170, 170, 170, 255);
 
+        /// Move a color towards white (for hover/active states of
+        /// author-specified thumb colors)
+        fn lighten(color: Color, amount: f32) -> Color {
+            let [r, g, b, a] = color.components;
+            Color::new([
+                r + (1.0 - r) * amount,
+                g + (1.0 - g) * amount,
+                b + (1.0 - b) * amount,
+                a,
+            ])
+        }
+
         for horizontal in [false, true] {
             if !self.node.wants_scrollbar(horizontal) {
                 continue;
@@ -606,12 +632,43 @@ impl ElementCx<'_, '_> {
             let Some(thumb) = self.node.scrollbar_thumb(horizontal) else {
                 continue;
             };
-            let color = if drag_target == Some((node_id, horizontal)) {
-                THUMB_ACTIVE_COLOR
-            } else if hovered_thumb == Some((node_id, horizontal)) {
-                THUMB_HOVER_COLOR
-            } else {
-                THUMB_COLOR
+
+            // Track (only when the author specified a track color)
+            if let Some(track_color) = custom_track {
+                let padding_box = self.frame.padding_box;
+                let track_rect = if horizontal {
+                    Rect::new(
+                        padding_box.x0,
+                        thumb.y0 * self.scale,
+                        padding_box.x1,
+                        thumb.y1 * self.scale,
+                    )
+                } else {
+                    Rect::new(
+                        thumb.x0 * self.scale,
+                        padding_box.y0,
+                        thumb.x1 * self.scale,
+                        padding_box.y1,
+                    )
+                };
+                scene.fill(
+                    Fill::NonZero,
+                    self.transform,
+                    track_color,
+                    None,
+                    &track_rect,
+                );
+            }
+
+            let is_active = drag_target == Some((node_id, horizontal));
+            let is_hovered = hovered_thumb == Some((node_id, horizontal));
+            let color = match custom_thumb {
+                Some(base) if is_active => lighten(base, 0.3),
+                Some(base) if is_hovered => lighten(base, 0.15),
+                Some(base) => base,
+                None if is_active => THUMB_ACTIVE_COLOR,
+                None if is_hovered => THUMB_HOVER_COLOR,
+                None => THUMB_COLOR,
             };
             let rect = Rect::new(
                 thumb.x0 * self.scale,

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -628,65 +628,6 @@ impl ElementCx<'_, '_> {
             )
         };
 
-        /// WCAG relative luminance of an sRGB color (alpha ignored).
-        fn relative_luminance(color: Color) -> f32 {
-            fn lin(c: f32) -> f32 {
-                if c <= 0.04045 {
-                    c / 12.92
-                } else {
-                    ((c + 0.055) / 1.055).powf(2.4)
-                }
-            }
-            let [r, g, b, _] = color.components;
-            0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
-        }
-
-        /// WCAG contrast ratio between two relative luminances.
-        fn contrast_ratio(l1: f32, l2: f32) -> f32 {
-            let (hi, lo) = if l1 > l2 { (l1, l2) } else { (l2, l1) };
-            (hi + 0.05) / (lo + 0.05)
-        }
-
-        /// Per-channel blend towards black (`pole = 0.0`) or white (`1.0`),
-        /// preserving alpha.
-        fn mix_towards(color: Color, pole: f32, t: f32) -> Color {
-            let [r, g, b, a] = color.components;
-            Color::new([
-                r + (pole - r) * t,
-                g + (pole - g) * t,
-                b + (pole - b) * t,
-                a,
-            ])
-        }
-
-        /// Hover/active state of an author-specified thumb color: blend
-        /// towards black or white (whichever has contrast headroom) just far
-        /// enough to reach `target` contrast with the rest state, so feedback
-        /// stays visible for any color. Transparent passes through unchanged.
-        fn blend_for_contrast(color: Color, target: f32) -> Color {
-            if color.components[3] == 0.0 {
-                return color;
-            }
-            let base_lum = relative_luminance(color);
-            let pole = if contrast_ratio(base_lum, 1.0) >= contrast_ratio(base_lum, 0.0) {
-                1.0
-            } else {
-                0.0
-            };
-            // Contrast grows monotonically towards the pole: bisect the blend
-            // fraction to land just past the target ratio.
-            let (mut lo, mut hi) = (0.0_f32, 1.0_f32);
-            for _ in 0..8 {
-                let mid = (lo + hi) / 2.0;
-                let lum = relative_luminance(mix_towards(color, pole, mid));
-                if contrast_ratio(base_lum, lum) < target {
-                    lo = mid;
-                } else {
-                    hi = mid;
-                }
-            }
-            mix_towards(color, pole, hi)
-        }
         // Chromium's hovered/pressed scrollbar contrast ratios.
         const HOVER_CONTRAST: f32 = 1.8;
         const ACTIVE_CONTRAST: f32 = 1.3;
@@ -721,8 +662,8 @@ impl ElementCx<'_, '_> {
             let is_active = drag_target == Some((node_id, horizontal));
             let is_hovered = hovered_thumb == Some((node_id, horizontal));
             let color = match custom_thumb {
-                Some(base) if is_active => blend_for_contrast(base, ACTIVE_CONTRAST),
-                Some(base) if is_hovered => blend_for_contrast(base, HOVER_CONTRAST),
+                Some(base) if is_active => crate::color::blend_for_contrast(base, ACTIVE_CONTRAST),
+                Some(base) if is_hovered => crate::color::blend_for_contrast(base, HOVER_CONTRAST),
                 Some(base) => base,
                 None if is_active => thumb_active,
                 None if is_hovered => thumb_hover,

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -571,12 +571,11 @@ fn convert_rect(rect: &parley::BoundingBox) -> kurbo::Rect {
 }
 
 impl ElementCx<'_, '_> {
-    /// Paint overlay scrollbar thumbs for scroll containers (`overflow:
-    /// scroll`, or `auto` when the content overflows — never `hidden`/
-    /// `clip`, which scroll only programmatically). Like other overlay
-    /// scrollbar UIs, thumbs only appear while the scroll container is
-    /// hovered or scrolled away from the origin; this also keeps them out
-    /// of (static, unhovered) reftest screenshots.
+    /// Paint overlay scrollbar thumbs for scroll containers: `overflow:
+    /// scroll`, or `auto` when the content overflows (never `hidden`/`clip`,
+    /// which scroll only programmatically). Thumbs only appear while the
+    /// container is hovered or scrolled away from the origin, which also
+    /// keeps them out of static reftest screenshots.
     ///
     /// Geometry comes from [`Node::scrollbar_thumb`], shared with the
     /// thumb-drag hit testing in blitz-dom.
@@ -596,9 +595,8 @@ impl ElementCx<'_, '_> {
         let drag_target = self.context.dom.scrollbar_drag_target();
         let hovered_thumb = self.context.dom.hovered_scrollbar();
 
-        // scrollbar-color colors the scrollbar; it does not change overlay
-        // visibility behavior (matching Firefox/WebKit rendering of the
-        // property — persistence is UA policy, not author styling).
+        // scrollbar-color doesn't affect overlay visibility: persistence is
+        // UA policy, not author styling.
         let node_id = self.node.id;
         let is_drag_target = matches!(drag_target, Some((target_id, _)) if target_id == node_id);
         if !self.node.is_hovered()
@@ -609,21 +607,89 @@ impl ElementCx<'_, '_> {
             return;
         }
 
-        const THUMB_COLOR: Color = Color::from_rgba8(128, 128, 128, 178);
-        const THUMB_HOVER_COLOR: Color = Color::from_rgba8(152, 152, 152, 222);
-        const THUMB_ACTIVE_COLOR: Color = Color::from_rgba8(170, 170, 170, 255);
+        // Default thumb palette for the used color scheme; thumbs paint as
+        // fill plus a thin contrast stroke so they read over same-colored
+        // content.
+        let dark_scheme =
+            self.context.dom.viewport().color_scheme == blitz_traits::shell::ColorScheme::Dark;
+        let (thumb_rest, thumb_hover, thumb_active, stroke_color) = if dark_scheme {
+            (
+                Color::from_rgba8(214, 214, 214, 178),
+                Color::from_rgba8(190, 190, 190, 222),
+                Color::from_rgba8(172, 172, 172, 255),
+                Color::from_rgba8(0, 0, 0, 102),
+            )
+        } else {
+            (
+                Color::from_rgba8(128, 128, 128, 178),
+                Color::from_rgba8(152, 152, 152, 222),
+                Color::from_rgba8(170, 170, 170, 255),
+                Color::from_rgba8(255, 255, 255, 102),
+            )
+        };
 
-        /// Move a color towards white (for hover/active states of
-        /// author-specified thumb colors)
-        fn lighten(color: Color, amount: f32) -> Color {
+        /// WCAG relative luminance of an sRGB color (alpha ignored).
+        fn relative_luminance(color: Color) -> f32 {
+            fn lin(c: f32) -> f32 {
+                if c <= 0.04045 {
+                    c / 12.92
+                } else {
+                    ((c + 0.055) / 1.055).powf(2.4)
+                }
+            }
+            let [r, g, b, _] = color.components;
+            0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+        }
+
+        /// WCAG contrast ratio between two relative luminances.
+        fn contrast_ratio(l1: f32, l2: f32) -> f32 {
+            let (hi, lo) = if l1 > l2 { (l1, l2) } else { (l2, l1) };
+            (hi + 0.05) / (lo + 0.05)
+        }
+
+        /// Per-channel blend towards black (`pole = 0.0`) or white (`1.0`),
+        /// preserving alpha.
+        fn mix_towards(color: Color, pole: f32, t: f32) -> Color {
             let [r, g, b, a] = color.components;
             Color::new([
-                r + (1.0 - r) * amount,
-                g + (1.0 - g) * amount,
-                b + (1.0 - b) * amount,
+                r + (pole - r) * t,
+                g + (pole - g) * t,
+                b + (pole - b) * t,
                 a,
             ])
         }
+
+        /// Hover/active state of an author-specified thumb color: blend
+        /// towards black or white (whichever has contrast headroom) just far
+        /// enough to reach `target` contrast with the rest state, so feedback
+        /// stays visible for any color. Transparent passes through unchanged.
+        fn blend_for_contrast(color: Color, target: f32) -> Color {
+            if color.components[3] == 0.0 {
+                return color;
+            }
+            let base_lum = relative_luminance(color);
+            let pole = if contrast_ratio(base_lum, 1.0) >= contrast_ratio(base_lum, 0.0) {
+                1.0
+            } else {
+                0.0
+            };
+            // Contrast grows monotonically towards the pole: bisect the blend
+            // fraction to land just past the target ratio.
+            let (mut lo, mut hi) = (0.0_f32, 1.0_f32);
+            for _ in 0..8 {
+                let mid = (lo + hi) / 2.0;
+                let lum = relative_luminance(mix_towards(color, pole, mid));
+                if contrast_ratio(base_lum, lum) < target {
+                    lo = mid;
+                } else {
+                    hi = mid;
+                }
+            }
+            mix_towards(color, pole, hi)
+        }
+        // Chromium's hovered/pressed scrollbar contrast ratios.
+        const HOVER_CONTRAST: f32 = 1.8;
+        const ACTIVE_CONTRAST: f32 = 1.3;
 
         for horizontal in [false, true] {
             if !self.node.wants_scrollbar(horizontal) {
@@ -633,23 +699,15 @@ impl ElementCx<'_, '_> {
                 continue;
             };
 
+            let rect = thumb.scale_from_origin(self.scale);
+
             // Track (only when the author specified a track color)
             if let Some(track_color) = custom_track {
                 let padding_box = self.frame.padding_box;
                 let track_rect = if horizontal {
-                    Rect::new(
-                        padding_box.x0,
-                        thumb.y0 * self.scale,
-                        padding_box.x1,
-                        thumb.y1 * self.scale,
-                    )
+                    Rect::new(padding_box.x0, rect.y0, padding_box.x1, rect.y1)
                 } else {
-                    Rect::new(
-                        thumb.x0 * self.scale,
-                        padding_box.y0,
-                        thumb.x1 * self.scale,
-                        padding_box.y1,
-                    )
+                    Rect::new(rect.x0, padding_box.y0, rect.x1, padding_box.y1)
                 };
                 scene.fill(
                     Fill::NonZero,
@@ -663,19 +721,13 @@ impl ElementCx<'_, '_> {
             let is_active = drag_target == Some((node_id, horizontal));
             let is_hovered = hovered_thumb == Some((node_id, horizontal));
             let color = match custom_thumb {
-                Some(base) if is_active => lighten(base, 0.3),
-                Some(base) if is_hovered => lighten(base, 0.15),
+                Some(base) if is_active => blend_for_contrast(base, ACTIVE_CONTRAST),
+                Some(base) if is_hovered => blend_for_contrast(base, HOVER_CONTRAST),
                 Some(base) => base,
-                None if is_active => THUMB_ACTIVE_COLOR,
-                None if is_hovered => THUMB_HOVER_COLOR,
-                None => THUMB_COLOR,
+                None if is_active => thumb_active,
+                None if is_hovered => thumb_hover,
+                None => thumb_rest,
             };
-            let rect = Rect::new(
-                thumb.x0 * self.scale,
-                thumb.y0 * self.scale,
-                thumb.x1 * self.scale,
-                thumb.y1 * self.scale,
-            );
             let radius = if horizontal {
                 rect.height() / 2.0
             } else {
@@ -688,6 +740,19 @@ impl ElementCx<'_, '_> {
                 None,
                 &rect.to_rounded_rect(radius),
             );
+            // Contrast stroke, default thumbs only: an author-specified
+            // scrollbar-color is rendered exactly as given.
+            if custom_thumb.is_none() {
+                let stroke_width = self.scale;
+                let stroke_rect = rect.inset(-stroke_width / 2.0);
+                scene.stroke(
+                    &Stroke::new(stroke_width),
+                    self.transform,
+                    stroke_color,
+                    None,
+                    &stroke_rect.to_rounded_rect(radius - stroke_width / 2.0),
+                );
+            }
         }
     }
 

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -435,6 +435,14 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                                 cx.draw_children(scene, cx.transform, child_clip_rect);
                             },
                         );
+
+                        // Overlay scrollbars, drawn unscrolled above the
+                        // clipped content.
+                        #[cfg(feature = "scrollbars")]
+                        {
+                            cx.transform = unscrolled_transform;
+                            cx.draw_scrollbars(scene, overflow_x, overflow_y);
+                        }
                     },
                 );
 
@@ -563,6 +571,117 @@ fn convert_rect(rect: &parley::BoundingBox) -> kurbo::Rect {
 }
 
 impl ElementCx<'_, '_> {
+    /// Paint overlay scrollbar thumbs for scroll containers (`overflow:
+    /// scroll`, or `auto` when the content overflows — never `hidden`/
+    /// `clip`, which scroll only programmatically). Like other overlay
+    /// scrollbar UIs, thumbs only appear while the scroll container is
+    /// hovered or scrolled away from the origin; this also keeps them out
+    /// of (static, unhovered) reftest screenshots.
+    #[cfg(feature = "scrollbars")]
+    fn draw_scrollbars(
+        &self,
+        scene: &mut impl PaintScene,
+        overflow_x: Overflow,
+        overflow_y: Overflow,
+    ) {
+        /// Whether an axis shows a bar: always for `scroll`, only when the
+        /// content actually overflows for `auto`, never for anything else.
+        fn wants_bar(overflow: Overflow, scroll_extent: f64) -> bool {
+            match overflow {
+                Overflow::Scroll => true,
+                Overflow::Auto => scroll_extent > 0.5,
+                _ => false,
+            }
+        }
+
+        /// Fill one axis' thumb: length proportional to the visible fraction
+        /// (clamped to a minimum), positioned by scroll progress, inset from
+        /// the padding-box edge. All lengths in scaled device pixels.
+        fn draw_thumb(
+            scene: &mut impl PaintScene,
+            transform: Affine,
+            scale: f64,
+            padding_box: Rect,
+            scroll_extent: f64,
+            scroll_offset: f64,
+            horizontal: bool,
+        ) {
+            const THUMB_THICKNESS: f64 = 6.0;
+            const THUMB_MARGIN: f64 = 2.0;
+            const MIN_THUMB_LENGTH: f64 = 16.0;
+            const THUMB_COLOR: Color = Color::from_rgba8(128, 128, 128, 178);
+
+            if scroll_extent <= 0.5 {
+                return;
+            }
+            let viewport_len = if horizontal {
+                padding_box.width()
+            } else {
+                padding_box.height()
+            };
+            let max_scroll = scroll_extent * scale;
+            let thumb_len = (viewport_len * viewport_len / (viewport_len + max_scroll))
+                .max(MIN_THUMB_LENGTH * scale)
+                .min(viewport_len);
+            let progress = (scroll_offset * scale / max_scroll).clamp(0.0, 1.0);
+            let thumb_start = progress * (viewport_len - thumb_len);
+            let thickness = THUMB_THICKNESS * scale;
+            let margin = THUMB_MARGIN * scale;
+            let rect = if horizontal {
+                Rect::new(
+                    padding_box.x0 + thumb_start,
+                    padding_box.y1 - margin - thickness,
+                    padding_box.x0 + thumb_start + thumb_len,
+                    padding_box.y1 - margin,
+                )
+            } else {
+                Rect::new(
+                    padding_box.x1 - margin - thickness,
+                    padding_box.y0 + thumb_start,
+                    padding_box.x1 - margin,
+                    padding_box.y0 + thumb_start + thumb_len,
+                )
+            };
+            let thumb = rect.to_rounded_rect(thickness / 2.0);
+            scene.fill(Fill::NonZero, transform, THUMB_COLOR, None, &thumb);
+        }
+
+        if !self.node.is_hovered()
+            && self.node.scroll_offset.x == 0.0
+            && self.node.scroll_offset.y == 0.0
+        {
+            return;
+        }
+
+        let layout = &self.node.final_layout;
+        let padding_box = self.frame.padding_box;
+
+        let scroll_height = layout.scroll_height() as f64;
+        if wants_bar(overflow_y, scroll_height) {
+            draw_thumb(
+                scene,
+                self.transform,
+                self.scale,
+                padding_box,
+                scroll_height,
+                self.node.scroll_offset.y,
+                false,
+            );
+        }
+        let scroll_width = layout.scroll_width() as f64;
+        if wants_bar(overflow_x, scroll_width) {
+            draw_thumb(
+                scene,
+                self.transform,
+                self.scale,
+                padding_box,
+                scroll_width,
+                self.node.scroll_offset.x,
+                true,
+            );
+        }
+    }
+
     fn draw_inline_layout(&self, scene: &mut impl PaintScene, pos: Point) {
         if self.node.flags.is_inline_root() {
             let text_layout = self.element

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -54,6 +54,11 @@ pub struct BlitzDomPainter<'dom, 'a> {
     pub(crate) initial_y: f64,
     /// The id of the document's root element (cached to avoid re-resolving it for every element)
     pub(crate) root_element_id: Option<usize>,
+    /// Scrollbar hover/drag state, resolved once per scene like the root element
+    #[cfg(feature = "scrollbars")]
+    pub(crate) hovered_scrollbar: Option<blitz_dom::node::ScrollbarRef>,
+    #[cfg(feature = "scrollbars")]
+    pub(crate) scrollbar_drag_target: Option<blitz_dom::node::ScrollbarRef>,
     pub(crate) layer_manager: LayerManager,
     /// Cached selection ranges for O(1) lookup: node_id -> (start_offset, end_offset)
     pub(crate) selection_ranges: HashMap<usize, (usize, usize)>,
@@ -90,6 +95,10 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             initial_x,
             initial_y,
             root_element_id,
+            #[cfg(feature = "scrollbars")]
+            hovered_scrollbar: dom.hovered_scrollbar(),
+            #[cfg(feature = "scrollbars")]
+            scrollbar_drag_target: dom.scrollbar_drag_target(),
             layer_manager,
             selection_ranges,
             custom_widget_scenes,
@@ -582,7 +591,8 @@ impl ElementCx<'_, '_> {
     #[cfg(feature = "scrollbars")]
     fn draw_scrollbars(&self, scene: &mut impl PaintScene) {
         // css-scrollbars-1 scrollbar-color: author thumb/track colors
-        use blitz_dom::node::ScrollbarColor;
+        use blitz_dom::node::{ScrollbarColor, ScrollbarRef};
+        use taffy::AbsoluteAxis;
         let (custom_thumb, custom_track) = match self.node.scrollbar_color() {
             ScrollbarColor::Auto => (None, None),
             ScrollbarColor::Colors { thumb, track } => {
@@ -590,13 +600,13 @@ impl ElementCx<'_, '_> {
             }
         };
 
-        let drag_target = self.context.dom.scrollbar_drag_target();
-        let hovered_thumb = self.context.dom.hovered_scrollbar();
+        let drag_target = self.context.scrollbar_drag_target;
+        let hovered_thumb = self.context.hovered_scrollbar;
 
         // scrollbar-color doesn't affect overlay visibility: persistence is
         // UA policy, not author styling.
         let node_id = self.node.id;
-        let is_drag_target = matches!(drag_target, Some((target_id, _)) if target_id == node_id);
+        let is_drag_target = drag_target.is_some_and(|s| s.node_id == node_id);
         if !self.node.is_hovered()
             && !is_drag_target
             && self.node.scroll_offset.x == 0.0
@@ -630,11 +640,11 @@ impl ElementCx<'_, '_> {
         const HOVER_CONTRAST: f32 = 1.8;
         const ACTIVE_CONTRAST: f32 = 1.3;
 
-        for horizontal in [false, true] {
-            if !self.node.wants_scrollbar(horizontal) {
+        for axis in [AbsoluteAxis::Vertical, AbsoluteAxis::Horizontal] {
+            if !self.node.wants_scrollbar(axis) {
                 continue;
             }
-            let Some(thumb) = self.node.scrollbar_thumb(horizontal) else {
+            let Some(thumb) = self.node.scrollbar_thumb(axis) else {
                 continue;
             };
 
@@ -643,10 +653,13 @@ impl ElementCx<'_, '_> {
             // Track (only when the author specified a track color)
             if let Some(track_color) = custom_track {
                 let padding_box = self.frame.padding_box;
-                let track_rect = if horizontal {
-                    Rect::new(padding_box.x0, rect.y0, padding_box.x1, rect.y1)
-                } else {
-                    Rect::new(rect.x0, padding_box.y0, rect.x1, padding_box.y1)
+                let track_rect = match axis {
+                    AbsoluteAxis::Horizontal => {
+                        Rect::new(padding_box.x0, rect.y0, padding_box.x1, rect.y1)
+                    }
+                    AbsoluteAxis::Vertical => {
+                        Rect::new(rect.x0, padding_box.y0, rect.x1, padding_box.y1)
+                    }
                 };
                 scene.fill(
                     Fill::NonZero,
@@ -657,8 +670,9 @@ impl ElementCx<'_, '_> {
                 );
             }
 
-            let is_active = drag_target == Some((node_id, horizontal));
-            let is_hovered = hovered_thumb == Some((node_id, horizontal));
+            let this = ScrollbarRef { node_id, axis };
+            let is_active = drag_target == Some(this);
+            let is_hovered = hovered_thumb == Some(this);
             let color = match custom_thumb {
                 Some(base) if is_active => crate::color::blend_for_contrast(base, ACTIVE_CONTRAST),
                 Some(base) if is_hovered => crate::color::blend_for_contrast(base, HOVER_CONTRAST),
@@ -667,10 +681,9 @@ impl ElementCx<'_, '_> {
                 None if is_hovered => thumb_hover,
                 None => thumb_rest,
             };
-            let radius = if horizontal {
-                rect.height() / 2.0
-            } else {
-                rect.width() / 2.0
+            let radius = match axis {
+                AbsoluteAxis::Horizontal => rect.height() / 2.0,
+                AbsoluteAxis::Vertical => rect.width() / 2.0,
             };
             scene.fill(
                 Fill::NonZero,

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -8,17 +8,11 @@ use style::{
     values::computed::{BorderStyle, OutlineStyle},
 };
 
-use crate::{color::ToColorColor as _, kurbo_css::Edge, render::ElementCx};
-
-/// The WCAG contrast ratio (>= 1) between two colours, matching Chrome's
-/// `color_utils::GetContrastRatio`.
-fn contrast_ratio(a: Color, b: Color) -> f32 {
-    // `relative_luminance` is defined on `OpaqueColor`; discard the alpha (which
-    // it ignores anyway) with `split`.
-    let la = a.split().0.relative_luminance() + 0.05;
-    let lb = b.split().0.relative_luminance() + 0.05;
-    if la > lb { la / lb } else { lb / la }
-}
+use crate::{
+    color::{ToColorColor as _, contrast_ratio},
+    kurbo_css::Edge,
+    render::ElementCx,
+};
 
 /// A darker version of a colour (mirrors WebKit/Blink's `Color::Dark`): the
 /// brightest channel is reduced by a fixed amount and the others scaled to match,

--- a/packages/blitz/Cargo.toml
+++ b/packages/blitz/Cargo.toml
@@ -15,6 +15,7 @@ default = ["net", "accessibility", "tracing"]
 net = ["dep:tokio", "dep:url", "dep:blitz-net"]
 accessibility = ["blitz-shell/accessibility"]
 tracing = ["dep:tracing", "blitz-shell/tracing", "blitz-html/tracing", "blitz-net/tracing"]
+scrollbars = ["blitz-paint/scrollbars"]
 
 [dependencies]
 # Blitz dependencies

--- a/packages/dioxus-native/Cargo.toml
+++ b/packages/dioxus-native/Cargo.toml
@@ -42,6 +42,7 @@ vello-cpu-base = ["dep:anyrender_vello_cpu"]
 
 font-embolden = ["blitz-paint/font-embolden"]
 apple-font-embolden = ["blitz-paint/apple-font-embolden"]
+scrollbars = ["blitz-paint/scrollbars"]
 
 # Other features
 # No-op on wasm32 (blitz_net::Provider needs tokio's threaded runtime); launch_cfg


### PR DESCRIPTION
Implements scrollbar support end to end [as per the w3 spec](https://www.w3.org/TR/css-scrollbars-1/) and compared against Blink/Chromium for any edge cases.

Generated via Claude Fable, code quality reviewed manually. PR Desc was handwritten.

## Changes made:

- Scroll containers now paint an overlay scrollbar thumb (hidden at rest, shown on hover/scroll)
- Thumbs can be dragged to scroll, with hover/drag highlighting
- `scrollbar-color` and `scrollbar-width` (`thin`/`none`) are supported
- Everything is behind a `scrollbars` cargo feature, **off by default**

## Notes

- Awaiting servo/stylo#413 to get merged to revert Cargo.toml and Cargo.lock, stylo source was switched so tests pass and I could test.

## Out of scope / deliberately skipped

- Fade in/out animations and hover thickening needs repaint timer so they were skipped to be implemented in a separate pr
- Scrollbars on the viewport itself were skipped because blitz does not paint those at all yet.
- RTL and vertical writing modes - blitz doesn't support RTL scroll ranges yet.
- Thumb hit-testing inside CSS transforms, pointer-math limitations were skipped, added a fixme in code so we don't forget about it.
- Classic space reserving scrollbars, `scrollbar-gutter`
