### PR TITLE
Stop `position: fixed` resolving against a positioned ancestor

### DIFF
--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -21,7 +21,11 @@ thread_local! {
     pub(crate) static LAYOUT_CTX: RefCell<Option<Box<LayoutContext<TextBrush>>>> = const { RefCell::new(None) };
 }
 
+use style::properties::ComputedValues;
+use style::properties::generated::longhands::position::computed_value::T as Position;
 use style::selector_parser::RestyleDamage;
+use style::values::computed::Rotate;
+use style::values::generics::transform::{Scale, Translate};
 use taffy::AvailableSpace;
 
 use crate::{
@@ -82,6 +86,9 @@ impl BaseDocument {
 
         self.resolve_deferred_tasks();
         timer.record_time("pconstruct");
+
+        self.hoist_fixed_position_nodes();
+        timer.record_time("hoist");
 
         // Merge stylo into taffy
         self.flush_styles_to_layout(root_node_id);
@@ -289,6 +296,99 @@ impl BaseDocument {
             }
 
             doc.nodes[node_id].set_damage(damage);
+        }
+    }
+
+    /// Reparent `position: fixed` nodes onto the root element for layout.
+    ///
+    /// Taffy has no `Fixed` position, so `stylo_taffy` maps it to `Absolute`. An
+    /// absolutely positioned node resolves its insets against its containing
+    /// block, which for a fixed node must be the viewport. Laid out in place it
+    /// would instead resolve against the nearest positioned ancestor, so both its
+    /// offset and — when opposite insets are set — its size come out wrong.
+    ///
+    /// Reparenting them onto the root element takes the positioned ancestor out
+    /// of the picture. This runs after `resolve_layout_children` and before
+    /// `flush_styles_to_layout`, which derives `paint_children` from
+    /// `layout_children`, so painting and hit testing follow the hoist without
+    /// further work.
+    ///
+    /// Note this is not yet the full containing block a browser would use. The
+    /// root element takes its height from its content, whereas the initial
+    /// containing block is always viewport-sized, so `inset: 0` still sizes
+    /// against the document rather than the viewport. Closing that gap needs an
+    /// ICB distinct from the root element.
+    ///
+    /// A transformed ancestor becomes the containing block for its fixed
+    /// descendants, so those are left where they are.
+    ///
+    /// <https://drafts.csswg.org/css-position/#fixed-pos>
+    /// <https://drafts.csswg.org/css-transforms-1/#propdef-transform>
+    pub fn hoist_fixed_position_nodes(&mut self) {
+        let root_id = self.root_element().id;
+
+        let mut hoisted: Vec<NodeId> = Vec::new();
+        collect_fixed(self, root_id, false, &mut hoisted);
+
+        for node_id in hoisted {
+            let Some(parent_id) = self.nodes[node_id].layout_parent.get() else {
+                continue;
+            };
+            if parent_id == root_id {
+                continue;
+            }
+
+            if let Some(children) = self.nodes[parent_id].layout_children.borrow_mut().as_mut() {
+                children.retain(|id| *id != node_id);
+            }
+            if let Some(children) = self.nodes[root_id].layout_children.borrow_mut().as_mut() {
+                children.push(node_id);
+            }
+            self.nodes[node_id].layout_parent.set(Some(root_id));
+        }
+
+        fn collect_fixed(
+            doc: &BaseDocument,
+            node_id: NodeId,
+            under_transform: bool,
+            out: &mut Vec<NodeId>,
+        ) {
+            let children = doc.nodes[node_id].layout_children.borrow().clone();
+            let Some(children) = children else {
+                return;
+            };
+
+            for child_id in children {
+                let Some(child) = doc.nodes.get(child_id) else {
+                    continue;
+                };
+                let Some(styles) = child.primary_styles() else {
+                    continue;
+                };
+
+                if !under_transform && styles.clone_position() == Position::Fixed {
+                    out.push(child_id);
+                }
+
+                collect_fixed(
+                    doc,
+                    child_id,
+                    under_transform || establishes_containing_block(&styles),
+                    out,
+                );
+            }
+        }
+
+        /// Whether a node becomes the containing block for fixed descendants.
+        ///
+        /// TODO: `filter`, `backdrop-filter`, `will-change`, `contain` and
+        /// `perspective` also do this.
+        fn establishes_containing_block(styles: &ComputedValues) -> bool {
+            let box_styles = styles.get_box();
+            !box_styles.transform.0.is_empty()
+                || !matches!(box_styles.translate, Translate::None)
+                || !matches!(box_styles.rotate, Rotate::None)
+                || !matches!(box_styles.scale, Scale::None)
         }
     }
 

--- a/packages/blitz-html/tests/fixed_position.rs
+++ b/packages/blitz-html/tests/fixed_position.rs
@@ -1,0 +1,152 @@
+//! `position: fixed` must not resolve against the nearest positioned ancestor.
+//!
+//! Taffy has no `Fixed` position, so `stylo_taffy` maps it to `Absolute`. Laid
+//! out in place, a fixed node resolved its insets against its nearest positioned
+//! ancestor, so its offset was wrong and — when opposite insets were both set —
+//! so was its size. Fixed nodes are now reparented onto the root element.
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+const VIEWPORT: (u32, u32) = (1000, 700);
+
+fn document(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(
+                VIEWPORT.0,
+                VIEWPORT.1,
+                1.0,
+                ColorScheme::Light,
+            )),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+#[track_caller]
+fn assert_box(doc: &HtmlDocument, id: &str, expected: (f32, f32, f32, f32)) {
+    let node_id = doc
+        .get_element_by_id(id)
+        .unwrap_or_else(|| panic!("no element with id {id}"));
+    let node = &doc.tree()[node_id];
+    let position = node.absolute_position(0.0, 0.0);
+    let size = node.final_layout().size;
+
+    let actual = (position.x, position.y, size.width, size.height);
+    assert_eq!(
+        actual, expected,
+        "#{id}: expected x,y,w,h {expected:?} but got {actual:?}"
+    );
+}
+
+const HTML: &str = r#"<html><body style="margin:0">
+    <div id="free" style="position:fixed;top:10px;left:10px;width:120px;height:40px"></div>
+    <div id="ancestor" style="position:relative;left:200px;top:150px;width:300px;height:200px">
+        <div id="nested" style="position:fixed;top:10px;left:10px;width:120px;height:40px"></div>
+    </div>
+</body></html>"#;
+
+#[test]
+fn fixed_nodes_ignore_a_positioned_ancestor() {
+    let doc = document(HTML);
+
+    // Already correct: with no positioned ancestor, `absolute` and `fixed`
+    // resolve against the same box.
+    assert_box(&doc, "free", (10.0, 10.0, 120.0, 40.0));
+
+    // Was offset by the ancestor's origin, landing at 210,160.
+    assert_box(&doc, "nested", (10.0, 10.0, 120.0, 40.0));
+}
+
+#[test]
+fn opposite_insets_size_against_the_root_rather_than_the_ancestor() {
+    let doc = document(
+        r#"<html><body style="margin:0">
+        <div id="ancestor" style="position:relative;left:200px;top:150px;width:300px;height:200px">
+            <div id="stretch" style="position:fixed;inset:0"></div>
+        </div>
+    </body></html>"#,
+    );
+
+    let node_id = doc.get_element_by_id("stretch").unwrap();
+    let node = &doc.tree()[node_id];
+    let position = node.absolute_position(0.0, 0.0);
+
+    // Was 200,150 sized 300x200 — the ancestor's box.
+    assert_eq!((position.x, position.y), (0.0, 0.0));
+    assert_eq!(node.final_layout().size.width, VIEWPORT.0 as f32);
+}
+
+/// The root element is the layout root and takes its height from its content,
+/// so opposite insets still size against that rather than against the viewport.
+/// A browser resolves them against the initial containing block, which is always
+/// viewport-sized regardless of how tall or short the document is. Blitz has no
+/// separate ICB node, so this cannot be expressed by reparenting alone.
+#[test]
+#[ignore = "requires an initial containing block distinct from the root element"]
+fn opposite_insets_should_size_against_the_viewport() {
+    let doc = document(
+        r#"<html><body style="margin:0">
+        <div id="short" style="height:20px"></div>
+        <div id="stretch" style="position:fixed;inset:0"></div>
+    </body></html>"#,
+    );
+
+    assert_box(
+        &doc,
+        "stretch",
+        (0.0, 0.0, VIEWPORT.0 as f32, VIEWPORT.1 as f32),
+    );
+}
+
+#[test]
+fn hoisting_survives_reconstruction() {
+    let mut doc = document(HTML);
+
+    // Full reconstruction rebuilds `layout_children` from the DOM tree, undoing
+    // the reparent, so it has to be reapplied on every pass.
+    doc.set_incremental_layout(false);
+    for _ in 0..5 {
+        doc.resolve(0.0);
+    }
+    assert_box(&doc, "nested", (10.0, 10.0, 120.0, 40.0));
+
+    // The incremental path preserves `layout_children` rather than rebuilding
+    // it, so reapplying the hoist has to be idempotent.
+    doc.set_incremental_layout(true);
+    for _ in 0..5 {
+        doc.resolve(0.0);
+    }
+    assert_box(&doc, "nested", (10.0, 10.0, 120.0, 40.0));
+}
+
+#[test]
+fn a_transformed_ancestor_keeps_its_fixed_descendants() {
+    // css-transforms-1: a transformed element is the containing block for its
+    // fixed descendants, so this one must be left where it is. Transforms are
+    // applied at paint time and do not move layout boxes, so the check is on
+    // the layout parent rather than on the resolved position.
+    let doc = document(
+        r#"<html><body style="margin:0">
+        <div id="ancestor" style="transform:translate(200px,150px);width:300px;height:200px">
+            <div id="nested" style="position:fixed;top:10px;left:10px;width:120px;height:40px"></div>
+        </div>
+    </body></html>"#,
+    );
+
+    let ancestor = doc.get_element_by_id("ancestor").unwrap();
+    let nested = doc.get_element_by_id("nested").unwrap();
+
+    assert_eq!(
+        doc.tree()[nested].layout_parent.get(),
+        Some(ancestor),
+        "a fixed node under a transformed ancestor must not be hoisted"
+    );
+}


### PR DESCRIPTION
Taffy has no `Fixed` position, so `stylo_taffy` maps it to `Absolute` ([`convert.rs:231`](https://github.com/DioxusLabs/blitz/blob/main/packages/stylo_taffy/src/convert.rs#L231)). An absolutely positioned node resolves its insets against its containing block, so a fixed node laid out in place resolves against its nearest positioned ancestor instead of the viewport.

## Repro

```html
<div style="position:relative;left:200px;top:150px;width:300px;height:200px">
  <div id="a" style="position:fixed;top:10px;left:10px;width:120px;height:40px"></div>
  <div id="b" style="position:fixed;inset:0"></div>
</div>
```

| | before | after | browser |
| --- | --- | --- | --- |
| `#a` | `210,160` | `10,10` | `10,10` |
| `#b` position | `200,150` | `0,0` | `0,0` |
| `#b` width | `300` | viewport width | viewport width |
| `#b` height | `200` | root element height | viewport height |

With no positioned ancestor the result was already correct, because `absolute` and `fixed` then share a containing block. That is probably why this went unnoticed.

## Approach

Fixed nodes are reparented onto the root element in a new `hoist_fixed_position_nodes`, called between `resolve_layout_children` and `flush_styles_to_layout`. Since `flush_styles_to_layout` derives `paint_children` from `layout_children`, painting and hit testing follow the reparent with no further work.

The hoist runs on every pass and is idempotent, so it holds across both branches of `resolve_layout_children` — the one that rebuilds `layout_children` and the one that preserves them. There is a test for that.

A transformed ancestor is the containing block for its fixed descendants per [css-transforms-1](https://drafts.csswg.org/css-transforms-1/#propdef-transform), so those are skipped. `filter`, `backdrop-filter`, `will-change`, `contain` and `perspective` also establish one; those are marked TODO rather than handled.

## What this does not fix

The root element takes its height from its content, whereas the initial containing block is always viewport-sized regardless of document height. So `inset: 0` still sizes against the document. Reparenting alone cannot express this — it needs an ICB node distinct from the root element, which felt like a larger design question than this PR should decide. `opposite_insets_should_size_against_the_viewport` is `#[ignore]`d with the browser-correct expectation, ready to be unignored if you add one.

Happy to take that on in a follow-up if you have a preferred shape for it.

## Testing

`packages/blitz-html/tests/fixed_position.rs` — 4 tests plus the ignored one above. Existing `blitz-dom`, `blitz-html` and `stylo_taffy` suites pass unchanged, including `paint_order`, which was the one most at risk from moving nodes between paint parents. `cargo fmt` and `cargo clippy --all-features` are clean.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/549?analyze=true)

> 💡 [Connect your GitHub account](https://dioxus.staging.devinenterprise.com/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->

<!-- wpt-results-start -->
## WPT results

**10** newly passing, **48** newly failing (net -38).

<details>
<summary>Full diff (58 changed tests)</summary>

```diff
- Pass => Fail css/CSS2/abspos/static-fixed-inside-abspos.html
+ Fail => Pass css/CSS2/backgrounds/background-root-023.xht
- Pass => Fail css/CSS2/box-display/containing-block-021.xht
- Pass => Fail css/CSS2/box-display/containing-block-022.xht
- Pass => Fail css/CSS2/margin-padding-clear/margin-collapse-103.xht
- Pass => Fail css/CSS2/positioning/abspos-013.xht
+ Fail => Pass css/CSS2/positioning/abspos-015.xht
- Pass => Fail css/CSS2/positioning/position-fixed-001.xht
+ Fail => Pass css/CSS2/positioning/position-fixed-007.xht
- Pass => Fail css/CSS2/visuren/left-offset-position-fixed-001.xht
- Pass => Fail css/CSS2/visuren/right-offset-position-fixed-001.xht
- Pass => Fail css/css-anchor-position/anchor-scroll-nested.html
+ Fail => Pass css/css-anchor-position/position-try-switch-to-fixed-anchor.html
- Pass => Fail css/css-anchor-position/scroll-to-anchored-fixed-000.html
- Pass => Fail css/css-anchor-position/scroll-to-anchored-fixed-001.html
- Pass => Fail css/css-anchor-position/scroll-to-anchored-fixed-002.html
- Pass => Fail css/css-anchor-position/scroll-to-anchored-fixed-003.html
- Pass => Fail css/css-anchor-position/scroll-to-anchored-fixed-004.html
- Pass => Fail css/css-anchor-position/scroll-to-anchored-fixed-005.html
- Pass => Fail css/css-anchor-position/scroll-to-anchored-fixed-006.html
- Pass => Fail css/css-break/out-of-flow-in-multicolumn-026.html
- Pass => Fail css/css-contain/contain-layout-007.html
- Pass => Fail css/css-contain/contain-layout-021.html
- Pass => Fail css/css-contain/contain-layout-containing-block-fixed-001.html
- Pass => Fail css/css-contain/contain-paint-010.html
- Pass => Fail css/css-contain/contain-paint-containing-block-fixed-001.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-items-019.html
- Pass => Fail css/css-grid/grid-items/grid-items-relative-positioned-containing-block-004.html
- Pass => Fail css/css-grid/grid-items/grid-items-relative-positioned-containing-block-005.html
- Pass => Fail css/css-grid/grid-items/grid-items-relative-positioned-containing-block-006.html
- Pass => Fail css/css-masking/clip-path/clip-path-fixed-nested.html
- Pass => Fail css/css-masking/clip-path/clip-path-fixed-scroll.html
+ Fail => Pass css/css-overflow/scroll-markers/scroll-target-group-012.html
- Pass => Fail css/css-overflow/scrollbar-gutter-fixedpos-003.html
- Pass => Fail css/css-overflow/scrollbar-gutter-fixedpos-004.html
+ Fail => Pass css/css-page/fixedpos-005-print.html
- Pass => Fail css/css-position/position-relative-003.html
- Pass => Fail css/css-position/position-relative-004.html
- Pass => Fail css/css-sizing/intrinsic-height-fixedpos-percentage-child.html
+ Fail => Pass css/css-transforms/perspective-containing-block-dynamic-1a.html
- Pass => Fail css/css-transforms/perspective-containing-block-dynamic-1b.html
- Pass => Fail css/css-transforms/transform-containing-block-dynamic-1b.html
- Pass => Fail css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html
- Pass => Fail css/css-will-change/will-change-fixedpos-cb-001.html
- Pass => Fail css/css-will-change/will-change-fixedpos-cb-004.html
- Pass => Fail css/css-will-change/will-change-fixpos-cb-contain-1.html
- Pass => Fail css/css-will-change/will-change-fixpos-cb-filter-1.html
- Pass => Fail css/css-will-change/will-change-fixpos-cb-offset-path-1.html
- Pass => Fail css/css-will-change/will-change-fixpos-cb-perspective-1.html
+ Fail => Pass css/css-will-change/will-change-fixpos-cb-position-1.html
- Pass => Fail css/css-will-change/will-change-fixpos-cb-transform-1.html
- Pass => Fail css/css-will-change/will-change-fixpos-cb-transform-style-1.html
- Pass => Fail css/css-will-change/will-change-fixpos-cb-translate-1.html
- Pass => Fail css/css-will-change/will-change-fixpos-cb-webkit-perspective-1.html
+ Fail => Pass css/filter-effects/filter-cb-dynamic-1a.html
- Pass => Fail css/filter-effects/filter-cb-dynamic-1b.html
- Pass => Fail css/filter-effects/filtered-block-is-container.html
- Pass => Fail css/filter-effects/filtered-inline-is-container.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30398818710).</sub>
<!-- wpt-results-end -->
