### PR TITLE
Switch to struct mutation for renderer options

### DIFF
--- a/examples/wgpu_texture/src/html.rs
+++ b/examples/wgpu_texture/src/html.rs
@@ -19,11 +19,10 @@ fn create_renderer() -> anyrender_vello::VelloWindowRenderer {
 /// Create renderer
 fn create_renderer() -> anyrender_vello_hybrid::VelloHybridWindowRenderer {
     use anyrender_vello_hybrid::{VelloHybridRendererOptions, VelloHybridWindowRenderer};
-    VelloHybridWindowRenderer::with_options(VelloHybridRendererOptions {
-        features: Some(FEATURES),
-        limits: Some(limits()),
-        ..VelloHybridRendererOptions::default()
-    })
+    let mut options = VelloHybridRendererOptions::default();
+    options.features = Some(FEATURES);
+    options.limits = Some(limits());
+    VelloHybridWindowRenderer::with_options(options)
 }
 
 pub fn launch_html() {

--- a/packages/dioxus-native/src/dioxus_renderer.rs
+++ b/packages/dioxus-native/src/dioxus_renderer.rs
@@ -44,11 +44,10 @@ impl DioxusNativeWindowRenderer {
 
     #[cfg(any(feature = "vello-hybrid", feature = "vello"))]
     pub fn with_features_and_limits(features: Option<Features>, limits: Option<Limits>) -> Self {
-        let vello_renderer = InnerRenderer::with_options(InnerRendererOptions {
-            features,
-            limits,
-            ..Default::default()
-        });
+        let mut options = InnerRendererOptions::default();
+        options.features = features;
+        options.limits = limits;
+        let vello_renderer = InnerRenderer::with_options(options);
         Self::with_inner_renderer(vello_renderer)
     }
 


### PR DESCRIPTION
## Summary
This pull request changes how Renderer Options are constructed as DioxusLabs/anyrender#70 will mark them as `#[non_exhaustive]`.

We now construct the default options then modify them to our desired options.

This pull request has no breaking changes so it should be able to be accepted regardless of if DioxusLabs/anyrender#70 gets accepted.

## Key Changes
- `dioxus-native`: Change from constructing with struct notation and `::default()` to making the `::default()` then modifying it.
- `examples/wgpu_texture`: Change from constructing with struct notation and `::default()` to making the `::default()` then modifying it.