### PR TITLE
Firefox devtools server: fix "invalid property name" warnings in the Rules view

### DIFF
--- a/packages/blitz-devtools-server/src/actors/page_style.rs
+++ b/packages/blitz-devtools-server/src/actors/page_style.rs
@@ -194,6 +194,14 @@ impl Actor for PageStyleActor {
                                 "value": decl.value,
                                 "priority": if decl.important { "important" } else { "" },
                                 "important": decl.important,
+                                // These declarations come from Stylo's
+                                // PropertyDeclarationBlock, which has already
+                                // dropped anything it couldn't parse. Without
+                                // these flags the Rules view shows an
+                                // "invalid property name" warning on every
+                                // declaration.
+                                "isNameValid": true,
+                                "isValid": true,
                                 "isUsed": { "used": true },
                                 "terminator": "",
                             })


### PR DESCRIPTION
## Summary

Stacked between #557 and #558. Every declaration in the Rules panel showed a yellow ⚠ "Invalid property name" tooltip: Firefox's `TextProperty` reads server-provided `isNameValid`/`isValid` flags off each declaration in the `getApplied` rule forms, and a missing flag is falsy.

Fix: emit `"isNameValid": true, "isValid": true` on each declaration in `PageStyle`'s form. Unconditionally `true` is correct here because the declarations are serialized from Stylo's `PropertyDeclarationBlock`, which already dropped anything it couldn't parse.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a297018e1b9d4cef96d3628aed9b8384
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**0** newly passing, **0** newly failing (net 0), **3** added tests.

<details>
<summary>Full diff (3 changed tests)</summary>

```diff
+ ADD css/compositing/mix-blend-mode/mix-blend-mode-root-element-transform-crash.html
+ ADD css/css-conditional/container-queries/style-query-registered-custom-root-relative-units-change.html
+ ADD css/css-pseudo/crashtests/chrome-536997542-crash.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30510765231).</sub>
<!-- wpt-results-end -->
