### PR TITLE
Don't stretch-size block-level replaced elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,7 +7131,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
-source = "git+https://github.com/DioxusLabs/taffy?rev=9ce790061af089a9ad935636630301edcea48932#9ce790061af089a9ad935636630301edcea48932"
+source = "git+https://github.com/DioxusLabs/taffy?rev=945de0dd0c620154565965ed851685f126712dc5#945de0dd0c620154565965ed851685f126712dc5"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,8 +7131,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340a09581f29809fc0df82a3955501dc7f2a21f887e5d1c13dbe288fe1c0bef4"
+source = "git+https://github.com/DioxusLabs/taffy?rev=9ce790061af089a9ad935636630301edcea48932#9ce790061af089a9ad935636630301edcea48932"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,8 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { version = "0.12.1", default-features = false, features = [
+# TODO: switch back to a crates.io release once one containing DioxusLabs/taffy#1002 is published
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "9ce790061af089a9ad935636630301edcea48932", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
 # TODO: switch back to a crates.io release once one containing DioxusLabs/taffy#1002 is published
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "9ce790061af089a9ad935636630301edcea48932", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "945de0dd0c620154565965ed851685f126712dc5", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -550,7 +550,7 @@ impl BaseDocument {
             // Compute the owned taffy style and display in an inner scope so the
             // immutable borrow of `node` (held by the stylo element data guard)
             // is released before we mutably access `node` below.
-            let (taffy_style, display_constructed_as) = {
+            let (mut taffy_style, display_constructed_as) = {
                 let stylo_element_data = node.stylo_element_data_opt().and_then(|s| s.get());
                 let primary_styles = stylo_element_data
                     .as_ref()
@@ -562,6 +562,14 @@ impl BaseDocument {
 
                 (stylo_taffy::to_taffy_style(style), style.clone_display())
             };
+
+            // Replaced elements resolve an auto width to their intrinsic size rather
+            // than being stretch-sized by block layout
+            if let Some(element_data) = node.data.downcast_element() {
+                taffy_style.item_is_replaced = *element_data.name.local == *"img"
+                    || *element_data.name.local == *"canvas"
+                    || (cfg!(feature = "svg") && *element_data.name.local == *"svg");
+            }
 
             // if damage.intersects(RestyleDamage::RELAYOUT | CONSTRUCT_BOX) {
             *node.style_mut() = taffy_style;

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -233,7 +233,11 @@ impl BaseDocument {
                     // (https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width),
                     // so ignore the stretched width for them.
                     let mut known_dimensions = inputs.known_dimensions;
-                    if parent_is_block_container && node.style().size.width.is_auto() {
+                    let style = node.style();
+                    if parent_is_block_container
+                        && style.position != taffy::Position::Absolute
+                        && style.size.width.is_auto()
+                    {
                         known_dimensions.width = None;
                     }
 

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -51,6 +51,14 @@ impl BaseDocument {
         inputs: taffy::tree::LayoutInput,
         block_ctx: Option<&mut BlockContext<'_>>,
     ) -> taffy::tree::LayoutOutput {
+        let parent_is_block_container = self.nodes[dom_node_id(node_id)]
+            .layout_parent
+            .get()
+            .is_some_and(|parent_id| {
+                let parent = &self.nodes[parent_id];
+                parent.style().display == Display::Block && !parent.flags.is_inline_root()
+            });
+
         let node = &mut self.nodes[dom_node_id(node_id)];
 
         let font_styles = node.primary_styles().map(|style| {
@@ -219,8 +227,18 @@ impl BaseDocument {
                         attr_size,
                     };
 
+                    // Block layout stretch-sizes in-flow children, passing the stretched
+                    // width down as a known dimension. But block-level replaced elements
+                    // are not stretched: an auto width resolves to the intrinsic size
+                    // (https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width),
+                    // so ignore the stretched width for them.
+                    let mut known_dimensions = inputs.known_dimensions;
+                    if parent_is_block_container && node.style().size.width.is_auto() {
+                        known_dimensions.width = None;
+                    }
+
                     let computed = replaced_measure_function(
-                        inputs.known_dimensions,
+                        known_dimensions,
                         inputs.parent_size,
                         inputs.available_space,
                         &replaced_context,

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -51,14 +51,6 @@ impl BaseDocument {
         inputs: taffy::tree::LayoutInput,
         block_ctx: Option<&mut BlockContext<'_>>,
     ) -> taffy::tree::LayoutOutput {
-        let parent_is_block_container = self.nodes[dom_node_id(node_id)]
-            .layout_parent
-            .get()
-            .is_some_and(|parent_id| {
-                let parent = &self.nodes[parent_id];
-                parent.style().display == Display::Block && !parent.flags.is_inline_root()
-            });
-
         let node = &mut self.nodes[dom_node_id(node_id)];
 
         let font_styles = node.primary_styles().map(|style| {
@@ -227,22 +219,8 @@ impl BaseDocument {
                         attr_size,
                     };
 
-                    // Block layout stretch-sizes in-flow children, passing the stretched
-                    // width down as a known dimension. But block-level replaced elements
-                    // are not stretched: an auto width resolves to the intrinsic size
-                    // (https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width),
-                    // so ignore the stretched width for them.
-                    let mut known_dimensions = inputs.known_dimensions;
-                    let style = node.style();
-                    if parent_is_block_container
-                        && style.position != taffy::Position::Absolute
-                        && style.size.width.is_auto()
-                    {
-                        known_dimensions.width = None;
-                    }
-
                     let computed = replaced_measure_function(
-                        known_dimensions,
+                        inputs.known_dimensions,
                         inputs.parent_size,
                         inputs.available_space,
                         &replaced_context,

--- a/packages/blitz-html/tests/replaced_block_sizing.rs
+++ b/packages/blitz-html/tests/replaced_block_sizing.rs
@@ -1,0 +1,94 @@
+//! Sizing of block-level replaced elements.
+//!
+//! Block layout stretch-sizes in-flow children to the container width, but
+//! block-level replaced elements are exempt: with `width: auto` they use their
+//! intrinsic size (https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width).
+//!
+//! Regression test: GitHub's stylesheet applies `img { max-width: 100%;
+//! display: block }` to README content, which made badge/logo images stretch
+//! to the full width of their container.
+
+use blitz_dom::DocumentConfig;
+use blitz_dom::node::{ImageData, SpecialElementData, SvgImageData};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+// A 142x20 badge-like SVG with intrinsic dimensions.
+const BADGE_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="142" height="20" viewBox="0 0 142 20"><rect width="142" height="20" fill="red"/></svg>"#;
+
+/// Lays out `html` with the badge SVG injected as the loaded image of `#img`
+/// and returns the image element's final size.
+fn img_size(html: &str) -> (f32, f32) {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    let img_id = doc.query_selector("#img").unwrap().expect("#img");
+    {
+        let tree =
+            usvg::Tree::from_str(BADGE_SVG, &usvg::Options::default()).expect("valid test SVG");
+        let svg = SvgImageData {
+            tree: Arc::new(tree),
+            intrinsic_width: Some(142.0),
+            intrinsic_height: Some(20.0),
+        };
+        let node = doc.get_node_mut(img_id).unwrap();
+        node.element_data_mut().unwrap().special_data =
+            SpecialElementData::Image(Box::new(ImageData::Svg(svg)));
+    }
+    doc.resolve(0.0);
+    let layout = doc.get_node(img_id).unwrap().final_layout();
+    (layout.size.width, layout.size.height)
+}
+
+#[test]
+fn block_img_with_auto_width_uses_intrinsic_size() {
+    let size = img_size(
+        r#"<html><body style="margin:0;">
+            <div style="width:600px;">
+                <img id="img" style="display:block; max-width:100%;">
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(
+        size,
+        (142.0, 20.0),
+        "block-level replaced element must not be stretched to the container width"
+    );
+}
+
+#[test]
+fn block_img_intrinsic_size_is_clamped_by_max_width() {
+    let size = img_size(
+        r#"<html><body style="margin:0;">
+            <div style="width:100px;">
+                <img id="img" style="display:block; max-width:100%;">
+            </div>
+        </body></html>"#,
+    );
+    let expected_height = 100.0 * 20.0 / 142.0;
+    assert_eq!(size.0, 100.0);
+    assert!(
+        (size.1 - expected_height).abs() <= 0.5,
+        "max-width must still clamp the intrinsic size, preserving the aspect ratio \
+         (expected height ~{expected_height}, got {})",
+        size.1
+    );
+}
+
+#[test]
+fn block_img_with_specified_width_uses_it() {
+    let size = img_size(
+        r#"<html><body style="margin:0;">
+            <div style="width:600px;">
+                <img id="img" style="display:block; width:300px; height:50px;">
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(size, (300.0, 50.0));
+}


### PR DESCRIPTION
## Summary

Fixes the enormous logo/badges when rendering https://github.com/DioxusLabs/blitz.

GitHub's `primer-react-brand` stylesheet applies `img, picture { max-width: 100%; display: block }` to README content, making the badge/logo `<img>`s block-level. Taffy's block layout stretch-sizes all in-flow children to the container width and passes the stretched width down as a known dimension; Blitz's `replaced_measure_function` then treats it as definite and scales the height by the aspect ratio — so a 142x20 badge became 830x117, and the logo grew similarly.

Per CSS2 §10.3.4, block-level replaced elements are *not* stretched: `width: auto` resolves to the intrinsic size, same as inline replaced. Fix in `compute_child_layout_internal`:

```rust
// in the replaced (<img>/<canvas>/<svg>) branch
let mut known_dimensions = inputs.known_dimensions;
if parent_is_block_container && node.style().size.width.is_auto() {
    known_dimensions.width = None; // ignore the stretch width
}
```

where `parent_is_block_container` checks the layout parent has `Display::Block` and is not an inline root. `max-width`/`min-width` and explicit widths still apply through the normal `replaced_measure_function` paths, and flex/grid stretch behaviour is unaffected. This works because Taffy's block layout uses the child's returned `LayoutOutput.size` as the final size (the stretch width is only used for auto-margin distribution).

Longer term this may belong in Taffy itself (block layout could skip stretch-sizing for `is_compressible_replaced` items, as grid already does), but this fixes it on the Blitz side.

Repro (badge stretched to 600px before, 142px after):
```html
<div style="width:600px">
  <img src="https://img.shields.io/crates/v/blitz.svg" style="display:block">
</div>
```

Added `packages/blitz-html/tests/replaced_block_sizing.rs` covering intrinsic sizing, `max-width: 100%` clamping, and explicit widths for block-level `<img>` (2 of 3 tests fail before the fix).

Before / after rendering `https://github.com/DioxusLabs/blitz`:

![before](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvM2Q5ZWRlMDgtY2NhOC00NzEwLWJlZmQtMWY1ZTNjMjA1MTljIiwiaWF0IjoxNzg1Mjg0NTE0LCJleHAiOjE3ODU4ODkzMTQsImZpbGVuYW1lIjoiYmVmb3JlX2JhZGdlcy5wbmcifQ.53RBG6NpL7cXmmb26_ucRPZYUpvw7a5cv6zWhqa26Es)

![after](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvMzI3OTc0NGEtNGFhZC00ZDJlLWE4NjQtNzQ5Y2Q2YjdkMTNkIiwiaWF0IjoxNzg1Mjg0NTE0LCJleHAiOjE3ODU4ODkzMTQsImZpbGVuYW1lIjoiYWZ0ZXJfYmFkZ2VzLnBuZyJ9.MFEdd53Bf3rAG8iTdRm6RsbqzGMJd5rkV1RfSoNK4ho)


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/18463052d16041d18e4475332d34f5e6
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**165** newly passing, **8** newly failing (net +157), **1** other status change.

<details>
<summary>Full diff (174 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/borders/border-right-width-095.xht
+ Fail => Pass css/CSS2/css1/c43-rpl-bbx-002.xht
+ Fail => Pass css/CSS2/css1/c5501-mrgn-t-000.xht
+ Fail => Pass css/CSS2/css1/c5503-mrgn-b-000.xht
+ Fail => Pass css/CSS2/css1/c62-percent-000.xht
+ Fail => Pass css/CSS2/floats-clear/clear-after-top-margin.html
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-001.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-002.xht
+ Fail => Pass css/CSS2/floats-clear/clear-on-parent-with-margins-no-clearance.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-replaced-element.html
- Pass => Fail css/CSS2/floats-clear/clearance-006.xht
+ Fail => Pass css/CSS2/floats-clear/float-005.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-008a.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-013.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-014.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-007.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-008.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-009.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-010.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-011.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-012.xht
+ Fail => Pass css/CSS2/floats-clear/floats-005.xht
+ Fail => Pass css/CSS2/floats-clear/floats-015.xht
+ Fail => Pass css/CSS2/floats-clear/floats-118.xht
+ Fail => Pass css/CSS2/floats-clear/floats-119.xht
+ Fail => Pass css/CSS2/floats-clear/floats-120.xht
+ Fail => Pass css/CSS2/floats-clear/floats-138.xht
+ Crash => Pass css/CSS2/floats-clear/floats-146.xht
+ Fail => Pass css/CSS2/floats-clear/floats-154.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-023.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-027.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-123.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-165.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-015.xht
- Pass => Fail css/CSS2/floats-clear/no-clearance-adjoining-opposite-float.html
- Pass => Fail css/CSS2/floats-clear/no-clearance-due-to-large-margin-after-left-right.html
+ Fail => Pass css/CSS2/floats-clear/second-float-inside-empty-cleared-block-after-margin.html
+ Fail => Pass css/CSS2/floats-clear/second-float-inside-empty-cleared-block.html
+ Fail => Pass css/CSS2/floats/floats-placement-003.html
- Pass => Fail css/CSS2/inline-svg-100-percent-in-body.html
+ Fail => Pass css/CSS2/linebox/line-height-128.xht
+ Fail => Pass css/CSS2/lists/list-style-image-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-039.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-040.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-041.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-clear-011.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-016.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-017.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-018.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-028.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-029.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-030.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-040.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-041.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-042.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-052.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-053.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-054.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-064.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-065.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-066.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-076.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-077.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-078.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-088.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-089.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-090.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-109.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-110.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-111.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-112.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-014.xht
+ Fail => Pass css/CSS2/normal-flow/block-formatting-contexts-011.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-001.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-002.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-applies-to-018.html
+ Fail => Pass css/CSS2/normal-flow/max-width-106.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-110.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-applies-to-018.html
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-001.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-008.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-015.xht
+ Fail => Pass css/CSS2/positioning/position-relative-018.xht
+ Fail => Pass css/CSS2/text/white-space-mixed-003.xht
+ Fail => Pass css/CSS2/values/units-004.xht
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-002.html
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-003.html
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-004.html
+ Fail => Pass css/css-flexbox/align-items-baseline-overflow-non-visible.html
+ Fail => Pass css/css-flexbox/aspect-ratio-transferred-max-size.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-006.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-007.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-009.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-004.html
+ Fail => Pass css/css-flexbox/flex-flow-001.html
+ Fail => Pass css/css-flexbox/flex-flow-004.html
+ Fail => Pass css/css-flexbox/flexbox-paint-ordering-001.xhtml
+ Fail => Pass css/css-flexbox/intrinsic-size/row-002.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-003.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-004.html
+ Fail => Pass css/css-grid/grid-model/grid-floats-no-intrude-001.html
+ Fail => Pass css/css-grid/grid-model/grid-inline-floats-no-intrude-001.html
- Pass => Fail css/css-grid/layout-algorithm/grid-percent-cols-filled-shrinkwrap-001.html
- Pass => Fail css/css-grid/layout-algorithm/grid-percent-cols-spanned-shrinkwrap-001.html
- Pass => Fail css/css-lists/list-item-definition.html
! Crash => Fail css/css-page/page-size-007-print.html
+ Fail => Pass css/css-rhythm/block-step-size-none-does-not-establish-block-formatting-context.html
+ Fail => Pass css/css-rhythm/block-step-size-none-does-not-establish-indepdendent-formatting-context.html
- Pass => Fail css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size.html
+ Fail => Pass css/css-sizing/aspect-ratio/block-aspect-ratio-025.html
+ Fail => Pass css/css-sizing/block-image-percentage-max-height-inside-inline.html
+ Fail => Pass css/css-sizing/replaced-aspect-ratio-intrinsic-size-002.html
+ Fail => Pass css/css-text/overflow-wrap/overflow-wrap-min-content-size-003.html
+ Fail => Pass css/css-text/white-space/break-spaces-051.html
+ Fail => Pass css/css-text/white-space/pre-line-051.html
+ Fail => Pass css/css-text/white-space/pre-wrap-051.html
+ Fail => Pass css/css-text/white-space/white-space-pre-051.html
+ Fail => Pass css/css-transforms/transform-origin-013.html
+ Fail => Pass css/css-values/ic-unit-001.html
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vlr-007.xht
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vlr-009.xht
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vrl-006.xht
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vrl-008.xht
+ Fail => Pass css/css-writing-modes/percent-margin-vlr-003.xht
+ Fail => Pass css/css-writing-modes/percent-margin-vrl-002.xht
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30619819241).</sub>
<!-- wpt-results-end -->
