### PR TITLE
Parse documents with an XHTML-namespaced root element as XHTML

### DIFF
--- a/packages/blitz-html/src/html_sink.rs
+++ b/packages/blitz-html/src/html_sink.rs
@@ -66,6 +66,20 @@ impl<'m, 'doc> DocumentHtmlParser<'m, 'doc> {
         }
     }
 
+    /// Detects documents without an XML or DOCTYPE declaration whose root `<html>` element
+    /// declares the XHTML namespace (e.g. `<html xmlns="http://www.w3.org/1999/xhtml">`)
+    fn root_element_has_xhtml_namespace(html: &str) -> bool {
+        let rest = html.trim_start_matches('\u{feff}').trim_start();
+        let Some(rest) = rest.strip_prefix("<html") else {
+            return false;
+        };
+        let Some(tag_end) = rest.find('>') else {
+            return false;
+        };
+        rest[..tag_end].contains("xmlns=\"http://www.w3.org/1999/xhtml\"")
+            || rest[..tag_end].contains("xmlns='http://www.w3.org/1999/xhtml'")
+    }
+
     pub fn parse_into_mutator<'a, 'd>(mutr: &'a mut DocumentMutator<'d>, html: &str) {
         let mut sink = DocumentHtmlParser::new(mutr);
 
@@ -73,7 +87,8 @@ impl<'m, 'doc> DocumentHtmlParser<'m, 'doc> {
             || html.starts_with("<!DOCTYPE") && {
                 let first_line = html.lines().next().unwrap();
                 first_line.contains("XHTML") || first_line.contains("xhtml")
-            };
+            }
+            || Self::root_element_has_xhtml_namespace(html);
 
         if is_xhtml_doc {
             // Parse as XHTML


### PR DESCRIPTION
## Summary

Split out of the letter/word-spacing WPT work (see also the inline edge-strut and ligature PRs). Several WPT files (e.g. the CSS2 `letter-spacing-0NN` references) are XHTML documents with **no XML declaration and no XHTML DOCTYPE**, only an XHTML-namespaced root element:

```html
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
```

`DocumentHtmlParser::parse_into_mutator` only sniffed for `<?xml` or an XHTML DOCTYPE on the first line, so these documents were parsed as HTML, producing different trees/rendering than their XHTML test counterparts. A new `root_element_has_xhtml_namespace` check scans the root `<html ...>` tag for `xmlns="http://www.w3.org/1999/xhtml"` and routes such documents to the XML parser.

## WPT results (css/css-text + css/CSS2/text)

841 → 869 passing (+28 fixed / 0 regressed): 28 tests in the CSS2 `letter-spacing-004..100` blocks whose references are namespace-only XHTML files.

Verified with `cargo fmt --all -- --check`, `cargo check --workspace`, `cargo clippy --workspace`, and per-test `wptreport.json` comparison against main.


Link to Devin session: https://app.devin.ai/sessions/4fc97f74ea1b446b84389f19af7fc263
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/531?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->