### PR TITLE
Opportunistically cache inline min/max content widths when there are no in-flow inline boxes

### DIFF
--- a/examples/bench_inline.rs
+++ b/examples/bench_inline.rs
@@ -1,0 +1,103 @@
+//! Benchmark layout of a page: initial layout + relayouts at alternating viewport widths.
+//! Usage: cargo run --release --example bench_inline <url-or-file> [iterations]
+
+use blitz_dom::DocumentConfig;
+use blitz_html::HtmlDocument;
+use blitz_net::Provider;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use reqwest::Url;
+use std::sync::Arc;
+use std::time::Instant;
+
+const USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0";
+
+#[tokio::main]
+async fn main() {
+    let url_string = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "https://en.wikipedia.org/wiki/Roman_Egypt".into());
+    let iterations: usize = std::env::args()
+        .nth(2)
+        .and_then(|arg| arg.parse().ok())
+        .unwrap_or(20);
+
+    let url = Url::parse(&url_string)
+        .unwrap_or_else(|_| Url::parse(&format!("https://{url_string}")).expect("Invalid url"));
+    let url_string = url.to_string();
+
+    let html = match url.scheme() {
+        "file" => String::from_utf8(std::fs::read(url.path()).unwrap()).unwrap(),
+        _ => {
+            let client = reqwest::Client::new();
+            client
+                .get(url)
+                .header("User-Agent", USER_AGENT)
+                .send()
+                .await
+                .unwrap()
+                .text()
+                .await
+                .unwrap()
+        }
+    };
+
+    let scale = 2.0f32;
+    let height = 800u32;
+    let width = 1200u32;
+
+    let net = Arc::new(Provider::new(None));
+
+    let base_url = std::env::var("BENCH_BASE_URL").ok().or(Some(url_string));
+
+    let mut document = HtmlDocument::from_html(
+        &html,
+        DocumentConfig {
+            base_url,
+            net_provider: Some(Arc::clone(&net) as _),
+            viewport: Some(Viewport::new(
+                width * (scale as u32),
+                height * (scale as u32),
+                scale,
+                ColorScheme::Light,
+            )),
+            ..Default::default()
+        },
+    );
+
+    // Load assets
+    loop {
+        document.resolve(0.0);
+        if net.is_empty() {
+            break;
+        }
+    }
+
+    // Initial full layouts at alternating widths
+    let mut initial_times = Vec::new();
+    let mut relayout_times = Vec::new();
+
+    let start = Instant::now();
+    document.as_mut().resolve(0.0);
+    initial_times.push(start.elapsed().as_secs_f64() * 1000.0);
+
+    for i in 0..iterations {
+        let w = if i % 2 == 0 { 1210 } else { 1200 };
+        document.as_mut().set_viewport(Viewport::new(
+            w * (scale as u32),
+            height * (scale as u32),
+            scale,
+            ColorScheme::Light,
+        ));
+        let start = Instant::now();
+        document.as_mut().resolve(0.0);
+        relayout_times.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    relayout_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let min = relayout_times.first().copied().unwrap_or(0.0);
+    let median = relayout_times[relayout_times.len() / 2];
+    let mean: f64 = relayout_times.iter().sum::<f64>() / relayout_times.len() as f64;
+
+    println!("initial resolve: {:.2}ms", initial_times[0]);
+    println!("relayout (n={iterations}): min {min:.2}ms / median {median:.2}ms / mean {mean:.2}ms");
+}

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -284,6 +284,7 @@ impl BaseDocument {
         };
 
         // Update inline boxes
+        let mut has_inflow_inline_boxes = false;
         for ibox in inline_layout.layout.inline_boxes_mut() {
             let style = &self.nodes[ibox.id as usize].style;
             let margin = style
@@ -299,6 +300,7 @@ impl BaseDocument {
                 ibox.width = 0.0;
                 ibox.height = 0.0;
             } else {
+                has_inflow_inline_boxes = true;
                 let output = self.compute_child_layout(NodeId::from(ibox.id), child_inputs);
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
                 ibox.height = (margin.top + margin.bottom + output.size.height) * scale;
@@ -330,12 +332,15 @@ impl BaseDocument {
             .width
             .map(|w| (w * scale) - pbw)
             .unwrap_or_else(|| {
-                // TODO: Cache content widths.
-                //
-                // This is a little tricky as the size of the inline boxes may depend on whether we are sizing under
-                // and a min-content or max-content constraint. So if we want to compute both widths in one pass then
-                // we need to store both a min-content and max-content size on each box.
-                let content_sizes = inline_layout.layout.calculate_content_widths();
+                // The size of in-flow inline boxes may depend on whether we are sizing under a min-content
+                // or max-content constraint, so the content widths can only be cached when there are none.
+                // Caching both a min-content and max-content size on each box would allow the cache to be
+                // used unconditionally.
+                let content_sizes = if has_inflow_inline_boxes {
+                    inline_layout.layout.calculate_content_widths()
+                } else {
+                    inline_layout.content_widths()
+                };
                 let min_content_width = content_sizes.min;
                 let max_content_width = content_sizes.max;
 

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -329,9 +329,9 @@ impl BaseDocument {
 
                     // If layout doesn't contain any inline boxes, then it is safe to populate the content_widths
                     // cache during this parallelized stage.
-                    // if layout.layout.inline_boxes().is_empty() {
-                    //     layout.content_widths();
-                    // }
+                    if layout.layout.inline_boxes().is_empty() {
+                        layout.content_widths();
+                    }
 
                     ConstructionTaskResult {
                         node_id: task.node_id,


### PR DESCRIPTION
## Summary

Inline layout currently calls `parley::Layout::calculate_content_widths()` every time it is sized under an unknown width (so once for the min-content pass and again for the max-content pass). This is only necessary when the IFC contains in-flow inline boxes, whose sizes may differ between the two constraints. When there are none, the content widths are constraint-independent and can be computed once and cached.

- `compute_inline_layout_inner` now tracks `has_inflow_inline_boxes` (inline boxes that are not `position: absolute`/floated) while updating inline box sizes, and uses the existing `TextLayout::content_widths()` cache (invalidated on rebuild/damage) when there are none:

```rust
let content_sizes = if has_inflow_inline_boxes {
    inline_layout.layout.calculate_content_widths()
} else {
    inline_layout.content_widths() // cached
};
```

- Enables the previously commented-out cache prepopulation in `resolve_deferred_tasks`, so freshly (re)constructed inline layouts without inline boxes get their content widths computed during the (potentially parallel) construction stage.
- Adds `examples/bench_inline.rs`: loads a URL/file, resolves fully, then times repeated relayouts at alternating viewport widths.

## Measurements (https://en.wikipedia.org/wiki/Roman_Egypt, 1200px width, 2x scale, release build)

Using `bench_inline` against a locally saved copy of the page (assets fetched live), 20 relayouts per run, 3 runs each. Time spent in the content-width computation was instrumented separately (total across initial resolve + 20 relayouts):

| Config | content-width time (total) | relayout median |
|---|---|---|
| baseline (default features) | ~28–29ms | ~139–141ms |
| cached (default features) | ~15–16ms | ~138–140ms |
| baseline (`incremental`) | ~2.6ms | ~66–67ms |
| cached (`incremental`) | ~0.6ms | ~66–69ms |

So the caching roughly halves the `calculate_content_widths` work (calls drop from ~39k to ~6.5k uncached + ~26k cache hits across the run in the non-incremental config), but on this page that computation is only ~0.5% of total layout time, so the end-to-end relayout time is unchanged within noise. Rendering output is byte-identical to `main` (matching screenshot md5s).

Larger wins here would likely require caching min/max-content sizes on each inline box so the cache can also be used for IFCs that contain in-flow inline boxes (noted in the updated comment).

Link to Devin session: https://app.devin.ai/sessions/9867a3902b21427d8ffc9c372294f5ab
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/520?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->