### PR TITLE
Add `use_back_button` hook for (Android) back button

### DIFF
--- a/apps/browser/src/main.rs
+++ b/apps/browser/src/main.rs
@@ -11,7 +11,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use std::sync::Arc;
 
 use blitz_traits::net::Url;
-use dioxus_native::{NodeHandle, WindowAttributes, prelude::*};
+use dioxus_native::{NodeHandle, WindowAttributes, prelude::*, use_back_button};
 
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowAttributesMacOS;
@@ -135,6 +135,13 @@ fn app() -> Element {
         if let Some(handle) = url_input_handle() {
             drop(handle.set_focus(true));
         }
+    });
+
+    // Navigate back in the active tab's history when the (Android) hardware
+    // back button is pressed. `go_back` is a no-op when there is no history to
+    // go back to.
+    use_back_button(move || {
+        active_tab(tabs, active_tab_id()).go_back();
     });
 
     // HACK: Winit doesn't support "safe area" on Android yet.

--- a/packages/dioxus-native/src/hooks.rs
+++ b/packages/dioxus-native/src/hooks.rs
@@ -2,7 +2,11 @@ use crate::event_handlers::{WindowEventHandlers, WinitEventHandlerId};
 
 use dioxus_core::{Runtime, consume_context, current_scope_id, use_hook_with_cleanup};
 use std::rc::Rc;
-use winit::{event::WindowEvent, event_loop::ActiveEventLoop};
+use winit::{
+    event::{ElementState, WindowEvent},
+    event_loop::ActiveEventLoop,
+    keyboard::{Key, NamedKey},
+};
 
 /// Register an event handler that runs when a winit event is processed.
 pub fn use_window_event(
@@ -21,4 +25,25 @@ pub fn use_window_event(
         },
         move |handler| handler.remove(),
     )
+}
+
+/// Register a handler that runs when the back button is pressed.
+///
+/// This builds on top of [`use_window_event`]: the back button is delivered by `winit` as a
+/// [`WindowEvent::KeyboardInput`] whose logical key is [`NamedKey::BrowserBack`]. This most
+/// commonly comes from the Android hardware/system back button, but may also be produced by a
+/// keyboard or mouse back key on other platforms. The provided `handler` is called once each
+/// time the button is pressed (key repeats are ignored).
+///
+/// Returns a [`WinitEventHandlerId`] which can be used to remove the handler.
+pub fn use_back_button(mut handler: impl FnMut() + 'static) -> WinitEventHandlerId {
+    use_window_event(move |event, _target| {
+        if let WindowEvent::KeyboardInput { event, .. } = event
+            && event.state == ElementState::Pressed
+            && !event.repeat
+            && event.logical_key == Key::Named(NamedKey::BrowserBack)
+        {
+            handler();
+        }
+    })
 }

--- a/packages/dioxus-native/src/lib.rs
+++ b/packages/dioxus-native/src/lib.rs
@@ -58,7 +58,7 @@ pub use {
 pub use blitz_dom::{FontContext, Widget, build_single_font_ctx};
 pub use config::Config;
 pub use event_handlers::WinitEventHandlerId;
-pub use hooks::use_window_event;
+pub use hooks::{use_back_button, use_window_event};
 pub use winit;
 pub use winit::dpi::{LogicalSize, PhysicalSize};
 pub use winit::window::WindowAttributes;


### PR DESCRIPTION
Also support back buttons on other platforms, but is primarily designed for use on Android.