### PR TITLE
Colour-code WPT diff output and sort it by test name

### DIFF
--- a/.github/scripts/wpt_diff_to_pr.py
+++ b/.github/scripts/wpt_diff_to_pr.py
@@ -69,12 +69,15 @@ def parse_diff(text):
 
 
 def format_lines(diff):
+    """Render the changes as diff-syntax lines sorted by test name."""
     lines = []
-    for before, after, test in diff.newly_passing + diff.newly_failing + diff.other_changes:
-        lines.append(f"{before} => {after} {test}")
-    lines.extend(f"ADD  {test}" for test in diff.added)
-    lines.extend(f"REM  {test}" for test in diff.removed)
-    return lines
+    for marker, entries in [("+", diff.newly_passing), ("-", diff.newly_failing), ("!", diff.other_changes)]:
+        for before, after, test in entries:
+            lines.append((test, f"{marker} {before} => {after} {test}"))
+    lines.extend((test, f"+ ADD {test}") for test in diff.added)
+    lines.extend((test, f"- REM {test}") for test in diff.removed)
+    lines.sort()
+    return [line for _, line in lines]
 
 
 def render(diff, run_url):
@@ -105,10 +108,10 @@ def render(diff, run_url):
         out.append("<details>")
         out.append(f"<summary>Full diff ({len(lines)} changed tests)</summary>")
         out.append("")
-        out.append("```")
+        out.append("```diff")
         out.extend(shown)
         if truncated:
-            out.append(f"... and {len(lines) - len(shown)} more (see the workflow logs)")
+            out.append(f"# ... and {len(lines) - len(shown)} more (see the workflow logs)")
         out.append("```")
         out.append("")
         out.append("</details>")


### PR DESCRIPTION

<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/536?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30122573655).</sub>
<!-- wpt-results-end -->
