### PR TITLE
Implement remaining assertion attributes in WPT attr_test runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9252,6 +9252,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde_json",
+ "stylo_traits",
  "supports-hyperlinks",
  "taffy",
  "terminal-link",

--- a/wpt/runner/Cargo.toml
+++ b/wpt/runner/Cargo.toml
@@ -22,6 +22,7 @@ anyrender_vello = { workspace = true, optional = true }
 anyrender_vello_cpu = { workspace = true, optional = true }
 
 taffy = { workspace = true }
+style_traits = { workspace = true }
 parley = { workspace = true }
 peniko = { workspace = true }
 image = { workspace = true, features = ["png"] }

--- a/wpt/runner/src/test_runners/attr_test.rs
+++ b/wpt/runner/src/test_runners/attr_test.rs
@@ -1,4 +1,5 @@
 use blitz_dom::Node;
+use style_traits::ToCss;
 
 use super::{SubtestResult, parse_and_resolve_document};
 use crate::{SubtestCounts, TestStatus, ThreadCtx};
@@ -74,6 +75,13 @@ pub fn check_node_layout(node: &Node) -> Vec<String> {
         taffy::Rect::ZERO
     };
 
+    let client_width =
+        layout.size.width - layout.border.left - layout.border.right - layout.scrollbar_size.width;
+    let client_height = layout.size.height
+        - layout.border.top
+        - layout.border.bottom
+        - layout.scrollbar_size.height;
+
     node.attrs()
         .map(|attrs| {
             attrs
@@ -112,28 +120,35 @@ pub fn check_node_layout(node: &Node) -> Vec<String> {
                             check_attr(name, value, layout.location.y - parent_border.top)
                         }
 
-                        // TODO: other check types
-                        "data-expected-client-width" => {
-                            Err(format!("Unsupported assertion: {name}"))
-                        }
-                        "data-expected-client-height" => {
-                            Err(format!("Unsupported assertion: {name}"))
-                        }
+                        "data-expected-client-width" => check_attr(name, value, client_width),
+                        "data-expected-client-height" => check_attr(name, value, client_height),
                         "data-expected-scroll-width" => {
-                            Err(format!("Unsupported assertion: {name}"))
+                            check_attr(name, value, client_width.max(layout.content_size.width))
                         }
                         "data-expected-scroll-height" => {
-                            Err(format!("Unsupported assertion: {name}"))
+                            check_attr(name, value, client_height.max(layout.content_size.height))
                         }
                         "data-expected-bounding-client-rect-width" => {
-                            Err(format!("Unsupported assertion: {name}"))
+                            check_attr(name, value, layout.size.width)
                         }
                         "data-expected-bounding-client-rect-height" => {
-                            Err(format!("Unsupported assertion: {name}"))
+                            check_attr(name, value, layout.size.height)
                         }
-                        "data-total-x" => Err(format!("Unsupported assertion: {name}")),
-                        "data-total-y" => Err(format!("Unsupported assertion: {name}")),
-                        "data-expected-display" => Err(format!("Unsupported assertion: {name}")),
+                        "data-total-x" => check_attr(name, value, total_offset(node).0),
+                        "data-total-y" => check_attr(name, value, total_offset(node).1),
+                        "data-expected-display" => {
+                            let display = node
+                                .primary_styles()
+                                .map(|styles| styles.clone_display().to_css_string())
+                                .unwrap_or_default();
+                            if display == **value {
+                                Ok(())
+                            } else {
+                                Err(format!(
+                                    "assert_equals: {name} expected {value} got {display}"
+                                ))
+                            }
+                        }
 
                         // Not a check attribute
                         _ => Ok(()),
@@ -143,6 +158,27 @@ pub fn check_node_layout(node: &Node) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn total_offset(node: &Node) -> (f32, f32) {
+    let mut x = 0.0;
+    let mut y = 0.0;
+    let mut current = node;
+    loop {
+        let layout = &current.final_layout;
+        let parent_border = if let Some(parent_id) = current.parent {
+            current.with(parent_id).final_layout.border
+        } else {
+            taffy::Rect::ZERO
+        };
+        x += layout.location.x - parent_border.left;
+        y += layout.location.y - parent_border.top;
+        match current.parent {
+            Some(parent_id) => current = current.with(parent_id),
+            None => break,
+        }
+    }
+    (x, y)
 }
 
 fn check_attr(attr_name: &str, attr_val: &str, actual: f32) -> Result<(), String> {

--- a/wpt/runner/src/test_runners/attr_test.rs
+++ b/wpt/runner/src/test_runners/attr_test.rs
@@ -182,9 +182,11 @@ fn total_offset(node: &Node) -> (f32, f32) {
 }
 
 fn check_attr(attr_name: &str, attr_val: &str, actual: f32) -> Result<(), String> {
-    let expected: f32 = attr_val
-        .parse()
-        .expect("Failed to parse check attribute as f32");
+    let Ok(expected) = attr_val.parse::<f32>() else {
+        return Err(format!(
+            "assert_equals: failed to parse {attr_name} value {attr_val} as f32"
+        ));
+    };
 
     let equal = assert_with_tolerance(expected, actual);
 


### PR DESCRIPTION
## Summary

Implements all previously-unsupported `data-expected-*` / `data-*` assertion attributes in `check_node_layout` (wpt/runner/src/test_runners/attr_test.rs), which previously returned `Err("Unsupported assertion: ...")` and failed any subtest using them:

- `data-expected-client-width/height`: `size - border - scrollbar_size` (DOM clientWidth/clientHeight)
- `data-expected-scroll-width/height`: `client_size.max(content_size)` (DOM scrollWidth/scrollHeight)
- `data-expected-bounding-client-rect-width/height`: border-box `layout.size` (no transform support yet)
- `data-total-x/y`: new `total_offset(node)` walks the ancestor chain accumulating `location - parent_border` (matching the existing `data-offset-x/y` approximation, summed over the chain like check-layout-th.js's offsetParent walk)
- `data-expected-display`: string-compares against `primary_styles().clone_display().to_css_string()` (adds a `style_traits` dep to the wpt crate for `ToCss`)

Link to Devin session: https://app.devin.ai/sessions/127be29a75d44d8db40fe27aa4a0beed
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/533?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->

<!-- wpt-results-start -->
## WPT results

**17** newly passing, **0** newly failing (net +17).

<details>
<summary>Full diff (17 changed tests)</summary>

```
Fail => Pass css/css-conditional/container-queries/no-layout-containment-scroll.html
Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-005.html
Fail => Pass css/css-flexbox/flexitem-stretch-image.html
Fail => Pass css/css-flexbox/svg-root-as-flex-item-006.html
Fail => Pass css/css-overflow/overflow-empty-child-box.html
Fail => Pass css/css-overflow/scrollable-overflow-transform-009.html
Fail => Pass css/css-overflow/scrollable-overflow-with-nested-elements-001.html
Fail => Pass css/css-overflow/scrollable-overflow-with-nested-elements-002.html
Fail => Pass css/css-overflow/scrollable-overflow-with-nested-elements-003.html
Fail => Pass css/css-overflow/scrollable-overflow-with-nested-elements-004.html
Fail => Pass css/css-sizing/intrinsic-percent-replaced-028.html
Fail => Pass css/css-sizing/stretch/indefinite-1.html
Fail => Pass css/css-sizing/stretch/indefinite-2.html
Fail => Pass css/css-sizing/stretch/indefinite-3.html
Fail => Pass css/css-sizing/stretch/indefinite-5.html
Fail => Pass css/css-sizing/stretch/indefinite-6.html
Fail => Pass css/css-tables/absolute-tables-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30118849126).</sub>
<!-- wpt-results-end -->
