### PR TITLE
Give the focus outline a style, so it is actually painted

### DIFF
--- a/packages/blitz-dom/assets/default.css
+++ b/packages/blitz-dom/assets/default.css
@@ -74,7 +74,7 @@ textarea {
 
 input:focus,
 textarea:focus {
-    outline: 2px #4D90FE;
+    outline: 2px solid #4D90FE;
 }
 
 button,


### PR DESCRIPTION
The UA stylesheet already has the right rule:

```css
input:focus,
textarea:focus {
    outline: 2px #4D90FE;
}
```

but the `outline` shorthand omits the style keyword, so [`outline-style` resets to `none`](https://drafts.csswg.org/css-ui/#outline) and nothing is drawn. **Keyboard users get no focus indicator on any input or textarea.**

Adding `solid` is the whole fix.

## This is not an outline-painting bug

Outline painting works. Same page, same engine:

| CSS | Result |
| --- | --- |
| `outline: 2px #4D90FE` (the current UA rule) | nothing painted |
| `outline: 2px solid #4D90FE` | ring painted correctly |

So the rule was simply inert.

## Testing

`packages/blitz-html/tests/focus_outline.rs` asserts an idle field resolves to no outline and a focused one resolves to something paintable, for both `<input>` and `<textarea>`. Reverting the keyword makes both tests fail, so it cannot silently regress.

Found while comparing a React and Tailwind app rendered by Blitz against the same app in Chrome: everything matched except the focus ring.

Independent of #549 and #550.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/551?analyze=true)

> 💡 [Connect your GitHub account](https://dioxus.staging.devinenterprise.com/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/blitz/pull/551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30400697657).</sub>
<!-- wpt-results-end -->
