### PR TITLE
Map the rest of HTML's semantic elements to AccessKit roles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,7 @@ dependencies = [
 name = "blitz-html"
 version = "0.3.0-beta.1"
 dependencies = [
+ "accesskit",
  "anyrender",
  "anyrender_vello_cpu",
  "blitz-dom",

--- a/packages/blitz-dom/src/accessibility.rs
+++ b/packages/blitz-dom/src/accessibility.rs
@@ -45,19 +45,90 @@ impl BaseDocument {
         } else if let Some(element_data) = node.element_data() {
             let name = element_data.name.local.to_string();
 
-            // TODO match more roles
+            // <https://www.w3.org/TR/html-aam-1.0/>
             let role = match &*name {
-                "button" => Role::Button,
-                "div" => Role::GenericContainer,
+                // Document structure
+                "article" => Role::Article,
+                "aside" => Role::Complementary,
+                "footer" => Role::Footer,
                 "header" => Role::Header,
+                "main" => Role::Main,
+                "nav" => Role::Navigation,
+                "search" => Role::Search,
+                "section" => Role::Section,
                 "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => Role::Heading,
                 "p" => Role::Paragraph,
-                "section" => Role::Section,
+                "blockquote" => Role::Blockquote,
+                "figure" => Role::Figure,
+                "figcaption" | "caption" => Role::Caption,
+                "hr" => Role::Splitter,
+
+                // Grouping
+                "ul" | "ol" | "menu" => Role::List,
+                "li" => Role::ListItem,
+                "dl" => Role::DescriptionList,
+                "dt" => Role::Term,
+                "dd" => Role::Definition,
+                "dialog" => Role::Dialog,
+                "fieldset" => Role::Group,
+                "form" => Role::Form,
+                "div" => Role::GenericContainer,
+
+                // Tables
+                "table" => Role::Table,
+                "thead" | "tbody" | "tfoot" => Role::RowGroup,
+                "tr" => Role::Row,
+                "td" => Role::Cell,
+                "th" => match element_data.attr(local_name!("scope")) {
+                    Some("row") | Some("rowgroup") => Role::RowHeader,
+                    _ => Role::ColumnHeader,
+                },
+
+                // Interactive
+                // An <a> is only a link when it has an href.
+                "a" => match element_data.attr(local_name!("href")) {
+                    Some(_) => Role::Link,
+                    None => Role::GenericContainer,
+                },
+                "button" => Role::Button,
+                "label" => Role::Label,
+                "legend" => Role::Label,
+                "select" => match element_data.attr(local_name!("multiple")) {
+                    Some(_) => Role::ListBox,
+                    None => Role::ComboBox,
+                },
+                "option" => Role::ListBoxOption,
+                "textarea" => Role::MultilineTextInput,
+                "progress" => Role::ProgressIndicator,
+                "meter" => Role::Meter,
+                "output" => Role::Status,
+                "summary" => Role::DisclosureTriangle,
+
+                // Inline semantics
+                "code" => Role::Code,
+                "em" => Role::Emphasis,
+                "strong" => Role::Strong,
+                "mark" => Role::Mark,
+                "time" => Role::Time,
+                "img" => Role::Image,
+                "iframe" => Role::Iframe,
+
                 "input" => {
                     let ty = element_data.attr(local_name!("type")).unwrap_or("text");
                     match ty {
-                        "number" => Role::NumberInput,
+                        "button" | "submit" | "reset" => Role::Button,
                         "checkbox" => Role::CheckBox,
+                        "color" => Role::ColorWell,
+                        "date" => Role::DateInput,
+                        "datetime-local" => Role::DateTimeInput,
+                        "email" => Role::EmailInput,
+                        "number" => Role::NumberInput,
+                        "password" => Role::PasswordInput,
+                        "radio" => Role::RadioButton,
+                        "range" => Role::Slider,
+                        "search" => Role::SearchInput,
+                        "tel" => Role::PhoneNumberInput,
+                        "time" => Role::TimeInput,
                         _ => Role::TextInput,
                     }
                 }

--- a/packages/blitz-html/Cargo.toml
+++ b/packages/blitz-html/Cargo.toml
@@ -11,12 +11,14 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
+accessibility = ["blitz-dom/accessibility", "dep:accesskit"]
 tracing = ["dep:tracing", "blitz-dom/tracing"]
 
 [dependencies]
 # Blitz dependencies
 blitz-dom = { workspace = true }
 blitz-traits = { workspace = true }
+accesskit = { workspace = true, optional = true }
 
 # Servo dependencies
 html5ever = { workspace = true }

--- a/packages/blitz-html/tests/accessibility_roles.rs
+++ b/packages/blitz-html/tests/accessibility_roles.rs
@@ -1,0 +1,200 @@
+//! HTML elements map to their AccessKit roles.
+//!
+//! Only a handful of elements were mapped, so links, lists, tables, labels and
+//! landmarks all arrived as [`Role::Unknown`] and assistive technology had
+//! nothing to navigate by.
+//!
+//! <https://www.w3.org/TR/html-aam-1.0/>
+
+#![cfg(feature = "accessibility")]
+
+use accesskit::{NodeId, Role};
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// The `html_tag` of every element that still maps to [`Role::Unknown`].
+fn unknown_tags(html: &str) -> Vec<String> {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+
+    let mut tags: Vec<String> = doc
+        .build_accessibility_tree()
+        .nodes
+        .into_iter()
+        .filter(|(_, node)| node.role() == Role::Unknown)
+        .filter_map(|(_, node)| node.html_tag().map(|tag| tag.to_string()))
+        .collect();
+    tags.sort();
+    tags
+}
+
+/// Resolve the role of the element matching `id` in the document.
+#[track_caller]
+fn assert_role(html: &str, element_id: &str, expected: Role) {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+
+    let node_id = doc
+        .get_element_by_id(element_id)
+        .unwrap_or_else(|| panic!("no element with id {element_id}"));
+
+    let roles: HashMap<NodeId, Role> = doc
+        .build_accessibility_tree()
+        .nodes
+        .into_iter()
+        .map(|(id, node)| (id, node.role()))
+        .collect();
+
+    let actual = roles
+        .get(&NodeId(node_id.as_u64()))
+        .copied()
+        .unwrap_or(Role::Unknown);
+
+    assert_eq!(
+        actual, expected,
+        "#{element_id}: expected {expected:?} but got {actual:?}"
+    );
+}
+
+#[test]
+fn landmarks_and_structure() {
+    let html = r#"<html><body>
+        <nav id="nav"></nav>
+        <main id="main"></main>
+        <aside id="aside"></aside>
+        <footer id="footer"></footer>
+        <article id="article"></article>
+        <blockquote id="quote"></blockquote>
+        <figure id="figure"></figure>
+    </body></html>"#;
+
+    assert_role(html, "nav", Role::Navigation);
+    assert_role(html, "main", Role::Main);
+    assert_role(html, "aside", Role::Complementary);
+    assert_role(html, "footer", Role::Footer);
+    assert_role(html, "article", Role::Article);
+    assert_role(html, "quote", Role::Blockquote);
+    assert_role(html, "figure", Role::Figure);
+}
+
+#[test]
+fn lists_and_tables() {
+    let html = r#"<html><body>
+        <ul id="ul"><li id="li">item</li></ul>
+        <ol id="ol"></ol>
+        <table id="table">
+            <thead id="thead"><tr id="tr"><th id="col">Key</th></tr></thead>
+            <tbody><tr><td id="cell">Value</td><th id="row" scope="row">R</th></tr></tbody>
+        </table>
+    </body></html>"#;
+
+    assert_role(html, "ul", Role::List);
+    assert_role(html, "ol", Role::List);
+    assert_role(html, "li", Role::ListItem);
+    assert_role(html, "table", Role::Table);
+    assert_role(html, "thead", Role::RowGroup);
+    assert_role(html, "tr", Role::Row);
+    assert_role(html, "col", Role::ColumnHeader);
+    assert_role(html, "cell", Role::Cell);
+    assert_role(html, "row", Role::RowHeader);
+}
+
+#[test]
+fn an_anchor_is_a_link_only_with_an_href() {
+    let html = r##"<html><body>
+        <a id="link" href="#x">link</a>
+        <a id="anchor">not a link</a>
+    </body></html>"##;
+
+    assert_role(html, "link", Role::Link);
+    assert_role(html, "anchor", Role::GenericContainer);
+}
+
+#[test]
+fn form_controls() {
+    let html = r#"<html><body>
+        <label id="label">Name</label>
+        <select id="select"></select>
+        <select id="multi" multiple></select>
+        <textarea id="textarea"></textarea>
+        <progress id="progress"></progress>
+        <meter id="meter"></meter>
+        <input id="radio" type="radio">
+        <input id="range" type="range">
+        <input id="email" type="email">
+        <input id="password" type="password">
+        <input id="submit" type="submit">
+    </body></html>"#;
+
+    assert_role(html, "label", Role::Label);
+    assert_role(html, "select", Role::ComboBox);
+    assert_role(html, "multi", Role::ListBox);
+    assert_role(html, "textarea", Role::MultilineTextInput);
+    assert_role(html, "progress", Role::ProgressIndicator);
+    assert_role(html, "meter", Role::Meter);
+    assert_role(html, "radio", Role::RadioButton);
+    assert_role(html, "range", Role::Slider);
+    assert_role(html, "email", Role::EmailInput);
+    assert_role(html, "password", Role::PasswordInput);
+    assert_role(html, "submit", Role::Button);
+}
+
+#[test]
+fn previously_mapped_roles_are_unchanged() {
+    let html = r#"<html><body>
+        <button id="button"></button>
+        <div id="div"></div>
+        <header id="header"></header>
+        <h2 id="heading"></h2>
+        <p id="para"></p>
+        <section id="section"></section>
+        <input id="text" type="text">
+        <input id="number" type="number">
+        <input id="checkbox" type="checkbox">
+    </body></html>"#;
+
+    assert_role(html, "button", Role::Button);
+    assert_role(html, "div", Role::GenericContainer);
+    assert_role(html, "header", Role::Header);
+    assert_role(html, "heading", Role::Heading);
+    assert_role(html, "para", Role::Paragraph);
+    assert_role(html, "section", Role::Section);
+    assert_role(html, "text", Role::TextInput);
+    assert_role(html, "number", Role::NumberInput);
+    assert_role(html, "checkbox", Role::CheckBox);
+}
+
+#[test]
+fn a_semantic_page_has_no_unknown_elements() {
+    let html = r##"<html><body>
+        <header><h1>Title</h1><nav><a href="#a">One</a></nav></header>
+        <main>
+            <p>Body</p>
+            <ul><li>Item</li></ul>
+            <table><tr><th>K</th><td>V</td></tr></table>
+            <label>Name <input type="text"></label>
+        </main>
+        <footer>End</footer>
+    </body></html>"##;
+
+    // <html>, <head> and <body> have no roles of their own. Everything else in
+    // this document should map to something an assistive technology can use.
+    assert_eq!(unknown_tags(html), vec!["body", "head", "html"]);
+}


### PR DESCRIPTION
`build_accessibility_node` maps nine elements and carries a `// TODO match more roles`, so everything else arrives as `Role::Unknown` — including most of what assistive technology actually navigates by.

On a small but fully semantic page (header, nav, main, a list, a table, a labelled input), **21 nodes came back `unknown`**:

```
window
  header
    heading
    unknown          <- <nav>
      unknown        <- <a>
  unknown            <- <main>
    unknown          <- <ul>
      unknown        <- <li>
    unknown          <- <table>
      unknown        <- <tr>
        unknown      <- <th>
    unknown          <- <label>
```

A screen reader gets no landmarks, no list structure, no table structure and no labels.

## What this adds

Mappings from [HTML-AAM](https://www.w3.org/TR/html-aam-1.0/):

| Group | Elements |
| --- | --- |
| Landmarks | `nav` `main` `aside` `footer` `article` `search` |
| Grouping | `ul`/`ol` `li` `dl`/`dt`/`dd` `fieldset` `form` `dialog` `blockquote` `figure` `figcaption` `hr` |
| Tables | `table` `thead`/`tbody`/`tfoot` `tr` `td` `th` |
| Interactive | `a` `label` `legend` `select` `option` `textarea` `progress` `meter` `output` `summary` |
| Inline | `code` `em` `strong` `mark` `time` `img` `iframe` |

`<input>` gains `button`/`submit`/`reset`, `color`, `date`, `datetime-local`, `email`, `password`, `radio`, `range`, `search`, `tel`, `time`.

Three mappings are conditional, per spec:

- `<a>` is a `Link` only with an `href`; without one it is a `GenericContainer`.
- `<th>` is a `RowHeader` when `scope` is `row`/`rowgroup`, `ColumnHeader` otherwise.
- `<select>` is a `ListBox` with `multiple`, `ComboBox` otherwise.

Existing mappings are untouched, and `previously_mapped_roles_are_unchanged` pins that.

## Testing

`packages/blitz-html/tests/accessibility_roles.rs` — 6 tests. The last one asserts that on a semantic page the only unmapped elements are `html`, `head` and `body`, and prints the offending tags on failure rather than a bare count.

The tests need `blitz-dom`s `accessibility` feature, which `blitz-html` did not expose, so it gains an `accessibility` feature forwarding to it:

```bash
cargo test -p blitz-html --features accessibility
```

Existing `blitz-dom` and `blitz-html` suites pass unchanged. `cargo fmt` and `cargo clippy` clean.

Independent of #549 — both branch from `main` and touch different files.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/550?analyze=true)

> 💡 [Connect your GitHub account](https://dioxus.staging.devinenterprise.com/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30365453892).</sub>
<!-- wpt-results-end -->
