### PR TITLE
Add svg-text feature so consumers can opt out of usvg's text-shaping stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ anyrender_skia = { version = "0.9.0" }
 anyrender_vello = { version = "0.12.0" }
 anyrender_vello_cpu = { version = "0.14.0" }
 anyrender_vello_hybrid = { version = "0.8.0" }
-anyrender_svg = { version = "0.12.0" }
+anyrender_svg = { version = "0.12.0", default-features = false, features = ["image_format_png", "image_format_gif", "image_format_jpeg", "image_format_webp"] }
 wgpu_context = { version = "0.7.0" }
 
 # Linebender + Fontations + WGPU + SVG
@@ -121,7 +121,7 @@ linebender_resource_handle = "0.1"
 peniko = "0.6.0"
 kurbo = "0.13.1"
 wgpu = "29"
-usvg = "0.46"
+usvg = { version = "0.46", default-features = false }
 
 # Windowing & Input
 raw-window-handle = "0.6.0"

--- a/packages/blitz-dom/Cargo.toml
+++ b/packages/blitz-dom/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 [features]
 default = [
     "svg",
+    "svg-text",
     "woff",
     "accessibility",
     "system-fonts",
@@ -22,6 +23,10 @@ default = [
 custom-widget = ["dep:anyrender", "accessibility"]
 tracing = ["dep:tracing"]
 svg = ["dep:usvg"]
+# Text support (<text> elements) within SVG documents. Pulls in usvg's text
+# shaping stack (rustybuzz, fontdb). Disable (default-features = false) if you
+# don't render SVG text to slim the dependency tree.
+svg-text = ["svg", "usvg/text", "usvg/system-fonts", "usvg/memmap-fonts"]
 # WOFF decoding (using the "wuff" crate which is pure Rust)
 woff = ["dep:wuff"]
 accessibility = ["accesskit"]

--- a/packages/blitz-dom/src/util.rs
+++ b/packages/blitz-dom/src/util.rs
@@ -40,10 +40,12 @@ pub fn decode_font_bytes(bytes: &[u8]) -> Cow<'_, [u8]> {
 }
 
 #[cfg(feature = "svg")]
-use std::sync::{Arc, LazyLock};
-#[cfg(feature = "svg")]
+use std::sync::Arc;
+#[cfg(feature = "svg-text")]
+use std::sync::LazyLock;
+#[cfg(feature = "svg-text")]
 use usvg::fontdb;
-#[cfg(feature = "svg")]
+#[cfg(feature = "svg-text")]
 pub(crate) static FONT_DB: LazyLock<Arc<fontdb::Database>> = LazyLock::new(|| {
     let mut db = fontdb::Database::new();
     db.load_system_fonts();
@@ -170,10 +172,15 @@ pub fn walk_tree(indent: usize, node: &Node) {
 pub(crate) fn parse_svg_image(source: &[u8]) -> Result<crate::node::SvgImageData, usvg::Error> {
     use usvg::roxmltree;
 
+    #[cfg(feature = "svg-text")]
     let options = usvg::Options {
         fontdb: Arc::clone(&*FONT_DB),
         ..Default::default()
     };
+    // Without svg-text, usvg is built without its `text` feature: <text>
+    // elements inside SVG documents are not shaped or rendered.
+    #[cfg(not(feature = "svg-text"))]
+    let options = usvg::Options::default();
 
     // Transparently decompress gzip-compressed SVGZ, as `Tree::from_data` does.
     let decompressed;

--- a/packages/blitz-paint/Cargo.toml
+++ b/packages/blitz-paint/Cargo.toml
@@ -11,9 +11,11 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["svg"]
+default = ["svg", "svg-text"]
 tracing = ["dep:tracing"]
 svg = ["dep:anyrender_svg", "dep:usvg", "blitz-dom/svg"]
+# Text support (<text> elements) within SVG documents; see blitz-dom's svg-text.
+svg-text = ["svg", "blitz-dom/svg-text", "anyrender_svg/text"]
 custom-widget = ["blitz-dom/custom-widget"]
 font-embolden = []
 apple-font-embolden = []


### PR DESCRIPTION
## Motivation

`usvg`'s default features include `text` (SVG `<text>` shaping), which pulls in `rustybuzz` — recently flagged unmaintained by [RUSTSEC-2026-0206](https://rustsec.org/advisories/RUSTSEC-2026-0206) (maintainer announcement: harfbuzz/rustybuzz#166), with no fixed version available: `usvg` 0.47 still depends on it, and its suggested replacement (`harfrust`) hasn't been adopted upstream yet.

Consumers that never render `<text>` elements inside SVG documents — e.g. server-side HTML-to-image rendering where all text is HTML (shaped by parley) and SVGs are shape-only icons/logos/barcodes — currently can't drop that stack: Cargo feature unification is additive, and blitz-dom/blitz-paint's `svg` defaults force-enable `usvg/text` for every downstream. The advisory then fails `cargo deny`/`cargo audit` gates in those projects with no recourse except forking.

## Change

Adds an `svg-text` feature to `blitz-dom` and `blitz-paint`:

- **Included in both crates' `default` sets — default behavior is completely unchanged.**
- `blitz-dom`: `svg-text = ["svg", "usvg/text", "usvg/system-fonts", "usvg/memmap-fonts"]`; the workspace `usvg` dep drops default features; the `FONT_DB` glue and the `usvg::Options` font wiring are gated on `svg-text`.
- `blitz-paint`: pass-through `svg-text = ["svg", "blitz-dom/svg-text", "anyrender_svg/text"]`; the workspace `anyrender_svg` dep drops default features but keeps the four `image_format_*` features so raster images inside SVGs keep decoding.

With `default-features = false, features = ["svg"]`, usvg is built without its text stack: `rustybuzz`, `fontdb`, `fontconfig-parser`, and the `unicode-*` shaping crates leave the dependency tree; `<text>` elements inside SVG documents are not rendered (everything else — paths, shapes, gradients, embedded raster images — is unaffected).

## Testing

- `cargo check -p blitz-dom -p blitz-paint` (defaults, svg-text on) — compiles, lockfile unchanged in content.
- `cargo check -p blitz-dom -p blitz-paint --no-default-features --features svg` (opt-out) — compiles; `rustybuzz`/`fontdb` absent from the resolved graph.

Happy to adjust naming (`svg-text` vs `svg_text`), feature composition, or scope if you'd prefer a different shape.