### PR TITLE
Pin the WPT repo commit tested against in CI

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -39,12 +39,7 @@ jobs:
           packages: libfontconfig1-dev
           version: 1.0
       - name: Clone WPT tests
-        run: |
-          git init ./wpt/tests
-          cd ./wpt/tests
-          git remote add origin https://github.com/web-platform-tests/wpt
-          git fetch --depth 1 origin "$WPT_COMMIT"
-          git checkout FETCH_HEAD
+        run: git clone --depth 1 --revision "$WPT_COMMIT" https://github.com/web-platform-tests/wpt ./wpt/tests
       - name: Build WPT runner
         run: cargo build -rp wpt
       - name: Run WPT tests

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -14,6 +14,7 @@ env:
   RUSTDOCFLAGS: "-D warnings"
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
   WPT_DIR: "./wpt/tests"
+  WPT_COMMIT: "a95401e4e06351eb1e15f0e15cf50abf08fa545f"
 
 permissions:
   contents: read
@@ -38,7 +39,12 @@ jobs:
           packages: libfontconfig1-dev
           version: 1.0
       - name: Clone WPT tests
-        run: git clone --depth 1 --single-branch https://github.com/web-platform-tests/wpt ./wpt/tests
+        run: |
+          git init ./wpt/tests
+          cd ./wpt/tests
+          git remote add origin https://github.com/web-platform-tests/wpt
+          git fetch --depth 1 origin "$WPT_COMMIT"
+          git checkout FETCH_HEAD
       - name: Build WPT runner
         run: cargo build -rp wpt
       - name: Run WPT tests


### PR DESCRIPTION
## Summary
CI previously cloned the tip of web-platform-tests/wpt on every run, so upstream WPT changes could cause result diffs unrelated to the PR under test. The workflow now pins the tested revision via a `WPT_COMMIT` env var (currently `a95401e4`, upstream HEAD at time of writing):

```
git clone --depth 1 --revision "$WPT_COMMIT" https://github.com/web-platform-tests/wpt ./wpt/tests
```

`--revision` requires Git ≥2.49, which GitHub-hosted runners provide. Bump `WPT_COMMIT` in `.github/workflows/wpt.yml` to update the tested WPT revision.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/4db54edc6283408ab7a6ef64c1a3d450
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30513895479).</sub>
<!-- wpt-results-end -->
