### PR TITLE
CI: trim dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         if: ${{ matrix.platform.os == 'ubuntu-24.04' || matrix.platform.os == 'ubuntu-24.04-arm' }}
         uses: jlumbroso/free-disk-space@v1.3.1
         with: # speed things up a bit
-          android: false
+          android: ${{ matrix.platform.target != 'aarch64-linux-android' }}
           large-packages: false
           swap-storage: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libgtk-3-dev libxdo-dev
+          packages: libfontconfig-dev
           version: 1.0
       - run: cargo build --workspace
 
@@ -47,7 +47,7 @@ jobs:
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libgtk-3-dev libxdo-dev
+          packages: libfontconfig-dev
           version: 1.0
       - run: cargo build --workspace
 
@@ -60,7 +60,7 @@ jobs:
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libgtk-3-dev libxdo-dev
+          packages: libfontconfig-dev
           version: 1.0
       - run: cargo build -p rdme --features incremental
 
@@ -73,7 +73,7 @@ jobs:
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libgtk-3-dev libxdo-dev
+          packages: libfontconfig-dev
           version: 1.0
       - run: cargo test --workspace
 
@@ -86,7 +86,7 @@ jobs:
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libgtk-3-dev libxdo-dev
+          packages: libfontconfig-dev
           version: 1.0
       - run: cargo build -p counter
 
@@ -132,7 +132,7 @@ jobs:
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libgtk-3-dev libxdo-dev
+          packages: libfontconfig-dev
           version: 1.0
       - run: cargo clippy --workspace -- -D warnings
 

--- a/.github/workflows/publish-browser.yml
+++ b/.github/workflows/publish-browser.yml
@@ -140,7 +140,7 @@ jobs:
         if: ${{ matrix.platform.os == 'ubuntu-24.04' || matrix.platform.os == 'ubuntu-24.04-arm' }}
         uses: jlumbroso/free-disk-space@v1.3.1
         with: # speed things up a bit
-          android: false
+          android: ${{ matrix.platform.target != 'aarch64-linux-android' }}
           large-packages: false
           swap-storage: false
 

--- a/.github/workflows/publish-browser.yml
+++ b/.github/workflows/publish-browser.yml
@@ -144,12 +144,6 @@ jobs:
           large-packages: false
           swap-storage: false
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        if: ${{ startsWith(matrix.platform.os, 'ubuntu') }}
-        with:
-          packages: libgtk-3-dev libxdo-dev libwebkit2gtk-4.1-dev build-essential curl wget file libssl-dev libayatana-appindicator3-dev librsvg2-dev
-          version: 1.0
-
       - name: Bundle browser
         run: dx bundle --package browser --release --profile production --target ${{ matrix.platform.target }} --locked --verbose --trace ${{ matrix.platform.args }}
         env:


### PR DESCRIPTION
Use less time and disk space in CI by:

- Remove Android SDK when not building for Android (free up disk space)
- Install fontconfig rather than the whole of GTK