### PR TITLE
Map cellspacing / cellpadding attributes as presentational hints

### DIFF
--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -856,6 +856,30 @@ impl<'a> TElement for BlitzNode<'a> {
             None
         }
 
+        fn push_border_spacing<F>(push: &mut F, px: f32)
+        where
+            F: FnMut(PropertyDeclaration),
+        {
+            use style::values::generics::border::GenericBorderSpacing;
+            use style::values::specified::length::NonNegativeLength;
+            let side = NonNegativeLength::from_px(px);
+            let bs = GenericBorderSpacing::new(side.clone(), side);
+            push(PropertyDeclaration::BorderSpacing(bs));
+        }
+
+        fn push_cell_padding<F>(push: &mut F, px: f32)
+        where
+            F: FnMut(PropertyDeclaration),
+        {
+            use style::values::generics::NonNegative;
+            use style::values::specified::{LengthPercentage, NoCalcLength};
+            let side = NonNegative(LengthPercentage::Length(NoCalcLength::from_px(px)));
+            push(PropertyDeclaration::PaddingTop(side.clone()));
+            push(PropertyDeclaration::PaddingRight(side.clone()));
+            push(PropertyDeclaration::PaddingBottom(side.clone()));
+            push(PropertyDeclaration::PaddingLeft(side));
+        }
+
         fn parse_size_attr(
             value: &str,
             filter_fn: impl FnOnce(&f32) -> bool,
@@ -991,6 +1015,39 @@ impl<'a> TElement for BlitzNode<'a> {
             if *name == local_name!("hidden") {
                 use style::values::specified::Display;
                 push_style(PropertyDeclaration::Display(Display::None));
+            }
+
+            // https://html.spec.whatwg.org/multipage/rendering.html#tables-2
+            // `<table cellspacing="N">` maps to `border-spacing: Npx`.
+            if *name == local_name!("cellspacing") && *tag == local_name!("table") {
+                if let Ok(px) = value.parse::<u32>() {
+                    push_border_spacing(&mut push_style, px as f32);
+                }
+            }
+        }
+
+        // https://html.spec.whatwg.org/multipage/rendering.html#tables-2
+        // `<table cellpadding="N">` inherits down to every descendant TD/TH
+        // as `padding: Npx`. The UA sheet writes this via a descendant
+        // selector; presentational-hints attach to a single element, so
+        // we walk up from the cell to find the nearest ancestor <table>'s
+        // cellpadding attribute value.
+        if *tag == local_name!("td") || *tag == local_name!("th") {
+            let mut cur = self.parent;
+            while let Some(pid) = cur {
+                let parent = &self.tree()[pid];
+                let Some(pe) = parent.data.downcast_element() else {
+                    cur = parent.parent;
+                    continue;
+                };
+                if pe.name.local != local_name!("table") {
+                    cur = parent.parent;
+                    continue;
+                }
+                if let Some(px) = pe.attr_parsed::<u32>(local_name!("cellpadding")) {
+                    push_cell_padding(&mut push_style, px as f32);
+                }
+                break;
             }
         }
     }


### PR DESCRIPTION
## Summary

Implements the mapping defined in the [HTML Rendering spec's Tables
section](https://html.spec.whatwg.org/multipage/rendering.html#tables-2) for
the legacy `cellspacing` and `cellpadding` table attributes as CSS
presentational hints, so that `<table cellspacing="0">` /
`<table cellpadding="0">` actually zero out the UA sheet's `border-spacing: 2px`
and `td { padding: 1px }` defaults. Without this, any WPT (or real page) that
relies on the boilerplate `cellspacing="0" cellpadding="0"` to reach a clean
starting geometry renders with UA padding still applied.

## Approach

- **cellspacing** — attribute on `<table>` → push `PropertyDeclaration::BorderSpacing`
  from the element's own attribute iteration (same shape as the existing
  `align` / `width` / `height` / `bgcolor` / `hidden` hints).
- **cellpadding** — the attribute lives on `<table>` but the effect is on
  descendant `<td>`/`<th>` cells. Chrome and Firefox express this via a UA-sheet
  descendant selector; Stylo doesn't expose that surface to embedders, so we
  walk up from each cell to the first ancestor `<table>` and read its
  `cellpadding` attribute at presentational-hint time.

Both attributes are parsed per the spec's [rules for parsing non-negative
integers](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-non-negative-integers)
(approximated with `str::parse::<u32>`), matching Blink/Gecko's
`ParseHTMLNonNegativeInteger` semantics for the common case. A stricter,
whitespace-trimming HTML-integer parser could be shared across
`colspan` / `rowspan` / new hints in a follow-up.

## Verification

WPT `css/css-tables` (339 tests, 205 run) on `main@11279518`:

| | PASS | FAIL |
|---|---|---|
| main | 64 | 141 |
| this PR | **67** | 138 |

Specifically fixes:

- `colspan-001.html` — FAIL → PASS (5/5 subtests)
- `colspan-002.html` — FAIL → PASS (5/5 subtests)
- `colspan-003.html` — FAIL → PASS (5/5 subtests)

No regressions in the suite.

## Follow-ups (out of scope)

- Shared `parse_html_non_negative_integer` helper (would also tighten
  `colspan` / `rowspan` in `layout/table.rs`, currently `.parse().ok()`
  without whitespace trimming or `+` prefix handling).
- Other pixel-length presentational hints not yet implemented: `<table border>`,
  `<img hspace>` / `<vspace>`, `<hr size>`, `<body/iframe marginwidth/height>`.
