### PR TITLE
Firefox devtools server: box model and highlighting for inline spans

### DIFF
--- a/packages/blitz-devtools-server/Cargo.toml
+++ b/packages/blitz-devtools-server/Cargo.toml
@@ -30,3 +30,5 @@ bytes = { workspace = true }
 
 [dev-dependencies]
 blitz-html = { workspace = true }
+# Text must be laid out with real fonts for inline fragment geometry to be non-zero
+blitz-dom = { workspace = true, features = ["system-fonts"] }

--- a/packages/blitz-devtools-server/src/actors.rs
+++ b/packages/blitz-devtools-server/src/actors.rs
@@ -131,6 +131,51 @@ impl Connection {
             self.insert_actor(actor);
         }
     }
+
+    pub(crate) fn notify_picker_event(
+        &mut self,
+        event: &crate::PickerEvent,
+        docs: &mut dyn DocumentProvider,
+    ) {
+        use crate::PickerEvent;
+        use crate::actors::walker::WalkerActor;
+
+        let event_doc_id = match *event {
+            PickerEvent::Hovered { doc_id, .. }
+            | PickerEvent::Picked { doc_id, .. }
+            | PickerEvent::Canceled { doc_id } => doc_id,
+        };
+
+        // Find this connection's walkers that are currently picking on the
+        // document the event is for
+        let walker_names: Vec<ActorId> = self
+            .actors
+            .values()
+            .filter_map(|actor| {
+                let any: &dyn Any = actor.as_ref();
+                let walker = any.downcast_ref::<WalkerActor>()?;
+                (walker.picking && walker.doc_id == event_doc_id).then(|| walker.name())
+            })
+            .collect();
+
+        for walker_name in walker_names {
+            let Some(mut actor) = self.actors.remove(&walker_name) else {
+                continue;
+            };
+            {
+                let any: &mut dyn Any = actor.as_mut();
+                let walker = any.downcast_mut::<WalkerActor>().unwrap();
+                let mut ctx = DevtoolContext {
+                    writer: &mut self.writer,
+                    actors: &mut self.actors,
+                    actors_to_create: Vec::new(),
+                    docs,
+                };
+                walker.handle_picker_event(&mut ctx, event);
+            }
+            self.insert_actor(actor);
+        }
+    }
 }
 
 pub(crate) struct DevtoolContext<'a> {

--- a/packages/blitz-devtools-server/src/actors/page_style.rs
+++ b/packages/blitz-devtools-server/src/actors/page_style.rs
@@ -325,11 +325,31 @@ fn layout_form(doc: &BaseDocument, node_id: NodeId) -> Option<JsonValue> {
         }
     }
 
+    // Non-atomic inline elements have no layout box of their own (they are
+    // laid out as style spans that may fragment across line boxes): report
+    // the bounding rect of their fragments, as Firefox does.
+    let (width, height) = match doc.inline_fragment_rects(node_id) {
+        Some(_) => match doc.get_client_bounding_rect(node_id) {
+            Some(rect) => (rect.width as f32, rect.height as f32),
+            None => (0.0, 0.0),
+        },
+        None => (
+            layout.size.width
+                - layout.border.left
+                - layout.border.right
+                - layout.padding.left
+                - layout.padding.right,
+            layout.size.height
+                - layout.border.top
+                - layout.border.bottom
+                - layout.padding.top
+                - layout.padding.bottom,
+        ),
+    };
+
     Some(json!({
-        "width": layout.size.width - layout.border.left - layout.border.right
-            - layout.padding.left - layout.padding.right,
-        "height": layout.size.height - layout.border.top - layout.border.bottom
-            - layout.padding.top - layout.padding.bottom,
+        "width": width,
+        "height": height,
         "autoMargins": auto_margins,
         "margin-top": px(layout.margin.top),
         "margin-right": px(layout.margin.right),

--- a/packages/blitz-devtools-server/src/actors/walker.rs
+++ b/packages/blitz-devtools-server/src/actors/walker.rs
@@ -25,6 +25,11 @@ pub(crate) struct WalkerActor {
     layout_actor_name: Option<String>,
     node_to_actor: HashMap<NodeId, String>,
     actor_to_node: HashMap<String, NodeId>,
+    /// Whether the element picker is currently active for this walker
+    pub(crate) picking: bool,
+    /// The node last reported via a `pickerNodeHovered` event (used to
+    /// avoid re-sending events while hovering the same node)
+    pub(crate) last_picker_node: Option<NodeId>,
 }
 
 impl WalkerActor {
@@ -35,6 +40,8 @@ impl WalkerActor {
             layout_actor_name: None,
             node_to_actor: HashMap::new(),
             actor_to_node: HashMap::new(),
+            picking: false,
+            last_picker_node: None,
         }
     }
 
@@ -158,6 +165,118 @@ impl WalkerActor {
         result.flatten()
     }
 
+    /// Build the form of a node plus the forms of any of its ancestors the
+    /// client doesn't know about yet, so that it can connect the node to its
+    /// existing tree (the protocol's "disconnectedNode" type)
+    pub(crate) fn disconnected_node(
+        &mut self,
+        doc: &BaseDocument,
+        node_id: NodeId,
+    ) -> Option<(JsonValue, Vec<JsonValue>)> {
+        let known_nodes: Vec<NodeId> = self.node_to_actor.keys().copied().collect();
+        let node_form = self.node_form(doc, node_id)?;
+
+        let mut new_parents = Vec::new();
+        let mut current = doc.get_node(node_id).and_then(|n| n.parent);
+        while let Some(ancestor_id) = current {
+            let already_known = known_nodes.contains(&ancestor_id);
+            if let Some(form) = self.node_form(doc, ancestor_id) {
+                new_parents.push(form);
+            }
+            if already_known {
+                break;
+            }
+            current = doc.get_node(ancestor_id).and_then(|n| n.parent);
+        }
+
+        Some((node_form, new_parents))
+    }
+
+    /// Resolve the DOM node to report for a picker event at the given
+    /// viewport position: the topmost hit node, mapped to the nearest
+    /// ancestor that is shown in the devtools tree (non-anonymous and not a
+    /// whitespace-only text node)
+    fn picker_target(doc: &BaseDocument, x: f32, y: f32) -> Option<NodeId> {
+        let hit = doc.hit(x, y)?;
+        let mut node_id = doc.nearest_non_anonymous_ancestor(hit.node_id)?;
+        while let Some(node) = doc.get_node(node_id) {
+            if !node.is_whitespace_node() {
+                return Some(node_id);
+            }
+            node_id = node.parent?;
+        }
+        None
+    }
+
+    /// React to an element-picker input event reported by the embedder,
+    /// emitting the corresponding `pickerNode*` event to the client
+    pub(crate) fn handle_picker_event(
+        &mut self,
+        ctx: &mut DevtoolContext<'_>,
+        event: &crate::PickerEvent,
+    ) {
+        use crate::PickerEvent;
+        let doc_id = self.doc_id;
+        match *event {
+            PickerEvent::Hovered { x, y, .. } => {
+                let result = ctx
+                    .with_doc(doc_id, |doc| {
+                        let node_id = Self::picker_target(doc, x, y)?;
+                        if self.last_picker_node == Some(node_id) {
+                            return None;
+                        }
+                        self.last_picker_node = Some(node_id);
+                        doc.devtools_mut().highlight_node = Some(node_id);
+                        doc.shell_provider.request_redraw();
+                        self.disconnected_node(doc, node_id)
+                    })
+                    .flatten();
+                if let Some((node, new_parents)) = result {
+                    ctx.write_msg(
+                        self.name(),
+                        json!({
+                            "type": "pickerNodeHovered",
+                            "node": { "node": node, "newParents": new_parents },
+                        }),
+                    );
+                }
+            }
+            PickerEvent::Picked { x, y, .. } => {
+                self.picking = false;
+                self.last_picker_node = None;
+                let result = ctx
+                    .with_doc(doc_id, |doc| {
+                        let node_id = Self::picker_target(doc, x, y);
+                        doc.devtools_mut().element_picker = false;
+                        doc.devtools_mut().highlight_node = None;
+                        doc.shell_provider.request_redraw();
+                        let node_id = node_id?;
+                        self.disconnected_node(doc, node_id)
+                    })
+                    .flatten();
+                if let Some((node, new_parents)) = result {
+                    ctx.write_msg(
+                        self.name(),
+                        json!({
+                            "type": "pickerNodePicked",
+                            "node": { "node": node, "newParents": new_parents },
+                        }),
+                    );
+                }
+            }
+            PickerEvent::Canceled { .. } => {
+                self.picking = false;
+                self.last_picker_node = None;
+                ctx.with_doc(doc_id, |doc| {
+                    doc.devtools_mut().element_picker = false;
+                    doc.devtools_mut().highlight_node = None;
+                    doc.shell_provider.request_redraw();
+                });
+                ctx.write_msg(self.name(), json!({ "type": "pickerNodeCanceled" }));
+            }
+        }
+    }
+
     /// Build a "unique" selector for a node (best effort)
     fn unique_selector(doc: &BaseDocument, node: &Node) -> String {
         let Some(element) = node.element_data() else {
@@ -254,28 +373,9 @@ impl Actor for WalkerActor {
                     .node_for_actor(node_actor)
                     .ok_or(ActorMessageErr::NoSuchNode)?;
 
-                let known_nodes: Vec<NodeId> = self.node_to_actor.keys().copied().collect();
                 let result = ctx.with_doc(doc_id, |doc| {
                     let node_id = doc.query_selector(&selector).ok().flatten()?;
-                    let node_form = self.node_form(doc, node_id)?;
-
-                    // Send forms for any ancestors that the client doesn't
-                    // know about yet, so that it can connect the node to
-                    // its existing tree
-                    let mut new_parents = Vec::new();
-                    let mut current = doc.get_node(node_id).and_then(|n| n.parent);
-                    while let Some(ancestor_id) = current {
-                        let already_known = known_nodes.contains(&ancestor_id);
-                        if let Some(form) = self.node_form(doc, ancestor_id) {
-                            new_parents.push(form);
-                        }
-                        if already_known {
-                            break;
-                        }
-                        current = doc.get_node(ancestor_id).and_then(|n| n.parent);
-                    }
-
-                    Some((node_form, new_parents))
+                    self.disconnected_node(doc, node_id)
                 });
 
                 match result.ok_or(ActorMessageErr::NoSuchDocument)? {
@@ -358,6 +458,30 @@ impl Actor for WalkerActor {
                     self.name(),
                     json!({ "node": { "node": form, "newParents": [] } }),
                 );
+                Ok(())
+            }
+            // Enter element-picking mode: mouse events over the page are
+            // intercepted and reported via pickerNodeHovered/pickerNodePicked
+            // events instead of being delivered to the page. `pick` is one-way
+            // (no reply).
+            "pick" => {
+                self.picking = true;
+                self.last_picker_node = None;
+                ctx.with_doc(doc_id, |doc| {
+                    doc.devtools_mut().element_picker = true;
+                    doc.shell_provider.request_redraw();
+                });
+                Ok(())
+            }
+            "cancelPick" => {
+                self.picking = false;
+                self.last_picker_node = None;
+                ctx.with_doc(doc_id, |doc| {
+                    doc.devtools_mut().element_picker = false;
+                    doc.devtools_mut().highlight_node = None;
+                    doc.shell_provider.request_redraw();
+                });
+                ctx.write_msg(self.name(), json!({}));
                 Ok(())
             }
             "getOffsetParent" => {

--- a/packages/blitz-devtools-server/src/actors/walker.rs
+++ b/packages/blitz-devtools-server/src/actors/walker.rs
@@ -462,8 +462,9 @@ impl Actor for WalkerActor {
             }
             // Enter element-picking mode: mouse events over the page are
             // intercepted and reported via pickerNodeHovered/pickerNodePicked
-            // events instead of being delivered to the page. `pick` is one-way
-            // (no reply).
+            // events instead of being delivered to the page. Unlike
+            // `clearPicker`, `pick` is not oneway: the client awaits an empty
+            // reply.
             "pick" => {
                 self.picking = true;
                 self.last_picker_node = None;
@@ -471,6 +472,7 @@ impl Actor for WalkerActor {
                     doc.devtools_mut().element_picker = true;
                     doc.shell_provider.request_redraw();
                 });
+                ctx.write_msg(self.name(), json!({}));
                 Ok(())
             }
             "cancelPick" => {

--- a/packages/blitz-devtools-server/src/actors/watcher.rs
+++ b/packages/blitz-devtools-server/src/actors/watcher.rs
@@ -106,8 +106,12 @@ impl WatcherActor {
                 "browsingContextID": doc_id,
                 "isTopLevelTarget": true,
                 "targetType": "frame",
+                // We have no subframes; this tells the client not to query
+                // them (the `frames` trait must still be true, as the toolbox
+                // gates the element picker button on it)
+                "ignoreSubFrames": true,
                 "traits": {
-                    "frames": false,
+                    "frames": true,
                     "isBrowsingContext": true,
                     "logInPage": false,
                     "navigation": false,

--- a/packages/blitz-devtools-server/src/lib.rs
+++ b/packages/blitz-devtools-server/src/lib.rs
@@ -122,6 +122,17 @@ impl DevtoolsServer {
         }
     }
 
+    /// Notify the server of an element-picker input event (called by the
+    /// embedder from its input handling path while
+    /// [`DevtoolSettings::element_picker`](blitz_traits::devtools::DevtoolSettings)
+    /// is set). Emits the corresponding `pickerNode*` walker events to any
+    /// devtools client currently picking on that document.
+    pub fn notify_picker_event(&mut self, event: PickerEvent, docs: &mut dyn DocumentProvider) {
+        for conn in self.connections.values_mut() {
+            conn.notify_picker_event(&event, docs);
+        }
+    }
+
     fn handle_event(&mut self, event: DevtoolsEvent, docs: &mut dyn DocumentProvider) {
         match event.data {
             DevtoolsEventData::ConnectionOpened(connection) => {
@@ -169,6 +180,19 @@ struct Connection {
     writer_task: JoinHandle<()>,
     writer: MessageWriter,
     actors: HashMap<ActorId, Box<dyn Actor>>,
+}
+
+/// An element-picker input event, reported by the embedder while picker mode
+/// is active. Coordinates are in the same viewport-relative CSS pixel space
+/// as [`BaseDocument::hit`](blitz_dom::BaseDocument::hit).
+#[derive(Debug, Clone, Copy)]
+pub enum PickerEvent {
+    /// The mouse moved over the document
+    Hovered { doc_id: usize, x: f32, y: f32 },
+    /// The primary mouse button was pressed over the document
+    Picked { doc_id: usize, x: f32, y: f32 },
+    /// Picking was cancelled (e.g. the user pressed Escape)
+    Canceled { doc_id: usize },
 }
 
 pub struct DevtoolsEvent {

--- a/packages/blitz-devtools-server/tests/handshake.rs
+++ b/packages/blitz-devtools-server/tests/handshake.rs
@@ -61,7 +61,8 @@ fn session_initialization() {
     let html = "<html><head><title>Test Page</title></head>\
          <body><div id=\"container\" style=\"display: flex\">\
          <span class=\"a\">Hello</span> <span class=\"b\">World</span>\
-         </div></body></html>";
+         </div><p id=\"para\" style=\"width: 100px\">aaaa aaaa \
+         <span id=\"wrapped\">bbbb bbbb bbbb bbbb</span> aaaa</p></body></html>";
     let mut doc: BaseDocument = HtmlDocument::from_html(
         html,
         DocumentConfig {
@@ -326,6 +327,44 @@ fn client_session(mut stream: TcpStream, picker_sender: Sender<PickerKind>) {
         write_packet(
             &mut stream,
             serde_json::json!({ "to": highlighter_actor, "type": "show", "node": text_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["value"], true);
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": highlighter_actor, "type": "hide" }),
+        );
+        let _ = read_packet(&mut stream);
+
+        // A non-atomic inline element that wraps across line boxes has no
+        // layout box of its own: getLayout must report the bounding rect of
+        // its line-box fragments, and highlighting it must work
+        write_packet(
+            &mut stream,
+            serde_json::json!({
+                "to": walker_actor,
+                "type": "querySelector",
+                "node": walker["root"]["actor"],
+                "selector": "#wrapped",
+            }),
+        );
+        let msg = read_packet(&mut stream);
+        let wrapped = &msg["node"];
+        assert_eq!(wrapped["nodeName"], "SPAN");
+        let wrapped_actor = wrapped["actor"].as_str().unwrap().to_string();
+
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": page_style_actor, "type": "getLayout", "node": wrapped_actor }),
+        );
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["display"], "inline");
+        assert!(msg["width"].as_f64().unwrap() > 0.0);
+        assert!(msg["height"].as_f64().unwrap() > 0.0);
+
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": highlighter_actor, "type": "show", "node": wrapped_actor }),
         );
         let msg = read_packet(&mut stream);
         assert_eq!(msg["value"], true);

--- a/packages/blitz-devtools-server/tests/handshake.rs
+++ b/packages/blitz-devtools-server/tests/handshake.rs
@@ -335,15 +335,14 @@ fn client_session(mut stream: TcpStream, picker_sender: Sender<PickerKind>) {
         );
         let _ = read_packet(&mut stream);
 
-        // Element picker: `pick` is one-way (no reply); simulated mouse
-        // events should produce pickerNodeHovered/pickerNodePicked events
+        // Element picker: after `pick`'s empty reply, simulated mouse events
+        // should produce pickerNodeHovered/pickerNodePicked events
         write_packet(
             &mut stream,
             serde_json::json!({ "to": walker_actor, "type": "pick", "doFocus": false }),
         );
-        // `pick` has no reply to synchronize on: give the server loop time to
-        // process it before simulating picker input
-        std::thread::sleep(Duration::from_millis(300));
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["from"], walker_actor);
         picker_sender.send(PickerKind::Hovered(10.0, 10.0)).unwrap();
         let msg = read_packet(&mut stream);
         assert_eq!(msg["from"], walker_actor);

--- a/packages/blitz-devtools-server/tests/handshake.rs
+++ b/packages/blitz-devtools-server/tests/handshake.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::{Sender, channel};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use blitz_devtools_server::{DevtoolsServer, DevtoolsWaker, DocumentProvider};
+use blitz_devtools_server::{DevtoolsServer, DevtoolsWaker, DocumentProvider, PickerEvent};
 use blitz_dom::{BaseDocument, DocumentConfig};
 use blitz_html::HtmlDocument;
 use blitz_traits::shell::{ColorScheme, Viewport};
@@ -89,12 +89,25 @@ fn session_initialization() {
     // Run the client on a separate thread; process messages when woken on
     // this thread (which owns the document), simulating the embedder's
     // event loop. `BaseDocument` is not `Send`, so it must stay here.
+    // Channel used by the client thread to simulate embedder-side element
+    // picker input events (mouse moves/clicks while picking)
+    let (picker_sender, picker_receiver) = channel::<PickerKind>();
+    let doc_id = provider.0.id();
+
     let done = Arc::new(Mutex::new(false));
     std::thread::scope(|scope| {
         let done2 = Arc::clone(&done);
         scope.spawn(move || {
-            client_session(stream);
-            *done2.lock().unwrap() = true;
+            // Set the done flag even if the client panics, so the server
+            // loop below doesn't spin forever on test failure
+            struct DoneGuard(Arc<Mutex<bool>>);
+            impl Drop for DoneGuard {
+                fn drop(&mut self) {
+                    *self.0.lock().unwrap() = true;
+                }
+            }
+            let _guard = DoneGuard(done2);
+            client_session(stream, picker_sender);
         });
 
         while !*done.lock().unwrap() {
@@ -104,11 +117,23 @@ fn session_initialization() {
             {
                 server.process_messages(&mut provider);
             }
+            while let Ok(kind) = picker_receiver.try_recv() {
+                let event = match kind {
+                    PickerKind::Hovered(x, y) => PickerEvent::Hovered { doc_id, x, y },
+                    PickerKind::Picked(x, y) => PickerEvent::Picked { doc_id, x, y },
+                };
+                server.notify_picker_event(event, &mut provider);
+            }
         }
     });
 }
 
-fn client_session(mut stream: TcpStream) {
+enum PickerKind {
+    Hovered(f32, f32),
+    Picked(f32, f32),
+}
+
+fn client_session(mut stream: TcpStream, picker_sender: Sender<PickerKind>) {
     {
         // Initial notification from the root actor
         let msg = read_packet(&mut stream);
@@ -309,5 +334,34 @@ fn client_session(mut stream: TcpStream) {
             serde_json::json!({ "to": highlighter_actor, "type": "hide" }),
         );
         let _ = read_packet(&mut stream);
+
+        // Element picker: `pick` is one-way (no reply); simulated mouse
+        // events should produce pickerNodeHovered/pickerNodePicked events
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": walker_actor, "type": "pick", "doFocus": false }),
+        );
+        // `pick` has no reply to synchronize on: give the server loop time to
+        // process it before simulating picker input
+        std::thread::sleep(Duration::from_millis(300));
+        picker_sender.send(PickerKind::Hovered(10.0, 10.0)).unwrap();
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["from"], walker_actor);
+        assert_eq!(msg["type"], "pickerNodeHovered");
+        let hovered_actor = msg["node"]["node"]["actor"].as_str().unwrap().to_string();
+
+        picker_sender.send(PickerKind::Picked(10.0, 10.0)).unwrap();
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["type"], "pickerNodePicked");
+        assert_eq!(msg["node"]["node"]["actor"], hovered_actor.as_str());
+        assert_eq!(msg["node"]["node"]["nodeType"], 1);
+
+        // cancelPick after picking has stopped is a no-op with an empty reply
+        write_packet(
+            &mut stream,
+            serde_json::json!({ "to": walker_actor, "type": "cancelPick" }),
+        );
+        let msg = read_packet(&mut stream);
+        assert_eq!(msg["from"], walker_actor);
     }
 }

--- a/packages/blitz-shell/src/application.rs
+++ b/packages/blitz-shell/src/application.rs
@@ -87,6 +87,71 @@ impl<Rend: WindowRenderer> BlitzApplication<Rend> {
         self.windows.values_mut().find(|w| w.doc.id() == doc_id)
     }
 
+    /// Intercept window input events while the devtools element picker is
+    /// active: mouse movement and clicks are reported to the devtools client
+    /// (which highlights/selects the corresponding node) instead of being
+    /// delivered to the page, and Escape cancels picking. Returns `true` if
+    /// the event was consumed.
+    #[cfg(feature = "devtools")]
+    fn handle_picker_event(&mut self, window_id: WindowId, event: &WindowEvent) -> bool {
+        use blitz_devtools_server::PickerEvent;
+        use winit::event::ElementState;
+        use winit::keyboard::{Key, NamedKey};
+
+        if self.devtools.is_none() {
+            return false;
+        }
+        let Some(window) = self.windows.get(&window_id) else {
+            return false;
+        };
+        if !window.doc.inner().devtools().element_picker {
+            return false;
+        }
+        let doc_id = window.doc.id();
+
+        let picker_event = match event {
+            WindowEvent::PointerMoved { position, .. } => {
+                let coords = window.pointer_coords(*position);
+                PickerEvent::Hovered {
+                    doc_id,
+                    x: coords.page_x,
+                    y: coords.page_y,
+                }
+            }
+            WindowEvent::PointerButton {
+                state, position, ..
+            } => {
+                if *state != ElementState::Pressed {
+                    return true;
+                }
+                let coords = window.pointer_coords(*position);
+                PickerEvent::Picked {
+                    doc_id,
+                    x: coords.page_x,
+                    y: coords.page_y,
+                }
+            }
+            WindowEvent::KeyboardInput { event, .. } => {
+                if event.state != ElementState::Pressed
+                    || event.logical_key != Key::Named(NamedKey::Escape)
+                {
+                    return false;
+                }
+                PickerEvent::Canceled { doc_id }
+            }
+            _ => return false,
+        };
+
+        if let Some(mut devtools) = self.devtools.take() {
+            let mut provider = WindowsDocumentProvider {
+                windows: &mut self.windows,
+            };
+            devtools.notify_picker_event(picker_event, &mut provider);
+            self.devtools = Some(devtools);
+        }
+        true
+    }
+
     pub fn handle_blitz_shell_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
@@ -215,6 +280,11 @@ impl<Rend: WindowRenderer> ApplicationHandler for BlitzApplication<Rend> {
             if self.windows.is_empty() {
                 event_loop.exit();
             }
+            return;
+        }
+
+        #[cfg(feature = "devtools")]
+        if self.handle_picker_event(window_id, &event) {
             return;
         }
 

--- a/packages/blitz-shell/src/application.rs
+++ b/packages/blitz-shell/src/application.rs
@@ -20,6 +20,12 @@ pub struct BlitzApplication<Rend: WindowRenderer> {
     pub event_queue: Receiver<BlitzShellEvent>,
     #[cfg(feature = "devtools")]
     pub devtools: Option<blitz_devtools_server::DevtoolsServer>,
+    /// Windows with a swallowed element-picker button press whose matching
+    /// release must also be swallowed (picking ends on the press, so by
+    /// release time the picker flag is already off; letting the release
+    /// through would corrupt the view's pressed-buttons state)
+    #[cfg(feature = "devtools")]
+    picker_pressed_windows: std::collections::HashSet<WindowId>,
 }
 
 /// Adapter that gives devtools actors access to the application's documents
@@ -53,6 +59,8 @@ impl<Rend: WindowRenderer> BlitzApplication<Rend> {
             event_queue,
             #[cfg(feature = "devtools")]
             devtools: None,
+            #[cfg(feature = "devtools")]
+            picker_pressed_windows: std::collections::HashSet::new(),
         };
 
         // Opt-in devtools server: enabled by setting the BLITZ_DEVTOOLS_PORT
@@ -101,6 +109,12 @@ impl<Rend: WindowRenderer> BlitzApplication<Rend> {
         if self.devtools.is_none() {
             return false;
         }
+        if let WindowEvent::PointerButton { state, .. } = event
+            && *state == ElementState::Released
+            && self.picker_pressed_windows.remove(&window_id)
+        {
+            return true;
+        }
         let Some(window) = self.windows.get(&window_id) else {
             return false;
         };
@@ -124,6 +138,7 @@ impl<Rend: WindowRenderer> BlitzApplication<Rend> {
                 if *state != ElementState::Pressed {
                     return true;
                 }
+                self.picker_pressed_windows.insert(window_id);
                 let coords = window.pointer_coords(*position);
                 PickerEvent::Picked {
                     doc_id,

--- a/packages/blitz-traits/src/devtools.rs
+++ b/packages/blitz-traits/src/devtools.rs
@@ -15,6 +15,10 @@ pub struct DevtoolSettings {
     /// padding, border, and margin of a specific node (set by e.g. a
     /// remote devtools inspector)
     pub highlight_node: Option<NodeId>,
+    /// Element picker mode: mouse events are intercepted (not delivered to
+    /// the page) and reported to a remote devtools inspector so the user
+    /// can pick an element by hovering/clicking it
+    pub element_picker: bool,
 }
 
 impl DevtoolSettings {


### PR DESCRIPTION
## Summary

Devtools-side consumer of the inline fragment rects introduced in #569 (the core geometry + built-in highlighting now lives there; this PR is the remaining Firefox devtools integration).

- `PageStyle.getLayout` (Box Model panel): for non-atomic inline elements, report width/height from the fragment union rect (`get_client_bounding_rect`) instead of the zero-sized Taffy layout.
- The highlighter/hover overlay already renders per-line fragments via #569's paint change; the devtools highlighter needs no protocol changes — picking an inline span highlights each line fragment.
- Handshake integration test: fixture gains a width-constrained wrapped `<span>`; asserts it resolves as a `SPAN`, `getLayout` reports `display: inline` with positive width/height, and highlighter show/hide works on it. The devtools test document is now laid out with real fonts (`blitz-dom` `system-fonts` dev-dependency), without which inline text has zero-sized geometry.

Verified end-to-end in real Firefox (picker, per-line highlight bars, Box Model values, alistapart.com `.byline` case) — see PR comments for recordings and measurements.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a297018e1b9d4cef96d3628aed9b8384
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30516817282).</sub>
<!-- wpt-results-end -->
