### PR TITLE
Fix stale node_id_mapping entries when detached subtrees are dropped

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -793,17 +793,28 @@ impl BaseDocument {
     }
 
     pub(crate) fn drop_node_ignoring_parent(&mut self, node_id: usize) -> Option<Node> {
+        self.drop_node_ignoring_parent_with(node_id, &mut |_| {})
+    }
+
+    /// Like [`Self::drop_node_ignoring_parent`], but calls `on_drop` with the id of
+    /// every dropped node (the node itself and all of its descendants).
+    pub(crate) fn drop_node_ignoring_parent_with(
+        &mut self,
+        node_id: usize,
+        on_drop: &mut dyn FnMut(usize),
+    ) -> Option<Node> {
         let mut node = self.nodes.try_remove(node_id);
         if let Some(node) = &mut node {
+            on_drop(node_id);
             if let Some(before) = node.before {
-                self.drop_node_ignoring_parent(before);
+                self.drop_node_ignoring_parent_with(before, on_drop);
             }
             if let Some(after) = node.after {
-                self.drop_node_ignoring_parent(after);
+                self.drop_node_ignoring_parent_with(after, on_drop);
             }
 
             for &child in &node.children {
-                self.drop_node_ignoring_parent(child);
+                self.drop_node_ignoring_parent_with(child, on_drop);
             }
         }
         node

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -418,9 +418,19 @@ impl DocumentMutator<'_> {
     }
 
     pub fn remove_and_drop_node(&mut self, node_id: usize) -> Option<Node> {
+        self.remove_and_drop_node_with(node_id, &mut |_| {})
+    }
+
+    /// Like [`Self::remove_and_drop_node`], but calls `on_drop` with the id of
+    /// every dropped node (the node itself and all of its descendants).
+    pub fn remove_and_drop_node_with(
+        &mut self,
+        node_id: usize,
+        on_drop: &mut dyn FnMut(usize),
+    ) -> Option<Node> {
         self.process_removed_subtree(node_id);
 
-        let node = self.doc.drop_node_ignoring_parent(node_id);
+        let node = self.doc.drop_node_ignoring_parent_with(node_id, on_drop);
 
         // Update child_idx values
         if let Some(parent_id) = node.as_ref().and_then(|node| node.parent) {
@@ -467,9 +477,19 @@ impl DocumentMutator<'_> {
 
     // Tree mutation methods
     pub fn remove_node_if_unparented(&mut self, node_id: usize) {
+        self.remove_node_if_unparented_with(node_id, &mut |_| {});
+    }
+
+    /// Like [`Self::remove_node_if_unparented`], but calls `on_drop` with the id of
+    /// every dropped node (the node itself and all of its descendants).
+    pub fn remove_node_if_unparented_with(
+        &mut self,
+        node_id: usize,
+        on_drop: &mut dyn FnMut(usize),
+    ) {
         if let Some(node) = self.doc.get_node(node_id) {
             if node.parent.is_none() {
-                self.remove_and_drop_node(node_id);
+                self.remove_and_drop_node_with(node_id, on_drop);
             }
         }
     }

--- a/packages/dioxus-native-dom/src/mutation_writer.rs
+++ b/packages/dioxus-native-dom/src/mutation_writer.rs
@@ -17,6 +17,8 @@ pub struct DioxusState {
     pub(crate) stack: Vec<NodeId>,
     /// Mapping from vdom ElementId -> rdom NodeId
     pub(crate) node_id_mapping: Vec<Option<NodeId>>,
+    /// Reverse mapping from rdom NodeId -> vdom ElementId
+    pub(crate) element_id_mapping: FxHashMap<NodeId, ElementId>,
     /// Count of each handler type (indexed by `DomEventKind` discriminant)
     pub(crate) event_handler_counts: [u32; 64],
     /// Mounted events queued as elements are mounted
@@ -30,6 +32,7 @@ impl DioxusState {
             templates: FxHashMap::default(),
             stack: vec![root_id],
             node_id_mapping: vec![Some(root_id)],
+            element_id_mapping: FxHashMap::from_iter([(root_id, ElementId(0))]),
             event_handler_counts: [0; 64],
             queued_mounted_events: Vec::new(),
         }
@@ -87,8 +90,15 @@ impl MutationWriter<'_> {
             self.state.node_id_mapping.resize(element_id + 1, None);
         }
 
-        // Set the new mapping
-        self.state.node_id_mapping[element_id] = Some(node_id);
+        // Set the new mapping (and keep the reverse mapping in sync)
+        if let Some(old_node_id) = self.state.node_id_mapping[element_id].replace(node_id)
+            && self.state.element_id_mapping.get(&old_node_id) == Some(&ElementId(element_id))
+        {
+            self.state.element_id_mapping.remove(&old_node_id);
+        }
+        self.state
+            .element_id_mapping
+            .insert(node_id, ElementId(element_id));
     }
 
     /// Create a ElementId -> NodeId mapping and push the node to the stack
@@ -108,10 +118,22 @@ impl WriteMutations for MutationWriter<'_> {
     fn assign_node_id(&mut self, path: &'static [u8], id: ElementId) {
         trace!("assign_node_id path:{:?} id:{}", path, id.0);
 
-        // If there is an existing node already mapped to that ID and it has no parent, then drop it
+        // If there is an existing node already mapped to that ID and it has no parent, then drop it.
+        // Dropping the node also drops all of its descendants, so clear the mappings of every
+        // dropped node to prevent them dangling and aliasing onto unrelated nodes when the
+        // underlying slab slots are reused.
         // TODO: more automated GC/ref-counted semantics for node lifetimes
         if let Some(node_id) = self.state.try_element_to_node_id(id) {
-            self.docm.remove_node_if_unparented(node_id);
+            let state = &mut *self.state;
+            self.docm
+                .remove_node_if_unparented_with(node_id, &mut |dropped_node_id| {
+                    if let Some(element_id) = state.element_id_mapping.remove(&dropped_node_id)
+                        && state.node_id_mapping.get(element_id.0).copied().flatten()
+                            == Some(dropped_node_id)
+                    {
+                        state.node_id_mapping[element_id.0] = None;
+                    }
+                });
         }
 
         // Map the node at specified path

--- a/packages/dioxus-native-dom/tests/stale_node_mapping.rs
+++ b/packages/dioxus-native-dom/tests/stale_node_mapping.rs
@@ -1,0 +1,250 @@
+//! Regression tests for stale `node_id_mapping` entries after node removal.
+//! See https://github.com/DioxusLabs/dioxus/pull/5182
+//!
+//! When `remove_node` (or `replace_node_with`) detaches a node, the
+//! `node_id_mapping` entries for the node's subtree are (intentionally) not
+//! cleared, so that dioxus-core can reuse the detached DOM nodes. However,
+//! when the detached subtree is later dropped via `remove_node_if_unparented`
+//! (called from `assign_node_id`), only the mapping for the ElementId being
+//! reassigned is updated. Any *descendant* of the dropped subtree that has its
+//! own ElementId mapping is left pointing at a freed slab slot.
+//!
+//! When that slab slot is reused for a brand-new (not yet parented) node and
+//! the stale ElementId is then reused by dioxus-core via `AssignId`,
+//! `remove_node_if_unparented` incorrectly drops the new node, causing an
+//! "invalid key" slab panic in blitz-dom's `DocumentMutator` later in the
+//! same render (matching the stack trace reported in the PR).
+
+use blitz_dom::DocumentConfig;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use dioxus::prelude::*;
+use dioxus_core::ScopeId;
+use dioxus_native_dom::DioxusDocument;
+use std::cell::Cell;
+use std::rc::Rc;
+
+#[derive(Props, Clone)]
+struct AppProps {
+    generation: Rc<Cell<usize>>,
+    view: fn(usize) -> Element,
+}
+
+impl PartialEq for AppProps {
+    fn eq(&self, other: &Self) -> bool {
+        self.generation == other.generation && std::ptr::fn_addr_eq(self.view, other.view)
+    }
+}
+
+fn app(props: AppProps) -> Element {
+    (props.view)(props.generation.get())
+}
+
+struct Harness {
+    doc: DioxusDocument,
+    generation: Rc<Cell<usize>>,
+}
+
+impl Harness {
+    fn new(view: fn(usize) -> Element) -> Self {
+        let generation = Rc::new(Cell::new(0));
+        let vdom = VirtualDom::new_with_props(
+            app,
+            AppProps {
+                generation: Rc::clone(&generation),
+                view,
+            },
+        );
+        let mut doc = DioxusDocument::new(
+            vdom,
+            DocumentConfig {
+                viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+                ..Default::default()
+            },
+        );
+        doc.initial_build();
+        Self { doc, generation }
+    }
+
+    fn step(&mut self) {
+        use blitz_dom::Document as _;
+        self.generation.set(self.generation.get() + 1);
+        self.doc.vdom.mark_dirty(ScopeId::APP);
+        self.doc.poll(None);
+    }
+}
+
+/// Check that every ElementId -> NodeId mapping points at a node that still
+/// exists in the document. A mapping pointing at a freed slab slot will cause
+/// an "invalid key" panic (or worse: silent deletion of an unrelated node
+/// that happens to reuse the slot) on a later render.
+fn assert_no_stale_mappings(doc: &DioxusDocument, context: &str) {
+    let inner = doc.inner.borrow();
+    let mut stale = Vec::new();
+    for raw_id in 0..4096 {
+        let element_id = dioxus_core::ElementId(raw_id);
+        if let Some(node_id) = doc.vdom_state.try_element_to_node_id(element_id)
+            && inner.get_node(node_id).is_none()
+        {
+            stale.push((raw_id, node_id));
+        }
+    }
+    assert!(
+        stale.is_empty(),
+        "stale node_id_mapping entries (ElementId, NodeId) after {context}: {stale:?}"
+    );
+}
+
+fn bare_text(generation: usize) -> Element {
+    rsx! { "bare text {generation}" }
+}
+
+fn section_with_list(generation: usize, n: usize) -> Element {
+    rsx! {
+        section {
+            header { id: "gen-{generation}", "header" }
+            for i in 0..n {
+                div { key: "{i}", "item {i}" }
+            }
+        }
+    }
+}
+
+fn nested_divs(generation: usize) -> Element {
+    rsx! {
+        article {
+            div { class: "gen-{generation}",
+                div { id: "gen-{generation}", "deep {generation}" }
+            }
+        }
+        aside { "aside" }
+    }
+}
+
+/// Minimal deterministic sequence of template swaps that panics with
+/// "invalid key" inside blitz-dom's `DocumentMutator` (in `node_at_path`
+/// via `assign_node_id`) on the 3rd re-render.
+fn minimal_panic_app(generation: usize) -> Element {
+    match generation {
+        0 => nested_divs(generation),
+        1 => bare_text(generation),
+        2 => section_with_list(generation, 0),
+        _ => nested_divs(generation),
+    }
+}
+
+#[test]
+fn template_swaps_do_not_panic() {
+    let mut harness = Harness::new(minimal_panic_app);
+    for _ in 0..3 {
+        harness.step();
+    }
+}
+
+/// Toggles between templates where one variant has a nested element with a
+/// dynamic attribute (which is assigned an ElementId via `AssignId`).
+/// Detects the stale mapping (the precursor to the panic) directly.
+fn toggle_app(generation: usize) -> Element {
+    let class = format!("gen-{generation}");
+    match generation % 3 {
+        0 => rsx! {
+            div {
+                div { class: "{class}",
+                    span { "nested {generation}" }
+                }
+                "text {generation}"
+            }
+            div { "sibling" }
+        },
+        1 => rsx! {
+            p { "different template {generation}" }
+        },
+        _ => rsx! {
+            section {
+                header { id: "{class}", "header" }
+                for i in 0..(generation % 5) {
+                    div { key: "{i}", "item {i}" }
+                }
+            }
+        },
+    }
+}
+
+#[test]
+fn template_swaps_do_not_leave_stale_mappings() {
+    let mut harness = Harness::new(toggle_app);
+    for i in 0..20 {
+        harness.step();
+        assert_no_stale_mappings(&harness.doc, &format!("step {i}"));
+    }
+}
+
+/// Pseudo-random mix of templates designed to maximise ElementId and NodeId
+/// (slab slot) reuse. Panics with "invalid key" within a handful of steps.
+fn fuzz_app(generation: usize) -> Element {
+    // Simple LCG for deterministic pseudo-random variety
+    let r = generation
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    let variant = (r >> 33) % 6;
+    let n = (r >> 40) % 7;
+    let class = format!("gen-{generation}");
+    match variant {
+        0 => rsx! {
+            div {
+                div { class: "{class}", span { "nested {generation}" } }
+                "text {generation}"
+            }
+        },
+        1 => rsx! {
+            p { "different template {generation}" }
+        },
+        2 => section_with_list(generation, n),
+        3 => rsx! {
+            ul {
+                for i in 0..n {
+                    li { key: "{i}", class: "item-{i}-{generation}",
+                        span { "item {i} gen {generation}" }
+                    }
+                }
+            }
+        },
+        4 => nested_divs(generation),
+        _ => bare_text(generation),
+    }
+}
+
+#[test]
+fn fuzz_template_swaps_do_not_panic() {
+    let mut harness = Harness::new(fuzz_app);
+    for _ in 0..1000 {
+        harness.step();
+    }
+}
+
+/// A keyed list where items are removed and re-added, forcing ElementId reuse
+/// in dioxus-core and NodeId (slab slot) reuse in blitz-dom.
+fn list_app(generation: usize) -> Element {
+    // Vary the list length up and down so nodes are removed and recreated
+    let len = [5usize, 0, 3, 1, 6, 2, 0, 4][generation % 8];
+    rsx! {
+        ul {
+            for i in 0..len {
+                li { key: "{i}", class: "item-{i}-{generation}",
+                    span { "item {i} gen {generation}" }
+                }
+            }
+        }
+        if generation.is_multiple_of(2) {
+            footer { "footer {generation}" }
+        }
+    }
+}
+
+#[test]
+fn keyed_list_grow_shrink() {
+    let mut harness = Harness::new(list_app);
+    for i in 0..300 {
+        harness.step();
+        assert_no_stale_mappings(&harness.doc, &format!("step {i}"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the "invalid key" slab panic reported in [dioxus#5182](https://github.com/DioxusLabs/dioxus/pull/5182).

Root cause: `MutationWriter::assign_node_id` drops a detached node via `remove_node_if_unparented` which recursively drops the *whole subtree*, but only the mapping for the ElementId being reassigned gets updated. Descendants' `node_id_mapping` entries are left pointing at freed slab slots. When a slot is reused for a fresh (not-yet-parented) node and the stale ElementId is reused via `AssignId`, the new node is incorrectly dropped and a later mutation panics with "invalid key".

The fix keeps the existing "leak until ElementId reuse" GC strategy (preserving dioxus-core's detached-node reuse) but clears the mappings of *every* dropped node:

- `blitz-dom`: add `_with` variants of `remove_node_if_unparented` / `remove_and_drop_node` / `drop_node_ignoring_parent` that report the id of each dropped node (the node and all descendants, including before/after pseudo-elements). Existing methods delegate with a no-op callback.
- `dioxus-native-dom`: `DioxusState` gains a reverse `element_id_mapping: FxHashMap<NodeId, ElementId>`, kept in sync by `set_id_mapping`. `assign_node_id` now passes an `on_drop` callback that clears both the reverse entry and the forward `node_id_mapping` entry for every dropped node (guarded by a check that the forward entry still points at the dropped node).