### PR TITLE
Propagate first baseline from inline layout to Taffy

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -724,6 +724,12 @@ impl BaseDocument {
         // println!("known_dimensions: w: {:?} h: {:?}", inputs.known_dimensions.width, inputs.known_dimensions.height);
         // println!("\n");
 
+        let first_baseline = inline_layout
+            .layout
+            .lines()
+            .next()
+            .map(|line| (line.metrics().baseline / scale) + container_pb.top);
+
         // Put layout back
         self.nodes[node_id]
             .data
@@ -734,7 +740,10 @@ impl BaseDocument {
         LayoutOutput {
             size: final_size,
             content_size: measured_size + padding.sum_axes(),
-            first_baselines: Point::NONE,
+            first_baselines: Point {
+                x: None,
+                y: first_baseline,
+            },
             top_margin: CollapsibleMarginSet::ZERO,
             bottom_margin: CollapsibleMarginSet::ZERO,
             margins_can_collapse_through: !has_styles_preventing_being_collapsed_through


### PR DESCRIPTION
## Summary

Inline roots previously returned `first_baselines: Point::NONE` from `compute_inline_layout`, so Taffy fell back to synthesizing every text-containing flex item's baseline from its bottom border edge (`baseline.unwrap_or(size.height)`). This made `align-items: baseline` / `align-self: baseline` align items by their bottom edges instead of their text baselines.

Fix: read Parley's first line metrics and return them as the inline root's first baseline (relative to the border box):

```rust
let first_baseline = inline_layout.layout.lines().next()
    .map(|line| (line.metrics().baseline / scale) + container_pb.top);
```

WPT `css/css-flexbox` results: 654 → 657 tests passed (1714 → 1721 subtests). Fixes `flexbox_align-items-baseline.html`, `flexbox-align-self-baseline-horiz-004.xhtml`, `flexbox-align-self-baseline-horiz-005.xhtml`, `align-items-004.htm` (the last two also need the companion Taffy fixes).

Note: `flexbox-align-self-horiz-001-block.xhtml` flips to failing — its *reference* rendering relies on inline-block baseline alignment inside text flow, which Parley's `InlineBox` doesn't support (no baseline field); the test page itself now renders correctly.

Companion Taffy PR: DioxusLabs/taffy — flex container baseline synthesis, wrap-reverse baseline alignment, scroll-container baseline clamping, and block first-baseline propagation.

Link to Devin session: https://app.devin.ai/sessions/aeca5969ff4b42aa8aeca4aee0b79f3f
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**10** newly passing, **9** newly failing (net +1), **1** added test.

<details>
<summary>Full diff (20 changed tests)</summary>

```diff
- Pass => Fail css/css-contain/contain-layout-baseline-002.html
- Pass => Fail css/css-contain/contain-layout-baseline-003.html
+ Fail => Pass css/css-flexbox/align-items-004.htm
+ Fail => Pass css/css-flexbox/flexbox-align-self-baseline-horiz-004.xhtml
+ Fail => Pass css/css-flexbox/flexbox-align-self-baseline-horiz-005.xhtml
- Pass => Fail css/css-flexbox/flexbox-align-self-horiz-001-block.xhtml
+ Fail => Pass css/css-flexbox/flexbox_align-items-baseline.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-001.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-002.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-003.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-004.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-005.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-006.html
- Pass => Fail css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-001.html
- Pass => Fail css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-003.html
- Pass => Fail css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-lr-001.html
- Pass => Fail css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-rl-001.html
- Pass => Fail css/css-multicol/baseline-001.html
- Pass => Fail css/css-multicol/baseline-002.html
+ ADD css/css-overflow/unicode-bidi-plaintext-scroll-direction.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30141734433).</sub>
<!-- wpt-results-end -->
