### PR TITLE
WPT: render ref tests over a white background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9246,6 +9246,7 @@ dependencies = [
  "os_info",
  "owo-colors",
  "parley",
+ "peniko",
  "png 0.17.16",
  "pollster",
  "rayon",

--- a/wpt/runner/Cargo.toml
+++ b/wpt/runner/Cargo.toml
@@ -23,6 +23,7 @@ anyrender_vello_cpu = { workspace = true, optional = true }
 
 taffy = { workspace = true }
 parley = { workspace = true }
+peniko = { workspace = true }
 image = { workspace = true, features = ["png"] }
 url = { workspace = true }
 data-url = { workspace = true }

--- a/wpt/runner/src/test_runners/ref_test.rs
+++ b/wpt/runner/src/test_runners/ref_test.rs
@@ -1,6 +1,9 @@
 use anyrender::{ImageRenderer as _, PaintScene as _};
+use blitz_dom::util::Color;
 use blitz_paint::paint_scene;
 use image::{ImageBuffer, ImageFormat};
+use peniko::Fill;
+use peniko::kurbo::Rect;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -118,6 +121,16 @@ fn render_html_to_buffer(
     ctx.renderer.render_to_vec(
         |scene| {
             scene.reset();
+
+            // Render white background
+            scene.fill(
+                Fill::NonZero,
+                Default::default(),
+                Color::WHITE,
+                Default::default(),
+                &Rect::new(0.0, 0.0, WIDTH as f64, HEIGHT as f64),
+            );
+
             paint_scene(scene, &mut document, SCALE, WIDTH, HEIGHT, 0, 0);
         },
         buf,


### PR DESCRIPTION
## Summary

WPT ref-test buffers were compared over a transparent background, which broke comparisons in both directions:

- Test pages that correctly render as "all white" (white boxes covering red, or content pushed off-screen) produced `(255,255,255,255)` pixels while `reference/blank.html` produced `(0,0,0,0)`, so every test whose ref is `blank.html` could never pass.
- Black text (`0,0,0,255`) on an unpainted background (`0,0,0,0`) was indistinguishable to the differ in the RGB channels, so some genuinely-different renders passed by accident.

The runner now fills the scene with `Color::WHITE` before `paint_scene`, matching `examples/screenshot.rs` and the window renderer. The `image_is_blank` guard from eea4f103 is retained: an all-zero buffer now unambiguously means nothing was painted at all (a catastrophic render failure).