### PR TITLE
Disable optional ligatures when letter-spacing is non-zero

### DIFF
--- a/packages/blitz-dom/src/stylo_to_parley.rs
+++ b/packages/blitz-dom/src/stylo_to_parley.rs
@@ -319,7 +319,22 @@ pub(crate) fn style(
     let font_style = self::font_style(font_styles.font_style);
     let font_width = self::font_width(font_styles.font_stretch);
     let font_variations = self::font_variations(&font_styles.font_variation_settings);
-    let font_features = self::font_features(font_styles);
+    let mut font_features = self::font_features(font_styles);
+
+    // Per css-text-3, when the spacing between characters is not zero user agents
+    // should not apply optional ligatures. Disabling features are inserted at the
+    // start of the list so that explicit author settings take precedence.
+    if letter_spacing != 0.0 {
+        font_features.splice(
+            0..0,
+            [
+                feature(b"liga", 0),
+                feature(b"clig", 0),
+                feature(b"dlig", 0),
+                feature(b"hlig", 0),
+            ],
+        );
+    }
 
     // Convert font family
     let families: Vec<_> = font_styles

--- a/packages/blitz-dom/src/stylo_to_parley.rs
+++ b/packages/blitz-dom/src/stylo_to_parley.rs
@@ -324,6 +324,7 @@ pub(crate) fn style(
     // Per css-text-3, when the spacing between characters is not zero user agents
     // should not apply optional ligatures. Disabling features are inserted at the
     // start of the list so that explicit author settings take precedence.
+    // TODO: move this fix into parley
     if letter_spacing != 0.0 {
         font_features.splice(
             0..0,


### PR DESCRIPTION
## Summary

Split out of the letter/word-spacing WPT work (see also the inline edge-strut and XHTML-sniffing PRs). Per [css-text-3 §8.2](https://drafts.csswg.org/css-text-3/#letter-spacing-property), UAs should not apply optional ligatures when the spacing between characters is not zero. In `stylo_to_parley::style`, when the resolved `letter-spacing` is non-zero we now disable the optional ligature features:

```rust
if letter_spacing != 0.0 {
    font_features.splice(0..0, [feature(b"liga", 0), feature(b"clig", 0),
                                feature(b"dlig", 0), feature(b"hlig", 0)]);
}
```

Disabling features are inserted at the *start* of the list so explicit author `font-feature-settings` (appended after) take precedence.

## WPT results (css/css-text + css/CSS2/text)

No regressions (841 → 841 in isolation; the tests this enables — e.g. `letter-spacing-ligatures-004/005` — also need the inline edge-strut and XHTML-sniffing PRs to pass, and are counted there/in combination). With all three PRs combined: 841 → 878 passing.

Verified with `cargo fmt --all -- --check`, `cargo check --workspace`, `cargo clippy --workspace`, and per-test `wptreport.json` comparison against main.


Link to Devin session: https://app.devin.ai/sessions/4fc97f74ea1b446b84389f19af7fc263
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`6e05d5e`](https://github.com/dioxuslabs/blitz/pull/532/commits/6e05d5ec935330482e4a589c89c496763bbdb04d) |

<a href="https://dioxus.staging.devinenterprise.com/review/dioxuslabs/blitz/pull/532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->