### PR TITLE
Firefox devtools server: DOM, style and layout inspectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "blitz-devtools-server"
+version = "0.3.0-beta.1"
+dependencies = [
+ "blitz-dom",
+ "blitz-html",
+ "blitz-traits",
+ "bytes",
+ "cssparser",
+ "serde",
+ "serde_json",
+ "stylo",
+ "stylo_traits",
+ "taffy",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+]
+
+[[package]]
 name = "blitz-dom"
 version = "0.3.0-beta.1"
 dependencies = [
@@ -1005,6 +1024,7 @@ dependencies = [
  "anyrender",
  "arboard",
  "atomic_refcell",
+ "blitz-devtools-server",
  "blitz-dom",
  "blitz-paint",
  "blitz-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "packages/blitz-net",
     "packages/blitz-paint",
     "packages/blitz-shell",
+    "packages/blitz-devtools-server",
     "packages/blitz",
     "packages/stylo_taffy",
     "packages/dioxus-native",
@@ -44,6 +45,7 @@ blitz-html = { version = "=0.3.0-beta.1", path = "./packages/blitz-html", defaul
 blitz-net = { version = "=0.3.0-beta.1", path = "./packages/blitz-net", default-features = false }
 blitz-paint = { version = "=0.3.0-beta.1", path = "./packages/blitz-paint", default-features = false }
 blitz-shell = { version = "=0.3.0-beta.1", path = "./packages/blitz-shell", default-features = false }
+blitz-devtools-server = { version = "=0.3.0-beta.1", path = "./packages/blitz-devtools-server" }
 blitz-traits = { version = "=0.3.0-beta.1", path = "./packages/blitz-traits", default-features = false }
 stylo_taffy = { version = "=0.3.0-beta.1", path = "./packages/stylo_taffy", default-features = false }
 dioxus-native = { version = "0.7.0", path = "./packages/dioxus-native", default-features = false }
@@ -151,6 +153,8 @@ html-escape = "0.2.13"
 percent-encoding = "2.3.1"
 png = "0.18"
 serde = "1"
+serde_json = "1"
+tokio-util = { version = "0.7", default-features = false }
 
 # Dioxus Native
 webbrowser = "1.0"

--- a/packages/blitz-devtools-server/Cargo.toml
+++ b/packages/blitz-devtools-server/Cargo.toml
@@ -30,3 +30,5 @@ bytes = { workspace = true }
 
 [dev-dependencies]
 blitz-html = { workspace = true }
+# Text must be laid out with real fonts for inline fragment geometry to be non-zero
+blitz-dom = { workspace = true, features = ["system-fonts"] }

--- a/packages/blitz-devtools-server/Cargo.toml
+++ b/packages/blitz-devtools-server/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "blitz-devtools-server"
+description = "(Firefox) devtools protocol server implementation"
+documentation = "https://docs.rs/blitz-devtools-server"
+version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+edition.workspace = true
+
+[dependencies]
+# Blitz dependencies
+blitz-traits = { workspace = true }
+blitz-dom = { workspace = true }
+
+# Style / layout dependencies
+style = { workspace = true }
+style_traits = { workspace = true }
+cssparser = { workspace = true }
+taffy = { workspace = true }
+
+# Networking dependencies
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net", "sync", "io-util", "macros"] }
+tokio-util = { workspace = true, features = ["codec"] }
+tokio-stream = "0.1.17"
+bytes = { workspace = true }
+
+[dev-dependencies]
+blitz-html = { workspace = true }

--- a/packages/blitz-devtools-server/src/actors.rs
+++ b/packages/blitz-devtools-server/src/actors.rs
@@ -100,6 +100,15 @@ impl Connection {
         // handled with `&mut self` while other actors remain accessible
         // through the context.
         let Some(mut actor) = self.actors.remove(&msg.to) else {
+            // Firefox sends getUniqueSelector directly to node actors, which
+            // are virtual (owned by the walker) rather than registered actors.
+            // Reply with a placeholder selector rather than noSuchActor, which
+            // would break the Rules and Flexbox panels.
+            if msg.to.starts_with("node-") && msg.type_ == "getUniqueSelector" {
+                self.writer
+                    .write_msg(msg.to, serde_json::json!({ "value": "" }));
+                return;
+            }
             self.writer.write_err(msg.to, ActorMessageErr::NoSuchActor);
             return;
         };

--- a/packages/blitz-devtools-server/src/actors.rs
+++ b/packages/blitz-devtools-server/src/actors.rs
@@ -1,0 +1,168 @@
+pub mod css_properties;
+pub mod device;
+pub mod highlighter;
+pub mod inspector;
+pub mod layout;
+pub mod page_style;
+pub mod preference;
+pub mod process;
+pub mod root;
+pub mod stubs;
+pub mod tab;
+pub mod walker;
+pub mod watcher;
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering as Ao};
+
+pub(crate) use device::DeviceActor;
+pub(crate) use preference::PreferenceActor;
+pub(crate) use process::ProcessActor;
+pub(crate) use root::RootActor;
+
+use crate::{Connection, DocumentProvider, GenericClientMessage, JsonValue, MessageWriter};
+
+pub(crate) type ActorId = String;
+
+pub(crate) fn generate_name(base: &str) -> String {
+    static ACTOR_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let id = ACTOR_ID_COUNTER.fetch_add(1, Ao::Relaxed);
+    format!("{base}-{id}")
+}
+
+// https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#error-packets
+pub(crate) enum ActorMessageErr {
+    NoSuchActor,
+    UnrecognizedPacketType,
+    MissingParameter,
+    BadParameterType,
+    NoSuchNode,
+    NoSuchDocument,
+}
+
+impl ActorMessageErr {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            ActorMessageErr::NoSuchActor => "noSuchActor",
+            ActorMessageErr::UnrecognizedPacketType => "unrecognizedPacketType",
+            ActorMessageErr::MissingParameter => "missingParameter",
+            ActorMessageErr::BadParameterType => "badParameterType",
+            ActorMessageErr::NoSuchNode => "noSuchNode",
+            ActorMessageErr::NoSuchDocument => "noSuchDocument",
+        }
+    }
+
+    pub(crate) fn message(&self) -> &'static str {
+        match self {
+            ActorMessageErr::NoSuchActor => "No such actor",
+            ActorMessageErr::UnrecognizedPacketType => "Unrecognized packet type",
+            ActorMessageErr::MissingParameter => "Missing parameter",
+            ActorMessageErr::BadParameterType => "Bad parameter type",
+            ActorMessageErr::NoSuchNode => "No such node",
+            ActorMessageErr::NoSuchDocument => "No such document",
+        }
+    }
+}
+
+pub(crate) trait Actor: Any + Send + 'static {
+    fn name(&self) -> String;
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr>;
+}
+
+impl Connection {
+    pub(crate) fn init(&mut self) {
+        let pref = PreferenceActor::new();
+        let device = DeviceActor::new();
+        let process = ProcessActor::new();
+        let root = RootActor::new(pref.name(), device.name(), process.name());
+        self.insert_actor(Box::new(pref));
+        self.insert_actor(Box::new(device));
+        self.insert_actor(Box::new(process));
+        self.insert_actor(Box::new(root));
+    }
+
+    pub(crate) fn insert_actor(&mut self, actor: Box<dyn Actor>) {
+        self.actors.insert(actor.name(), actor);
+    }
+
+    pub(crate) fn handle_message(
+        &mut self,
+        msg: GenericClientMessage,
+        docs: &mut dyn DocumentProvider,
+    ) {
+        // Temporarily remove the target actor from the map so that it can be
+        // handled with `&mut self` while other actors remain accessible
+        // through the context.
+        let Some(mut actor) = self.actors.remove(&msg.to) else {
+            self.writer.write_err(msg.to, ActorMessageErr::NoSuchActor);
+            return;
+        };
+
+        let mut ctx = DevtoolContext {
+            writer: &mut self.writer,
+            actors: &mut self.actors,
+            actors_to_create: Vec::new(),
+            docs,
+        };
+
+        let result = actor.handle_message(&mut ctx, msg);
+        if let Err(err) = result {
+            ctx.write_err(actor.name(), err);
+        }
+
+        let actors_to_create = std::mem::take(&mut ctx.actors_to_create);
+        self.insert_actor(actor);
+        for actor in actors_to_create {
+            self.insert_actor(actor);
+        }
+    }
+}
+
+pub(crate) struct DevtoolContext<'a> {
+    pub(crate) writer: &'a mut MessageWriter,
+    pub(crate) actors: &'a mut HashMap<ActorId, Box<dyn Actor>>,
+    pub(crate) actors_to_create: Vec<Box<dyn Actor>>,
+    pub(crate) docs: &'a mut dyn DocumentProvider,
+}
+
+impl DevtoolContext<'_> {
+    /// Register a new actor with the connection. It will become routable once
+    /// the current message has finished processing.
+    pub(crate) fn push_actor(&mut self, actor: Box<dyn Actor>) {
+        self.actors_to_create.push(actor);
+    }
+
+    pub(crate) fn write_msg(&mut self, from: String, data: JsonValue) {
+        self.writer.write_msg(from, data);
+    }
+    pub(crate) fn write_err(&mut self, from: String, err: ActorMessageErr) {
+        self.writer.write_err(from, err);
+    }
+
+    pub(crate) fn actor<T: Actor>(&self, name: &str) -> &T {
+        (&*self.actors[name] as &dyn Any).downcast_ref().unwrap()
+    }
+
+    /// Run a callback with access to the document with the given id, returning
+    /// `None` if no such document exists
+    pub(crate) fn with_doc<R>(
+        &mut self,
+        doc_id: usize,
+        cb: impl FnOnce(&mut blitz_dom::BaseDocument) -> R,
+    ) -> Option<R> {
+        let mut cb = Some(cb);
+        let mut result = None;
+        self.docs.with_document(doc_id, &mut |doc| {
+            if let Some(cb) = cb.take() {
+                result = Some(cb(doc));
+            }
+        });
+        result
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/css_properties.rs
+++ b/packages/blitz-devtools-server/src/actors/css_properties.rs
@@ -1,0 +1,77 @@
+use serde_json::json;
+use style::properties::{LonghandId, NonCustomPropertyId, PropertyId, ShorthandId};
+
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext, generate_name};
+use crate::{GenericClientMessage, JsonValue};
+
+/// Provides the client with the database of supported CSS properties,
+/// generated from Stylo's property definitions.
+pub(crate) struct CssPropertiesActor {
+    name: String,
+}
+
+impl CssPropertiesActor {
+    pub(crate) fn new() -> Self {
+        Self {
+            name: generate_name("css-properties"),
+        }
+    }
+
+    fn css_database() -> JsonValue {
+        let mut properties = serde_json::Map::new();
+        for id in NonCustomPropertyId::iter() {
+            // Skip aliases and internal/pref-disabled properties
+            if id.as_alias().is_some() {
+                continue;
+            }
+            if !PropertyId::NonCustom(id).enabled_for_all_content() {
+                continue;
+            }
+
+            let (is_inherited, subproperties): (bool, Vec<&'static str>) =
+                match id.longhand_or_shorthand() {
+                    Ok(longhand) => (longhand.inherited(), vec![longhand.name()]),
+                    Err(shorthand) => (
+                        shorthand_inherited(shorthand),
+                        shorthand.longhands().map(|l| l.name()).collect(),
+                    ),
+                };
+
+            properties.insert(
+                id.name().to_string(),
+                json!({
+                    "isInherited": is_inherited,
+                    "values": [],
+                    "supports": [],
+                    "subproperties": subproperties,
+                }),
+            );
+        }
+        JsonValue::Object(properties)
+    }
+}
+
+/// A shorthand is considered inherited if all of its longhands are inherited
+fn shorthand_inherited(shorthand: ShorthandId) -> bool {
+    shorthand.longhands().all(LonghandId::inherited)
+}
+
+impl Actor for CssPropertiesActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "getCSSDatabase" => {
+                ctx.write_msg(self.name(), json!({ "properties": Self::css_database() }));
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/device.rs
+++ b/packages/blitz-devtools-server/src/actors/device.rs
@@ -1,0 +1,52 @@
+use serde_json::json;
+
+use crate::GenericClientMessage;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext};
+
+use super::generate_name;
+
+pub(crate) struct DeviceActor {
+    name: String,
+}
+
+impl DeviceActor {
+    pub(crate) fn new() -> Self {
+        Self {
+            name: generate_name("device"),
+        }
+    }
+}
+
+impl Actor for DeviceActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "getDescription" => {
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "value": {
+                        "apptype":"blitz",
+                        "name":"Blitz",
+                        "brandName":"Blitz",
+                        "version": env!("CARGO_PKG_VERSION").to_string(),
+                        "appbuildid": format!("Version {}", env!("CARGO_PKG_VERSION").to_string()),
+                        "platformversion":"135.0",
+                        // "platformbuildid":"Version 1.0",
+                        // "useragent":"Mozilla/5.0 (macOS; AArch64) Ladybird/1.0",
+                        // "os":"macOS",
+                        // "arch":"AArch64"
+                    }}),
+                );
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/highlighter.rs
+++ b/packages/blitz-devtools-server/src/actors/highlighter.rs
@@ -43,15 +43,20 @@ impl Actor for HighlighterActor {
                     .and_then(|v| v.as_str())
                     .ok_or(ActorMessageErr::MissingParameter)?
                     .to_string();
+                // Tolerate non-node actors: Firefox passes the target/inspector
+                // actor when showing e.g. the ViewportSizeOnResizeHighlighter,
+                // and a noSuchNode error would abort its [root-node] listener
+                // and leave the markup view empty.
                 let node_id = InspectorActor::with_walker(ctx, &self.walker_name, |walker, _| {
                     walker.node_for_actor(&node_actor)
-                })
-                .ok_or(ActorMessageErr::NoSuchNode)?;
-
-                ctx.with_doc(doc_id, |doc| {
-                    doc.devtools_mut().highlight_node = Some(node_id);
-                    doc.shell_provider.request_redraw();
                 });
+
+                if let Some(node_id) = node_id {
+                    ctx.with_doc(doc_id, |doc| {
+                        doc.devtools_mut().highlight_node = Some(node_id);
+                        doc.shell_provider.request_redraw();
+                    });
+                }
                 ctx.write_msg(self.name(), json!({ "value": true }));
                 Ok(())
             }

--- a/packages/blitz-devtools-server/src/actors/highlighter.rs
+++ b/packages/blitz-devtools-server/src/actors/highlighter.rs
@@ -1,0 +1,79 @@
+use serde_json::json;
+
+use crate::GenericClientMessage;
+use crate::actors::inspector::InspectorActor;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext, generate_name};
+
+/// The highlighter actor renders a box-model overlay (content/padding/
+/// border/margin) over a node when the user hovers it in the markup view.
+/// It works by setting `DevtoolSettings::highlight_node` on the document
+/// and requesting a redraw; blitz-paint then draws the overlay.
+pub(crate) struct HighlighterActor {
+    name: String,
+    doc_id: usize,
+    walker_name: String,
+}
+
+impl HighlighterActor {
+    pub(crate) fn new(doc_id: usize, walker_name: String) -> Self {
+        Self {
+            name: generate_name("highlighter"),
+            doc_id,
+            walker_name,
+        }
+    }
+}
+
+impl Actor for HighlighterActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        let doc_id = self.doc_id;
+        match &*message.type_ {
+            "show" => {
+                let msg = message.data.json()?;
+                let node_actor = msg
+                    .get("node")
+                    .and_then(|v| v.as_str())
+                    .ok_or(ActorMessageErr::MissingParameter)?
+                    .to_string();
+                let node_id = InspectorActor::with_walker(ctx, &self.walker_name, |walker, _| {
+                    walker.node_for_actor(&node_actor)
+                })
+                .ok_or(ActorMessageErr::NoSuchNode)?;
+
+                ctx.with_doc(doc_id, |doc| {
+                    doc.devtools_mut().highlight_node = Some(node_id);
+                    doc.shell_provider.request_redraw();
+                });
+                ctx.write_msg(self.name(), json!({ "value": true }));
+                Ok(())
+            }
+            "hide" => {
+                ctx.with_doc(doc_id, |doc| {
+                    doc.devtools_mut().highlight_node = None;
+                    doc.shell_provider.request_redraw();
+                });
+                ctx.write_msg(self.name(), json!({}));
+                Ok(())
+            }
+            "finalize" => {
+                ctx.with_doc(doc_id, |doc| {
+                    if doc.devtools().highlight_node.is_some() {
+                        doc.devtools_mut().highlight_node = None;
+                        doc.shell_provider.request_redraw();
+                    }
+                });
+                // finalize is a one-way message: no reply
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/highlighter.rs
+++ b/packages/blitz-devtools-server/src/actors/highlighter.rs
@@ -53,7 +53,20 @@ impl Actor for HighlighterActor {
 
                 if let Some(node_id) = node_id {
                     ctx.with_doc(doc_id, |doc| {
-                        doc.devtools_mut().highlight_node = Some(node_id);
+                        // Text and comment nodes don't have a layout of their
+                        // own: highlight the nearest element ancestor instead
+                        let mut highlight_id = Some(node_id);
+                        while let Some(id) = highlight_id {
+                            let Some(node) = doc.get_node(id) else {
+                                highlight_id = None;
+                                break;
+                            };
+                            if node.element_data().is_some() {
+                                break;
+                            }
+                            highlight_id = node.parent;
+                        }
+                        doc.devtools_mut().highlight_node = highlight_id;
                         doc.shell_provider.request_redraw();
                     });
                 }

--- a/packages/blitz-devtools-server/src/actors/inspector.rs
+++ b/packages/blitz-devtools-server/src/actors/inspector.rs
@@ -1,0 +1,133 @@
+use serde_json::json;
+
+use crate::GenericClientMessage;
+use crate::actors::highlighter::HighlighterActor;
+use crate::actors::page_style::PageStyleActor;
+use crate::actors::walker::WalkerActor;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext, generate_name};
+
+/// The inspector actor is the entry point to the DOM/style inspection
+/// actors: the walker (DOM tree), page style (style panels), and
+/// highlighters.
+pub(crate) struct InspectorActor {
+    name: String,
+    doc_id: usize,
+    walker_name: Option<String>,
+    page_style_name: Option<String>,
+}
+
+impl InspectorActor {
+    pub(crate) fn new(doc_id: usize) -> Self {
+        Self {
+            name: generate_name("inspector"),
+            doc_id,
+            walker_name: None,
+            page_style_name: None,
+        }
+    }
+
+    fn ensure_walker(&mut self, ctx: &mut DevtoolContext<'_>) -> String {
+        if let Some(name) = &self.walker_name {
+            return name.clone();
+        }
+        let walker = WalkerActor::new(self.doc_id);
+        let name = walker.name();
+        self.walker_name = Some(name.clone());
+        ctx.push_actor(Box::new(walker));
+        name
+    }
+
+    /// Run a callback with mutable access to the walker actor, which may
+    /// either be already registered or newly created (pending registration)
+    pub(crate) fn with_walker<R>(
+        ctx: &mut DevtoolContext<'_>,
+        walker_name: &str,
+        cb: impl FnOnce(&mut WalkerActor, &mut DevtoolContext<'_>) -> R,
+    ) -> R {
+        if let Some(idx) = ctx
+            .actors_to_create
+            .iter()
+            .position(|actor| actor.name() == walker_name)
+        {
+            let mut walker = ctx.actors_to_create.remove(idx);
+            let walker_ref = (walker.as_mut() as &mut dyn std::any::Any)
+                .downcast_mut::<WalkerActor>()
+                .unwrap();
+            let result = cb(walker_ref, ctx);
+            ctx.actors_to_create.push(walker);
+            result
+        } else {
+            let mut walker = ctx.actors.remove(walker_name).unwrap();
+            let walker_ref = (walker.as_mut() as &mut dyn std::any::Any)
+                .downcast_mut::<WalkerActor>()
+                .unwrap();
+            let result = cb(walker_ref, ctx);
+            ctx.actors.insert(walker_name.to_string(), walker);
+            result
+        }
+    }
+}
+
+impl Actor for InspectorActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "getWalker" => {
+                let walker_name = self.ensure_walker(ctx);
+                let root =
+                    Self::with_walker(ctx, &walker_name, |walker, ctx| walker.root_form(ctx));
+                let root = root.ok_or(ActorMessageErr::NoSuchDocument)?;
+
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "walker": {
+                        "actor": walker_name,
+                        "root": root,
+                    }}),
+                );
+                Ok(())
+            }
+            "getPageStyle" => {
+                let page_style_name = match &self.page_style_name {
+                    Some(name) => name.clone(),
+                    None => {
+                        let walker_name = self.ensure_walker(ctx);
+                        let page_style = PageStyleActor::new(self.doc_id, walker_name);
+                        let name = page_style.name();
+                        self.page_style_name = Some(name.clone());
+                        ctx.push_actor(Box::new(page_style));
+                        name
+                    }
+                };
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "pageStyle": {
+                        "actor": page_style_name,
+                        "traits": {},
+                    }}),
+                );
+                Ok(())
+            }
+            "getHighlighterByType" => {
+                let walker_name = self.ensure_walker(ctx);
+                let highlighter = HighlighterActor::new(self.doc_id, walker_name);
+                let name = highlighter.name();
+                ctx.push_actor(Box::new(highlighter));
+                ctx.write_msg(self.name(), json!({ "highlighter": { "actor": name } }));
+                Ok(())
+            }
+            "supportsHighlighters" => {
+                ctx.write_msg(self.name(), json!({ "value": true }));
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/layout.rs
+++ b/packages/blitz-devtools-server/src/actors/layout.rs
@@ -1,0 +1,428 @@
+use blitz_dom::BaseDocument;
+use blitz_traits::node_id::NodeId;
+use serde_json::json;
+use style::properties::{LonghandId, PropertyDeclarationId};
+use taffy::DetailedGridTracksInfo;
+
+use crate::actors::inspector::InspectorActor;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext, generate_name};
+use crate::{GenericClientMessage, JsonValue};
+
+/// The layout actor provides flexbox and grid inspection data.
+pub(crate) struct LayoutActor {
+    name: String,
+    doc_id: usize,
+    walker_name: String,
+}
+
+impl LayoutActor {
+    pub(crate) fn new(doc_id: usize, walker_name: String) -> Self {
+        Self {
+            name: generate_name("layout"),
+            doc_id,
+            walker_name,
+        }
+    }
+}
+
+/// Serialize a computed style property to a string
+fn str_prop(doc: &BaseDocument, node_id: NodeId, id: LonghandId) -> String {
+    doc.get_node(node_id)
+        .and_then(|node| node.primary_styles())
+        .map(|styles| styles.computed_value_to_string(PropertyDeclarationId::Longhand(id)))
+        .unwrap_or_default()
+}
+
+/// Whether a node's computed display is a flex container
+fn is_flex_container(doc: &BaseDocument, node_id: NodeId) -> bool {
+    str_prop(doc, node_id, LonghandId::Display).contains("flex")
+}
+
+/// Whether a node's computed display is a grid container
+fn is_grid_container(doc: &BaseDocument, node_id: NodeId) -> bool {
+    str_prop(doc, node_id, LonghandId::Display).contains("grid")
+}
+
+/// Find the flex container for a node: the node itself if it is a flex
+/// container, otherwise its parent if that is one
+fn find_flex_container(
+    doc: &BaseDocument,
+    node_id: NodeId,
+    only_look_at_parents: bool,
+) -> Option<NodeId> {
+    if !only_look_at_parents && is_flex_container(doc, node_id) {
+        return Some(node_id);
+    }
+    let parent_id = doc.get_node(node_id)?.parent?;
+    is_flex_container(doc, parent_id).then_some(parent_id)
+}
+
+/// The `properties` object of a flex container form
+fn flex_container_properties(doc: &BaseDocument, container_id: NodeId) -> JsonValue {
+    json!({
+        "align-content": str_prop(doc, container_id, LonghandId::AlignContent),
+        "align-items": str_prop(doc, container_id, LonghandId::AlignItems),
+        "flex-direction": str_prop(doc, container_id, LonghandId::FlexDirection),
+        "flex-wrap": str_prop(doc, container_id, LonghandId::FlexWrap),
+        "justify-content": str_prop(doc, container_id, LonghandId::JustifyContent),
+    })
+}
+
+/// Serialize the tracks of one grid axis to devtools grid fragment format
+fn tracks_form(tracks: &DetailedGridTracksInfo) -> JsonValue {
+    let track_count = tracks.sizes.len();
+    let explicit_start = tracks.negative_implicit_tracks as usize;
+    let explicit_end = explicit_start + tracks.explicit_tracks as usize;
+    let track_type = |idx: usize| -> &'static str {
+        if idx >= explicit_start && idx < explicit_end {
+            "explicit"
+        } else {
+            "implicit"
+        }
+    };
+
+    let mut lines = Vec::with_capacity(track_count + 1);
+    let mut track_forms = Vec::with_capacity(track_count);
+    let mut position: f32 = 0.0;
+    for (idx, size) in tracks.sizes.iter().enumerate() {
+        // The gutter *before* track idx (gutters has len tracks + 1)
+        let gutter_before = tracks.gutters.get(idx).copied().unwrap_or(0.0);
+        position += gutter_before;
+
+        lines.push(json!({
+            "breadth": gutter_before,
+            "names": [],
+            "number": idx + 1,
+            "start": position - gutter_before / 2.0,
+            "type": track_type(idx),
+        }));
+        track_forms.push(json!({
+            "breadth": size,
+            "start": position,
+            "state": "static",
+            "type": track_type(idx),
+        }));
+        position += size;
+    }
+    let final_gutter = tracks.gutters.get(track_count).copied().unwrap_or(0.0);
+    lines.push(json!({
+        "breadth": final_gutter,
+        "names": [],
+        "number": track_count + 1,
+        "start": position + final_gutter / 2.0,
+        "type": track_type(track_count.saturating_sub(1)),
+    }));
+
+    json!({ "lines": lines, "tracks": track_forms })
+}
+
+/// Build the grid fragment for a grid container from the detailed grid info
+/// stored during layout
+fn grid_fragments(doc: &BaseDocument, container_id: NodeId) -> Option<JsonValue> {
+    let node = doc.get_node(container_id)?;
+    let grid_info = node.element_data()?.detailed_grid_info.as_ref()?;
+    Some(json!([{
+        "areas": [],
+        "cols": tracks_form(&grid_info.columns),
+        "rows": tracks_form(&grid_info.rows),
+    }]))
+}
+
+/// Collect all grid containers in the document (in tree order)
+fn collect_grid_containers(doc: &BaseDocument, node_id: NodeId, out: &mut Vec<NodeId>) {
+    let Some(node) = doc.get_node(node_id) else {
+        return;
+    };
+    if node.is_element() && is_grid_container(doc, node_id) {
+        out.push(node_id);
+    }
+    for child_id in node.children.iter() {
+        collect_grid_containers(doc, *child_id, out);
+    }
+}
+
+impl Actor for LayoutActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        let doc_id = self.doc_id;
+        match &*message.type_ {
+            "getCurrentFlexbox" => {
+                let msg = message.data.json()?;
+                let node_actor = msg
+                    .get("node")
+                    .and_then(|v| v.as_str())
+                    .ok_or(ActorMessageErr::MissingParameter)?
+                    .to_string();
+                let only_look_at_parents = msg
+                    .get("onlyLookAtParents")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                let node_id = InspectorActor::with_walker(ctx, &self.walker_name, |walker, _| {
+                    walker.node_for_actor(&node_actor)
+                })
+                .ok_or(ActorMessageErr::NoSuchNode)?;
+
+                let container = ctx
+                    .with_doc(doc_id, |doc| {
+                        find_flex_container(doc, node_id, only_look_at_parents)
+                    })
+                    .flatten();
+
+                let Some(container_id) = container else {
+                    ctx.write_msg(self.name(), json!({ "flexbox": null }));
+                    return Ok(());
+                };
+
+                let flexbox = FlexboxActor::new(doc_id, self.walker_name.clone(), container_id);
+                let flexbox_name = flexbox.name();
+                ctx.push_actor(Box::new(flexbox));
+
+                let container_actor =
+                    InspectorActor::with_walker(ctx, &self.walker_name, |walker, _| {
+                        walker.actor_for_node(container_id)
+                    });
+                let properties = ctx
+                    .with_doc(doc_id, |doc| flex_container_properties(doc, container_id))
+                    .ok_or(ActorMessageErr::NoSuchDocument)?;
+
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "flexbox": {
+                        "actor": flexbox_name,
+                        "containerNodeActorID": container_actor,
+                        "properties": properties,
+                    }}),
+                );
+                Ok(())
+            }
+            "getGrids" => {
+                let container_ids = ctx
+                    .with_doc(doc_id, |doc| {
+                        let root_id = doc.root_node().id;
+                        let mut out = Vec::new();
+                        collect_grid_containers(doc, root_id, &mut out);
+                        out
+                    })
+                    .ok_or(ActorMessageErr::NoSuchDocument)?;
+
+                let mut grids = Vec::new();
+                for container_id in container_ids {
+                    let fragments = ctx
+                        .with_doc(doc_id, |doc| grid_fragments(doc, container_id))
+                        .flatten();
+                    let Some(fragments) = fragments else {
+                        continue;
+                    };
+                    let container_actor =
+                        InspectorActor::with_walker(ctx, &self.walker_name, |walker, _| {
+                            walker.actor_for_node(container_id)
+                        });
+                    let (direction, writing_mode) = ctx
+                        .with_doc(doc_id, |doc| {
+                            (
+                                str_prop(doc, container_id, LonghandId::Direction),
+                                str_prop(doc, container_id, LonghandId::WritingMode),
+                            )
+                        })
+                        .unwrap_or_default();
+
+                    let grid = GridActor::new(doc_id, container_id);
+                    let grid_name = grid.name();
+                    ctx.push_actor(Box::new(grid));
+
+                    grids.push(json!({
+                        "actor": grid_name,
+                        "containerNodeActorID": container_actor,
+                        "direction": direction,
+                        "gridFragments": fragments,
+                        "isSubgrid": false,
+                        "writingMode": writing_mode,
+                    }));
+                }
+
+                ctx.write_msg(self.name(), json!({ "grids": grids }));
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}
+
+/// A flexbox actor represents one flex container
+pub(crate) struct FlexboxActor {
+    name: String,
+    doc_id: usize,
+    walker_name: String,
+    container_id: NodeId,
+}
+
+impl FlexboxActor {
+    pub(crate) fn new(doc_id: usize, walker_name: String, container_id: NodeId) -> Self {
+        Self {
+            name: generate_name("flexbox"),
+            doc_id,
+            walker_name,
+            container_id,
+        }
+    }
+}
+
+impl Actor for FlexboxActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        let doc_id = self.doc_id;
+        let container_id = self.container_id;
+        match &*message.type_ {
+            "getFlexItems" => {
+                // Gather the item data with document access
+                struct ItemData {
+                    node_id: NodeId,
+                    main_base_size: f32,
+                    main_min_size: f32,
+                    main_max_size: JsonValue,
+                    cross_min_size: f32,
+                    cross_max_size: JsonValue,
+                    main_axis_direction: String,
+                    cross_axis_direction: String,
+                    flex_grow: String,
+                    flex_shrink: String,
+                    flex_basis: String,
+                }
+
+                let items = ctx
+                    .with_doc(doc_id, |doc| {
+                        let container = doc.get_node(container_id)?;
+                        let direction = str_prop(doc, container_id, LonghandId::FlexDirection);
+                        let horizontal = !direction.starts_with("column");
+                        let (main_axis_direction, cross_axis_direction) = if horizontal {
+                            ("horizontal-lr".to_string(), "vertical-tb".to_string())
+                        } else {
+                            ("vertical-tb".to_string(), "horizontal-lr".to_string())
+                        };
+
+                        let mut items = Vec::new();
+                        for child_id in container.children.iter().copied() {
+                            let Some(child) = doc.get_node(child_id) else {
+                                continue;
+                            };
+                            if !child.is_element() {
+                                continue;
+                            }
+                            let layout = child.final_layout();
+                            let main_size = if horizontal {
+                                layout.size.width
+                            } else {
+                                layout.size.height
+                            };
+                            items.push(ItemData {
+                                node_id: child_id,
+                                main_base_size: main_size,
+                                main_min_size: 0.0,
+                                main_max_size: json!(null),
+                                cross_min_size: 0.0,
+                                cross_max_size: json!(null),
+                                main_axis_direction: main_axis_direction.clone(),
+                                cross_axis_direction: cross_axis_direction.clone(),
+                                flex_grow: str_prop(doc, child_id, LonghandId::FlexGrow),
+                                flex_shrink: str_prop(doc, child_id, LonghandId::FlexShrink),
+                                flex_basis: str_prop(doc, child_id, LonghandId::FlexBasis),
+                            });
+                        }
+                        Some(items)
+                    })
+                    .flatten()
+                    .ok_or(ActorMessageErr::NoSuchNode)?;
+
+                let mut item_forms = Vec::with_capacity(items.len());
+                for item in items {
+                    let node_actor =
+                        InspectorActor::with_walker(ctx, &self.walker_name, |walker, _| {
+                            walker.actor_for_node(item.node_id)
+                        });
+                    let item_actor = crate::actors::stubs::StubActor::new("flex-item");
+                    let item_actor_name = item_actor.name();
+                    ctx.push_actor(Box::new(item_actor));
+
+                    item_forms.push(json!({
+                        "actor": item_actor_name,
+                        "nodeActorID": node_actor,
+                        "flexItemSizing": {
+                            "crossAxisDirection": item.cross_axis_direction,
+                            "mainAxisDirection": item.main_axis_direction,
+                            "crossMaxSize": item.cross_max_size,
+                            "crossMinSize": item.cross_min_size,
+                            "mainBaseSize": item.main_base_size,
+                            "mainDeltaSize": 0,
+                            "mainMaxSize": item.main_max_size,
+                            "mainMinSize": item.main_min_size,
+                            "lineGrowthState": "growing",
+                            "clampState": "unclamped",
+                        },
+                        "properties": {
+                            "flex-basis": item.flex_basis,
+                            "flex-grow": item.flex_grow,
+                            "flex-shrink": item.flex_shrink,
+                        },
+                        "computedStyle": {
+                            "flexGrow": item.flex_grow,
+                            "flexShrink": item.flex_shrink,
+                        },
+                    }));
+                }
+
+                ctx.write_msg(self.name(), json!({ "flexItems": item_forms }));
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}
+
+/// A grid actor represents one grid container
+pub(crate) struct GridActor {
+    name: String,
+    #[allow(dead_code)]
+    doc_id: usize,
+    #[allow(dead_code)]
+    container_id: NodeId,
+}
+
+impl GridActor {
+    pub(crate) fn new(doc_id: usize, container_id: NodeId) -> Self {
+        Self {
+            name: generate_name("grid"),
+            doc_id,
+            container_id,
+        }
+    }
+}
+
+impl Actor for GridActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        _message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        ctx.write_msg(self.name(), json!({}));
+        Ok(())
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/layout.rs
+++ b/packages/blitz-devtools-server/src/actors/layout.rs
@@ -354,7 +354,7 @@ impl Actor for FlexboxActor {
                         InspectorActor::with_walker(ctx, &self.walker_name, |walker, _| {
                             walker.actor_for_node(item.node_id)
                         });
-                    let item_actor = crate::actors::stubs::StubActor::new("flex-item");
+                    let item_actor = FlexItemActor::new(item.node_id);
                     let item_actor_name = item_actor.name();
                     ctx.push_actor(Box::new(item_actor));
 
@@ -385,11 +385,44 @@ impl Actor for FlexboxActor {
                     }));
                 }
 
-                ctx.write_msg(self.name(), json!({ "flexItems": item_forms }));
+                // Firefox's layout spec names this response property
+                // "flexitems" (all lowercase)
+                ctx.write_msg(self.name(), json!({ "flexitems": item_forms }));
                 Ok(())
             }
             _ => Err(ActorMessageErr::UnrecognizedPacketType),
         }
+    }
+}
+
+/// A flex-item actor that remembers the DOM node it represents, so
+/// `walker.getNodeFromActor` can resolve it
+pub(crate) struct FlexItemActor {
+    name: String,
+    pub(crate) node_id: NodeId,
+}
+
+impl FlexItemActor {
+    pub(crate) fn new(node_id: NodeId) -> Self {
+        Self {
+            name: generate_name("flex-item"),
+            node_id,
+        }
+    }
+}
+
+impl Actor for FlexItemActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        _message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        ctx.write_msg(self.name(), json!({}));
+        Ok(())
     }
 }
 

--- a/packages/blitz-devtools-server/src/actors/page_style.rs
+++ b/packages/blitz-devtools-server/src/actors/page_style.rs
@@ -288,6 +288,8 @@ fn px(value: f32) -> String {
 /// Build the `getLayout` (box model) response for a node
 fn layout_form(doc: &BaseDocument, node_id: NodeId) -> Option<JsonValue> {
     let node = doc.get_node(node_id)?;
+    // Text and comment nodes don't carry a layout of their own
+    node.element_data()?;
     let layout = node.final_layout();
 
     let styles = node.primary_styles();

--- a/packages/blitz-devtools-server/src/actors/page_style.rs
+++ b/packages/blitz-devtools-server/src/actors/page_style.rs
@@ -194,6 +194,14 @@ impl Actor for PageStyleActor {
                                 "value": decl.value,
                                 "priority": if decl.important { "important" } else { "" },
                                 "important": decl.important,
+                                // These declarations come from Stylo's
+                                // PropertyDeclarationBlock, which has already
+                                // dropped anything it couldn't parse. Without
+                                // these flags the Rules view shows an
+                                // "invalid property name" warning on every
+                                // declaration.
+                                "isNameValid": true,
+                                "isValid": true,
                                 "isUsed": { "used": true },
                                 "terminator": "",
                             })

--- a/packages/blitz-devtools-server/src/actors/page_style.rs
+++ b/packages/blitz-devtools-server/src/actors/page_style.rs
@@ -212,18 +212,30 @@ impl Actor for PageStyleActor {
                         })
                         .collect();
 
+                    // An empty selector string makes Firefox's rule-editor
+                    // throw in parsePseudoClassesAndAttributes, leaving the
+                    // Rules panel empty. Fall back to "*".
+                    let selector_text = if entry.selector_text.is_empty() {
+                        "*".to_string()
+                    } else {
+                        entry.selector_text.clone()
+                    };
                     json_entries.push(json!({
                         "rule": {
                             "actor": rule_actor_name,
                             "type": entry.rule_type,
                             "href": entry.href,
                             "cssText": css_text,
-                            "authoredText": format!("{} {{ {} }}", entry.selector_text, css_text),
-                            "selectors": [entry.selector_text],
+                            "authoredText": format!("{} {{ {} }}", selector_text, css_text),
+                            "selectors": [selector_text],
                             "selectorsSpecificity": [entry.specificity],
                             "line": entry.line,
                             "column": entry.column,
                             "declarations": declarations,
+                            // Firefox's rule-editor requires ancestorData;
+                            // without it the Rules panel throws and renders
+                            // empty
+                            "ancestorData": [],
                             "traits": { "canSetRuleText": false },
                         },
                         "pseudoElement": null,
@@ -237,6 +249,13 @@ impl Actor for PageStyleActor {
             }
             "isPositionEditable" => {
                 ctx.write_msg(self.name(), json!({ "value": false }));
+                Ok(())
+            }
+            // Firefox's Rules view calls getUsedFontFaces when populating;
+            // an unrecognizedPacketType error aborts the populate and leaves
+            // the Rules panel empty
+            "getUsedFontFaces" => {
+                ctx.write_msg(self.name(), json!({ "fontFaces": [] }));
                 Ok(())
             }
             _ => Err(ActorMessageErr::UnrecognizedPacketType),

--- a/packages/blitz-devtools-server/src/actors/page_style.rs
+++ b/packages/blitz-devtools-server/src/actors/page_style.rs
@@ -1,0 +1,496 @@
+use std::collections::HashMap;
+
+use blitz_dom::BaseDocument;
+use blitz_traits::node_id::NodeId;
+use cssparser::ToCss as _;
+use serde_json::json;
+use style::properties::{LonghandId, NonCustomPropertyId, PropertyDeclarationId, PropertyId};
+use style::rule_tree::CascadeOrigin;
+use style::stylesheets::{CssRule, Origin};
+
+use crate::actors::inspector::InspectorActor;
+use crate::actors::stubs::StubActor;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext, generate_name};
+use crate::{GenericClientMessage, JsonValue};
+
+/// Rule type constants from the CSSOM spec (and Firefox devtools)
+const STYLE_RULE: u32 = 1;
+/// Pseudo rule type used by Firefox devtools for element inline styles
+const ELEMENT_RULE: u32 = 100;
+
+/// The page style actor provides the data for the style inspector panels:
+/// box model layout, computed styles, and matched ("applied") style rules.
+pub(crate) struct PageStyleActor {
+    name: String,
+    doc_id: usize,
+    walker_name: String,
+}
+
+/// Metadata about the style rule that a declaration block came from,
+/// obtained by walking the document's stylesheets
+struct RuleMetadata {
+    selector_text: String,
+    href: String,
+    origin: Origin,
+    line: u32,
+    column: u32,
+}
+
+impl PageStyleActor {
+    pub(crate) fn new(doc_id: usize, walker_name: String) -> Self {
+        Self {
+            name: generate_name("page-style"),
+            doc_id,
+            walker_name,
+        }
+    }
+
+    /// Build a map from declaration-block pointer to rule metadata by
+    /// walking all of the document's stylesheets
+    fn rule_metadata(doc: &BaseDocument) -> HashMap<*const std::ffi::c_void, RuleMetadata> {
+        let guard_holder = doc.guard();
+        let guard = guard_holder.read();
+
+        let mut map = HashMap::new();
+
+        fn visit_rules(
+            rules: &[CssRule],
+            guard: &style::shared_lock::SharedRwLockReadGuard,
+            href: &str,
+            origin: Origin,
+            map: &mut HashMap<*const std::ffi::c_void, RuleMetadata>,
+        ) {
+            for rule in rules {
+                match rule {
+                    CssRule::Style(locked_rule) => {
+                        let style_rule = locked_rule.read_with(guard);
+                        let key = style_rule.block.heap_ptr();
+                        map.insert(
+                            key,
+                            RuleMetadata {
+                                selector_text: style_rule.selectors.to_css_string(),
+                                href: href.to_string(),
+                                origin,
+                                line: style_rule.source_location.line,
+                                column: style_rule.source_location.column,
+                            },
+                        );
+                        if let Some(nested) = &style_rule.rules {
+                            visit_rules(&nested.read_with(guard).0, guard, href, origin, map);
+                        }
+                    }
+                    CssRule::Media(media_rule) => {
+                        visit_rules(
+                            &media_rule.rules.read_with(guard).0,
+                            guard,
+                            href,
+                            origin,
+                            map,
+                        );
+                    }
+                    CssRule::Supports(supports_rule) => {
+                        visit_rules(
+                            &supports_rule.rules.read_with(guard).0,
+                            guard,
+                            href,
+                            origin,
+                            map,
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        for (href, origin, sheet) in doc
+            .author_stylesheets()
+            .map(|sheet| ("", Origin::Author, sheet))
+            .chain(
+                doc.useragent_stylesheets()
+                    .map(|sheet| ("ua.css", Origin::UserAgent, sheet)),
+            )
+        {
+            let contents = sheet.0.contents.read_with(&guard);
+            let rules = contents.rules.read_with(&guard);
+            visit_rules(&rules.0, &guard, href, origin, &mut map);
+        }
+
+        map
+    }
+}
+
+impl Actor for PageStyleActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        let doc_id = self.doc_id;
+        match &*message.type_ {
+            "getLayout" => {
+                let node_id = resolve_node(ctx, &self.walker_name, message.data.json()?)?;
+                let layout = ctx
+                    .with_doc(doc_id, |doc| layout_form(doc, node_id))
+                    .flatten()
+                    .ok_or(ActorMessageErr::NoSuchNode)?;
+                ctx.write_msg(self.name(), layout);
+                Ok(())
+            }
+            "getComputed" => {
+                let node_id = resolve_node(ctx, &self.walker_name, message.data.json()?)?;
+                let computed = ctx
+                    .with_doc(doc_id, |doc| computed_form(doc, node_id))
+                    .flatten()
+                    .ok_or(ActorMessageErr::NoSuchNode)?;
+                ctx.write_msg(self.name(), json!({ "computed": computed }));
+                Ok(())
+            }
+            "getApplied" => {
+                let msg = message.data.json()?;
+                let inherited = msg
+                    .get("inherited")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
+                let node_id = resolve_node(ctx, &self.walker_name, msg)?;
+
+                // Collect the matched rules (and the node ids they're
+                // inherited from) with document access
+                let entries = ctx
+                    .with_doc(doc_id, |doc| applied_entries(doc, node_id, inherited))
+                    .ok_or(ActorMessageErr::NoSuchDocument)?;
+
+                // Then resolve node ids to node actor names via the walker,
+                // registering rule actor stubs as we go
+                let mut json_entries = Vec::with_capacity(entries.len());
+                for entry in entries {
+                    let rule_actor = StubActor::new("style-rule");
+                    let rule_actor_name = rule_actor.name();
+                    ctx.push_actor(Box::new(rule_actor));
+
+                    let inherited_form = match entry.inherited_from {
+                        Some(ancestor_id) => {
+                            let form = InspectorActor::with_walker(
+                                ctx,
+                                &self.walker_name,
+                                |walker, ctx| {
+                                    ctx.with_doc(doc_id, |doc| walker.node_form(doc, ancestor_id))
+                                },
+                            );
+                            form.flatten().unwrap_or(JsonValue::Null)
+                        }
+                        None => JsonValue::Null,
+                    };
+
+                    let declarations: Vec<JsonValue> = entry
+                        .declarations
+                        .iter()
+                        .map(|decl| {
+                            json!({
+                                "name": decl.name,
+                                "value": decl.value,
+                                "priority": if decl.important { "important" } else { "" },
+                                "important": decl.important,
+                                "isUsed": { "used": true },
+                                "terminator": "",
+                            })
+                        })
+                        .collect();
+
+                    let css_text: String = entry
+                        .declarations
+                        .iter()
+                        .map(|decl| {
+                            if decl.important {
+                                format!("{}: {} !important; ", decl.name, decl.value)
+                            } else {
+                                format!("{}: {}; ", decl.name, decl.value)
+                            }
+                        })
+                        .collect();
+
+                    json_entries.push(json!({
+                        "rule": {
+                            "actor": rule_actor_name,
+                            "type": entry.rule_type,
+                            "href": entry.href,
+                            "cssText": css_text,
+                            "authoredText": format!("{} {{ {} }}", entry.selector_text, css_text),
+                            "selectors": [entry.selector_text],
+                            "selectorsSpecificity": [entry.specificity],
+                            "line": entry.line,
+                            "column": entry.column,
+                            "declarations": declarations,
+                            "traits": { "canSetRuleText": false },
+                        },
+                        "pseudoElement": null,
+                        "isSystem": entry.is_system,
+                        "inherited": inherited_form,
+                    }));
+                }
+
+                ctx.write_msg(self.name(), json!({ "entries": json_entries }));
+                Ok(())
+            }
+            "isPositionEditable" => {
+                ctx.write_msg(self.name(), json!({ "value": false }));
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}
+
+/// Resolve the `node` parameter of a message to a `NodeId` via the walker
+fn resolve_node(
+    ctx: &mut DevtoolContext<'_>,
+    walker_name: &str,
+    msg: &JsonValue,
+) -> Result<NodeId, ActorMessageErr> {
+    let node_actor = msg
+        .get("node")
+        .and_then(|v| v.as_str())
+        .ok_or(ActorMessageErr::MissingParameter)?
+        .to_string();
+    InspectorActor::with_walker(ctx, walker_name, |walker, _| {
+        walker.node_for_actor(&node_actor)
+    })
+    .ok_or(ActorMessageErr::NoSuchNode)
+}
+
+/// Serialize an f32 as a CSS pixel string
+fn px(value: f32) -> String {
+    format!("{value}px")
+}
+
+/// Build the `getLayout` (box model) response for a node
+fn layout_form(doc: &BaseDocument, node_id: NodeId) -> Option<JsonValue> {
+    let node = doc.get_node(node_id)?;
+    let layout = node.final_layout();
+
+    let styles = node.primary_styles();
+    let str_prop = |id: LonghandId| -> String {
+        styles
+            .as_ref()
+            .map(|s| s.computed_value_to_string(PropertyDeclarationId::Longhand(id)))
+            .unwrap_or_default()
+    };
+
+    let mut auto_margins = serde_json::Map::new();
+    if let Some(styles) = styles.as_ref() {
+        let margin = styles.get_margin();
+        if margin.margin_top.is_auto() {
+            auto_margins.insert("top".to_string(), json!("auto"));
+        }
+        if margin.margin_right.is_auto() {
+            auto_margins.insert("right".to_string(), json!("auto"));
+        }
+        if margin.margin_bottom.is_auto() {
+            auto_margins.insert("bottom".to_string(), json!("auto"));
+        }
+        if margin.margin_left.is_auto() {
+            auto_margins.insert("left".to_string(), json!("auto"));
+        }
+    }
+
+    Some(json!({
+        "width": layout.size.width - layout.border.left - layout.border.right
+            - layout.padding.left - layout.padding.right,
+        "height": layout.size.height - layout.border.top - layout.border.bottom
+            - layout.padding.top - layout.padding.bottom,
+        "autoMargins": auto_margins,
+        "margin-top": px(layout.margin.top),
+        "margin-right": px(layout.margin.right),
+        "margin-bottom": px(layout.margin.bottom),
+        "margin-left": px(layout.margin.left),
+        "border-top-width": px(layout.border.top),
+        "border-right-width": px(layout.border.right),
+        "border-bottom-width": px(layout.border.bottom),
+        "border-left-width": px(layout.border.left),
+        "padding-top": px(layout.padding.top),
+        "padding-right": px(layout.padding.right),
+        "padding-bottom": px(layout.padding.bottom),
+        "padding-left": px(layout.padding.left),
+        "display": str_prop(LonghandId::Display),
+        "float": str_prop(LonghandId::Float),
+        "line-height": str_prop(LonghandId::LineHeight),
+        "position": str_prop(LonghandId::Position),
+        "z-index": str_prop(LonghandId::ZIndex),
+        "box-sizing": str_prop(LonghandId::BoxSizing),
+    }))
+}
+
+/// Build the `getComputed` response for a node: every longhand property
+/// serialized from the node's computed style
+fn computed_form(doc: &BaseDocument, node_id: NodeId) -> Option<JsonValue> {
+    let node = doc.get_node(node_id)?;
+    let styles = node.primary_styles()?;
+
+    let mut computed = serde_json::Map::new();
+    for id in NonCustomPropertyId::iter() {
+        let Ok(longhand) = id.longhand_or_shorthand() else {
+            continue;
+        };
+        if id.as_alias().is_some() {
+            continue;
+        }
+        if !PropertyId::NonCustom(id).enabled_for_all_content() {
+            continue;
+        }
+        let value = styles.computed_value_to_string(PropertyDeclarationId::Longhand(longhand));
+        computed.insert(
+            longhand.name().to_string(),
+            json!({ "matched": true, "value": value }),
+        );
+    }
+    Some(JsonValue::Object(computed))
+}
+
+/// A single declaration in an applied rule
+struct AppliedDeclaration {
+    name: String,
+    value: String,
+    important: bool,
+}
+
+/// A single entry in the `getApplied` response, gathered with document
+/// access and serialized to JSON afterwards
+struct AppliedEntry {
+    rule_type: u32,
+    selector_text: String,
+    href: String,
+    line: u32,
+    column: u32,
+    specificity: u32,
+    is_system: bool,
+    declarations: Vec<AppliedDeclaration>,
+    inherited_from: Option<NodeId>,
+}
+
+/// Collect the applied style rules for a node (and optionally the inherited
+/// rules from its ancestors) by walking Stylo's rule tree
+fn applied_entries(doc: &BaseDocument, node_id: NodeId, inherited: bool) -> Vec<AppliedEntry> {
+    let metadata = PageStyleActor::rule_metadata(doc);
+    let guard_holder = doc.guard();
+    let guard = guard_holder.read();
+
+    let mut entries = Vec::new();
+
+    let mut current = Some(node_id);
+    while let Some(current_id) = current {
+        let Some(node) = doc.get_node(current_id) else {
+            break;
+        };
+        let inherited_from = (current_id != node_id).then_some(current_id);
+
+        // The inline style attribute (only for the node itself)
+        if inherited_from.is_none()
+            && let Some(element) = node.element_data()
+            && let Some(style_attr) = &element.style_attribute
+        {
+            let block = style_attr.read_with(&guard);
+            let declarations = block_declarations(block, false);
+            if !declarations.is_empty() {
+                entries.push(AppliedEntry {
+                    rule_type: ELEMENT_RULE,
+                    selector_text: "element".to_string(),
+                    href: String::new(),
+                    line: 0,
+                    column: 0,
+                    specificity: 0,
+                    is_system: false,
+                    declarations,
+                    inherited_from: None,
+                });
+            }
+        }
+
+        if let Some(styles) = node.primary_styles()
+            && let Some(rules) = &styles.rules
+        {
+            for rule_node in rules.self_and_ancestors() {
+                let Some(source) = rule_node.style_source() else {
+                    continue;
+                };
+                let block = source.read(&guard);
+
+                // Skip the inline style attribute (handled above)
+                let is_style_attribute = node
+                    .element_data()
+                    .and_then(|element| element.style_attribute.as_ref())
+                    .is_some_and(|style_attr| {
+                        style::servo_arc::Arc::ptr_eq(source.get(), style_attr)
+                    });
+                if is_style_attribute {
+                    continue;
+                }
+
+                // For inherited entries, only include rules with at
+                // least one inherited property
+                let inherited_only = inherited_from.is_some();
+                let declarations = block_declarations(block, inherited_only);
+                if declarations.is_empty() {
+                    continue;
+                }
+
+                let origin_is_ua = rule_node.cascade_level().origin() == CascadeOrigin::UA;
+                let key = source.get().heap_ptr();
+                let meta = metadata.get(&key);
+
+                entries.push(AppliedEntry {
+                    rule_type: STYLE_RULE,
+                    selector_text: meta.map(|m| m.selector_text.clone()).unwrap_or_default(),
+                    href: meta.map(|m| m.href.clone()).unwrap_or_default(),
+                    line: meta.map(|m| m.line).unwrap_or(0),
+                    column: meta.map(|m| m.column).unwrap_or(0),
+                    specificity: 0,
+                    is_system: meta
+                        .map(|m| m.origin == Origin::UserAgent)
+                        .unwrap_or(origin_is_ua),
+                    declarations,
+                    inherited_from,
+                });
+            }
+        }
+
+        if !inherited {
+            break;
+        }
+        current = node.parent;
+    }
+
+    entries
+}
+
+/// Extract the declarations from a declaration block, optionally keeping
+/// only inherited properties
+fn block_declarations(
+    block: &style::properties::PropertyDeclarationBlock,
+    inherited_only: bool,
+) -> Vec<AppliedDeclaration> {
+    block
+        .declaration_importance_iter()
+        .filter_map(|(decl, importance)| {
+            let id = decl.id();
+            if inherited_only {
+                let is_inherited = match id {
+                    PropertyDeclarationId::Longhand(longhand) => longhand.inherited(),
+                    PropertyDeclarationId::Custom(_) => true,
+                };
+                if !is_inherited {
+                    return None;
+                }
+            }
+            let mut value = String::new();
+            decl.to_css(&mut value).ok()?;
+            Some(AppliedDeclaration {
+                name: id.name().to_string(),
+                value,
+                important: importance.important(),
+            })
+        })
+        .collect()
+}

--- a/packages/blitz-devtools-server/src/actors/page_style.rs
+++ b/packages/blitz-devtools-server/src/actors/page_style.rs
@@ -325,11 +325,31 @@ fn layout_form(doc: &BaseDocument, node_id: NodeId) -> Option<JsonValue> {
         }
     }
 
+    // Non-atomic inline elements have no layout box of their own (they are
+    // laid out as style spans that may fragment across line boxes): report
+    // the bounding rect of their fragments, as Firefox does.
+    let (width, height) = match doc.inline_fragment_rects(node_id) {
+        Some(_) => match doc.get_client_bounding_rect(node_id) {
+            Some(rect) => (rect.width as f32, rect.height as f32),
+            None => (0.0, 0.0),
+        },
+        None => (
+            layout.size.width
+                - layout.border.left
+                - layout.border.right
+                - layout.padding.left
+                - layout.padding.right,
+            layout.size.height
+                - layout.border.top
+                - layout.border.bottom
+                - layout.padding.top
+                - layout.padding.bottom,
+        ),
+    };
+
     Some(json!({
-        "width": layout.size.width - layout.border.left - layout.border.right
-            - layout.padding.left - layout.padding.right,
-        "height": layout.size.height - layout.border.top - layout.border.bottom
-            - layout.padding.top - layout.padding.bottom,
+        "width": width,
+        "height": height,
         "autoMargins": auto_margins,
         "margin-top": px(layout.margin.top),
         "margin-right": px(layout.margin.right),

--- a/packages/blitz-devtools-server/src/actors/preference.rs
+++ b/packages/blitz-devtools-server/src/actors/preference.rs
@@ -1,0 +1,50 @@
+use serde_json::json;
+
+use crate::GenericClientMessage;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext};
+
+use super::generate_name;
+
+pub(crate) struct PreferenceActor {
+    name: String,
+}
+
+impl PreferenceActor {
+    pub(crate) fn new() -> Self {
+        Self {
+            name: generate_name("preference"),
+        }
+    }
+}
+
+impl Actor for PreferenceActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "getBoolPref" => {
+                ctx.write_msg(self.name(), json!({ "value": false }));
+                Ok(())
+            }
+            "getIntPref" => {
+                ctx.write_msg(self.name(), json!({ "value": 0 }));
+                Ok(())
+            }
+            "getFloatPref" => {
+                ctx.write_msg(self.name(), json!({ "value": 0.0 }));
+                Ok(())
+            }
+            "getCharPref" => {
+                ctx.write_msg(self.name(), json!({ "value": "" }));
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/process.rs
+++ b/packages/blitz-devtools-server/src/actors/process.rs
@@ -1,0 +1,45 @@
+use serde_json::json;
+
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext};
+use crate::{GenericClientMessage, JsonValue};
+
+use super::generate_name;
+
+pub(crate) struct ProcessActor {
+    name: String,
+}
+
+impl ProcessActor {
+    pub(crate) fn new() -> Self {
+        Self {
+            name: generate_name("process"),
+        }
+    }
+
+    pub(crate) fn description(&self) -> JsonValue {
+        json!({
+            "actor": self.name(),
+            "id": 0, // TODO: track ID
+            "isParent": true,
+            "isWindowlessParent":false,
+            "traits": {
+                "watcher":true,
+                "supportsReloadDescriptor":true
+            }
+        })
+    }
+}
+
+impl Actor for ProcessActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        _ctx: &mut DevtoolContext<'_>,
+        _message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        Err(ActorMessageErr::UnrecognizedPacketType)
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/root.rs
+++ b/packages/blitz-devtools-server/src/actors/root.rs
@@ -1,0 +1,125 @@
+use serde_json::json;
+
+use crate::GenericClientMessage;
+use crate::actors::process::ProcessActor;
+use crate::actors::tab::TabDescriptorActor;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext};
+
+pub(crate) struct RootActor {
+    preference_actor_name: String,
+    device_actor_name: String,
+    process_actor_name: String,
+    /// Map from document id to tab descriptor actor name
+    tabs: Vec<(usize, String)>,
+}
+
+impl RootActor {
+    pub(crate) fn new(
+        preference_actor_name: String,
+        device_actor_name: String,
+        process_actor_name: String,
+    ) -> Self {
+        Self {
+            preference_actor_name,
+            device_actor_name,
+            process_actor_name,
+            tabs: Vec::new(),
+        }
+    }
+
+    /// Get (creating if necessary) the tab descriptor actor for a document id
+    fn tab_actor_name(&mut self, ctx: &mut DevtoolContext<'_>, doc_id: usize) -> String {
+        if let Some((_, name)) = self.tabs.iter().find(|(id, _)| *id == doc_id) {
+            return name.clone();
+        }
+        let tab = TabDescriptorActor::new(doc_id);
+        let name = tab.name();
+        self.tabs.push((doc_id, name.clone()));
+        ctx.push_actor(Box::new(tab));
+        name
+    }
+}
+
+impl Actor for RootActor {
+    fn name(&self) -> ActorId {
+        String::from("root")
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "connect" => {
+                ctx.write_msg(self.name(), json!({}));
+                Ok(())
+            }
+            "getRoot" => {
+                ctx.write_msg(
+                    self.name(),
+                    json!({
+                      "selected": 0,
+                      "deviceActor": self.device_actor_name.clone(),
+                      "preferenceActor": self.preference_actor_name.clone(),
+                    }),
+                );
+                Ok(())
+            }
+            "listTabs" => {
+                let doc_ids = ctx.docs.document_ids();
+                let mut tabs = Vec::with_capacity(doc_ids.len());
+                for (idx, doc_id) in doc_ids.into_iter().enumerate() {
+                    let actor_name = self.tab_actor_name(ctx, doc_id);
+                    if let Some(form) =
+                        TabDescriptorActor::form_for(ctx, &actor_name, doc_id, idx == 0)
+                    {
+                        tabs.push(form);
+                    }
+                }
+                ctx.write_msg(self.name(), json!({ "tabs": tabs }));
+                Ok(())
+            }
+            "getTab" => {
+                let msg = message.data.json()?;
+                let browser_id =
+                    msg.get("browserId")
+                        .and_then(|v| v.as_u64())
+                        .ok_or(ActorMessageErr::MissingParameter)? as usize;
+                let actor_name = self.tab_actor_name(ctx, browser_id);
+                let form = TabDescriptorActor::form_for(ctx, &actor_name, browser_id, true)
+                    .ok_or(ActorMessageErr::NoSuchDocument)?;
+                ctx.write_msg(self.name(), json!({ "tab": form }));
+                Ok(())
+            }
+            "listWorkers" => {
+                ctx.write_msg(self.name(), json!({ "workers": [] }));
+                Ok(())
+            }
+            "listAddons" => {
+                ctx.write_msg(self.name(), json!({ "addons": [] }));
+                Ok(())
+            }
+            "listServiceWorkerRegistrations" => {
+                ctx.write_msg(self.name(), json!({ "registrations": [] }));
+                Ok(())
+            }
+
+            "listProcesses" => {
+                let process = ctx.actor::<ProcessActor>(&self.process_actor_name);
+                let description = process.description();
+                ctx.write_msg(self.name(), json!({ "processes": [description] }));
+                Ok(())
+            }
+
+            "getProcess" => {
+                let process = ctx.actor::<ProcessActor>(&self.process_actor_name);
+                let description = process.description();
+                ctx.write_msg(self.name(), json!({ "processDescriptor": description }));
+                Ok(())
+            }
+
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/stubs.rs
+++ b/packages/blitz-devtools-server/src/actors/stubs.rs
@@ -1,0 +1,128 @@
+//! Minimal stub actors that exist so that devtools clients can complete
+//! their initialization sequence. They accept configuration/lifecycle
+//! messages and reply with empty (or empty-list) responses.
+
+use serde_json::json;
+
+use crate::GenericClientMessage;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext, generate_name};
+
+/// A generic stub actor which replies with an empty response to any message.
+/// Used for configuration actors (which receive `updateConfiguration`
+/// messages), the frame target, and other actors which need to exist but
+/// whose behavior is not (yet) implemented.
+pub(crate) struct StubActor {
+    name: String,
+}
+
+impl StubActor {
+    pub(crate) fn new(base: &str) -> Self {
+        Self {
+            name: generate_name(base),
+        }
+    }
+}
+
+impl Actor for StubActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "listFrames" => {
+                ctx.write_msg(self.name(), json!({ "frames": [] }));
+            }
+            "listWorkers" => {
+                ctx.write_msg(self.name(), json!({ "workers": [] }));
+            }
+            _ => {
+                ctx.write_msg(self.name(), json!({}));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Stub console actor: reports no cached messages and no listeners
+pub(crate) struct ConsoleActor {
+    name: String,
+}
+
+impl ConsoleActor {
+    pub(crate) fn new() -> Self {
+        Self {
+            name: generate_name("console"),
+        }
+    }
+}
+
+impl Actor for ConsoleActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "startListeners" => {
+                ctx.write_msg(self.name(), json!({ "startedListeners": [] }));
+            }
+            "stopListeners" => {
+                ctx.write_msg(self.name(), json!({ "stoppedListeners": [] }));
+            }
+            "getCachedMessages" => {
+                ctx.write_msg(self.name(), json!({ "messages": [] }));
+            }
+            "autocomplete" => {
+                ctx.write_msg(self.name(), json!({ "matches": [], "matchProp": "" }));
+            }
+            _ => {
+                ctx.write_msg(self.name(), json!({}));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Stub thread actor: accepts attach/reconfigure and reports no sources
+pub(crate) struct ThreadActor {
+    name: String,
+}
+
+impl ThreadActor {
+    pub(crate) fn new() -> Self {
+        Self {
+            name: generate_name("thread"),
+        }
+    }
+}
+
+impl Actor for ThreadActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "sources" => {
+                ctx.write_msg(self.name(), json!({ "sources": [] }));
+            }
+            _ => {
+                ctx.write_msg(self.name(), json!({}));
+            }
+        }
+        Ok(())
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/stubs.rs
+++ b/packages/blitz-devtools-server/src/actors/stubs.rs
@@ -40,6 +40,9 @@ impl Actor for StubActor {
             "listWorkers" => {
                 ctx.write_msg(self.name(), json!({ "workers": [] }));
             }
+            // The reflow actor's "start"/"stop" are oneway in the Firefox
+            // spec; replying produces "Unexpected packet" errors in the client
+            "start" | "stop" => {}
             _ => {
                 ctx.write_msg(self.name(), json!({}));
             }

--- a/packages/blitz-devtools-server/src/actors/tab.rs
+++ b/packages/blitz-devtools-server/src/actors/tab.rs
@@ -1,0 +1,110 @@
+use blitz_dom::BaseDocument;
+use serde_json::json;
+
+use crate::actors::watcher::{SessionNames, WatcherActor};
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext, generate_name};
+use crate::{GenericClientMessage, JsonValue};
+
+/// Descriptor actor representing a single Blitz document ("tab")
+pub(crate) struct TabDescriptorActor {
+    name: String,
+    doc_id: usize,
+    watcher_name: Option<String>,
+    session: Option<SessionNames>,
+}
+
+pub(crate) fn doc_title(doc: &BaseDocument) -> String {
+    doc.find_title_node()
+        .map(|node| node.text_content())
+        .unwrap_or_default()
+}
+
+impl TabDescriptorActor {
+    pub(crate) fn new(doc_id: usize) -> Self {
+        Self {
+            name: generate_name("tab"),
+            doc_id,
+            watcher_name: None,
+            session: None,
+        }
+    }
+
+    pub(crate) fn form_for(
+        ctx: &mut DevtoolContext<'_>,
+        actor_name: &str,
+        doc_id: usize,
+        selected: bool,
+    ) -> Option<JsonValue> {
+        let actor_name = actor_name.to_string();
+        ctx.with_doc(doc_id, |doc| {
+            json!({
+                "actor": actor_name,
+                "title": doc_title(doc),
+                "url": doc.url().to_string(),
+                "browserId": doc_id,
+                "browsingContextID": doc_id,
+                "outerWindowID": doc_id,
+                "isZombieTab": false,
+                "selected": selected,
+                "traits": {
+                    "watcher": true,
+                    "supportsReloadDescriptor": false,
+                },
+            })
+        })
+    }
+
+    fn ensure_watcher(&mut self, ctx: &mut DevtoolContext<'_>) -> (String, SessionNames) {
+        if let (Some(name), Some(session)) = (&self.watcher_name, &self.session) {
+            return (name.clone(), session.clone());
+        }
+        let watcher = WatcherActor::create(ctx, self.doc_id);
+        let name = watcher.name();
+        let session = watcher.session.clone();
+        self.watcher_name = Some(name.clone());
+        self.session = Some(session.clone());
+        ctx.push_actor(Box::new(watcher));
+        (name, session)
+    }
+}
+
+impl Actor for TabDescriptorActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "getTarget" => {
+                let (_, session) = self.ensure_watcher(ctx);
+                let form = WatcherActor::frame_target_form(ctx, self.doc_id, &session)
+                    .ok_or(ActorMessageErr::NoSuchDocument)?;
+                ctx.write_msg(self.name(), json!({ "frame": form }));
+                Ok(())
+            }
+            "getFavicon" => {
+                ctx.write_msg(self.name(), json!({ "favicon": "" }));
+                Ok(())
+            }
+            "getWatcher" => {
+                let (watcher_name, _) = self.ensure_watcher(ctx);
+                ctx.write_msg(
+                    self.name(),
+                    json!({
+                        "actor": watcher_name,
+                        "traits": {
+                            "resources": {},
+                            "frame": true,
+                        },
+                    }),
+                );
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}

--- a/packages/blitz-devtools-server/src/actors/walker.rs
+++ b/packages/blitz-devtools-server/src/actors/walker.rs
@@ -1,0 +1,379 @@
+use std::collections::HashMap;
+
+use blitz_dom::BaseDocument;
+use blitz_dom::node::{Node, NodeData};
+use blitz_traits::node_id::NodeId;
+use serde_json::json;
+
+use crate::actors::layout::LayoutActor;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext, generate_name};
+use crate::{GenericClientMessage, JsonValue};
+
+const ELEMENT_NODE: u32 = 1;
+const TEXT_NODE: u32 = 3;
+const COMMENT_NODE: u32 = 8;
+const DOCUMENT_NODE: u32 = 9;
+
+const MAX_INLINE_TEXT_LENGTH: usize = 50;
+
+/// The walker actor implements devtools' view of the DOM tree. It assigns
+/// stable actor names to Blitz `NodeId`s and serializes "node forms" for the
+/// markup view.
+pub(crate) struct WalkerActor {
+    name: String,
+    pub(crate) doc_id: usize,
+    layout_actor_name: Option<String>,
+    node_to_actor: HashMap<NodeId, String>,
+    actor_to_node: HashMap<String, NodeId>,
+}
+
+impl WalkerActor {
+    pub(crate) fn new(doc_id: usize) -> Self {
+        Self {
+            name: generate_name("walker"),
+            doc_id,
+            layout_actor_name: None,
+            node_to_actor: HashMap::new(),
+            actor_to_node: HashMap::new(),
+        }
+    }
+
+    /// Get (assigning if necessary) the actor name for a node
+    pub(crate) fn actor_for_node(&mut self, node_id: NodeId) -> String {
+        if let Some(name) = self.node_to_actor.get(&node_id) {
+            return name.clone();
+        }
+        let name = generate_name("node");
+        self.node_to_actor.insert(node_id, name.clone());
+        self.actor_to_node.insert(name.clone(), node_id);
+        name
+    }
+
+    /// Resolve a node actor name back to a `NodeId`
+    pub(crate) fn node_for_actor(&self, actor: &str) -> Option<NodeId> {
+        self.actor_to_node.get(actor).copied()
+    }
+
+    /// The DOM children of a node (excluding anonymous boxes, which live in
+    /// the layout tree rather than the DOM tree)
+    fn dom_children<'doc>(doc: &'doc BaseDocument, node: &Node) -> Vec<&'doc Node> {
+        node.children
+            .iter()
+            .filter_map(|child_id| doc.get_node(*child_id))
+            .filter(|child| !child.is_anonymous())
+            .collect()
+    }
+
+    /// Serialize a node to its devtools "form"
+    pub(crate) fn node_form(&mut self, doc: &BaseDocument, node_id: NodeId) -> Option<JsonValue> {
+        let node = doc.get_node(node_id)?;
+        let actor = self.actor_for_node(node_id);
+
+        let (node_type, node_name, node_value) = match &node.data {
+            NodeData::Document(_) => (DOCUMENT_NODE, "#document".to_string(), None),
+            NodeData::Element(el) | NodeData::AnonymousBlock(el) => {
+                (ELEMENT_NODE, el.name.local.to_uppercase(), None)
+            }
+            NodeData::Text(_) => (TEXT_NODE, "#text".to_string(), Some(node.text_content())),
+            NodeData::Comment => (COMMENT_NODE, "#comment".to_string(), None),
+        };
+
+        let attrs: Vec<JsonValue> = node
+            .attrs()
+            .unwrap_or_default()
+            .iter()
+            .map(|attr| json!({ "name": attr.name.local.to_string(), "value": attr.value }))
+            .collect();
+
+        let display_type = node
+            .primary_styles()
+            .map(|styles| display_string(&styles))
+            .unwrap_or_else(|| "block".to_string());
+        let is_displayed = display_type != "none";
+
+        let children = Self::dom_children(doc, node);
+        let num_children = children.len();
+
+        // If the node has a single small text child, represent it inline
+        let inline_text_child = if num_children == 1 && children[0].is_text_node() {
+            let text = children[0].text_content();
+            let child_id = children[0].id;
+            if text.len() <= MAX_INLINE_TEXT_LENGTH {
+                self.node_form(doc, child_id)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let parent = node
+            .parent
+            .map(|parent_id| self.actor_for_node(parent_id))
+            .unwrap_or_default();
+
+        let is_top_level_document = node.parent.is_none();
+
+        Some(json!({
+            "actor": actor,
+            "attrs": attrs,
+            "baseURI": doc.url().to_string(),
+            "causesOverflow": false,
+            "containerType": null,
+            "displayName": node_name.to_lowercase(),
+            "displayType": display_type,
+            "host": null,
+            "inlineTextChild": inline_text_child,
+            "isAfterPseudoElement": false,
+            "isAnonymous": node.is_anonymous(),
+            "isBeforePseudoElement": false,
+            "isDirectShadowHostChild": null,
+            "isDisplayed": is_displayed,
+            "isInHTMLDocument": true,
+            "isMarkerPseudoElement": false,
+            "isNativeAnonymous": false,
+            "isScrollable": false,
+            "isShadowHost": false,
+            "isShadowRoot": false,
+            "isTopLevelDocument": is_top_level_document,
+            "nodeName": node_name,
+            "nodeType": node_type,
+            "nodeValue": node_value,
+            "numChildren": num_children,
+            "parent": parent,
+            "shadowRootMode": null,
+            "traits": {
+                "supportsIsUsedInCustomProperty": false,
+            },
+        }))
+    }
+
+    /// The form of the document root node
+    pub(crate) fn root_form(&mut self, ctx: &mut DevtoolContext<'_>) -> Option<JsonValue> {
+        let result = ctx.with_doc(self.doc_id, |doc| {
+            let root_id = doc.root_node().id;
+            self.node_form(doc, root_id)
+        });
+        result.flatten()
+    }
+
+    /// Build a "unique" selector for a node (best effort)
+    fn unique_selector(doc: &BaseDocument, node: &Node) -> String {
+        let Some(element) = node.element_data() else {
+            return node.node_debug_str();
+        };
+        if let Some(id) = &element.id {
+            return format!("#{id}");
+        }
+        let tag = element.name.local.to_string();
+        // Disambiguate with :nth-child if the node has same-tag siblings
+        let nth = node
+            .parent
+            .and_then(|parent_id| doc.get_node(parent_id))
+            .and_then(|parent| {
+                let siblings = Self::dom_children(doc, parent);
+                if siblings
+                    .iter()
+                    .filter(|sibling| sibling.is_element())
+                    .count()
+                    > 1
+                {
+                    siblings
+                        .iter()
+                        .position(|sibling| sibling.id == node.id)
+                        .map(|idx| idx + 1)
+                } else {
+                    None
+                }
+            });
+        match nth {
+            Some(nth) => format!("{tag}:nth-child({nth})"),
+            None => tag,
+        }
+    }
+}
+
+impl Actor for WalkerActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        let doc_id = self.doc_id;
+        match &*message.type_ {
+            "children" => {
+                let msg = message.data.json()?;
+                let node_actor = msg
+                    .get("node")
+                    .and_then(|v| v.as_str())
+                    .ok_or(ActorMessageErr::MissingParameter)?;
+                let node_id = self
+                    .node_for_actor(node_actor)
+                    .ok_or(ActorMessageErr::NoSuchNode)?;
+
+                let nodes = ctx.with_doc(doc_id, |doc| {
+                    let Some(node) = doc.get_node(node_id) else {
+                        return Vec::new();
+                    };
+                    let child_ids: Vec<NodeId> =
+                        Self::dom_children(doc, node).iter().map(|c| c.id).collect();
+                    child_ids
+                        .into_iter()
+                        .filter_map(|child_id| self.node_form(doc, child_id))
+                        .collect::<Vec<_>>()
+                });
+                let nodes = nodes.ok_or(ActorMessageErr::NoSuchDocument)?;
+
+                ctx.write_msg(
+                    self.name(),
+                    json!({
+                        "hasFirst": true,
+                        "hasLast": true,
+                        "nodes": nodes,
+                    }),
+                );
+                Ok(())
+            }
+            "querySelector" => {
+                let msg = message.data.json()?;
+                let node_actor = msg
+                    .get("node")
+                    .and_then(|v| v.as_str())
+                    .ok_or(ActorMessageErr::MissingParameter)?;
+                let selector = msg
+                    .get("selector")
+                    .and_then(|v| v.as_str())
+                    .ok_or(ActorMessageErr::MissingParameter)?
+                    .to_string();
+                let _context_node = self
+                    .node_for_actor(node_actor)
+                    .ok_or(ActorMessageErr::NoSuchNode)?;
+
+                let known_nodes: Vec<NodeId> = self.node_to_actor.keys().copied().collect();
+                let result = ctx.with_doc(doc_id, |doc| {
+                    let node_id = doc.query_selector(&selector).ok().flatten()?;
+                    let node_form = self.node_form(doc, node_id)?;
+
+                    // Send forms for any ancestors that the client doesn't
+                    // know about yet, so that it can connect the node to
+                    // its existing tree
+                    let mut new_parents = Vec::new();
+                    let mut current = doc.get_node(node_id).and_then(|n| n.parent);
+                    while let Some(ancestor_id) = current {
+                        let already_known = known_nodes.contains(&ancestor_id);
+                        if let Some(form) = self.node_form(doc, ancestor_id) {
+                            new_parents.push(form);
+                        }
+                        if already_known {
+                            break;
+                        }
+                        current = doc.get_node(ancestor_id).and_then(|n| n.parent);
+                    }
+
+                    Some((node_form, new_parents))
+                });
+
+                match result.ok_or(ActorMessageErr::NoSuchDocument)? {
+                    Some((node, new_parents)) => {
+                        ctx.write_msg(
+                            self.name(),
+                            json!({ "node": node, "newParents": new_parents }),
+                        );
+                    }
+                    None => {
+                        ctx.write_msg(self.name(), json!({}));
+                    }
+                }
+                Ok(())
+            }
+            "watchRootNode" => {
+                // Send a "root-available" notification followed by an empty reply
+                let root = self.root_form(ctx).ok_or(ActorMessageErr::NoSuchDocument)?;
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "type": "root-available", "node": root }),
+                );
+                ctx.write_msg(self.name(), json!({}));
+                Ok(())
+            }
+            "documentElement" => {
+                let form = ctx.with_doc(doc_id, |doc| {
+                    let root = doc.root_node();
+                    let html_id = Self::dom_children(doc, root)
+                        .iter()
+                        .find(|child| child.is_element())
+                        .map(|child| child.id)?;
+                    self.node_form(doc, html_id)
+                });
+                let form = form.flatten().ok_or(ActorMessageErr::NoSuchDocument)?;
+                ctx.write_msg(self.name(), json!({ "node": form }));
+                Ok(())
+            }
+            "getUniqueSelector" => {
+                let msg = message.data.json()?;
+                let node_actor = msg
+                    .get("node")
+                    .and_then(|v| v.as_str())
+                    .ok_or(ActorMessageErr::MissingParameter)?;
+                let node_id = self
+                    .node_for_actor(node_actor)
+                    .ok_or(ActorMessageErr::NoSuchNode)?;
+                let selector = ctx
+                    .with_doc(doc_id, |doc| {
+                        doc.get_node(node_id)
+                            .map(|node| Self::unique_selector(doc, node))
+                    })
+                    .flatten()
+                    .unwrap_or_default();
+                ctx.write_msg(self.name(), json!({ "value": selector }));
+                Ok(())
+            }
+            "getOffsetParent" => {
+                ctx.write_msg(self.name(), json!({ "node": null }));
+                Ok(())
+            }
+            "getLayoutInspector" => {
+                let layout_name = match &self.layout_actor_name {
+                    Some(name) => name.clone(),
+                    None => {
+                        let layout = LayoutActor::new(self.doc_id, self.name());
+                        let name = layout.name();
+                        self.layout_actor_name = Some(name.clone());
+                        ctx.push_actor(Box::new(layout));
+                        name
+                    }
+                };
+                ctx.write_msg(self.name(), json!({ "actor": { "actor": layout_name } }));
+                Ok(())
+            }
+            "getMutations" => {
+                ctx.write_msg(self.name(), json!({ "mutations": [] }));
+                Ok(())
+            }
+            "isInDOMTree" => {
+                ctx.write_msg(self.name(), json!({ "attached": true }));
+                Ok(())
+            }
+            "retainNode"
+            | "unretainNode"
+            | "releaseNode"
+            | "clearPseudoClassLocks"
+            | "removeNode"
+            | "watchSeekableNodes" => {
+                ctx.write_msg(self.name(), json!({}));
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}
+
+/// Serialize a node's computed `display` value
+pub(crate) fn display_string(styles: &style::properties::ComputedValues) -> String {
+    use style::properties::{LonghandId, PropertyDeclarationId};
+    styles.computed_value_to_string(PropertyDeclarationId::Longhand(LonghandId::Display))
+}

--- a/packages/blitz-devtools-server/src/actors/walker.rs
+++ b/packages/blitz-devtools-server/src/actors/walker.rs
@@ -55,12 +55,13 @@ impl WalkerActor {
     }
 
     /// The DOM children of a node (excluding anonymous boxes, which live in
-    /// the layout tree rather than the DOM tree)
+    /// the layout tree rather than the DOM tree, and whitespace-only text
+    /// nodes, which are just noise in the inspector)
     fn dom_children<'doc>(doc: &'doc BaseDocument, node: &Node) -> Vec<&'doc Node> {
         node.children
             .iter()
             .filter_map(|child_id| doc.get_node(*child_id))
-            .filter(|child| !child.is_anonymous())
+            .filter(|child| !child.is_anonymous() && !child.is_whitespace_node())
             .collect()
     }
 

--- a/packages/blitz-devtools-server/src/actors/walker.rs
+++ b/packages/blitz-devtools-server/src/actors/walker.rs
@@ -332,6 +332,33 @@ impl Actor for WalkerActor {
                 ctx.write_msg(self.name(), json!({ "value": selector }));
                 Ok(())
             }
+            // Firefox resolves flex-item/grid actors to DOM nodes via this
+            // request
+            "getNodeFromActor" => {
+                let msg = message.data.json()?;
+                let actor_id = msg
+                    .get("actorID")
+                    .and_then(|v| v.as_str())
+                    .ok_or(ActorMessageErr::MissingParameter)?;
+                let node_id = ctx
+                    .actors
+                    .get(actor_id)
+                    .and_then(|actor| {
+                        let any: &dyn std::any::Any = actor.as_ref();
+                        any.downcast_ref::<crate::actors::layout::FlexItemActor>()
+                            .map(|a| a.node_id)
+                    })
+                    .ok_or(ActorMessageErr::NoSuchNode)?;
+                let form = ctx
+                    .with_doc(doc_id, |doc| self.node_form(doc, node_id))
+                    .flatten()
+                    .ok_or(ActorMessageErr::NoSuchNode)?;
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "node": { "node": form, "newParents": [] } }),
+                );
+                Ok(())
+            }
             "getOffsetParent" => {
                 ctx.write_msg(self.name(), json!({ "node": null }));
                 Ok(())

--- a/packages/blitz-devtools-server/src/actors/watcher.rs
+++ b/packages/blitz-devtools-server/src/actors/watcher.rs
@@ -1,0 +1,213 @@
+use serde_json::json;
+
+use crate::actors::css_properties::CssPropertiesActor;
+use crate::actors::inspector::InspectorActor;
+use crate::actors::stubs::{ConsoleActor, StubActor, ThreadActor};
+use crate::actors::tab::doc_title;
+use crate::actors::{Actor, ActorId, ActorMessageErr, DevtoolContext, generate_name};
+use crate::{GenericClientMessage, JsonValue};
+
+/// The actor names for the session actors associated with a single tab/frame target
+#[derive(Clone)]
+pub(crate) struct SessionNames {
+    pub frame_target: String,
+    pub inspector: String,
+    pub css_properties: String,
+    pub console: String,
+    pub thread: String,
+    pub target_configuration: String,
+    pub thread_configuration: String,
+    pub network_parent: String,
+    pub breakpoint_list: String,
+    pub blackboxing: String,
+    pub reflow: String,
+    pub style_sheets: String,
+    pub accessibility: String,
+}
+
+/// The watcher actor describes the debugging capabilities of a tab and hands
+/// out the (frame) target when the client starts watching.
+pub(crate) struct WatcherActor {
+    name: String,
+    doc_id: usize,
+    pub(crate) session: SessionNames,
+}
+
+impl WatcherActor {
+    /// Create the watcher along with all of its session actors, registering
+    /// them with the connection
+    pub(crate) fn create(ctx: &mut DevtoolContext<'_>, doc_id: usize) -> WatcherActor {
+        let inspector = InspectorActor::new(doc_id);
+        let css_properties = CssPropertiesActor::new();
+        let console = ConsoleActor::new();
+        let thread = ThreadActor::new();
+        let target_configuration = StubActor::new("target-configuration");
+        let thread_configuration = StubActor::new("thread-configuration");
+        let network_parent = StubActor::new("network-parent");
+        let breakpoint_list = StubActor::new("breakpoint-list");
+        let blackboxing = StubActor::new("blackboxing");
+        let reflow = StubActor::new("reflow");
+        let style_sheets = StubActor::new("style-sheets");
+        let accessibility = StubActor::new("accessibility");
+        let frame_target = StubActor::new("frame-target");
+
+        let session = SessionNames {
+            frame_target: frame_target.name(),
+            inspector: inspector.name(),
+            css_properties: css_properties.name(),
+            console: console.name(),
+            thread: thread.name(),
+            target_configuration: target_configuration.name(),
+            thread_configuration: thread_configuration.name(),
+            network_parent: network_parent.name(),
+            breakpoint_list: breakpoint_list.name(),
+            blackboxing: blackboxing.name(),
+            reflow: reflow.name(),
+            style_sheets: style_sheets.name(),
+            accessibility: accessibility.name(),
+        };
+
+        ctx.push_actor(Box::new(inspector));
+        ctx.push_actor(Box::new(css_properties));
+        ctx.push_actor(Box::new(console));
+        ctx.push_actor(Box::new(thread));
+        ctx.push_actor(Box::new(target_configuration));
+        ctx.push_actor(Box::new(thread_configuration));
+        ctx.push_actor(Box::new(network_parent));
+        ctx.push_actor(Box::new(breakpoint_list));
+        ctx.push_actor(Box::new(blackboxing));
+        ctx.push_actor(Box::new(reflow));
+        ctx.push_actor(Box::new(style_sheets));
+        ctx.push_actor(Box::new(accessibility));
+        ctx.push_actor(Box::new(frame_target));
+
+        WatcherActor {
+            name: generate_name("watcher"),
+            doc_id,
+            session,
+        }
+    }
+
+    /// Build the "frame target" form describing the browsing context target
+    /// and its supporting actors
+    pub(crate) fn frame_target_form(
+        ctx: &mut DevtoolContext<'_>,
+        doc_id: usize,
+        session: &SessionNames,
+    ) -> Option<JsonValue> {
+        let session = session.clone();
+        ctx.with_doc(doc_id, |doc| {
+            json!({
+                "actor": session.frame_target,
+                "title": doc_title(doc),
+                "url": doc.url().to_string(),
+                "browserId": doc_id,
+                "outerWindowID": doc_id,
+                "browsingContextID": doc_id,
+                "isTopLevelTarget": true,
+                "targetType": "frame",
+                "traits": {
+                    "frames": false,
+                    "isBrowsingContext": true,
+                    "logInPage": false,
+                    "navigation": false,
+                    "supportsTopLevelTargetFlag": true,
+                    "watchpoints": false,
+                },
+                "accessibilityActor": session.accessibility,
+                "consoleActor": session.console,
+                "cssPropertiesActor": session.css_properties,
+                "inspectorActor": session.inspector,
+                "reflowActor": session.reflow,
+                "styleSheetsActor": session.style_sheets,
+                "threadActor": session.thread,
+            })
+        })
+    }
+}
+
+impl Actor for WatcherActor {
+    fn name(&self) -> ActorId {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        message: GenericClientMessage,
+    ) -> Result<(), ActorMessageErr> {
+        match &*message.type_ {
+            "watchTargets" => {
+                let msg = message.data.json()?;
+                let target_type = msg
+                    .get("targetType")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("frame");
+
+                if target_type == "frame" {
+                    let target = Self::frame_target_form(ctx, self.doc_id, &self.session)
+                        .ok_or(ActorMessageErr::NoSuchDocument)?;
+                    ctx.write_msg(
+                        self.name(),
+                        json!({ "type": "target-available-form", "target": target }),
+                    );
+                }
+
+                // Notifications (messages with a `type` field) don't count as
+                // a reply, so send an empty reply to finish the request
+                ctx.write_msg(self.name(), json!({}));
+                Ok(())
+            }
+            // One-way messages that expect no reply
+            "unwatchTargets" | "unwatchResources" => Ok(()),
+            "watchResources" => {
+                ctx.write_msg(self.name(), json!({}));
+                Ok(())
+            }
+            "getParentBrowsingContextID" => {
+                ctx.write_msg(self.name(), json!({ "browsingContextID": self.doc_id }));
+                Ok(())
+            }
+            "getNetworkParentActor" => {
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "network": { "actor": self.session.network_parent } }),
+                );
+                Ok(())
+            }
+            "getTargetConfigurationActor" => {
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "configuration": {
+                        "actor": self.session.target_configuration,
+                        "configuration": {},
+                        "traits": { "supportedOptions": {} },
+                    }}),
+                );
+                Ok(())
+            }
+            "getThreadConfigurationActor" => {
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "configuration": { "actor": self.session.thread_configuration } }),
+                );
+                Ok(())
+            }
+            "getBreakpointListActor" => {
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "breakpointList": { "actor": self.session.breakpoint_list } }),
+                );
+                Ok(())
+            }
+            "getBlackboxingActor" => {
+                ctx.write_msg(
+                    self.name(),
+                    json!({ "blackboxing": { "actor": self.session.blackboxing } }),
+                );
+                Ok(())
+            }
+            _ => Err(ActorMessageErr::UnrecognizedPacketType),
+        }
+    }
+}

--- a/packages/blitz-devtools-server/src/lib.rs
+++ b/packages/blitz-devtools-server/src/lib.rs
@@ -1,0 +1,533 @@
+//! (Firefox) devtools protocol server implementation
+//!
+//! Implements the server side of the [Firefox Remote Debugging Protocol]
+//! allowing Firefox's devtools (in particular: the DOM, style and layout
+//! inspectors) to connect to and inspect Blitz documents.
+//!
+//! [Firefox Remote Debugging Protocol]: https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html
+
+use actors::{Actor, ActorId, ActorMessageErr};
+use blitz_dom::BaseDocument;
+use bytes::{Bytes, BytesMut};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+use std::io::IoSlice;
+use std::sync::mpsc::{Receiver, Sender, channel};
+use std::{error::Error, fmt::Display, sync::Arc};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc::Sender as TokioSender;
+use tokio::{net::TcpListener, task::JoinHandle};
+use tokio_stream::StreamExt;
+use tokio_util::codec::{Decoder, FramedRead};
+
+mod actors;
+
+pub(crate) type JsonValue = serde_json::Value;
+
+/// Provides devtools actors with synchronous access to the current set of
+/// Blitz documents. Implemented by the embedder (e.g. `BlitzApplication`),
+/// which owns the documents.
+pub trait DocumentProvider {
+    /// The ids of the currently open documents (in tab order)
+    fn document_ids(&self) -> Vec<usize>;
+    /// Run a callback with mutable access to the document with the given id.
+    /// The callback is not run if no such document exists.
+    fn with_document(&mut self, id: usize, cb: &mut dyn FnMut(&mut BaseDocument));
+}
+
+/// A waker used to notify the embedder's event loop that there are devtools
+/// messages waiting to be processed (via [`DevtoolsServer::process_messages`])
+pub trait DevtoolsWaker: Send + Sync {
+    /// Wake the event loop
+    fn wake(&self);
+}
+
+pub struct DevtoolsServer {
+    runtime: Option<tokio::runtime::Runtime>,
+    listener: Option<JoinHandle<()>>,
+    connections: HashMap<usize, Connection>,
+    waker: Arc<dyn DevtoolsWaker>,
+    event_queue: Receiver<DevtoolsEvent>,
+    event_sender: Sender<DevtoolsEvent>,
+    local_addr: Arc<std::sync::Mutex<Option<std::net::SocketAddr>>>,
+}
+
+impl DevtoolsServer {
+    pub fn new(waker: Arc<dyn DevtoolsWaker>) -> Self {
+        let (sender, receiver) = channel();
+        DevtoolsServer {
+            runtime: None,
+            listener: None,
+            connections: HashMap::new(),
+            waker,
+            event_sender: sender,
+            event_queue: receiver,
+            local_addr: Arc::new(std::sync::Mutex::new(None)),
+        }
+    }
+
+    /// The address the server is listening on (available once the listener
+    /// has started). Waits up to `timeout` for the listener to start.
+    pub fn wait_for_local_addr(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Option<std::net::SocketAddr> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Some(addr) = *self.local_addr.lock().unwrap() {
+                return Some(addr);
+            }
+            if std::time::Instant::now() > deadline {
+                return None;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    /// Start listening for devtools connections on the given address
+    /// (e.g. `127.0.0.1:6000`).
+    ///
+    /// The listener runs on a dedicated background thread. Incoming messages
+    /// are queued, and the waker is used to notify the embedder that it
+    /// should call [`process_messages`](Self::process_messages).
+    pub fn start_listening(&mut self, addr: &str) {
+        let sender = self.event_sender.clone();
+        let waker = self.waker.clone();
+        let msg_cb = Arc::new(move |event: DevtoolsEvent| {
+            if sender.send(event).is_ok() {
+                waker.wake();
+            }
+        }) as _;
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_io()
+            .build()
+            .expect("failed to build devtools tokio runtime");
+        let listener = runtime.spawn(start_devtools_server_no_err(
+            addr.to_string(),
+            msg_cb,
+            Arc::clone(&self.local_addr),
+        ));
+        self.runtime = Some(runtime);
+        self.listener = Some(listener);
+    }
+
+    /// Process any pending messages from devtools clients. Must be called on
+    /// the thread that owns the documents (typically the main/event-loop
+    /// thread) whenever the waker fires.
+    pub fn process_messages(&mut self, docs: &mut dyn DocumentProvider) {
+        while let Ok(event) = self.event_queue.try_recv() {
+            self.handle_event(event, docs);
+        }
+    }
+
+    fn handle_event(&mut self, event: DevtoolsEvent, docs: &mut dyn DocumentProvider) {
+        match event.data {
+            DevtoolsEventData::ConnectionOpened(connection) => {
+                self.connections.insert(event.connection_id, connection);
+            }
+            DevtoolsEventData::ConnectionClosed => {
+                if let Some(conn) = self.connections.remove(&event.connection_id) {
+                    conn.reader_task.abort();
+                    conn.writer_task.abort();
+                }
+            }
+            DevtoolsEventData::ClientMessage(msg) => {
+                msg.debug_log();
+
+                let Some(conn) = self.connections.get_mut(&event.connection_id) else {
+                    println!("Error: Devtools message from closed connection");
+                    return;
+                };
+
+                conn.handle_message(msg, docs);
+            }
+        }
+    }
+}
+
+impl Drop for DevtoolsServer {
+    fn drop(&mut self) {
+        if let Some(listener) = self.listener.take() {
+            listener.abort();
+        }
+        for conn in self.connections.values() {
+            conn.reader_task.abort();
+            conn.writer_task.abort();
+        }
+        if let Some(runtime) = self.runtime.take() {
+            runtime.shutdown_background();
+        }
+    }
+}
+
+struct Connection {
+    #[allow(dead_code)]
+    id: usize,
+    reader_task: JoinHandle<()>,
+    writer_task: JoinHandle<()>,
+    writer: MessageWriter,
+    actors: HashMap<ActorId, Box<dyn Actor>>,
+}
+
+pub struct DevtoolsEvent {
+    connection_id: usize,
+    data: DevtoolsEventData,
+}
+
+enum DevtoolsEventData {
+    /// A new connection was opened
+    ConnectionOpened(Connection),
+    /// Connection was closed and should be cleaned up
+    ConnectionClosed,
+    /// A message received from the client
+    ClientMessage(GenericClientMessage),
+}
+
+pub(crate) struct MessageWriter(TokioSender<ServerMessage<JsonValue>>);
+
+impl MessageWriter {
+    fn write_msg(&mut self, from: String, data: JsonValue) {
+        let _ = self.0.try_send(ServerMessage { from, data });
+    }
+    fn write_err(&mut self, from: String, err: ActorMessageErr) {
+        let data = json!({ "error": err.as_str(), "message": err.message() });
+        let _ = self.0.try_send(ServerMessage { from, data });
+    }
+}
+
+async fn start_devtools_server_no_err(
+    addr: String,
+    msg_cb: Arc<dyn Fn(DevtoolsEvent) + Send + Sync>,
+    local_addr: Arc<std::sync::Mutex<Option<std::net::SocketAddr>>>,
+) {
+    if let Err(err) = start_devtools_server(addr, msg_cb, local_addr).await {
+        println!("Devtools: server error: {err}");
+    }
+}
+
+async fn start_devtools_server(
+    addr: String,
+    sender: Arc<dyn Fn(DevtoolsEvent) + Send + Sync>,
+    local_addr: Arc<std::sync::Mutex<Option<std::net::SocketAddr>>>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let server = TcpListener::bind(&addr).await?;
+    if let Ok(addr) = server.local_addr() {
+        *local_addr.lock().unwrap() = Some(addr);
+    }
+    println!("Devtools: listening on: {addr}");
+
+    let mut connection_id_counter: usize = 0;
+
+    loop {
+        let (stream, _) = server.accept().await?;
+        let (reader, mut writer) = stream.into_split();
+
+        connection_id_counter += 1;
+        let connection_id = connection_id_counter;
+
+        println!("Devtools: new connection (id: {connection_id})");
+
+        // Spawn stream reader task
+        let reader_task = tokio::spawn({
+            let sender = Arc::clone(&sender);
+            async move {
+                let mut framed_reader = FramedRead::new(reader, MozRdpStreamTransport::default());
+                while let Some(msg) = framed_reader.next().await {
+                    match msg {
+                        Ok(msg) => {
+                            sender(DevtoolsEvent {
+                                connection_id,
+                                data: DevtoolsEventData::ClientMessage(msg),
+                            });
+                        }
+                        Err(e) => {
+                            println!("Err parsing devtools packet {e:?}");
+                            break;
+                        }
+                    }
+                }
+
+                // Stream ended: notify the main thread so the connection can
+                // be cleaned up
+                sender(DevtoolsEvent {
+                    connection_id,
+                    data: DevtoolsEventData::ConnectionClosed,
+                });
+            }
+        });
+
+        // Spawn stream writer task
+        let (outgoing_sender, mut outgoing_receiver) =
+            tokio::sync::mpsc::channel::<ServerMessage<JsonValue>>(100);
+        let writer_task = tokio::spawn(async move {
+            while let Some(msg) = outgoing_receiver.recv().await {
+                if msg.data.get("error").is_some() {
+                    println!("<< FROM:{} ERROR {}", msg.from, msg.data);
+                } else {
+                    println!("<< FROM:{} {}", msg.from, msg.data);
+                }
+
+                let encoded = serde_json::to_string(&msg).unwrap();
+                let len = encoded.len();
+                let len_s = format!("{len}:");
+                let write_result = writer
+                    .write_vectored(&[
+                        IoSlice::new(len_s.as_bytes()),
+                        IoSlice::new(encoded.as_bytes()),
+                    ])
+                    .await;
+                if write_result.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Send initial message
+        let mut writer = MessageWriter(outgoing_sender);
+        writer.write_msg(String::from("root"), json!({
+            "applicationType": "browser",
+            "traits": { "sources": false, "highlightable": true, "customHighlighters": true, "networkMonitor": false }
+        }));
+
+        let mut connection = Connection {
+            id: connection_id,
+            reader_task,
+            writer_task,
+            writer,
+            actors: HashMap::new(),
+        };
+        connection.init();
+
+        // Send event with new connection
+        sender(DevtoolsEvent {
+            connection_id,
+            data: DevtoolsEventData::ConnectionOpened(connection),
+        });
+    }
+}
+
+#[derive(Default)]
+struct MozRdpStreamTransport {
+    header: Option<MozRdpHeader>,
+}
+
+#[derive(Debug)]
+enum PacketDecodeErr {
+    HeaderTooLong,
+    InvalidHeader,
+    #[allow(dead_code)]
+    InvalidUtf8,
+    InvalidJson,
+    IoError(std::io::Error),
+}
+
+impl Display for PacketDecodeErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PacketDecodeErr::HeaderTooLong => write!(f, "Header too long"),
+            PacketDecodeErr::InvalidHeader => write!(f, "InvalidHeader"),
+            PacketDecodeErr::InvalidUtf8 => write!(f, "InvalidUTF8"),
+            PacketDecodeErr::InvalidJson => write!(f, "InvalidJson"),
+            PacketDecodeErr::IoError(err) => err.fmt(f),
+        }
+    }
+}
+
+impl Error for PacketDecodeErr {}
+
+impl From<std::io::Error> for PacketDecodeErr {
+    fn from(value: std::io::Error) -> Self {
+        PacketDecodeErr::IoError(value)
+    }
+}
+
+impl Decoder for MozRdpStreamTransport {
+    type Item = GenericClientMessage;
+
+    type Error = PacketDecodeErr;
+
+    fn decode_eof(&mut self, _src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        Ok(None)
+    }
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if src.is_empty() {
+            return Ok(None);
+        }
+
+        let header = match &self.header {
+            Some(header) => header,
+            None => {
+                let Some(position) = src.iter().position(|b| *b == b':') else {
+                    if src.len() > 1000 {
+                        // Input excessively long: assuming invalid packet
+                        return Err(PacketDecodeErr::HeaderTooLong);
+                    } else {
+                        // Incomplete header
+                        return Ok(None);
+                    }
+                };
+                let header_input = &src[0..position];
+
+                match MozRdpHeader::try_parse(header_input)
+                    .map_err(|_| PacketDecodeErr::InvalidHeader)?
+                {
+                    Some(header) => {
+                        let _ = src.split_to(position + 1);
+                        self.header = Some(header);
+                        self.header.as_ref().unwrap()
+                    }
+                    None => return Ok(None),
+                }
+            }
+        };
+
+        if src.len() < header.expected_data_length {
+            return Ok(None);
+        }
+
+        let header = self.header.take().unwrap();
+        match header.header_kind {
+            MozRdpPacketKind::Json => {
+                let data = src.split_to(header.expected_data_length).freeze();
+                let msg: ClientMessage<JsonValue> =
+                    serde_json::from_slice(&data).map_err(|_| PacketDecodeErr::InvalidJson)?;
+                Ok(Some(msg.into()))
+            }
+            MozRdpPacketKind::Bulk { to, type_ } => {
+                let data = src.split_to(header.expected_data_length).freeze();
+                Ok(Some(ClientMessage { to, type_, data }.into()))
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+enum MozRdpPacketKind {
+    Json,
+    Bulk { to: String, type_: String },
+}
+
+#[derive(Clone)]
+struct MozRdpHeader {
+    /// The length of the data indicated from the header.
+    expected_data_length: usize,
+    /// The kind of packet (JSON or Bulk)
+    header_kind: MozRdpPacketKind,
+}
+
+impl MozRdpHeader {
+    fn try_parse(input: &[u8]) -> Result<Option<Self>, ()> {
+        // Try to parse JSON packet header
+        if input.iter().all(|c| c.is_ascii_digit()) {
+            return Ok(Some(Self {
+                expected_data_length: str::from_utf8(input)
+                    .map_err(|_| ())?
+                    .parse()
+                    .map_err(|_| ())?,
+                header_kind: MozRdpPacketKind::Json,
+            }));
+        }
+
+        // Try to parse Bulk packet header
+        if input.starts_with(b"bulk ") {
+            let s = str::from_utf8(&input[5..]).map_err(|_| ())?;
+            let mut parts = s.splitn(3, ' ');
+            let to = parts.next().ok_or(())?;
+            let type_ = parts.next().ok_or(())?;
+            let length_str = parts.next().ok_or(())?;
+            let length = length_str.parse().map_err(|_| ())?;
+
+            return Ok(Some(Self {
+                expected_data_length: length,
+                header_kind: MozRdpPacketKind::Bulk {
+                    to: to.to_string(),
+                    type_: type_.to_string(),
+                },
+            }));
+        }
+
+        // Return error
+        Err(())
+    }
+}
+
+/// A Mozilla Remote Debugging Protocol packet with unparsed data field
+pub enum GenericClientData {
+    Json(JsonValue),
+    Bulk(Bytes),
+}
+
+pub(crate) type GenericClientMessage = ClientMessage<GenericClientData>;
+pub(crate) type JsonClientMessage = ClientMessage<JsonValue>;
+pub(crate) type BulkClientMessage = ClientMessage<Bytes>;
+
+impl From<JsonClientMessage> for GenericClientMessage {
+    fn from(value: JsonClientMessage) -> Self {
+        ClientMessage {
+            to: value.to,
+            type_: value.type_,
+            data: GenericClientData::Json(value.data),
+        }
+    }
+}
+
+impl From<BulkClientMessage> for GenericClientMessage {
+    fn from(value: BulkClientMessage) -> Self {
+        ClientMessage {
+            to: value.to,
+            type_: value.type_,
+            data: GenericClientData::Bulk(value.data),
+        }
+    }
+}
+
+impl GenericClientData {
+    pub(crate) fn json(&self) -> Result<&JsonValue, ActorMessageErr> {
+        match self {
+            GenericClientData::Json(value) => Ok(value),
+            GenericClientData::Bulk(_) => Err(ActorMessageErr::BadParameterType),
+        }
+    }
+}
+
+impl GenericClientMessage {
+    pub(crate) fn debug_log(&self) {
+        match &self.data {
+            GenericClientData::Json(json) => println!(
+                ">>   TO:{} {} {}",
+                self.to,
+                self.type_,
+                serde_json::to_string(&json).unwrap()
+            ),
+            GenericClientData::Bulk(bytes) => {
+                println!(
+                    ">> bulk to:{} type:{} ({} bytes)",
+                    self.to,
+                    self.type_,
+                    bytes.len()
+                )
+            }
+        }
+    }
+}
+
+/// A MozRdp message sent from the client
+#[derive(Serialize, Deserialize)]
+pub struct ClientMessage<T> {
+    pub to: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+    #[serde(flatten)]
+    pub data: T,
+}
+
+/// A MozRdp message sent from the server
+#[derive(Serialize, Deserialize)]
+pub struct ServerMessage<T> {
+    pub from: String,
+    #[serde(flatten)]
+    pub data: T,
+}

--- a/packages/blitz-devtools-server/tests/handshake.rs
+++ b/packages/blitz-devtools-server/tests/handshake.rs
@@ -271,7 +271,7 @@ fn client_session(mut stream: TcpStream) {
             serde_json::json!({ "to": flexbox_actor, "type": "getFlexItems" }),
         );
         let msg = read_packet(&mut stream);
-        let items = msg["flexItems"].as_array().expect("flex items");
+        let items = msg["flexitems"].as_array().expect("flex items");
         assert_eq!(items.len(), 2);
     }
 }

--- a/packages/blitz-devtools-server/tests/handshake.rs
+++ b/packages/blitz-devtools-server/tests/handshake.rs
@@ -273,5 +273,41 @@ fn client_session(mut stream: TcpStream) {
         let msg = read_packet(&mut stream);
         let items = msg["flexitems"].as_array().expect("flex items");
         assert_eq!(items.len(), 2);
+
+        // Highlighting a text node must not crash (it should highlight the
+        // nearest element ancestor instead)
+        write_packet(
+            &mut stream,
+            serde_json::json!({
+                "to": inspector_actor,
+                "type": "getHighlighterByType",
+                "typeName": "BoxModelHighlighter",
+            }),
+        );
+        let msg = read_packet(&mut stream);
+        let highlighter_actor = msg["highlighter"]["actor"].as_str().unwrap().to_string();
+
+        let span_actor = children[0]["actor"].as_str().unwrap().to_string();
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": walker_actor, "type": "children", "node": span_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        let span_children = msg["nodes"].as_array().expect("span children");
+        let text_node = &span_children[0];
+        assert_eq!(text_node["nodeType"], 3);
+        let text_actor = text_node["actor"].as_str().unwrap().to_string();
+
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": highlighter_actor, "type": "show", "node": text_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["value"], true);
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": highlighter_actor, "type": "hide" }),
+        );
+        let _ = read_packet(&mut stream);
     }
 }

--- a/packages/blitz-devtools-server/tests/handshake.rs
+++ b/packages/blitz-devtools-server/tests/handshake.rs
@@ -60,7 +60,7 @@ fn write_packet(stream: &mut TcpStream, packet: serde_json::Value) {
 fn session_initialization() {
     let html = "<html><head><title>Test Page</title></head>\
          <body><div id=\"container\" style=\"display: flex\">\
-         <span class=\"a\">Hello</span><span class=\"b\">World</span>\
+         <span class=\"a\">Hello</span> <span class=\"b\">World</span>\
          </div></body></html>";
     let mut doc: BaseDocument = HtmlDocument::from_html(
         html,

--- a/packages/blitz-devtools-server/tests/handshake.rs
+++ b/packages/blitz-devtools-server/tests/handshake.rs
@@ -61,7 +61,8 @@ fn session_initialization() {
     let html = "<html><head><title>Test Page</title></head>\
          <body><div id=\"container\" style=\"display: flex\">\
          <span class=\"a\">Hello</span> <span class=\"b\">World</span>\
-         </div></body></html>";
+         </div><p id=\"para\" style=\"width: 100px\">aaaa aaaa \
+         <span id=\"wrapped\">bbbb bbbb bbbb bbbb</span> aaaa</p></body></html>";
     let mut doc: BaseDocument = HtmlDocument::from_html(
         html,
         DocumentConfig {
@@ -301,6 +302,44 @@ fn client_session(mut stream: TcpStream) {
         write_packet(
             &mut stream,
             serde_json::json!({ "to": highlighter_actor, "type": "show", "node": text_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["value"], true);
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": highlighter_actor, "type": "hide" }),
+        );
+        let _ = read_packet(&mut stream);
+
+        // A non-atomic inline element that wraps across line boxes has no
+        // layout box of its own: getLayout must report the bounding rect of
+        // its line-box fragments, and highlighting it must work
+        write_packet(
+            &mut stream,
+            serde_json::json!({
+                "to": walker_actor,
+                "type": "querySelector",
+                "node": walker["root"]["actor"],
+                "selector": "#wrapped",
+            }),
+        );
+        let msg = read_packet(&mut stream);
+        let wrapped = &msg["node"];
+        assert_eq!(wrapped["nodeName"], "SPAN");
+        let wrapped_actor = wrapped["actor"].as_str().unwrap().to_string();
+
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": page_style_actor, "type": "getLayout", "node": wrapped_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["display"], "inline");
+        assert!(msg["width"].as_f64().unwrap() > 0.0);
+        assert!(msg["height"].as_f64().unwrap() > 0.0);
+
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": highlighter_actor, "type": "show", "node": wrapped_actor }),
         );
         let msg = read_packet(&mut stream);
         assert_eq!(msg["value"], true);

--- a/packages/blitz-devtools-server/tests/handshake.rs
+++ b/packages/blitz-devtools-server/tests/handshake.rs
@@ -1,0 +1,277 @@
+//! Integration test: connect to the devtools server over TCP and exercise
+//! the session-initialization message sequence against a real document.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::mpsc::{Sender, channel};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use blitz_devtools_server::{DevtoolsServer, DevtoolsWaker, DocumentProvider};
+use blitz_dom::{BaseDocument, DocumentConfig};
+use blitz_html::HtmlDocument;
+use blitz_traits::shell::{ColorScheme, Viewport};
+
+struct TestWaker(Mutex<Sender<()>>);
+impl DevtoolsWaker for TestWaker {
+    fn wake(&self) {
+        let _ = self.0.lock().unwrap().send(());
+    }
+}
+
+struct SingleDocProvider(BaseDocument);
+impl DocumentProvider for SingleDocProvider {
+    fn document_ids(&self) -> Vec<usize> {
+        vec![self.0.id()]
+    }
+    fn with_document(&mut self, id: usize, cb: &mut dyn FnMut(&mut BaseDocument)) {
+        if id == self.0.id() {
+            cb(&mut self.0);
+        }
+    }
+}
+
+/// Read a single `length:{json}` packet from the stream
+fn read_packet(stream: &mut TcpStream) -> serde_json::Value {
+    let mut header = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        stream.read_exact(&mut byte).expect("read header byte");
+        if byte[0] == b':' {
+            break;
+        }
+        header.push(byte[0]);
+        assert!(header.len() < 20, "header too long");
+    }
+    let len: usize = str::from_utf8(&header).unwrap().parse().unwrap();
+    let mut data = vec![0u8; len];
+    stream.read_exact(&mut data).expect("read packet body");
+    serde_json::from_slice(&data).expect("valid json packet")
+}
+
+fn write_packet(stream: &mut TcpStream, packet: serde_json::Value) {
+    let encoded = serde_json::to_string(&packet).unwrap();
+    stream
+        .write_all(format!("{}:{}", encoded.len(), encoded).as_bytes())
+        .unwrap();
+}
+
+#[test]
+fn session_initialization() {
+    let html = "<html><head><title>Test Page</title></head>\
+         <body><div id=\"container\" style=\"display: flex\">\
+         <span class=\"a\">Hello</span><span class=\"b\">World</span>\
+         </div></body></html>";
+    let mut doc: BaseDocument = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(1200, 800, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        },
+    )
+    .into();
+    doc.resolve(0.0);
+    let mut provider = SingleDocProvider(doc);
+
+    let (wake_sender, wake_receiver) = channel();
+    let mut server = DevtoolsServer::new(Arc::new(TestWaker(Mutex::new(wake_sender))));
+    // Port 0: let the OS assign a free port
+    server.start_listening("127.0.0.1:0");
+    let addr = server
+        .wait_for_local_addr(Duration::from_secs(10))
+        .expect("server should start listening");
+
+    let stream = TcpStream::connect(addr).expect("connect to devtools server");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+
+    // Run the client on a separate thread; process messages when woken on
+    // this thread (which owns the document), simulating the embedder's
+    // event loop. `BaseDocument` is not `Send`, so it must stay here.
+    let done = Arc::new(Mutex::new(false));
+    std::thread::scope(|scope| {
+        let done2 = Arc::clone(&done);
+        scope.spawn(move || {
+            client_session(stream);
+            *done2.lock().unwrap() = true;
+        });
+
+        while !*done.lock().unwrap() {
+            if wake_receiver
+                .recv_timeout(Duration::from_millis(50))
+                .is_ok()
+            {
+                server.process_messages(&mut provider);
+            }
+        }
+    });
+}
+
+fn client_session(mut stream: TcpStream) {
+    {
+        // Initial notification from the root actor
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["from"], "root");
+        assert_eq!(msg["applicationType"], "browser");
+
+        // getRoot
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": "root", "type": "getRoot" }),
+        );
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["from"], "root");
+        assert!(msg["deviceActor"].is_string());
+
+        // listTabs should return our document
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": "root", "type": "listTabs" }),
+        );
+        let msg = read_packet(&mut stream);
+        let tabs = msg["tabs"].as_array().expect("tabs array");
+        assert_eq!(tabs.len(), 1);
+        assert_eq!(tabs[0]["title"], "Test Page");
+        let tab_actor = tabs[0]["actor"].as_str().expect("tab actor name");
+
+        // getWatcher
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": tab_actor, "type": "getWatcher", "isServerTargetSwitchingEnabled": true }),
+        );
+        let msg = read_packet(&mut stream);
+        let watcher_actor = msg["actor"]
+            .as_str()
+            .expect("watcher actor name")
+            .to_string();
+
+        // watchTargets: expect a target-available-form notification then an
+        // empty reply
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": watcher_actor, "type": "watchTargets", "targetType": "frame" }),
+        );
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["type"], "target-available-form");
+        let target = &msg["target"];
+        assert_eq!(target["title"], "Test Page");
+        let inspector_actor = target["inspectorActor"].as_str().unwrap().to_string();
+        let css_properties_actor = target["cssPropertiesActor"].as_str().unwrap().to_string();
+        let _ = read_packet(&mut stream); // empty reply
+
+        // getCSSDatabase
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": css_properties_actor, "type": "getCSSDatabase" }),
+        );
+        let msg = read_packet(&mut stream);
+        let properties = msg["properties"].as_object().expect("css properties");
+        assert!(properties.contains_key("display"));
+        assert!(properties.contains_key("flex-direction"));
+        assert_eq!(properties["color"]["isInherited"], true);
+        assert_eq!(properties["display"]["isInherited"], false);
+
+        // getWalker
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": inspector_actor, "type": "getWalker" }),
+        );
+        let msg = read_packet(&mut stream);
+        let walker = &msg["walker"];
+        let walker_actor = walker["actor"].as_str().unwrap().to_string();
+        assert_eq!(walker["root"]["nodeType"], 9);
+
+        // querySelector for the flex container
+        write_packet(
+            &mut stream,
+            serde_json::json!({
+                "to": walker_actor,
+                "type": "querySelector",
+                "node": walker["root"]["actor"],
+                "selector": "#container",
+            }),
+        );
+        let msg = read_packet(&mut stream);
+        let node = &msg["node"];
+        assert_eq!(node["nodeName"], "DIV");
+        assert_eq!(node["displayType"], "flex");
+        let node_actor = node["actor"].as_str().unwrap().to_string();
+
+        // children of the container
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": walker_actor, "type": "children", "node": node_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        let children = msg["nodes"].as_array().expect("children nodes");
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0]["nodeName"], "SPAN");
+
+        // getPageStyle
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": inspector_actor, "type": "getPageStyle" }),
+        );
+        let msg = read_packet(&mut stream);
+        let page_style_actor = msg["pageStyle"]["actor"].as_str().unwrap().to_string();
+
+        // getComputed
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": page_style_actor, "type": "getComputed", "node": node_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        let computed = msg["computed"].as_object().expect("computed styles");
+        assert_eq!(computed["display"]["value"], "flex");
+
+        // getLayout
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": page_style_actor, "type": "getLayout", "node": node_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["display"], "flex");
+        assert!(msg["width"].is_number());
+
+        // getApplied
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": page_style_actor, "type": "getApplied", "node": node_actor, "inherited": true }),
+        );
+        let msg = read_packet(&mut stream);
+        let entries = msg["entries"].as_array().expect("applied entries");
+        // The div has an inline style attribute, which should be the first entry
+        assert!(!entries.is_empty());
+        let inline = &entries[0];
+        assert_eq!(inline["rule"]["type"], 100);
+        assert_eq!(inline["rule"]["declarations"][0]["name"], "display");
+        assert_eq!(inline["rule"]["declarations"][0]["value"], "flex");
+
+        // getLayoutInspector + getCurrentFlexbox
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": walker_actor, "type": "getLayoutInspector" }),
+        );
+        let msg = read_packet(&mut stream);
+        let layout_actor = msg["actor"]["actor"].as_str().unwrap().to_string();
+
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": layout_actor, "type": "getCurrentFlexbox", "node": node_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        let flexbox = &msg["flexbox"];
+        assert!(flexbox.is_object());
+        assert_eq!(flexbox["properties"]["flex-direction"], "row");
+        let flexbox_actor = flexbox["actor"].as_str().unwrap().to_string();
+
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": flexbox_actor, "type": "getFlexItems" }),
+        );
+        let msg = read_packet(&mut stream);
+        let items = msg["flexItems"].as_array().expect("flex items");
+        assert_eq!(items.len(), 2);
+    }
+}

--- a/packages/blitz-shell/Cargo.toml
+++ b/packages/blitz-shell/Cargo.toml
@@ -22,6 +22,8 @@ tracing = ["dep:tracing", "blitz-dom/tracing"]
 file-dialog = ["dep:rfd"]
 # Enables a data-uri-only NetProvider. Only needed if you aren't using the regular NetProvider
 data-uri = ["dep:data-url"]
+# Enables the Firefox devtools protocol server (opt-in via the BLITZ_DEVTOOLS_PORT env var)
+devtools = ["dep:blitz-devtools-server"]
 custom-widget = ["blitz-dom/custom-widget"]
 
 [dependencies]
@@ -29,6 +31,7 @@ custom-widget = ["blitz-dom/custom-widget"]
 blitz-traits = { workspace = true }
 blitz-dom = { workspace = true }
 blitz-paint = { workspace = true }
+blitz-devtools-server = { workspace = true, optional = true }
 anyrender = { workspace = true }
 
 # Windowing & Input

--- a/packages/blitz-shell/src/application.rs
+++ b/packages/blitz-shell/src/application.rs
@@ -18,16 +18,65 @@ pub struct BlitzApplication<Rend: WindowRenderer> {
     pub pending_windows: Vec<WindowConfig<Rend>>,
     pub proxy: BlitzShellProxy,
     pub event_queue: Receiver<BlitzShellEvent>,
+    #[cfg(feature = "devtools")]
+    pub devtools: Option<blitz_devtools_server::DevtoolsServer>,
+}
+
+/// Adapter that gives devtools actors access to the application's documents
+#[cfg(feature = "devtools")]
+struct WindowsDocumentProvider<'a, Rend: WindowRenderer> {
+    windows: &'a mut HashMap<WindowId, View<Rend>>,
+}
+
+#[cfg(feature = "devtools")]
+impl<Rend: WindowRenderer> blitz_devtools_server::DocumentProvider
+    for WindowsDocumentProvider<'_, Rend>
+{
+    fn document_ids(&self) -> Vec<usize> {
+        self.windows.values().map(|view| view.doc.id()).collect()
+    }
+
+    fn with_document(&mut self, id: usize, cb: &mut dyn FnMut(&mut blitz_dom::BaseDocument)) {
+        if let Some(view) = self.windows.values_mut().find(|view| view.doc.id() == id) {
+            cb(&mut view.doc.inner_mut());
+        }
+    }
 }
 
 impl<Rend: WindowRenderer> BlitzApplication<Rend> {
     pub fn new(proxy: BlitzShellProxy, event_queue: Receiver<BlitzShellEvent>) -> Self {
-        BlitzApplication {
+        #[allow(unused_mut)]
+        let mut app = BlitzApplication {
             windows: HashMap::new(),
             pending_windows: Vec::new(),
             proxy,
             event_queue,
+            #[cfg(feature = "devtools")]
+            devtools: None,
+        };
+
+        // Opt-in devtools server: enabled by setting the BLITZ_DEVTOOLS_PORT
+        // environment variable to the port to listen on
+        #[cfg(feature = "devtools")]
+        if let Ok(port) = std::env::var("BLITZ_DEVTOOLS_PORT") {
+            if let Ok(port) = port.parse::<u16>() {
+                app.start_devtools_server(port);
+            } else {
+                eprintln!("Devtools: invalid BLITZ_DEVTOOLS_PORT: {port}");
+            }
         }
+
+        app
+    }
+
+    /// Start a Firefox devtools protocol server listening on localhost at
+    /// the given port. Connect to it from Firefox via about:debugging.
+    #[cfg(feature = "devtools")]
+    pub fn start_devtools_server(&mut self, port: u16) {
+        use std::sync::Arc;
+        let mut server = blitz_devtools_server::DevtoolsServer::new(Arc::new(self.proxy.clone()));
+        server.start_listening(&format!("127.0.0.1:{port}"));
+        self.devtools = Some(server);
     }
 
     pub fn add_window(&mut self, window_config: WindowConfig<Rend>) {
@@ -88,6 +137,16 @@ impl<Rend: WindowRenderer> BlitzApplication<Rend> {
                             // TODO
                         }
                     }
+                }
+            }
+            #[cfg(feature = "devtools")]
+            BlitzShellEvent::DevtoolsPoll => {
+                if let Some(mut devtools) = self.devtools.take() {
+                    let mut provider = WindowsDocumentProvider {
+                        windows: &mut self.windows,
+                    };
+                    devtools.process_messages(&mut provider);
+                    self.devtools = Some(devtools);
                 }
             }
             BlitzShellEvent::Embedder(_) => {

--- a/packages/blitz-shell/src/event.rs
+++ b/packages/blitz-shell/src/event.rs
@@ -38,6 +38,10 @@ pub enum BlitzShellEvent {
         data: Arc<AccessKitEvent>,
     },
 
+    /// Devtools protocol messages are waiting to be processed
+    #[cfg(feature = "devtools")]
+    DevtoolsPoll,
+
     /// An arbitary event from the Blitz embedder
     Embedder(Arc<dyn Any + Send + Sync>),
 
@@ -93,6 +97,13 @@ impl BlitzShellProxy {
     fn send_event_impl(&self, event: BlitzShellEvent) {
         let _ = self.0.sender.send(event);
         self.wake_up();
+    }
+}
+
+#[cfg(feature = "devtools")]
+impl blitz_devtools_server::DevtoolsWaker for BlitzShellProxy {
+    fn wake(&self) {
+        self.send_event_impl(BlitzShellEvent::DevtoolsPoll)
     }
 }
 

--- a/packages/blitz/Cargo.toml
+++ b/packages/blitz/Cargo.toml
@@ -16,6 +16,7 @@ net = ["dep:tokio", "dep:url", "dep:blitz-net"]
 accessibility = ["blitz-shell/accessibility"]
 tracing = ["dep:tracing", "blitz-shell/tracing", "blitz-html/tracing", "blitz-net/tracing"]
 scrollbars = ["blitz-paint/scrollbars"]
+devtools = ["blitz-shell/devtools"]
 
 [dependencies]
 # Blitz dependencies


### PR DESCRIPTION
## Summary

Revives the Firefox devtools protocol server from #297 (rebased onto the current architecture) and extends it so that Firefox's DOM, style, and layout inspectors work against Blitz documents. Connect from Firefox via `about:debugging` → "Network Location" after running any blitz-shell app with `BLITZ_DEVTOOLS_PORT=6000` (feature `devtools` on `blitz-shell`/`blitz`).

### Architecture

Devtools messages are processed synchronously on the winit thread, which trivially satisfies the protocol's strict reply-ordering rule and gives actors direct document access with no async delegation:

```rust
// blitz-devtools-server
pub trait DocumentProvider {
    fn document_ids(&self) -> Vec<usize>;
    fn with_document(&mut self, id: usize, cb: &mut dyn FnMut(&mut BaseDocument));
}
pub trait DevtoolsWaker: Send + Sync { fn wake(&self); }
```

The tokio listener thread queues incoming packets and wakes the event loop (`BlitzShellProxy` implements `DevtoolsWaker` by sending a new `BlitzShellEvent::DevtoolsPoll`); `BlitzApplication` then calls `DevtoolsServer::process_messages(&mut WindowsDocumentProvider { windows })`.

Infra fixes vs #297: actors are `&mut self` (dispatched by temporarily removing the actor from the registry), error packets carry a `message` field, reader/writer tasks are aborted on disconnect (no panics on closed sockets), and the server is opt-in.

### Actors

- **Session plumbing**: `RootActor.listTabs` now enumerates real documents via `DocumentProvider` (title from `<title>`, real URL); `TabDescriptorActor`, `WatcherActor` (`watchTargets` → `target-available-form` sequence), frame-target/target-config/thread-config/console/thread stubs.
- **`CssPropertiesActor.getCSSDatabase`**: generated from Stylo's `NonCustomPropertyId::iter()` (inherited flag, shorthand→longhand mapping) instead of a hardcoded list.
- **Walker**: protocol node actors mapped to Blitz `NodeId`s; node forms, `children` (filters anonymous boxes), `querySelector` (with `newParents`), `watchRootNode`, `getUniqueSelector`, `getOffsetParent`.
- **PageStyle**: `getLayout` from `node.final_layout` + computed style; `getComputed` serializes all Stylo longhands; `getApplied` walks the Stylo rule tree (`StrongRuleNode::self_and_ancestors`) and matches declaration blocks back to stylesheet rules by pointer to recover selector text/source location, plus inline `style=""` and inherited rules from ancestors. Read-only for now (`modifyProperties`/rule editing deferred).
- **Layout**: `getCurrentFlexbox`/`getFlexItems` from Taffy final layout + computed flex styles; `getGrids` from Taffy's `DetailedGridInfo`, which is now captured during layout into `ElementData::detailed_grid_info`.
- **BoxModelHighlighter**: `show`/`hide` set a new `DevtoolSettings::highlight_node`, rendered by the existing blitz-paint debug overlay.

### Testing

`packages/blitz-devtools-server/tests/handshake.rs` drives a real TCP session against a `HtmlDocument` end-to-end: root handshake → `listTabs` → `getWatcher`/`watchTargets` → `getCSSDatabase` → walker `querySelector`/`children` → `getComputed`/`getLayout`/`getApplied` → `getCurrentFlexbox`/`getFlexItems`.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a297018e1b9d4cef96d3628aed9b8384
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30581491653).</sub>
<!-- wpt-results-end -->
