### PR TITLE
Update hover/active/focus state when the referenced node is removed

### DIFF
--- a/examples/mutations.rs
+++ b/examples/mutations.rs
@@ -1,0 +1,14 @@
+use dioxus_native::prelude::*;
+
+fn main() {
+    dioxus_native::launch(app);
+}
+
+fn app() -> Element {
+    rsx! {
+        "Outer"
+        div {
+            "Inner"
+        }
+    }
+}

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -235,10 +235,18 @@ pub struct BaseDocument {
     /// A Parley layout context
     pub(crate) layout_ctx: parley::LayoutContext<TextBrush>,
 
-    /// The node which is currently hovered (if any)
+    /// The real (non-anonymous) node which is currently hovered (if any).
+    /// This is never a layout-generated (anonymous) node, so it remains valid
+    /// across box-tree reconstruction.
     pub(crate) hover_node_id: Option<NodeId>,
+    /// The precise (may be anonymous) layout node under the pointer (if any).
+    /// This can be invalidated by box-tree reconstruction, and is re-resolved against
+    /// fresh layout at the end of every `resolve` pass.
+    pub(crate) hover_hit_node_id: Option<NodeId>,
     /// Whether the node which is currently hovered is a text node/span
     pub(crate) hover_node_is_text: bool,
+    /// The last known pointer position in client coordinates (viewport-relative, unscrolled).
+    pub(crate) last_client_pointer_position: Option<taffy::Point<f32>>,
     /// The node which is currently focussed (if any)
     pub(crate) focus_node_id: Option<NodeId>,
     /// The node which is currently active (if any)
@@ -448,7 +456,9 @@ impl BaseDocument {
             layout_ctx: parley::LayoutContext::new(),
 
             hover_node_id: None,
+            hover_hit_node_id: None,
             hover_node_is_text: false,
+            last_client_pointer_position: None,
             focus_node_id: None,
             active_node_id: None,
             mousedown_node_id: None,
@@ -805,6 +815,9 @@ impl BaseDocument {
         if self.hover_node_id == Some(node_id) {
             self.hover_node_id = None;
             self.hover_node_is_text = false;
+        }
+        if self.hover_hit_node_id == Some(node_id) {
+            self.hover_hit_node_id = None;
         }
         if self.active_node_id == Some(node_id) {
             self.active_node_id = None;
@@ -1350,6 +1363,23 @@ impl BaseDocument {
         self.hit_with_scrollbar(x, y).0
     }
 
+    /// Walk up the layout tree until a node that is not an anonymous block is
+    /// found. Anonymous blocks always have a non-anonymous parent, so this always terminates.
+    ///
+    /// Returns `None` if `node_id` (or an ancestor) no longer exists.
+    pub fn nearest_non_anonymous_ancestor(&self, node_id: NodeId) -> Option<NodeId> {
+        let mut canonical = node_id;
+        let mut current = Some(node_id);
+        while let Some(id) = current {
+            let node = self.get_node(id)?;
+            if node.is_anonymous() {
+                canonical = node.parent?;
+            }
+            current = node.parent;
+        }
+        Some(canonical)
+    }
+
     pub fn focus_next_node(&mut self) -> Option<NodeId> {
         let focussed_node_id = self.get_focussed_node_id()?;
         let id = self.next_node(&self.nodes[focussed_node_id], |node| node.is_focussable())?;
@@ -1367,9 +1397,12 @@ impl BaseDocument {
     }
 
     pub fn set_mousedown_node_id(&mut self, node_id: Option<NodeId>) {
-        self.mousedown_node_id = node_id;
+        self.mousedown_node_id = node_id.and_then(|id| self.nearest_non_anonymous_ancestor(id));
     }
     pub fn set_focus_to(&mut self, focus_node_id: NodeId) -> bool {
+        let Some(focus_node_id) = self.nearest_non_anonymous_ancestor(focus_node_id) else {
+            return false;
+        };
         if Some(focus_node_id) == self.focus_node_id {
             return false;
         }
@@ -1404,6 +1437,12 @@ impl BaseDocument {
             self.unactive_node();
         }
 
+        // hover_node_id is canonicalized when stored, so this always holds.
+        debug_assert!(
+            self.get_node(hover_node_id)
+                .is_some_and(|node| !node.is_anonymous()),
+            "interaction state must reference DOM nodes, not layout-generated nodes"
+        );
         let active_node_id = Some(hover_node_id);
 
         let node_path = self.maybe_node_layout_ancestors(active_node_id);
@@ -1502,6 +1541,14 @@ impl BaseDocument {
     }
 
     pub fn set_hover_to(&mut self, x: f32, y: f32) -> bool {
+        // Record the pointer position in client (unscrolled) coordinates so
+        // that `refresh_hover` can re-resolve hover state after layout or
+        // scroll changes.
+        self.last_client_pointer_position = Some(taffy::Point {
+            x: x - self.viewport_scroll.x as f32,
+            y: y - self.viewport_scroll.y as f32,
+        });
+
         let (hit, hovered_scrollbar) = self.hit_with_scrollbar(x, y);
         // A faded-out thumb is not interactive: pointer moves never fade
         // overlay scrollbars back in (only scrolling shows them).
@@ -1522,11 +1569,28 @@ impl BaseDocument {
             }
         }
         self.hovered_scrollbar = hovered_scrollbar;
-        let hover_node_id = hit.map(|hit| hit.node_id);
+
+        // Store both the precise layout node that was hit (transient: used for
+        // cursor/style queries) and its canonical DOM target (persistent: must
+        // not reference layout-generated nodes, whose ids die on box-tree
+        // reconstruction).
+        let hit_node_id = hit.map(|hit| hit.node_id);
+        let hover_node_id = hit_node_id.and_then(|id| self.nearest_non_anonymous_ancestor(id));
         let new_is_text = hit.map(|hit| hit.is_text).unwrap_or(false);
+
+        let hit_changed =
+            hit_node_id != self.hover_hit_node_id || new_is_text != self.hover_node_is_text;
+        self.hover_hit_node_id = hit_node_id;
+        self.hover_node_is_text = new_is_text;
 
         // Return early if the new node is the same as the already-hovered node
         if hover_node_id == self.hover_node_id {
+            if hit_changed {
+                // The canonical target is unchanged (so no restyle is needed)
+                // but the precise hit node changed, which can change the cursor
+                // (e.g. moving between text and non-text within one element).
+                self.shell_provider.set_cursor(self.get_cursor());
+            }
             return scrollbar_changed;
         }
 
@@ -1545,7 +1609,6 @@ impl BaseDocument {
         }
 
         self.hover_node_id = hover_node_id;
-        self.hover_node_is_text = new_is_text;
 
         // Update the cursor
         self.shell_provider.set_cursor(self.get_cursor());
@@ -1557,6 +1620,11 @@ impl BaseDocument {
     }
 
     pub fn clear_hover(&mut self) -> bool {
+        // The pointer is no longer over the document, so stop re-resolving
+        // hover state against it.
+        self.last_client_pointer_position = None;
+        self.hover_hit_node_id = None;
+
         let Some(hover_node_id) = self.hover_node_id else {
             return false;
         };
@@ -1578,8 +1646,26 @@ impl BaseDocument {
         true
     }
 
+    /// Re-resolve hover state against the current layout using the last known
+    /// pointer position.
+    ///
+    /// TODO: synthesizing pointerenter/pointerleave DOM events for
+    /// hover changes caused by layout shifts.
+    pub fn refresh_hover(&mut self) -> bool {
+        let Some(pos) = self.last_client_pointer_position else {
+            return false;
+        };
+        let x = pos.x + self.viewport_scroll.x as f32;
+        let y = pos.y + self.viewport_scroll.y as f32;
+        self.set_hover_to(x, y)
+    }
+
     pub fn get_hover_node_id(&self) -> Option<NodeId> {
         self.hover_node_id
+    }
+
+    pub fn get_mousedown_node_id(&self) -> Option<NodeId> {
+        self.mousedown_node_id
     }
 
     pub fn set_viewport(&mut self, viewport: Viewport) {
@@ -1726,7 +1812,15 @@ impl BaseDocument {
     }
 
     pub fn get_cursor(&self) -> Option<CursorIcon> {
-        let node = &self.nodes[self.get_hover_node_id()?];
+        // Prefer the precise hit node: `cursor` and `user-select` may be set on
+        // a pseudo-element or resolved on an anonymous box, and text hits carry
+        // is_text via the hit node. Fall back to the canonical hover node if
+        // the hit node has been removed (it is transient across resolves).
+        let node_id = self
+            .hover_hit_node_id
+            .filter(|&id| self.nodes.contains_key(id))
+            .or(self.get_hover_node_id())?;
+        let node = &self.nodes[node_id];
 
         if let Some(subdoc) = node.subdoc().map(|doc| doc.inner()) {
             return subdoc.get_cursor();
@@ -2408,6 +2502,97 @@ impl AsRef<BaseDocument> for BaseDocument {
 impl AsMut<BaseDocument> for BaseDocument {
     fn as_mut(&mut self) -> &mut BaseDocument {
         self
+    }
+}
+
+#[cfg(test)]
+mod hover_state_tests {
+    use super::*;
+    use crate::{Attribute, qual_name};
+    use blitz_traits::shell::ColorScheme;
+
+    /// Build `<html><body style="margin:0"><div style="width:300px">some text
+    /// <div style="height:50px"></div></div></body></html>` manually (the HTML
+    /// parser lives in blitz-html, which would be a circular dev-dependency).
+    /// The bare text next to a block sibling gets wrapped in an anonymous
+    /// block, which becomes the inline root: text hits report the anonymous
+    /// block as the hit node.
+    fn make_doc() -> (BaseDocument, NodeId) {
+        let mut doc = BaseDocument::new(DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        });
+        let root_id = doc.root_node().id;
+        let style = |value: &str| Attribute {
+            name: qual_name!("style"),
+            value: value.to_string(),
+        };
+
+        let mut mutator = doc.mutate();
+        let html = mutator.create_element(qual_name!("html"), vec![]);
+        let body = mutator.create_element(qual_name!("body"), vec![style("margin:0")]);
+        let container = mutator.create_element(qual_name!("div"), vec![style("width:300px")]);
+        let text = mutator.create_text_node("some text");
+        let block = mutator.create_element(qual_name!("div"), vec![style("height:50px")]);
+        mutator.append_children(container, &[text, block]);
+        mutator.append_children(body, &[container]);
+        mutator.append_children(html, &[body]);
+        mutator.append_children(root_id, &[html]);
+        drop(mutator);
+
+        doc.resolve(0.0);
+        (doc, container)
+    }
+
+    /// Whether text laid out with a real (non-zero-metric) font. Without the
+    /// `system-fonts` feature text measures 0x0 and text hits are impossible,
+    /// making these tests vacuous.
+    fn text_has_size(doc: &BaseDocument, container: NodeId) -> bool {
+        doc.nodes[container].final_layout().size.height > 50.0
+    }
+
+    /// Regression test: hovering bare text wrapped in an anonymous block must
+    /// report a text cursor. The hit node for such text is the anonymous
+    /// inline root itself, while the *stored* hover target is canonicalized to
+    /// the containing element — the cursor must be derived from the precise
+    /// hit node, not the canonical target.
+    #[test]
+    fn hovering_text_in_anonymous_block_reports_text_cursor() {
+        let (mut doc, container) = make_doc();
+        if !text_has_size(&doc, container) {
+            eprintln!("skipping: no usable font (text measures 0x0)");
+            return;
+        }
+
+        doc.set_hover_to(5.0, 8.0);
+        assert!(doc.hover_node_is_text, "expected a text hit");
+        let hit_id = doc.hover_hit_node_id.expect("expected a hit node");
+        assert!(
+            doc.nodes[hit_id].is_anonymous(),
+            "expected the hit node to be the anonymous inline root"
+        );
+        assert_eq!(
+            doc.get_hover_node_id(),
+            Some(container),
+            "expected the stored hover target to be the containing element"
+        );
+        assert_eq!(doc.get_cursor(), Some(CursorIcon::Text));
+    }
+
+    /// Hovering the empty region of the anonymous block (right of the text) is
+    /// not a text hit: default cursor, same canonical hover target.
+    #[test]
+    fn hovering_anonymous_block_whitespace_reports_default_cursor() {
+        let (mut doc, container) = make_doc();
+        if !text_has_size(&doc, container) {
+            eprintln!("skipping: no usable font (text measures 0x0)");
+            return;
+        }
+
+        doc.set_hover_to(250.0, 8.0);
+        assert!(!doc.hover_node_is_text);
+        assert_eq!(doc.get_hover_node_id(), Some(container));
+        assert_eq!(doc.get_cursor(), Some(CursorIcon::Default));
     }
 }
 

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -812,17 +812,64 @@ impl BaseDocument {
     /// (hover/active/focus/mousedown/selection/drag/scrollbar) that references
     /// it so that stale NodeIds are never dereferenced after the slot is freed.
     pub(crate) fn remove_node_from_tree(&mut self, node_id: NodeId) -> Option<Node> {
+        self.clear_interaction_state_for_removed_node(node_id);
+        self.nodes.remove(node_id)
+    }
+
+    /// The nearest element ancestor of `node_id` that is still in the
+    /// document. Used to retarget hover/active state when the node they
+    /// reference is removed. Tolerates already-removed ancestors (subtree
+    /// teardown proceeds root-first) by giving up and returning `None`.
+    fn nearest_surviving_element_ancestor(&self, node_id: NodeId) -> Option<NodeId> {
+        let mut current = self.get_node(node_id)?.parent;
+        while let Some(id) = current {
+            let node = self.get_node(id)?;
+            if node.is_element() && node.flags.is_in_document() {
+                return Some(id);
+            }
+            current = node.parent;
+        }
+        None
+    }
+
+    /// Clear any interaction state (hover/active/focus/mousedown/selection/
+    /// drag/scrollbar) that references `node_id`, which is being removed from
+    /// the document, running the usual teardown steps. `node_id` must still be
+    /// present in the slab.
+    ///
+    /// This matches browser semantics (WebKit `hoveredElementDidDetach` /
+    /// `elementInActiveChainDidDetach`, Blink `HoveredElementDetached` /
+    /// `ActiveChainNodeDetached`):
+    /// - Hover and active retarget to the nearest surviving element ancestor
+    ///   as a *transient bridge*: the HOVER/ACTIVE element-state bits along
+    ///   the surviving chain stay lit (no one-frame gap in `:hover`/`:active`
+    ///   styling), and the subsequent hover diff can unset exactly the right
+    ///   bits. Hover is then re-resolved against the pointer position by
+    ///   [`Self::refresh_hover`] at the end of the next resolve pass (the
+    ///   analogue of WebKit's "fake mouse move"), which corrects the bridge
+    ///   value — including cases where the removed node overflowed its
+    ///   ancestor's box, so the ancestor was never truly under the pointer.
+    /// - Focus resets to the body (encoded as `None`), running blur
+    ///   side-effects (clearing focus element state and disabling IME for
+    ///   text inputs).
+    pub(crate) fn clear_interaction_state_for_removed_node(&mut self, node_id: NodeId) {
+        if !self.nodes.contains_key(node_id) {
+            return;
+        }
+
         if self.hover_node_id == Some(node_id) {
-            self.hover_node_id = None;
+            self.hover_node_id = self.nearest_surviving_element_ancestor(node_id);
             self.hover_node_is_text = false;
         }
         if self.hover_hit_node_id == Some(node_id) {
             self.hover_hit_node_id = None;
         }
         if self.active_node_id == Some(node_id) {
-            self.active_node_id = None;
+            self.active_node_id = self.nearest_surviving_element_ancestor(node_id);
         }
         if self.focus_node_id == Some(node_id) {
+            let shell_provider = self.shell_provider.clone();
+            self.nodes[node_id].blur(shell_provider);
             self.focus_node_id = None;
         }
         if self.mousedown_node_id == Some(node_id) {
@@ -848,7 +895,6 @@ impl BaseDocument {
             self.drag_mode = DragMode::None;
         }
         self.scrollbar_activity.remove(&node_id);
-        self.nodes.remove(node_id)
     }
 
     pub(crate) fn drop_node_ignoring_parent(&mut self, node_id: NodeId) -> Option<Node> {

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1409,21 +1409,33 @@ impl BaseDocument {
         self.hit_with_scrollbar(x, y).0
     }
 
-    /// Walk up the layout tree until a node that is not an anonymous block is
-    /// found. Anonymous blocks always have a non-anonymous parent, so this always terminates.
+    /// Walk up the tree to the nearest DOM node whose id is stable across
+    /// box-tree reconstruction, so canonicalized interaction state never goes
+    /// stale.
+    ///
+    /// Layout-generated nodes (anonymous blocks and `::before`/`::after`
+    /// pseudo-elements, both stored as anonymous blocks) get new ids on every
+    /// reconstruction, so we skip any anonymous node *and* a non-anonymous node
+    /// whose parent is anonymous (the pseudo's text content). The first
+    /// non-anonymous node with a non-anonymous parent is a real DOM node; the
+    /// root element's `Document` parent guarantees termination.
     ///
     /// Returns `None` if `node_id` (or an ancestor) no longer exists.
     pub fn nearest_non_anonymous_ancestor(&self, node_id: NodeId) -> Option<NodeId> {
-        let mut canonical = node_id;
-        let mut current = Some(node_id);
-        while let Some(id) = current {
-            let node = self.get_node(id)?;
-            if node.is_anonymous() {
-                canonical = node.parent?;
+        // Recurse up the tree keeping a window of the current node and its
+        // parent, advancing one step per iteration so each node is looked up
+        // exactly once.
+        let mut node = self.get_node(node_id)?;
+        loop {
+            let parent = match node.parent {
+                Some(parent_id) => self.get_node(parent_id)?,
+                None => return Some(node.id),
+            };
+            if !node.is_anonymous() && !parent.is_anonymous() {
+                return Some(node.id);
             }
-            current = node.parent;
+            node = parent;
         }
-        Some(canonical)
     }
 
     pub fn focus_next_node(&mut self) -> Option<NodeId> {

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -799,8 +799,8 @@ impl BaseDocument {
     }
 
     /// Remove a node from the node tree, clearing any interaction state
-    /// (hover/active/focus) that references it so that stale NodeIds are
-    /// never dereferenced after the slot is freed.
+    /// (hover/active/focus/mousedown/selection/drag/scrollbar) that references
+    /// it so that stale NodeIds are never dereferenced after the slot is freed.
     pub(crate) fn remove_node_from_tree(&mut self, node_id: NodeId) -> Option<Node> {
         if self.hover_node_id == Some(node_id) {
             self.hover_node_id = None;
@@ -812,6 +812,29 @@ impl BaseDocument {
         if self.focus_node_id == Some(node_id) {
             self.focus_node_id = None;
         }
+        if self.mousedown_node_id == Some(node_id) {
+            self.mousedown_node_id = None;
+        }
+        if self.text_selection.anchor.node_or_parent == Some(node_id)
+            || self.text_selection.focus.node_or_parent == Some(node_id)
+        {
+            self.text_selection.clear();
+        }
+        if self
+            .hovered_scrollbar
+            .is_some_and(|scrollbar| scrollbar.node_id == node_id)
+        {
+            self.hovered_scrollbar = None;
+        }
+        let drag_references_node = match &self.drag_mode {
+            DragMode::Panning(state) => state.target == node_id,
+            DragMode::ScrollbarDrag(state) => state.scrollbar.node_id == node_id,
+            DragMode::Selecting | DragMode::None => false,
+        };
+        if drag_references_node {
+            self.drag_mode = DragMode::None;
+        }
+        self.scrollbar_activity.remove(&node_id);
         self.nodes.remove(node_id)
     }
 

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -798,6 +798,23 @@ impl BaseDocument {
         id
     }
 
+    /// Remove a node from the node tree, clearing any interaction state
+    /// (hover/active/focus) that references it so that stale NodeIds are
+    /// never dereferenced after the slot is freed.
+    pub(crate) fn remove_node_from_tree(&mut self, node_id: NodeId) -> Option<Node> {
+        if self.hover_node_id == Some(node_id) {
+            self.hover_node_id = None;
+            self.hover_node_is_text = false;
+        }
+        if self.active_node_id == Some(node_id) {
+            self.active_node_id = None;
+        }
+        if self.focus_node_id == Some(node_id) {
+            self.focus_node_id = None;
+        }
+        self.nodes.remove(node_id)
+    }
+
     pub(crate) fn drop_node_ignoring_parent(&mut self, node_id: NodeId) -> Option<Node> {
         self.drop_node_ignoring_parent_with(node_id, &mut |_| {})
     }
@@ -809,7 +826,7 @@ impl BaseDocument {
         node_id: NodeId,
         on_drop: &mut dyn FnMut(NodeId),
     ) -> Option<Node> {
-        let mut node = self.nodes.remove(node_id);
+        let mut node = self.remove_node_from_tree(node_id);
         if let Some(node) = &mut node {
             on_drop(node_id);
             if let Some(before) = node.before() {
@@ -847,7 +864,7 @@ impl BaseDocument {
             self.deallocate_anonymous_block(nested_id);
         }
 
-        self.nodes.remove(anon_id);
+        self.remove_node_from_tree(anon_id);
     }
 
     /// Whether the document has been mutated
@@ -897,7 +914,7 @@ impl BaseDocument {
 
     pub(crate) fn remove_and_drop_pe(&mut self, node_id: NodeId) -> Option<Node> {
         fn remove_pe_ignoring_parent(doc: &mut BaseDocument, node_id: NodeId) -> Option<Node> {
-            let mut node = doc.nodes.remove(node_id);
+            let mut node = doc.remove_node_from_tree(node_id);
             if let Some(node) = &mut node {
                 for &child in &node.children {
                     remove_pe_ignoring_parent(doc, child);

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -103,7 +103,7 @@ impl LayoutChildren {
                     self.children.remove(pos);
                 }
                 self.anonymous_blocks.retain(|id| *id != anon_id);
-                doc.nodes.remove(anon_id);
+                doc.remove_node_from_tree(anon_id);
             }
         }
 
@@ -696,7 +696,7 @@ fn flush_pseudo_elements(doc: &mut BaseDocument, node_id: NodeId) {
                     doc.nodes[pe_node_id]
                         .children
                         .retain(|&child_id| child_id != text_node_id);
-                    doc.nodes.remove(text_node_id);
+                    doc.remove_node_from_tree(text_node_id);
                     doc.nodes[node_id].insert_damage(ALL_DAMAGE);
                 }
                 (None, None) => {}

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -734,6 +734,9 @@ impl<'doc> DocumentMutator<'doc> {
                 doc.hover_node_id = None;
                 doc.hover_node_is_text = false;
             }
+            if doc.hover_hit_node_id == Some(node_id) {
+                doc.hover_hit_node_id = None;
+            }
 
             // Clear active state if this node was active
             // This prevents stale active_node_id references.

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -411,6 +411,11 @@ impl DocumentMutator<'_> {
 
     /// Remove the node from it's parent but don't drop it
     pub fn remove_node(&mut self, node_id: NodeId) {
+        // Process the subtree *before* severing the parent link so that
+        // interaction state referencing removed nodes can retarget to the
+        // nearest surviving ancestor.
+        self.process_removed_subtree(node_id);
+
         let node = &mut self.doc.nodes[node_id];
 
         // Update child_idx values
@@ -422,8 +427,6 @@ impl DocumentMutator<'_> {
             parent.children.retain(|id| *id != node_id);
             self.maybe_record_node(parent_id);
         }
-
-        self.process_removed_subtree(node_id);
     }
 
     pub fn remove_and_drop_node(&mut self, node_id: NodeId) -> Option<Node> {
@@ -725,43 +728,16 @@ impl<'doc> DocumentMutator<'doc> {
 
     fn process_removed_subtree(&mut self, node_id: NodeId) {
         self.doc.iter_subtree_mut(node_id, |node_id, doc| {
+            doc.nodes[node_id]
+                .flags
+                .set(NodeFlags::IS_IN_DOCUMENT, false);
+
+            // Clear any interaction state that references this node, running
+            // the usual teardown steps (unhover/unactive the surviving
+            // ancestor chain, IME disable on blur of a focused input).
+            doc.clear_interaction_state_for_removed_node(node_id);
+
             let node = &mut doc.nodes[node_id];
-            node.flags.set(NodeFlags::IS_IN_DOCUMENT, false);
-
-            // Clear hover state if this node was being hovered.
-            // This prevents stale hover_node_id references.
-            if doc.hover_node_id == Some(node_id) {
-                doc.hover_node_id = None;
-                doc.hover_node_is_text = false;
-            }
-            if doc.hover_hit_node_id == Some(node_id) {
-                doc.hover_hit_node_id = None;
-            }
-
-            // Clear active state if this node was active
-            // This prevents stale active_node_id references.
-            if doc.active_node_id == Some(node_id) {
-                doc.active_node_id = None;
-            }
-
-            // Clear focus state if this node was focused
-            // This prevents stale focus_node_id references.
-            if doc.focus_node_id == Some(node_id) {
-                doc.focus_node_id = None;
-            }
-
-            // Clear mousedown state if this node was the mousedown target
-            // This prevents stale mousedown_node_id references.
-            if doc.mousedown_node_id == Some(node_id) {
-                doc.mousedown_node_id = None;
-            }
-
-            // Clear the text selection if either endpoint references this node
-            if doc.text_selection.anchor.node_or_parent == Some(node_id)
-                || doc.text_selection.focus.node_or_parent == Some(node_id)
-            {
-                doc.text_selection.clear();
-            }
 
             // Remove any snapshot for this node to prevent stale snapshot references
             // during style invalidation.

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -747,6 +747,19 @@ impl<'doc> DocumentMutator<'doc> {
                 doc.focus_node_id = None;
             }
 
+            // Clear mousedown state if this node was the mousedown target
+            // This prevents stale mousedown_node_id references.
+            if doc.mousedown_node_id == Some(node_id) {
+                doc.mousedown_node_id = None;
+            }
+
+            // Clear the text selection if either endpoint references this node
+            if doc.text_selection.anchor.node_or_parent == Some(node_id)
+                || doc.text_selection.focus.node_or_parent == Some(node_id)
+            {
+                doc.text_selection.clear();
+            }
+
             // Remove any snapshot for this node to prevent stale snapshot references
             // during style invalidation.
             if node.has_snapshot() {

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -741,6 +741,12 @@ impl<'doc> DocumentMutator<'doc> {
                 doc.active_node_id = None;
             }
 
+            // Clear focus state if this node was focused
+            // This prevents stale focus_node_id references.
+            if doc.focus_node_id == Some(node_id) {
+                doc.focus_node_id = None;
+            }
+
             // Remove any snapshot for this node to prevent stale snapshot references
             // during style invalidation.
             if node.has_snapshot() {

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -91,7 +91,13 @@ impl BaseDocument {
         self.resolve_layout();
         timer.record_time("layout");
 
+        // Resolve transforms
+        //
+        // And the re-resolve hover node from point position against the fresh layout. Any
+        // resulting restyle is picked up on the next resolve pass. A redraw is requested
+        // if the hovered node actually changes.
         self.resolve_transforms(root_node_id);
+        self.refresh_hover();
         timer.record_time("transform");
 
         // Clear all damage and dirty flags

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -92,12 +92,7 @@ impl BaseDocument {
         timer.record_time("layout");
 
         // Resolve transforms
-        //
-        // And the re-resolve hover node from point position against the fresh layout. Any
-        // resulting restyle is picked up on the next resolve pass. A redraw is requested
-        // if the hovered node actually changes.
         self.resolve_transforms(root_node_id);
-        self.refresh_hover();
         timer.record_time("transform");
 
         // Clear all damage and dirty flags
@@ -108,6 +103,15 @@ impl BaseDocument {
             }
             timer.record_time("c_damage");
         }
+
+        // Re-resolve the hover node from the pointer position against the fresh
+        // layout. This must run *after* the damage/dirty flags are cleared
+        // above, so that the restyle hint and ancestor `dirty_descendants`
+        // flags set by any resulting hover change survive into the next resolve
+        // pass (the clearing loop would otherwise wipe them). Any resulting
+        // restyle is picked up on the next resolve pass; a redraw is requested
+        // if the hovered node actually changes.
+        self.refresh_hover();
 
         let mut subdoc_is_animating = false;
         for &node_id in &self.sub_document_nodes {

--- a/packages/blitz-html/tests/interaction_state_canonicalization.rs
+++ b/packages/blitz-html/tests/interaction_state_canonicalization.rs
@@ -1,0 +1,191 @@
+//! Persistent interaction state (hover/mousedown/active/focus) must only ever
+//! reference DOM nodes, never layout-generated nodes (anonymous boxes, pseudo
+//! elements) whose NodeIds are invalidated by box-tree reconstruction.
+//!
+//! Hit-test results are canonicalized when stored: a hit on an anonymous block
+//! resolves to its containing element, and a hit inside a pseudo-element
+//! subtree resolves to the originating element. This means interaction state
+//! survives reconstruction by construction (the canonical ids are stable), and
+//! hover is additionally re-resolved against fresh layout at the end of each
+//! `resolve` pass so that layout shifts under a stationary pointer update it.
+
+use blitz_dom::{Document, DocumentConfig, NodeId};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::{
+    events::{
+        BlitzPointerEvent, BlitzPointerId, MouseEventButton, MouseEventButtons, Point,
+        PointerCoords, PointerDetails, UiEvent,
+    },
+    shell::{ColorScheme, Viewport},
+};
+use std::sync::Arc;
+
+fn make_doc(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+fn node_id(doc: &HtmlDocument, selector: &str) -> NodeId {
+    doc.query_selector(selector).unwrap().expect(selector)
+}
+
+fn pointer_event(x: f32, y: f32, buttons: MouseEventButtons) -> BlitzPointerEvent {
+    BlitzPointerEvent {
+        id: BlitzPointerId::Mouse,
+        is_primary: true,
+        coords: PointerCoords {
+            page_x: x,
+            page_y: y,
+            screen_x: x,
+            screen_y: y,
+            client_x: x,
+            client_y: y,
+        },
+        button: MouseEventButton::Main,
+        buttons,
+        mods: Default::default(),
+        details: PointerDetails::default(),
+        element: Point::default(),
+        active_pointers: Default::default(),
+    }
+}
+
+/// A block container with mixed inline/block children: the inline-block span
+/// is wrapped in an anonymous block during box-tree construction. (An
+/// inline-block with explicit dimensions is used rather than bare text so the
+/// test doesn't depend on font availability/metrics.) The area to the right of
+/// the span still falls within the anonymous block, so hits there resolve to
+/// the anonymous block node.
+const ANON_HTML: &str = r#"<!DOCTYPE html>
+<html><head><style> body { margin: 0; } </style></head>
+<body><div id="container" style="width:300px;"><span id="inline" style="display:inline-block; width:100px; height:30px;"></span><div id="block" style="height:50px;"></div></div></body></html>
+"#;
+
+/// (x, y) inside the anonymous block wrapping the inline-block span, but to
+/// the right of the span itself (so the hit is the anonymous block).
+const ANON_POS: (f32, f32) = (250.0, 5.0);
+
+/// Sanity-check that the hit-test at ANON_POS really does hit an anonymous
+/// block whose canonical target is #container (otherwise the tests below
+/// prove nothing).
+fn assert_hit_is_anonymous(doc: &HtmlDocument) {
+    let container_id = node_id(doc, "#container");
+    let hit = doc.hit(ANON_POS.0, ANON_POS.1).expect("hit expected");
+    let hit_node = doc.get_node(hit.node_id).unwrap();
+    assert!(
+        hit_node.is_anonymous(),
+        "expected the hit-test to hit an anonymous block"
+    );
+    assert_eq!(
+        doc.nearest_non_anonymous_ancestor(hit.node_id),
+        Some(container_id)
+    );
+}
+
+#[test]
+fn hover_over_anonymous_block_targets_containing_element() {
+    let mut doc = make_doc(ANON_HTML);
+    assert_hit_is_anonymous(&doc);
+
+    doc.set_hover_to(ANON_POS.0, ANON_POS.1);
+    let hover_id = doc.get_hover_node_id().expect("expected a hover node");
+    assert_eq!(hover_id, node_id(&doc, "#container"));
+    assert!(!doc.get_node(hover_id).unwrap().is_anonymous());
+}
+
+#[test]
+fn hover_survives_box_tree_reconstruction() {
+    let mut doc = make_doc(ANON_HTML);
+    assert_hit_is_anonymous(&doc);
+
+    doc.set_hover_to(ANON_POS.0, ANON_POS.1);
+    let hover_id = doc.get_hover_node_id().expect("expected a hover node");
+
+    // Force full reconstruction on every resolve: all anonymous blocks are
+    // deallocated and recreated with new ids.
+    doc.set_incremental_layout(false);
+    doc.resolve(0.0);
+    doc.resolve(0.0);
+
+    // The canonical hover target is a real DOM node, so it survives.
+    assert_eq!(doc.get_hover_node_id(), Some(hover_id));
+    assert!(doc.get_node(hover_id).is_some());
+}
+
+#[test]
+fn mousedown_over_anonymous_block_survives_box_tree_reconstruction() {
+    let mut doc = make_doc(ANON_HTML);
+    assert_hit_is_anonymous(&doc);
+    let container_id = node_id(&doc, "#container");
+
+    doc.handle_ui_event(UiEvent::PointerDown(pointer_event(
+        ANON_POS.0,
+        ANON_POS.1,
+        MouseEventButtons::from(MouseEventButton::Main),
+    )));
+    assert_eq!(doc.get_mousedown_node_id(), Some(container_id));
+
+    // Reconstruct while the button is held.
+    doc.set_incremental_layout(false);
+    doc.resolve(0.0);
+    assert_eq!(doc.get_mousedown_node_id(), Some(container_id));
+
+    // Continuing the drag must not panic on a stale id.
+    doc.handle_ui_event(UiEvent::PointerMove(pointer_event(
+        ANON_POS.0 - 30.0,
+        ANON_POS.1,
+        MouseEventButtons::from(MouseEventButton::Main),
+    )));
+    doc.handle_ui_event(UiEvent::PointerUp(pointer_event(
+        ANON_POS.0 - 30.0,
+        ANON_POS.1,
+        MouseEventButtons::None,
+    )));
+}
+
+#[test]
+fn active_state_over_anonymous_block_survives_box_tree_reconstruction() {
+    let mut doc = make_doc(ANON_HTML);
+    assert_hit_is_anonymous(&doc);
+
+    doc.set_hover_to(ANON_POS.0, ANON_POS.1);
+    doc.active_node();
+
+    doc.set_incremental_layout(false);
+    doc.resolve(0.0);
+
+    // Must not panic with "invalid SlotMap key used"
+    doc.unactive_node();
+}
+
+#[test]
+fn hover_is_refreshed_after_layout_shift() {
+    let mut doc = make_doc(
+        r#"<!DOCTYPE html>
+<html><head><style> body { margin: 0; } </style></head>
+<body>
+    <div id="a" style="height:100px;"></div>
+    <div id="b" style="height:100px;"></div>
+</body></html>
+"#,
+    );
+    let a_id = node_id(&doc, "#a");
+    let b_id = node_id(&doc, "#b");
+
+    doc.set_hover_to(50.0, 50.0);
+    assert_eq!(doc.get_hover_node_id(), Some(a_id));
+
+    // Remove #a: #b moves up underneath the (stationary) pointer. Hover must
+    // be re-resolved during resolve() without any new pointer event.
+    doc.mutate().remove_and_drop_node(a_id);
+    doc.resolve(0.0);
+    assert_eq!(doc.get_hover_node_id(), Some(b_id));
+}

--- a/packages/blitz-html/tests/interaction_state_teardown.rs
+++ b/packages/blitz-html/tests/interaction_state_teardown.rs
@@ -1,0 +1,217 @@
+//! When a node referenced by interaction state is removed, the usual teardown
+//! steps must still run (matching browser semantics — WebKit
+//! `hoveredElementDidDetach`/`elementInActiveChainDidDetach`, Blink
+//! `HoveredElementDetached`/`ActiveChainNodeDetached`):
+//!
+//! - hover/active retarget to the nearest surviving element ancestor as a
+//!   transient bridge, so the `:hover`/`:active` styling on the surviving
+//!   chain never gaps; hover is then re-resolved against the (cached) pointer
+//!   position at the end of the next resolve pass (the analogue of WebKit's
+//!   "fake mouse move"), correcting the bridge value. Simply nulling the ids
+//!   would orphan the element-state bits set along the ancestor chain,
+//!   leaving stale `:hover`/`:active` styling.
+//! - focus: resets to the body (encoded as `None`), running blur side-effects
+//!   (in particular disabling IME for text inputs).
+
+use blitz_dom::{Document, DocumentConfig, NodeId};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::{
+    events::{
+        BlitzPointerEvent, BlitzPointerId, MouseEventButton, MouseEventButtons, Point,
+        PointerCoords, PointerDetails, UiEvent,
+    },
+    shell::{ColorScheme, ShellProvider, Viewport},
+};
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+struct RecordingShell {
+    ime_enabled_calls: Mutex<Vec<bool>>,
+}
+impl ShellProvider for RecordingShell {
+    fn set_ime_enabled(&self, is_enabled: bool) {
+        self.ime_enabled_calls.lock().unwrap().push(is_enabled);
+    }
+}
+
+fn make_doc(html: &str, shell: Option<Arc<RecordingShell>>) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            shell_provider: shell.map(|s| s as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+fn node_id(doc: &HtmlDocument, selector: &str) -> NodeId {
+    doc.query_selector(selector).unwrap().expect(selector)
+}
+
+fn pointer_event(x: f32, y: f32, buttons: MouseEventButtons) -> BlitzPointerEvent {
+    BlitzPointerEvent {
+        id: BlitzPointerId::Mouse,
+        is_primary: true,
+        coords: PointerCoords {
+            page_x: x,
+            page_y: y,
+            screen_x: x,
+            screen_y: y,
+            client_x: x,
+            client_y: y,
+        },
+        button: MouseEventButton::Main,
+        buttons,
+        mods: Default::default(),
+        details: PointerDetails::default(),
+        element: Point::default(),
+        active_pointers: Default::default(),
+    }
+}
+
+const NESTED_HTML: &str = r#"<!DOCTYPE html>
+<html><head><style> body { margin: 0; } </style></head>
+<body><div id="container" style="width:200px; height:200px;"><div id="inner" style="height:100px;"></div></div></body></html>
+"#;
+
+#[test]
+fn hover_bridges_to_surviving_ancestor_without_a_gap() {
+    let mut doc = make_doc(NESTED_HTML, None);
+    let container = node_id(&doc, "#container");
+    let inner = node_id(&doc, "#inner");
+
+    doc.set_hover_to(50.0, 50.0);
+    assert_eq!(doc.get_hover_node_id(), Some(inner));
+    assert!(doc.get_node(container).unwrap().is_hovered());
+
+    // Removing the hovered node retargets hover to the surviving ancestor:
+    // its :hover state must never gap (the pointer is still over it).
+    doc.mutate().remove_and_drop_node(inner);
+    assert_eq!(doc.get_hover_node_id(), Some(container));
+    assert!(
+        doc.get_node(container).unwrap().is_hovered(),
+        ":hover must not gap on the surviving ancestor when the hovered node is removed"
+    );
+
+    // The next resolve re-resolves hover against the (cached) pointer
+    // position, confirming the bridge value in this geometry.
+    doc.resolve(0.0);
+    assert_eq!(doc.get_hover_node_id(), Some(container));
+    assert!(doc.get_node(container).unwrap().is_hovered());
+
+    // Moving the pointer off the container clears its hover bit: the diff
+    // works because the chain was bridged rather than nulled.
+    doc.set_hover_to(300.0, 50.0);
+    assert_ne!(doc.get_hover_node_id(), Some(container));
+    assert!(
+        !doc.get_node(container).unwrap().is_hovered(),
+        "stale :hover element state left on ancestor after hovered node removal"
+    );
+}
+
+/// The transient bridge value can be geometrically wrong (here the removed
+/// node overflows its parent, so the pointer was never over the parent's
+/// box). The post-resolve coordinate re-resolution must correct it.
+#[test]
+fn hover_bridge_is_corrected_by_coordinate_reresolution() {
+    let mut doc = make_doc(
+        r#"<!DOCTYPE html>
+<html><head><style> body { margin: 0; } </style></head>
+<body><div id="container" style="position:relative; width:100px; height:100px;"><div id="inner" style="position:absolute; left:200px; top:0; width:100px; height:100px;"></div></div></body></html>
+"#,
+        None,
+    );
+    let container = node_id(&doc, "#container");
+    let inner = node_id(&doc, "#inner");
+
+    // Hover the overflowing abspos child: the pointer is outside the
+    // container's own box.
+    doc.set_hover_to(250.0, 50.0);
+    assert_eq!(doc.get_hover_node_id(), Some(inner));
+
+    // The bridge transiently claims the container is hovered...
+    doc.mutate().remove_and_drop_node(inner);
+    assert_eq!(doc.get_hover_node_id(), Some(container));
+
+    // ...but the next resolve re-resolves from the pointer position, which
+    // is not over the container, and unhoveres it.
+    doc.resolve(0.0);
+    assert_ne!(doc.get_hover_node_id(), Some(container));
+    assert!(
+        !doc.get_node(container).unwrap().is_hovered(),
+        "coordinate re-resolution must correct a geometrically-wrong bridge value"
+    );
+}
+
+#[test]
+fn active_state_bridges_mid_press_and_clears_on_release() {
+    let mut doc = make_doc(NESTED_HTML, None);
+    let container = node_id(&doc, "#container");
+    let inner = node_id(&doc, "#inner");
+
+    // Press on #inner: the whole ancestor chain becomes :active
+    doc.handle_ui_event(UiEvent::PointerDown(pointer_event(
+        50.0,
+        50.0,
+        MouseEventButtons::from(MouseEventButton::Main),
+    )));
+    assert!(doc.get_node(inner).unwrap().is_active());
+    assert!(doc.get_node(container).unwrap().is_active());
+
+    // Removing the active node mid-press bridges active state to the
+    // surviving ancestor: its :active styling must not gap while the button
+    // is still held.
+    doc.mutate().remove_and_drop_node(inner);
+    assert!(
+        doc.get_node(container).unwrap().is_active(),
+        ":active must not gap on the surviving ancestor while the press continues"
+    );
+
+    // Releasing the button clears :active from the surviving chain: this
+    // only works because the chain was bridged rather than nulled
+    // (`unactive_node` no-ops on a cleared id).
+    doc.resolve(0.0);
+    doc.handle_ui_event(UiEvent::PointerUp(pointer_event(
+        50.0,
+        50.0,
+        MouseEventButtons::None,
+    )));
+    assert!(
+        !doc.get_node(container).unwrap().is_active(),
+        "stale :active element state left on ancestor after release"
+    );
+}
+
+#[test]
+fn ime_is_disabled_when_focused_text_input_is_removed() {
+    let shell = Arc::new(RecordingShell::default());
+    let mut doc = make_doc(
+        r#"<!DOCTYPE html>
+<html><head><style> body { margin: 0; } </style></head>
+<body><input type="text" id="input"></body></html>
+"#,
+        Some(shell.clone()),
+    );
+    let input = node_id(&doc, "#input");
+
+    doc.set_focus_to(input);
+    assert_eq!(
+        shell.ime_enabled_calls.lock().unwrap().last(),
+        Some(&true),
+        "focusing a text input should enable IME"
+    );
+
+    doc.mutate().remove_and_drop_node(input);
+    assert_eq!(
+        shell.ime_enabled_calls.lock().unwrap().last(),
+        Some(&false),
+        "removing the focused text input should run blur side-effects and disable IME"
+    );
+    // Focus falls back to the root element (get_focussed_node_id's default
+    // when no node holds focus)
+    assert_ne!(doc.get_focussed_node_id(), Some(input));
+}

--- a/packages/blitz-html/tests/stale_interaction_state.rs
+++ b/packages/blitz-html/tests/stale_interaction_state.rs
@@ -1,11 +1,17 @@
-//! Interaction state (hover/active/focus) must not retain NodeIds for nodes
-//! that have been removed from the node tree.
+//! Interaction state (hover/active/focus/mousedown) must never retain NodeIds
+//! for layout-generated nodes (anonymous boxes, pseudo-elements), and must not
+//! retain NodeIds for DOM nodes that have been removed from the node tree.
 //!
 //! Regression test for https://github.com/DioxusLabs/blitz/issues/545: the
-//! hovered/active/focused node can be removed from the tree (e.g. a
-//! pseudo-element or anonymous block dropped during box reconstruction, or a
-//! DOM subtree removal). The stale NodeId then panics with "invalid SlotMap
-//! key used" on the next hover/active/focus update.
+//! hovered/active/focused node could be a pseudo-element or anonymous block
+//! dropped during box reconstruction (or a removed DOM subtree). The stale
+//! NodeId then panics with "invalid SlotMap key used" on the next
+//! hover/active/focus update.
+//!
+//! Interaction state is canonicalized when stored: hits on layout-generated
+//! nodes resolve to the nearest DOM ancestor (e.g. a pseudo-element's
+//! originating element), whose id is stable across box-tree reconstruction.
+//! State referencing genuinely removed DOM nodes is cleared.
 
 use blitz_dom::{Document, DocumentConfig};
 use blitz_html::{HtmlDocument, HtmlProvider};
@@ -62,21 +68,28 @@ fn make_doc() -> HtmlDocument {
     doc
 }
 
-/// Hover the ::before pseudo-element of #target and sanity-check that the
-/// hovered node is indeed the pseudo-element.
-fn hover_pseudo_element(doc: &mut HtmlDocument) -> blitz_traits::node_id::NodeId {
+/// Hover the ::before pseudo-element of #target. The stored hover target must
+/// be the *originating element* (#target), not the pseudo-element node itself.
+fn hover_pseudo_region(doc: &mut HtmlDocument) -> blitz_traits::node_id::NodeId {
     let target_id = doc.query_selector("#target").unwrap().unwrap();
     let before_id = doc
         .get_node(target_id)
         .unwrap()
         .before()
         .expect("::before node should exist");
+    assert_eq!(
+        doc.hit(5.0, 5.0)
+            .expect("hit should land somewhere")
+            .node_id,
+        before_id,
+        "expected the hit-test to hit the ::before pseudo-element"
+    );
 
     doc.set_hover_to(5.0, 5.0);
     let hover_id = doc.get_hover_node_id().expect("expected a hover node");
     assert_eq!(
-        hover_id, before_id,
-        "expected the hovered node to be the ::before pseudo-element"
+        hover_id, target_id,
+        "expected the stored hover target to be the pseudo's originating element"
     );
     hover_id
 }
@@ -91,45 +104,49 @@ fn remove_pseudo(doc: &mut HtmlDocument) {
 }
 
 #[test]
-fn hover_state_is_cleared_when_hovered_pseudo_element_is_dropped() {
+fn hover_state_survives_hovered_pseudo_element_being_dropped() {
     let mut doc = make_doc();
-    let hover_id = hover_pseudo_element(&mut doc);
+    let hover_id = hover_pseudo_region(&mut doc);
 
     remove_pseudo(&mut doc);
-    assert!(doc.get_node(hover_id).is_none());
 
+    // The canonical hover target (#target) is a real DOM node and survives the
+    // pseudo-element being dropped.
+    assert_eq!(doc.get_hover_node_id(), Some(hover_id));
+    assert!(doc.get_node(hover_id).is_some());
     // Must not panic with "invalid SlotMap key used"
-    assert!(doc.get_hover_node_id().is_none());
     doc.set_hover_to(5.0, 5.0);
 }
 
 #[test]
-fn active_state_is_cleared_when_active_pseudo_element_is_dropped() {
+fn active_state_survives_active_pseudo_element_being_dropped() {
     let mut doc = make_doc();
-    let hover_id = hover_pseudo_element(&mut doc);
+    let hover_id = hover_pseudo_region(&mut doc);
     doc.active_node();
 
     remove_pseudo(&mut doc);
-    assert!(doc.get_node(hover_id).is_none());
+    assert!(doc.get_node(hover_id).is_some());
 
     // Must not panic with "invalid SlotMap key used"
     doc.unactive_node();
 }
 
 #[test]
-fn mousedown_state_is_cleared_when_mousedown_node_is_dropped() {
+fn mousedown_state_survives_mousedown_pseudo_element_being_dropped() {
     let mut doc = make_doc();
-    let hover_id = hover_pseudo_element(&mut doc);
+    let target_id = doc.query_selector("#target").unwrap().unwrap();
 
-    // Press the mouse on the pseudo-element so mousedown_node_id references it
+    // Press the mouse on the pseudo-element. The stored mousedown target must
+    // be the originating element.
     doc.handle_ui_event(UiEvent::PointerDown(pointer_event(
         5.0,
         5.0,
         MouseEventButtons::from(MouseEventButton::Main),
     )));
+    assert_eq!(doc.get_mousedown_node_id(), Some(target_id));
 
     remove_pseudo(&mut doc);
-    assert!(doc.get_node(hover_id).is_none());
+    assert_eq!(doc.get_mousedown_node_id(), Some(target_id));
 
     // Drag with the button held (starts a selection drag from the mousedown
     // node). Must not panic with "invalid SlotMap key used".
@@ -143,6 +160,26 @@ fn mousedown_state_is_cleared_when_mousedown_node_is_dropped() {
         20.0,
         MouseEventButtons::None,
     )));
+}
+
+#[test]
+fn hover_state_is_reresolved_when_hovered_element_is_removed() {
+    let mut doc = make_doc();
+    let hover_id = hover_pseudo_region(&mut doc);
+
+    doc.mutate().remove_and_drop_node(hover_id);
+    doc.resolve(0.0);
+    assert!(doc.get_node(hover_id).is_none());
+
+    // The stale id must be gone, and hover must have been re-resolved against
+    // the new layout (the pointer is now over the <body>).
+    let new_hover_id = doc.get_hover_node_id();
+    assert_ne!(new_hover_id, Some(hover_id));
+    if let Some(id) = new_hover_id {
+        assert!(doc.get_node(id).is_some());
+    }
+    // Must not panic with "invalid SlotMap key used"
+    doc.set_hover_to(5.0, 5.0);
 }
 
 #[test]

--- a/packages/blitz-html/tests/stale_interaction_state.rs
+++ b/packages/blitz-html/tests/stale_interaction_state.rs
@@ -1,0 +1,103 @@
+//! Interaction state (hover/active/focus) must not retain NodeIds for nodes
+//! that have been removed from the node tree.
+//!
+//! Regression test for https://github.com/DioxusLabs/blitz/issues/545: the
+//! hovered/active/focused node can be removed from the tree (e.g. a
+//! pseudo-element or anonymous block dropped during box reconstruction, or a
+//! DOM subtree removal). The stale NodeId then panics with "invalid SlotMap
+//! key used" on the next hover/active/focus update.
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use markup5ever::{QualName, local_name, ns};
+use std::sync::Arc;
+
+const HTML: &str = r#"<!DOCTYPE html>
+<html><head><style>
+    body { margin: 0; }
+    #target { width: 100px; height: 100px; }
+    #target.with-pseudo:before { display: block; content: ""; width: 100px; height: 50px; }
+</style></head>
+<body><div id="target" class="with-pseudo"></div></body></html>
+"#;
+
+fn make_doc() -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        HTML,
+        DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+/// Hover the ::before pseudo-element of #target and sanity-check that the
+/// hovered node is indeed the pseudo-element.
+fn hover_pseudo_element(doc: &mut HtmlDocument) -> blitz_traits::node_id::NodeId {
+    let target_id = doc.query_selector("#target").unwrap().unwrap();
+    let before_id = doc
+        .get_node(target_id)
+        .unwrap()
+        .before()
+        .expect("::before node should exist");
+
+    doc.set_hover_to(5.0, 5.0);
+    let hover_id = doc.get_hover_node_id().expect("expected a hover node");
+    assert_eq!(
+        hover_id, before_id,
+        "expected the hovered node to be the ::before pseudo-element"
+    );
+    hover_id
+}
+
+/// Remove the class that generates the ::before pseudo-element so that the
+/// pseudo node is dropped on the next resolve.
+fn remove_pseudo(doc: &mut HtmlDocument) {
+    let target_id = doc.query_selector("#target").unwrap().unwrap();
+    let class_name = QualName::new(None, ns!(), local_name!("class"));
+    doc.mutate().clear_attribute(target_id, class_name);
+    doc.resolve(0.0);
+}
+
+#[test]
+fn hover_state_is_cleared_when_hovered_pseudo_element_is_dropped() {
+    let mut doc = make_doc();
+    let hover_id = hover_pseudo_element(&mut doc);
+
+    remove_pseudo(&mut doc);
+    assert!(doc.get_node(hover_id).is_none());
+
+    // Must not panic with "invalid SlotMap key used"
+    assert!(doc.get_hover_node_id().is_none());
+    doc.set_hover_to(5.0, 5.0);
+}
+
+#[test]
+fn active_state_is_cleared_when_active_pseudo_element_is_dropped() {
+    let mut doc = make_doc();
+    let hover_id = hover_pseudo_element(&mut doc);
+    doc.active_node();
+
+    remove_pseudo(&mut doc);
+    assert!(doc.get_node(hover_id).is_none());
+
+    // Must not panic with "invalid SlotMap key used"
+    doc.unactive_node();
+}
+
+#[test]
+fn focus_state_is_cleared_when_focused_node_is_dropped() {
+    let mut doc = make_doc();
+
+    let target_id = doc.query_selector("#target").unwrap().unwrap();
+    doc.set_focus_to(target_id);
+    doc.mutate().remove_and_drop_node(target_id);
+    doc.resolve(0.0);
+
+    // Must not panic with "invalid SlotMap key used"
+    doc.clear_focus();
+}

--- a/packages/blitz-html/tests/stale_interaction_state.rs
+++ b/packages/blitz-html/tests/stale_interaction_state.rs
@@ -7,11 +7,38 @@
 //! DOM subtree removal). The stale NodeId then panics with "invalid SlotMap
 //! key used" on the next hover/active/focus update.
 
-use blitz_dom::DocumentConfig;
+use blitz_dom::{Document, DocumentConfig};
 use blitz_html::{HtmlDocument, HtmlProvider};
-use blitz_traits::shell::{ColorScheme, Viewport};
+use blitz_traits::{
+    events::{
+        BlitzPointerEvent, BlitzPointerId, MouseEventButton, MouseEventButtons, Point,
+        PointerCoords, PointerDetails, UiEvent,
+    },
+    shell::{ColorScheme, Viewport},
+};
 use markup5ever::{QualName, local_name, ns};
 use std::sync::Arc;
+
+fn pointer_event(x: f32, y: f32, buttons: MouseEventButtons) -> BlitzPointerEvent {
+    BlitzPointerEvent {
+        id: BlitzPointerId::Mouse,
+        is_primary: true,
+        coords: PointerCoords {
+            page_x: x,
+            page_y: y,
+            screen_x: x,
+            screen_y: y,
+            client_x: x,
+            client_y: y,
+        },
+        button: MouseEventButton::Main,
+        buttons,
+        mods: Default::default(),
+        details: PointerDetails::default(),
+        element: Point::default(),
+        active_pointers: Default::default(),
+    }
+}
 
 const HTML: &str = r#"<!DOCTYPE html>
 <html><head><style>
@@ -87,6 +114,35 @@ fn active_state_is_cleared_when_active_pseudo_element_is_dropped() {
 
     // Must not panic with "invalid SlotMap key used"
     doc.unactive_node();
+}
+
+#[test]
+fn mousedown_state_is_cleared_when_mousedown_node_is_dropped() {
+    let mut doc = make_doc();
+    let hover_id = hover_pseudo_element(&mut doc);
+
+    // Press the mouse on the pseudo-element so mousedown_node_id references it
+    doc.handle_ui_event(UiEvent::PointerDown(pointer_event(
+        5.0,
+        5.0,
+        MouseEventButtons::from(MouseEventButton::Main),
+    )));
+
+    remove_pseudo(&mut doc);
+    assert!(doc.get_node(hover_id).is_none());
+
+    // Drag with the button held (starts a selection drag from the mousedown
+    // node). Must not panic with "invalid SlotMap key used".
+    doc.handle_ui_event(UiEvent::PointerMove(pointer_event(
+        20.0,
+        20.0,
+        MouseEventButtons::from(MouseEventButton::Main),
+    )));
+    doc.handle_ui_event(UiEvent::PointerUp(pointer_event(
+        20.0,
+        20.0,
+        MouseEventButtons::None,
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #545 ("invalid SlotMap key used" panics in `node_layout_ancestors` / `snapshot_node`).

`BaseDocument` caches `hover_node_id` / `active_node_id` / `focus_node_id`, but several removal paths free a node's slot without clearing them, so the next hover/active/focus update indexes the SlotMap with a stale key and panics (`Slab` reused indices silently; `SlotMap`, introduced in 5833d681, panics). Stale paths include:

- pseudo-elements dropped when their generating style goes away (`remove_and_drop_pe`) — hit-testing can set `hover_node_id` to a `::before`/`::after` node
- anonymous blocks deallocated during box reconstruction (`deallocate_anonymous_block`, whitespace-only anon blocks in `construct.rs`)
- `focus_node_id` was never cleared on any removal path (`process_removed_subtree` only cleared hover/active)

Fix: route every `nodes.remove()` through a new `BaseDocument::remove_node_from_tree`, which clears whichever of `hover_node_id`/`active_node_id`/`focus_node_id` (and `hover_node_is_text`) reference the removed node, and also clear `focus_node_id` in `process_removed_subtree` for detached-but-not-dropped subtrees.

New regression tests in `packages/blitz-html/tests/stale_interaction_state.rs` cover the hover, active, and focus cases; all three panic with "invalid SlotMap key used" (or retain a stale hover id) before this change.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/08d6c44651dc4fffbacacb07bfe0601b
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30401775526).</sub>
<!-- wpt-results-end -->

<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`b19cce4`](https://github.com/dioxuslabs/blitz/pull/546/commits/b19cce421f3f78c79754e46e6e94ea88bdb04cbd) |

<a href="https://dioxus.staging.devinenterprise.com/review/dioxuslabs/blitz/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->