### PR TITLE
Support display: table-caption in table layout

### DIFF
--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -31,6 +31,8 @@ pub struct TableContext {
     pub computed_grid_info: AtomicRefCell<Option<DetailedGridInfo>>,
     pub border_style: Option<ServoArc<Border>>,
     pub border_collapse: BorderCollapse,
+    /// Number of top table-caption boxes, which occupy the leading rows of the grid
+    pub top_caption_count: u16,
 }
 
 // #[derive(Debug, Clone, Eq, PartialEq)]
@@ -47,6 +49,14 @@ pub struct TableCell {
 }
 
 #[derive(Debug, Clone)]
+pub struct TableCaption {
+    node_id: usize,
+    style: taffy::Style<Atom>,
+    /// Whether the caption appeared before any row in the table
+    is_top: bool,
+}
+
+#[derive(Debug, Clone)]
 pub struct TableRow {
     // kind: TableItemKind,
     pub node_id: usize,
@@ -58,6 +68,7 @@ pub(crate) fn build_table_context(
     table_root_node_id: usize,
 ) -> (TableContext, Vec<usize>) {
     let mut cells: Vec<TableCell> = Vec::new();
+    let mut captions: Vec<TableCaption> = Vec::new();
     let mut rows: Vec<TableRow> = Vec::new();
     let mut row = 0u16;
     let mut col = 0u16;
@@ -102,6 +113,7 @@ pub(crate) fn build_table_context(
             &mut row,
             &mut col,
             &mut cells,
+            &mut captions,
             &mut rows,
             &mut column_sizes,
             &mut first_cell_border,
@@ -109,8 +121,40 @@ pub(crate) fn build_table_context(
     }
     column_sizes.resize(col as usize, style_helpers::auto());
 
+    // Table-caption boxes are placed in their own grid rows, spanning every column.
+    // Top captions occupy the leading rows so the grid rows of cells are shifted down.
+    let top_caption_count = captions.iter().filter(|c| c.is_top).count() as u16;
+    if top_caption_count > 0 {
+        for cell in cells.iter_mut() {
+            if let taffy::GridPlacement::Line(line) = cell.style.grid_row.start {
+                cell.style.grid_row.start =
+                    style_helpers::line(line.as_i16() + top_caption_count as i16);
+            }
+        }
+    }
+    let mut bottom_caption_row = row + top_caption_count;
+    let mut top_caption_row = 0i16;
+    for mut caption in captions {
+        let caption_row = if caption.is_top {
+            top_caption_row += 1;
+            top_caption_row
+        } else {
+            bottom_caption_row += 1;
+            bottom_caption_row as i16
+        };
+        caption.style.grid_row = taffy::Line {
+            start: style_helpers::line(caption_row),
+            end: style_helpers::span(1),
+        };
+        cells.push(TableCell {
+            node_id: caption.node_id,
+            style: caption.style,
+        });
+    }
+    let row_count = bottom_caption_row.max(row + top_caption_count);
+
     style.grid_template_columns = column_sizes.into_iter().map(|dim| dim.into()).collect();
-    style.grid_template_rows = vec![style_helpers::auto(); row as usize];
+    style.grid_template_rows = vec![style_helpers::auto(); row_count as usize];
 
     style.gap = match border_collapse {
         BorderCollapse::Separate => taffy::Size {
@@ -159,6 +203,7 @@ pub(crate) fn build_table_context(
             computed_grid_info: AtomicRefCell::new(None),
             border_collapse,
             border_style: first_cell_border,
+            top_caption_count,
         },
         layout_children,
     )
@@ -173,6 +218,7 @@ pub(crate) fn collect_table_cells(
     row: &mut u16,
     col: &mut u16,
     cells: &mut Vec<TableCell>,
+    captions: &mut Vec<TableCaption>,
     rows: &mut Vec<TableRow>,
     columns: &mut Vec<TrackSizingFunction>,
     first_cell_border: &mut Option<ServoArc<Border>>,
@@ -194,6 +240,22 @@ pub(crate) fn collect_table_cells(
         return;
     }
 
+    if display.outside() == DisplayOutside::TableCaption {
+        let stylo_style = &node.primary_styles().unwrap();
+        let mut style = stylo_taffy::to_taffy_style(stylo_style);
+        // A caption box spans the full width of the table grid
+        style.grid_column = taffy::Line {
+            start: style_helpers::line(1),
+            end: style_helpers::line(-1),
+        };
+        captions.push(TableCaption {
+            node_id,
+            style,
+            is_top: *row == 0,
+        });
+        return;
+    }
+
     match display.inside() {
         DisplayInside::TableRowGroup
         | DisplayInside::TableHeaderGroup
@@ -211,6 +273,7 @@ pub(crate) fn collect_table_cells(
                     row,
                     col,
                     cells,
+                    captions,
                     rows,
                     columns,
                     first_cell_border,
@@ -238,6 +301,7 @@ pub(crate) fn collect_table_cells(
                     row,
                     col,
                     cells,
+                    captions,
                     rows,
                     columns,
                     first_cell_border,


### PR DESCRIPTION
## Summary

Adds `display: table-caption` support to the grid-based table layout (captions were previously ignored entirely). Split out of #527.

- `collect_table_cells` collects boxes with `DisplayOutside::TableCaption` into a `captions` list instead of treating them as cells; captions encountered before any row are flagged `is_top`.
- `build_table_context` places each caption in its own grid row spanning all columns (`grid_column: line(1)..line(-1)`). Top captions occupy the leading rows — cell `grid_row` start lines are shifted down by `top_caption_count` — and other captions (`caption-side: bottom`) are placed after the last row.
- Caption margins are preserved, since margins apply to caption boxes (unlike table-internal boxes).
- `TableContext` gains a `top_caption_count: u16` field.

Fixes several `margin-*-applies-to-*` tests in the WPT `css/CSS2/margin-padding-clear` suite, which use captions in their references.

Link to Devin session: https://app.devin.ai/sessions/21f1724c57344d11b11401eff9508133
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/529?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->