### PR TITLE
Add a `requires_redraw` method to custom widgets

### DIFF
--- a/apps/browser/src/fps_overlay.rs
+++ b/apps/browser/src/fps_overlay.rs
@@ -66,7 +66,7 @@ impl FpsWidget {
 }
 
 impl Widget for FpsWidget {
-    fn is_animating(&self) -> bool {
+    fn requires_redraw(&self) -> bool {
         true
     }
 

--- a/apps/browser/src/fps_overlay.rs
+++ b/apps/browser/src/fps_overlay.rs
@@ -66,6 +66,10 @@ impl FpsWidget {
 }
 
 impl Widget for FpsWidget {
+    fn is_animating(&self) -> bool {
+        true
+    }
+
     fn destroy_surfaces(&mut self) {
         if let Ok(mut s) = self.stats.lock() {
             s.reset();

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -102,6 +102,10 @@ impl Widget for DemoWidget {
     fn can_create_surfaces(&mut self, _render_ctx: &mut dyn anyrender::RenderContext) {}
     fn destroy_surfaces(&mut self) {}
 
+    fn is_animating(&self) -> bool {
+        true
+    }
+
     fn attribute_changed(&mut self, name: &str, _old_value: Option<&str>, new_value: Option<&str>) {
         if name == "color" {
             self.color = new_value

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -102,7 +102,7 @@ impl Widget for DemoWidget {
     fn can_create_surfaces(&mut self, _render_ctx: &mut dyn anyrender::RenderContext) {}
     fn destroy_surfaces(&mut self) {}
 
-    fn is_animating(&self) -> bool {
+    fn requires_redraw(&self) -> bool {
         true
     }
 

--- a/examples/wgpu_texture/src/demo_renderer.rs
+++ b/examples/wgpu_texture/src/demo_renderer.rs
@@ -37,7 +37,7 @@ impl Widget for DemoWidget {
         self.state = DemoRendererState::Suspended;
     }
 
-    fn is_animating(&self) -> bool {
+    fn requires_redraw(&self) -> bool {
         true
     }
 

--- a/examples/wgpu_texture/src/demo_renderer.rs
+++ b/examples/wgpu_texture/src/demo_renderer.rs
@@ -37,6 +37,10 @@ impl Widget for DemoWidget {
         self.state = DemoRendererState::Suspended;
     }
 
+    fn is_animating(&self) -> bool {
+        true
+    }
+
     fn handle_event(&mut self, event: &blitz_traits::events::UiEvent) {
         let _ = event;
     }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1822,7 +1822,7 @@ impl BaseDocument {
             self.nodes[node_id]
                 .element_data()
                 .and_then(|el| el.custom_widget_data())
-                .is_some_and(|data| data.widget.is_animating())
+                .is_some_and(|data| data.widget.requires_redraw())
         });
         #[cfg(not(feature = "custom-widget"))]
         let custom_widget_is_animating = false;

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1818,14 +1818,19 @@ impl BaseDocument {
 
     pub fn is_animating(&self) -> bool {
         #[cfg(feature = "custom-widget")]
-        let has_custom_widgets = !self.custom_widget_nodes.is_empty();
+        let custom_widget_is_animating = self.custom_widget_nodes.iter().any(|&node_id| {
+            self.nodes[node_id]
+                .element_data()
+                .and_then(|el| el.custom_widget_data())
+                .is_some_and(|data| data.widget.is_animating())
+        });
         #[cfg(not(feature = "custom-widget"))]
-        let has_custom_widgets = false;
+        let custom_widget_is_animating = false;
 
         self.has_canvas
             | self.has_active_animations
             | self.subdoc_is_animating
-            | has_custom_widgets
+            | custom_widget_is_animating
             | (self.scroll_animation != ScrollAnimationState::None)
             | self.scrollbars_animating()
     }

--- a/packages/blitz-dom/src/node/custom_widget.rs
+++ b/packages/blitz-dom/src/node/custom_widget.rs
@@ -96,11 +96,11 @@ pub trait Widget {
 
     // Other
 
-    /// Whether the widget is currently animating.
+    /// Whether the widget currently requires redraws (e.g. because it is animating).
     ///
     /// Returning `true` causes the document to continuously schedule redraws
     /// (and hence repaints of the widget). Static widgets should return `false`.
-    fn is_animating(&self) -> bool {
+    fn requires_redraw(&self) -> bool {
         false
     }
 

--- a/packages/blitz-dom/src/node/custom_widget.rs
+++ b/packages/blitz-dom/src/node/custom_widget.rs
@@ -96,6 +96,14 @@ pub trait Widget {
 
     // Other
 
+    /// Whether the widget is currently animating.
+    ///
+    /// Returning `true` causes the document to continuously schedule redraws
+    /// (and hence repaints of the widget). Static widgets should return `false`.
+    fn is_animating(&self) -> bool {
+        false
+    }
+
     /// Handle input events (mouse, keyboard, etc)
     fn handle_event(&mut self, event: &UiEvent) {
         let _ = event;


### PR DESCRIPTION
## Summary

Fixes #563. Add `requires_redraw` method to custom widgets. Custom widgets now only trigger continuous frame drawing if their `requires_redraw` method returns `true`.

<!-- wpt-results-start -->
## WPT results

**0** newly passing, **0** newly failing (net 0), **3** added tests.

<details>
<summary>Full diff (3 changed tests)</summary>

```diff
+ ADD css/compositing/mix-blend-mode/mix-blend-mode-root-element-transform-crash.html
+ ADD css/css-conditional/container-queries/style-query-registered-custom-root-relative-units-change.html
+ ADD css/css-pseudo/crashtests/chrome-536997542-crash.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30513539246).</sub>
<!-- wpt-results-end -->
