### PR TITLE
Integrate parley white-space-collapse work (parley#680 + follow-ups)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "fontique"
 version = "0.11.0"
-source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
+source = "git+https://github.com/DioxusLabs/parley?branch=devin%2F1784926372-css-text-wpt-fixes#2ef11adbe3d1fe93e11894b0bc7e8a4ba98a2d60"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -5257,12 +5257,12 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
+source = "git+https://github.com/DioxusLabs/parley?branch=devin%2F1784926372-css-text-wpt-fixes#2ef11adbe3d1fe93e11894b0bc7e8a4ba98a2d60"
 
 [[package]]
 name = "parley"
 version = "0.11.0"
-source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
+source = "git+https://github.com/DioxusLabs/parley?branch=devin%2F1784926372-css-text-wpt-fixes#2ef11adbe3d1fe93e11894b0bc7e8a4ba98a2d60"
 dependencies = [
  "fontique",
  "harfrust",
@@ -5278,7 +5278,7 @@ dependencies = [
 [[package]]
 name = "parley_core"
 version = "0.11.0"
-source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
+source = "git+https://github.com/DioxusLabs/parley?branch=devin%2F1784926372-css-text-wpt-fixes#2ef11adbe3d1fe93e11894b0bc7e8a4ba98a2d60"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -5290,7 +5290,7 @@ dependencies = [
 [[package]]
 name = "parley_data"
 version = "0.11.0"
-source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
+source = "git+https://github.com/DioxusLabs/parley?branch=devin%2F1784926372-css-text-wpt-fixes#2ef11adbe3d1fe93e11894b0bc7e8a4ba98a2d60"
 dependencies = [
  "icu_properties",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -284,7 +284,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -315,7 +315,7 @@ dependencies = [
  "anyrender",
  "image",
  "peniko",
- "read-fonts",
+ "read-fonts 0.39.2",
  "serde",
  "serde_json",
  "sha2",
@@ -855,7 +855,7 @@ dependencies = [
  "percent-encoding",
  "rayon",
  "selectors",
- "skrifa",
+ "skrifa 0.42.1",
  "slab",
  "smallvec",
  "stylo",
@@ -1423,7 +1423,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2398,7 +2398,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2658,7 +2658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2806,6 +2806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "font-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,9 +2839,8 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
+version = "0.11.0"
+source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -2842,7 +2850,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts",
+ "read-fonts 0.40.2",
  "roxmltree 0.21.1",
  "smallvec",
  "windows",
@@ -3146,7 +3154,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "peniko",
- "skrifa",
+ "skrifa 0.42.1",
  "smallvec",
  "vello_common",
 ]
@@ -3330,13 +3338,13 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
+checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.40.2",
  "smallvec",
 ]
 
@@ -4653,7 +4661,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4772,7 +4780,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc8f19a1c361e5fb1a57e487b993ff8b3c44321b50ca86c9e2b235e57dc94008"
 dependencies = [
- "font-types",
+ "font-types 0.11.3",
 ]
 
 [[package]]
@@ -5249,32 +5257,40 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
 
 [[package]]
 name = "parley"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
+version = "0.11.0"
+source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
 dependencies = [
  "fontique",
  "harfrust",
  "hashbrown 0.17.1",
  "icu_normalizer",
  "icu_properties",
- "icu_segmenter",
  "linebender_resource_handle",
  "parlance",
+ "parley_core",
+ "skrifa 0.43.2",
+]
+
+[[package]]
+name = "parley_core"
+version = "0.11.0"
+source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
+ "parlance",
  "parley_data",
- "skrifa",
 ]
 
 [[package]]
 name = "parley_data"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
+version = "0.11.0"
+source = "git+https://github.com/nicoburns/parley?branch=better-white-space-collapse#2460f9c3eb3c67c84d147f896797ac6fc2610f3b"
 dependencies = [
  "icu_properties",
 ]
@@ -5884,7 +5900,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
- "font-types",
+ "font-types 0.11.3",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
+dependencies = [
+ "bytemuck",
+ "font-types 0.12.2",
+ "once_cell",
 ]
 
 [[package]]
@@ -6150,7 +6177,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6580,7 +6607,7 @@ checksum = "caad12d9a3f75948b725a643cd60aea6de9d20cb03d3e35221e7a8a31c549409"
 dependencies = [
  "fnv",
  "hashbrown 0.17.1",
- "skrifa",
+ "skrifa 0.42.1",
  "thiserror 2.0.18",
  "write-fonts",
 ]
@@ -6619,7 +6646,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.39.2",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.40.2",
 ]
 
 [[package]]
@@ -6726,7 +6763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7127,8 +7164,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340a09581f29809fc0df82a3955501dc7f2a21f887e5d1c13dbe288fe1c0bef4"
+source = "git+https://github.com/DioxusLabs/taffy?rev=8602368#86023685f5f29e5a50e9d9dcfbbee302c2f6f7b1"
 dependencies = [
  "arrayvec",
  "grid",
@@ -7169,7 +7205,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7740,7 +7776,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7951,7 +7987,7 @@ dependencies = [
  "log",
  "peniko",
  "png 0.18.1",
- "skrifa",
+ "skrifa 0.42.1",
  "static_assertions",
  "thiserror 2.0.18",
  "vello_encoding",
@@ -8001,7 +8037,7 @@ dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko",
- "skrifa",
+ "skrifa 0.42.1",
  "smallvec",
 ]
 
@@ -8631,7 +8667,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9278,11 +9314,11 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb731d4c4d93eacc69a1ad2f270f905788a98e4a3438267bcafbe08d3431c8d8"
 dependencies = [
- "font-types",
+ "font-types 0.11.3",
  "indexmap",
  "kurbo",
  "log",
- "read-fonts",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,11 @@ taffy = { version = "0.12.1", default-features = false, features = [
     "calc",
     "detailed_layout_info",
 ] }
-parley = { version = "0.10", default-features = false, features = ["std"] }
+# TODO: point back at a crates-io release once the white-space-collapse work
+# (parley#680 + follow-ups) is merged and published. This branch does NOT yet
+# include the required follow-up changes, so the workspace does not currently
+# compile — see the PR description.
+parley = { git = "https://github.com/nicoburns/parley", branch = "better-white-space-collapse", default-features = false, features = ["std"] }
 skrifa = { version = "0.42", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions
@@ -297,3 +301,7 @@ tracing-subscriber = "0.3"
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
+
+# TODO: remove once a taffy release including DioxusLabs/taffy#994 is published.
+[patch.crates-io]
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "8602368" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,10 +102,8 @@ taffy = { version = "0.12.1", default-features = false, features = [
     "detailed_layout_info",
 ] }
 # TODO: point back at a crates-io release once the white-space-collapse work
-# (parley#680 + follow-ups) is merged and published. This branch does NOT yet
-# include the required follow-up changes, so the workspace does not currently
-# compile — see the PR description.
-parley = { git = "https://github.com/nicoburns/parley", branch = "better-white-space-collapse", default-features = false, features = ["std"] }
+# (parley#680 + follow-ups) is merged and published.
+parley = { git = "https://github.com/DioxusLabs/parley", branch = "devin/1784926372-css-text-wpt-fixes", default-features = false, features = ["std"] }
 skrifa = { version = "0.42", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use markup5ever::{QualName, local_name, ns};
 use parley::{
-    FontContext, InlineBox, InlineBoxKind, LayoutContext, StyleProperty, TreeBuilder,
-    WhiteSpaceCollapse,
+    BaseDirection, FontContext, InlineBox, InlineBoxKind, LayoutContext, StyleProperty,
+    TreeBuilder, WhiteSpaceCollapse,
 };
 use slab::Slab;
 use style::{
@@ -936,6 +936,13 @@ pub(crate) fn build_inline_layout_into(
         .unwrap_or(WhiteSpaceCollapse::Collapse);
     builder.set_white_space_mode(collapse_mode);
 
+    // Set base (paragraph) direction from the CSS `direction` property
+    let base_direction = root_node_style
+        .as_ref()
+        .map(|s| stylo_to_parley::direction(s.clone_direction()))
+        .unwrap_or(BaseDirection::Auto);
+    builder.set_base_direction(base_direction);
+
     let text_transform = root_node_style
         .as_ref()
         .map(|s| s.clone_text_transform() & TextTransform::CASE_TRANSFORMS)
@@ -1077,6 +1084,7 @@ pub(crate) fn build_inline_layout_into(
                                 // Width and height are set during layout
                                 width: 0.0,
                                 height: 0.0,
+                                baseline: None,
                             });
                         } else if *tag_name == local_name!("br") {
                             // node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
@@ -1157,6 +1165,7 @@ pub(crate) fn build_inline_layout_into(
                             // Width and height are set during layout
                             width: 0.0,
                             height: 0.0,
+                            baseline: None,
                         });
                     }
                 };

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -409,13 +409,12 @@ impl BaseDocument {
                 let float_width = 0.0;
 
                 let computed_width = match available_space.width {
-                    AvailableSpace::MinContent => min_content_width.max(float_width),
-                    AvailableSpace::MaxContent => max_content_width + float_width,
+                    AvailableSpace::MinContent => min_content_width.max(float_width).ceil(),
+                    AvailableSpace::MaxContent => (max_content_width + float_width).ceil(),
                     AvailableSpace::Definite(limit) => (limit * scale)
-                        .min(max_content_width + float_width)
-                        .max(min_content_width),
-                }
-                .ceil();
+                        .min((max_content_width + float_width).ceil())
+                        .max(min_content_width.ceil()),
+                };
 
                 let style_width = node_size.width.map(|w| w * scale);
                 let min_width = node_min_size.width.map(|w| w * scale);
@@ -471,9 +470,17 @@ impl BaseDocument {
             return LayoutOutput::from_outer_size(clamped_size);
         }
 
+        // Tolerance for treating content that overflows the container by a subpixel-invisible
+        // amount as fitting, compensating for floating-point rounding error in a width derived
+        // from font metrics (e.g. a CSS `ch`-based width intended to exactly fit a whole number
+        // of characters). A thousandth of a (scaled) pixel is well below visible size differences.
+        const FIT_TOLERANCE: f32 = 0.001;
+
         #[cfg(not(feature = "floats"))]
         {
-            inline_layout.layout.break_all_lines(Some(width));
+            inline_layout
+                .layout
+                .break_all_lines(Some(width + FIT_TOLERANCE));
         }
 
         // Perform inline layout
@@ -484,6 +491,7 @@ impl BaseDocument {
             let mut has_active_floats = initial_slot.segment_id.is_some();
             let state = breaker.state_mut();
             state.set_layout_max_advance(width);
+            state.set_max_advance_fit_tolerance(FIT_TOLERANCE);
             state.set_line_max_advance(initial_slot.width * scale);
             state.set_line_x(initial_slot.x * scale);
             state.set_line_y((initial_slot.y * scale) as f64);
@@ -542,8 +550,20 @@ impl BaseDocument {
 
                         let margin_sum = margin.sum_axes();
 
-                        let output =
-                            self.compute_child_layout(NodeId::from(node_id), float_child_inputs);
+                        // A float with `width: auto` is shrink-to-fit (fit-content) sized:
+                        // the available space clamped between its min-content and max-content
+                        // sizes, rather than its max-content size outright.
+                        let available_width = (width / scale) - margin_sum.width;
+                        let output = self.compute_child_layout(
+                            NodeId::from(node_id),
+                            taffy::tree::LayoutInput {
+                                available_space: taffy::Size {
+                                    width: AvailableSpace::Definite(available_width),
+                                    height: AvailableSpace::MaxContent,
+                                },
+                                ..float_child_inputs
+                            },
+                        );
                         let min_y = state.line_y() as f32 / scale;
 
                         // Note: `pos` is content-box relative
@@ -559,7 +579,7 @@ impl BaseDocument {
                             block_ctx.find_content_slot(min_y as f32, Clear::None, None);
                         has_active_floats = next_slot.segment_id.is_some();
 
-                        state.set_line_max_advance(next_slot.width * scale);
+                        state.set_line_max_advance(next_slot.width * scale + FIT_TOLERANCE);
                         state.set_line_x(next_slot.x * scale);
                         state.set_line_y((next_slot.y * scale) as f64);
 
@@ -571,7 +591,7 @@ impl BaseDocument {
                         // dbg!(&layout.size);
                         // dbg!(&layout.location);
 
-                        state.append_inline_box_to_line(box_break_data.advance, 0.0);
+                        state.append_inline_box_to_line(box_break_data.advance, 0.0, 0.0);
 
                         // if float.is_floated() {
                         //     println!("INLINE FLOATED BOX ({}) {:?}", ibox.id, float);
@@ -616,19 +636,16 @@ impl BaseDocument {
         #[allow(unused_mut)]
         let mut height = inline_layout.layout.height();
 
-        // HACK. TODO: fix in Parley.
-        //
         // A forced line break (e.g. `<br>` or a preserved newline) at the end of the
         // inline content ends the final line box but must not generate an extra empty
         // line box after it. Parley produces a trailing empty line in this case
         // (text-editor semantics), so we exclude that line from the measured height.
-        // if inline_layout.text.ends_with('\n') {
-        //     if let Some(last_line) = inline_layout.layout.lines().last() {
-        //         if last_line.items().next().is_none() {
-        //             height -= last_line.metrics().line_height;
-        //         }
-        //     }
-        // }
+        if inline_layout.layout.len() > 1
+            && let Some(last_line) = inline_layout.layout.lines().last()
+            && last_line.text_range().is_empty()
+        {
+            height -= last_line.metrics().line_height;
+        }
 
         #[cfg(feature = "floats")]
         {

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -19,6 +19,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use style::Atom;
+use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::properties::ComputedValues;
 use style::properties::generated::longhands::position::computed_value::T as Position;
@@ -270,9 +271,33 @@ impl Node {
         }
     }
 
+    /// Whether the node is a text node that consists entirely of collapsible white space
+    /// (and can therefore be ignored for layout purposes).
     pub fn is_whitespace_node(&self) -> bool {
         match &self.data {
-            NodeData::Text(data) => data.content.chars().all(|c| c.is_ascii_whitespace()),
+            NodeData::Text(data) => {
+                data.content.chars().all(|c| c.is_ascii_whitespace())
+                    && self
+                        .primary_styles()
+                        .or_else(|| {
+                            self.parent
+                                .and_then(|parent_id| self.tree()[parent_id].primary_styles())
+                        })
+                        .map(|s| {
+                            match s.get_inherited_text().white_space_collapse {
+                                WhiteSpaceCollapse::Collapse => true,
+                                // Newlines are preserved, so the node is ignorable only if it
+                                // contains none.
+                                WhiteSpaceCollapse::PreserveBreaks => {
+                                    !data.content.contains(['\n', '\r'])
+                                }
+                                WhiteSpaceCollapse::Preserve | WhiteSpaceCollapse::BreakSpaces => {
+                                    false
+                                }
+                            }
+                        })
+                        .unwrap_or(true)
+            }
             _ => false,
         }
     }
@@ -1123,7 +1148,7 @@ impl Node {
                 if let Some((cluster, _side)) =
                     Cluster::from_point_exact(layout, x * scale, y * scale)
                 {
-                    let style_index = cluster.glyphs().next()?.style_index();
+                    let style_index = usize::from(cluster.style_index());
                     let node_id = layout.styles()[style_index].brush.id;
                     let text_pointer_events_none = self
                         .with(node_id)

--- a/packages/blitz-dom/src/stylo_to_parley.rs
+++ b/packages/blitz-dom/src/stylo_to_parley.rs
@@ -7,6 +7,7 @@ use crate::node::TextBrush;
 
 // Module of type aliases so we can refer to stylo types with nicer names
 pub(crate) mod stylo {
+    pub(crate) use style::computed_values::direction::T as Direction;
     pub(crate) use style::computed_values::font_variant_caps::T as FontVariantCaps;
     pub(crate) use style::computed_values::font_variant_position::T as FontVariantPosition;
     pub(crate) use style::computed_values::text_wrap_mode::T as TextWrapMode;
@@ -34,6 +35,13 @@ pub(crate) mod parley {
     pub(crate) use parley::fontique::QueryFamily;
     pub(crate) use parley::setting::*;
     pub(crate) use parley::style::*;
+}
+
+pub(crate) fn direction(input: stylo::Direction) -> parley::BaseDirection {
+    match input {
+        stylo::Direction::Ltr => parley::BaseDirection::Ltr,
+        stylo::Direction::Rtl => parley::BaseDirection::Rtl,
+    }
 }
 
 pub(crate) fn generic_font_family(input: stylo::GenericFontFamily) -> parley::GenericFamily {
@@ -281,10 +289,8 @@ pub(crate) fn white_space_collapse(input: stylo::WhiteSpaceCollapse) -> parley::
     match input {
         stylo::WhiteSpaceCollapse::Collapse => parley::WhiteSpaceCollapse::Collapse,
         stylo::WhiteSpaceCollapse::Preserve => parley::WhiteSpaceCollapse::Preserve,
-
-        // TODO: Implement PreserveBreaks and BreakSpaces modes
-        stylo::WhiteSpaceCollapse::PreserveBreaks => parley::WhiteSpaceCollapse::Preserve,
-        stylo::WhiteSpaceCollapse::BreakSpaces => parley::WhiteSpaceCollapse::Preserve,
+        stylo::WhiteSpaceCollapse::PreserveBreaks => parley::WhiteSpaceCollapse::PreserveBreaks,
+        stylo::WhiteSpaceCollapse::BreakSpaces => parley::WhiteSpaceCollapse::BreakSpaces,
     }
 }
 


### PR DESCRIPTION
## Summary

Blitz-side integration of parley#680 (white-space-collapse) plus the follow-up parley fixes (now pushed as a PR from `DioxusLabs/parley@devin/1784926372-css-text-wpt-fixes` against linebender/parley). Together they take the `css/css-text` WPT suite from 611 → **775 passing** (parley#680 alone: 636).

`Cargo.toml` temporarily points parley at the DioxusLabs/parley branch and patches taffy to the merged DioxusLabs/taffy#994 commit; both should be repointed at releases once published.

Changes:

- `stylo_to_parley::white_space_collapse`: `PreserveBreaks`/`BreakSpaces` now map to their parley equivalents instead of being folded into `Preserve`.
- CSS `direction` is plumbed to parley's new bidi base direction:
  ```rust
  builder.set_base_direction(stylo_to_parley::direction(root_style.clone_direction()));
  ```
  Fixes `eol-spaces-bidi-*` (trailing whitespace on the correct visual edge in RTL).
- `Node::is_whitespace_node()` is now white-space-style-aware: whitespace-only text nodes are only "whitespace nodes" (discardable) when their style actually collapses them; preserved newline-only nodes now reach the inline layout.
- Inline floats are shrink-to-fit sized with a single child layout using `AvailableSpace::Definite(available_width)` (matching DioxusLabs/taffy#994), replacing max-content-only sizing.
- Inline sizing under `AvailableSpace::Definite` no longer `ceil()`s the limit (only min/max-content are ceiled), avoiding 1px-too-wide fit-content floats.
- `break_all_lines` is called with a small `FIT_TOLERANCE` (0.001px, opt-in via parley's new `set_max_advance_fit_tolerance`) so text that exactly fits doesn't wrap due to float rounding.
- If the layout ends with a forced break, the resulting trailing empty line no longer contributes height (browser behavior, unlike editor behavior).
- parley 0.11-dev API compat: `InlineBox.baseline`, `append_inline_box_to_line` arity, `cluster.style_index()`.

Full test evidence and remaining failures: see the [css-text report](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctYzA4ZWNhZTVlODUwNGJlY2I0MWE1NmY1ZGYwYjE2N2UiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctYzA4ZWNhZTVlODUwNGJlY2I0MWE1NmY1ZGYwYjE2N2UvZjNkZDI3NDMtOWYyYS00YTI2LWJlNzEtM2FkYTgzNWIwMWEwIiwiaWF0IjoxNzg0OTI4MzI3LCJleHAiOjE3ODU1MzMxMjcsImZpbGVuYW1lIjoicGFybGV5LTY4MC1jc3MtdGV4dC1yZXBvcnQubWQifQ.Xy4rslJWzIODjiNeUFUuy7-2kQ7dE49t1p9_-zNsaQI).

Link to Devin session: https://app.devin.ai/sessions/f0e260cc5efa4c42aa65125d9f15c3b7
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/539?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->