### PR TITLE
Use a zipped artifact for the WPT diff so cross-run download works

### DIFF
--- a/.github/workflows/wpt-post-results.yml
+++ b/.github/workflows/wpt-post-results.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Download WPT diff
         uses: actions/download-artifact@v7
         with:
-          name: wptdiff.txt
+          name: wpt-diff
           path: ./wpt/output
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -74,9 +74,8 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
-          name: wptdiff.txt
+          name: wpt-diff
           path: ./wpt/output/wptdiff.txt
-          archive: false
       - name: Setup Github Pages
         if: github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v6


### PR DESCRIPTION

<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/542?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30128566520).</sub>
<!-- wpt-results-end -->
