### PR TITLE
Add a way to pretty-print the outer HTML of a node

### DIFF
--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -39,6 +39,12 @@ use taffy::{
 use super::stylo_data::StyloData;
 use super::{Attribute, ElementData};
 
+#[derive(Clone, Copy)]
+enum OutputStyle {
+    Normal,
+    Pretty,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DisplayOuter {
     Block,
@@ -751,13 +757,50 @@ impl Node {
         s
     }
 
+    /// Renders the HTML of this node and all its children as a `String` without extra whitespace.
+    ///
+    /// Example output:
+    ///
+    /// ```text
+    /// <html><head /><body><main id="main"><div class="arbitrary-class" /></main></body></html>
+    /// ```
     pub fn outer_html(&self) -> String {
         let mut output = String::new();
         self.write_outer_html(&mut output);
         output
     }
 
+    /// Renders the HTML of this node and all its children as a `String` with whitespace for human
+    /// readability.
+    ///
+    /// Example output:
+    ///
+    /// ```text
+    /// <html>
+    ///   <head />
+    ///   <body>
+    ///     <main id="main">
+    ///       <div class="arbitrary-class" />
+    ///     </main>
+    ///   </body>
+    /// </html>
+    /// ```
+    pub fn outer_html_pretty(&self) -> String {
+        let mut output = String::new();
+        self.write_outer_html_pretty(&mut output);
+        output
+    }
+
     pub fn write_outer_html(&self, writer: &mut String) {
+        self.write_outer_html_in_style(writer, OutputStyle::Normal, 0);
+    }
+
+    pub fn write_outer_html_pretty(&self, writer: &mut String) {
+        self.write_outer_html_in_style(writer, OutputStyle::Pretty, 0);
+    }
+
+    fn write_outer_html_in_style(&self, writer: &mut String, style: OutputStyle, nesting: usize) {
+        const INDENT: &'static str = "  ";
         let has_children = !self.children.is_empty();
         let current_color = self
             .primary_styles()
@@ -773,6 +816,11 @@ impl Node {
                 writer.push_str(data.content.as_str());
             }
             NodeData::Element(data) => {
+                if matches!(style, OutputStyle::Pretty) {
+                    for _ in 0..nesting {
+                        writer.push_str(INDENT)
+                    }
+                }
                 writer.push('<');
                 writer.push_str(&data.name.local);
 
@@ -795,15 +843,26 @@ impl Node {
                     writer.push_str(" /");
                 }
                 writer.push('>');
+                if matches!(style, OutputStyle::Pretty) {
+                    writer.push('\n');
+                }
 
                 if has_children {
                     for &child_id in &self.children {
-                        self.tree()[child_id].write_outer_html(writer);
+                        self.tree()[child_id].write_outer_html_in_style(writer, style, nesting + 1);
                     }
 
+                    if matches!(style, OutputStyle::Pretty) {
+                        for _ in 0..nesting {
+                            writer.push_str(INDENT)
+                        }
+                    }
                     writer.push_str("</");
                     writer.push_str(&data.name.local);
                     writer.push('>');
+                    if matches!(style, OutputStyle::Pretty) {
+                        writer.push('\n');
+                    }
                 }
             }
         }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -800,7 +800,7 @@ impl Node {
     }
 
     fn write_outer_html_in_style(&self, writer: &mut String, style: OutputStyle, nesting: usize) {
-        const INDENT: &'static str = "  ";
+        const INDENT: &str = "  ";
         let has_children = !self.children.is_empty();
         let current_color = self
             .primary_styles()


### PR DESCRIPTION
When asserting on the state of the DOM, it's useful to have the current DOM in the assertion failure message. This should then be rendered in a way which makes it easy to see the structure. Otherwise the output becomes a uniform block of text and symbols, making debugging harder.

Until now the `outer_html()` method on `Node` and friends only had one way to render the DOM: as plain HTML with no extra whitespace.

This adds an `outer_html_pretty()` variant which adds indentation and whitespace. It abstracts the existing `write_outer_html` to serve both variants. A new private enum `OutputStyle` switches between them.

Should this approach add too much overhead, it's also possible to do it in a way so that the extra bits are optimized out when one does not need them. That would require minor changes to this PR, which I am happy to do if desired.