### PR TITLE
Fix macOS delete key not updating text input

### DIFF
--- a/packages/blitz-dom/src/events/driver.rs
+++ b/packages/blitz-dom/src/events/driver.rs
@@ -252,6 +252,7 @@ impl<'doc, Handler: EventHandler> EventDriver<'doc, Handler> {
                 let mut dom_event =
                     DomEvent::new(target, DomEventData::AppleStandardKeybinding(data));
                 self.run_default_action(&mut dom_event);
+                self.process_queue();
             }
         };
 


### PR DESCRIPTION
On macOS, Backspace/Delete is handled through AppleStandardKeybinding. This updates the input value and queues an Input event, but does not call process_queue(). As a result, the framework state is not updated immediately.

How to reproduce:

1. Type some text into the input.
2. Press Backspace/Delete.
3. The input value changes, but the displayed state does not update until another event occurs.

<details><summary>Demo</summary>
<p>

```rust
use dioxus::prelude::*;

fn main() {
    dioxus_native::launch(app);
}

fn app() -> Element {
    let mut text = use_signal(|| String::new());

    rsx! {
        style { {CSS} }
        div { class: "app-container",
            div { class: "card",
                h1 { "Dioxus Input Demo" }
                p { class: "description",
                    "Type in the field below to see the text updated dynamically."
                }
                div { class: "input-wrapper",
                    input {
                        class: "input-field",
                        r#type: "text",
                        placeholder: "Type something here...",
                        value: "{text}",
                        oninput: move |e| text.set(e.value())
                    }
                }
                div { class: "output-container",
                    div { class: "output-label", "Live Preview" }
                    if text.read().is_empty() {
                        div { class: "output-placeholder", "Start typing to see your text here..." }
                    } else {
                        div { class: "output-text", "{text}" }
                    }
                }
                div { class: "meta-info",
                    span { "Characters: {text.read().chars().count()}" }
                    if !text.read().is_empty() {
                        button {
                            class: "clear-btn",
                            onclick: move |_| text.set(String::new()),
                            "Clear Text"
                        }
                    }
                }
            }
        }
    }
}

const CSS: &str = r#"
.app-container {
    display: flex;
    flex-direction: column;
    align-items: center;
    justify-content: center;
    min-height: 100vh;
    width: 100vw;
    background: linear-gradient(135deg, #1e1b4b, #0f172a);
    font-family: system-ui, -apple-system, sans-serif;
    color: #f8fafc;
    padding: 20px;
}

.card {
    width: 100%;
    max-width: 460px;
    background-color: #1e293b;
    border: 1px solid #334155;
    border-radius: 16px;
    padding: 32px;
}

h1 {
    font-size: 28px;
    font-weight: 700;
    color: #38bdf8;
    margin: 0 0 8px 0;
    text-align: center;
}

.description {
    font-size: 14px;
    color: #94a3b8;
    margin: 0 0 24px 0;
    text-align: center;
    line-height: 1.5;
}

.input-wrapper {
    margin-bottom: 20px;
    display: block;
}

.input-field {
    width: 100%;
    padding: 12px 16px;
    font-size: 16px;
    background-color: #0f172a;
    border: 2px solid #334155;
    border-radius: 8px;
    color: #f8fafc;
}

.input-field:focus {
    border-color: #38bdf8;
}

.output-container {
    background-color: #0f172a;
    border-radius: 8px;
    border: 1px solid #334155;
    padding: 16px;
    margin-bottom: 16px;
    min-height: 80px;
    display: block;
}

.output-label {
    font-size: 11px;
    text-transform: uppercase;
    letter-spacing: 0.05em;
    color: #64748b;
    margin-bottom: 8px;
    font-weight: 600;
}

.output-text {
    font-size: 16px;
    color: #e2e8f0;
}

.output-placeholder {
    font-size: 15px;
    color: #475569;
    font-style: italic;
}

.meta-info {
    display: flex;
    justify-content: space-between;
    align-items: center;
    font-size: 13px;
    color: #64748b;
}

.clear-btn {
    background-color: #38bdf8;
    color: #0f172a;
    border: none;
    padding: 6px 14px;
    border-radius: 6px;
    font-size: 12px;
    font-weight: 600;
}
"#;
```

</p>
</details> 