### PR TITLE
fix: build usvg without its text feature to drop unmaintained rustybuzz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ anyrender_skia = { version = "0.8.0" }
 anyrender_vello = { version = "0.10.1" }
 anyrender_vello_cpu = { version = "0.12.1" }
 anyrender_vello_hybrid = { version = "0.5.1" }
-anyrender_svg = { version = "0.11.0" }
+anyrender_svg = { version = "0.11.0", default-features = false, features = ["image_format_png", "image_format_gif", "image_format_jpeg", "image_format_webp"] }
 wgpu_context = { version = "0.6.0" }
 
 # Linebender + Fontations + WGPU + SVG
@@ -121,7 +121,7 @@ linebender_resource_handle = "0.1"
 peniko = "0.6.0"
 kurbo = "0.13.1"
 wgpu = "29"
-usvg = "0.46"
+usvg = { version = "0.46", default-features = false }
 
 # Windowing & Input
 raw-window-handle = "0.6.0"

--- a/packages/blitz-dom/src/util.rs
+++ b/packages/blitz-dom/src/util.rs
@@ -33,17 +33,6 @@ pub fn decode_font_bytes(bytes: &[u8]) -> Cow<'_, [u8]> {
     }
 }
 
-#[cfg(feature = "svg")]
-use std::sync::{Arc, LazyLock};
-#[cfg(feature = "svg")]
-use usvg::fontdb;
-#[cfg(feature = "svg")]
-pub(crate) static FONT_DB: LazyLock<Arc<fontdb::Database>> = LazyLock::new(|| {
-    let mut db = fontdb::Database::new();
-    db.load_system_fonts();
-    Arc::new(db)
-});
-
 #[derive(Clone, Copy, Debug)]
 pub enum ImageType {
     Image,
@@ -129,13 +118,12 @@ pub fn walk_tree(indent: usize, node: &Node) {
     }
 }
 
+// usvg is built without its `text` feature (no `fontdb`, no `rustybuzz`):
+// SVG `<text>` elements are not shaped or rendered. HTML text is shaped by
+// parley, so this only affects text nodes inside SVG documents.
 #[cfg(feature = "svg")]
 pub(crate) fn parse_svg(source: &[u8]) -> Result<usvg::Tree, usvg::Error> {
-    let options = usvg::Options {
-        fontdb: Arc::clone(&*FONT_DB),
-        ..Default::default()
-    };
-
+    let options = usvg::Options::default();
     let tree = usvg::Tree::from_data(source, &options)?;
     Ok(tree)
 }


### PR DESCRIPTION
usvg's default features include 'text' (SVG <text> shaping), which pulls in rustybuzz — flagged unmaintained by RUSTSEC-2026-0206 with no fixed upstream version (usvg 0.47 still depends on it). Neither blitz-dom nor blitz-paint needs it: HTML text is shaped by parley, and the usvg tree is only used to rasterize shape/path-based SVGs (images, icons, barcodes).

Depends on usvg with default-features = false and parses SVGs with usvg::Options::default() instead of a system-font fontdb. The only behavior change: <text> elements inside SVG documents are no longer rendered.

Remove this patch once upstream blitz stops enabling usvg's text feature or usvg migrates to harfrust.