### PR TITLE
Inline fragment rects: highlight inline spans per line box

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -53,6 +53,7 @@ use style::servo_arc::Arc as ServoArc;
 use style::values::GenericAtomIdent;
 use style::values::computed::ui::CursorKind;
 use style::values::computed::{Overflow, UserSelect};
+use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style::{
     device::Device,
     dom::{TDocument, TNode},
@@ -2216,6 +2217,30 @@ impl BaseDocument {
 
     /// Computes the size and position of the `Node` relative to the viewport
     pub fn get_client_bounding_rect(&self, node_id: NodeId) -> Option<BoundingRect> {
+        // Non-atomic inline elements have no layout box of their own: return
+        // the union of their per-line-box fragment rects.
+        if let Some(rects) = self.inline_fragment_rects(node_id) {
+            let x0 = rects.iter().map(|r| r.x).fold(f64::INFINITY, f64::min);
+            let y0 = rects.iter().map(|r| r.y).fold(f64::INFINITY, f64::min);
+            let x1 = rects
+                .iter()
+                .map(|r| r.x + r.width)
+                .fold(f64::NEG_INFINITY, f64::max);
+            let y1 = rects
+                .iter()
+                .map(|r| r.y + r.height)
+                .fold(f64::NEG_INFINITY, f64::max);
+            return match rects.is_empty() {
+                true => None,
+                false => Some(BoundingRect {
+                    x: x0,
+                    y: y0,
+                    width: x1 - x0,
+                    height: y1 - y0,
+                }),
+            };
+        }
+
         let node = self.get_node(node_id)?;
         let pos = node.absolute_position(0.0, 0.0);
 
@@ -2225,6 +2250,128 @@ impl BaseDocument {
             width: node.unrounded_layout().size.width as f64,
             height: node.unrounded_layout().size.height as f64,
         })
+    }
+
+    /// Computes the sizes and positions of the `Node`'s box fragments relative to the
+    /// viewport (CSSOM `getClientRects()` semantics). Nodes with their own layout box
+    /// return a single rect. Non-atomic inline elements (which are laid out as style
+    /// spans within an inline root's text layout) return one rect per line box.
+    pub fn node_client_rects(&self, node_id: NodeId) -> Vec<BoundingRect> {
+        match self.inline_fragment_rects(node_id) {
+            Some(rects) => rects,
+            None => self.get_client_bounding_rect(node_id).into_iter().collect(),
+        }
+    }
+
+    /// Computes per-line-box fragment rects for a non-atomic inline element by walking
+    /// the containing inline root's text layout. Returns `None` for nodes that have
+    /// their own layout box (which should use `get_client_bounding_rect` instead).
+    pub fn inline_fragment_rects(&self, node_id: NodeId) -> Option<Vec<BoundingRect>> {
+        use parley::PositionedLayoutItem;
+
+        let node = self.get_node(node_id)?;
+
+        // Only non-atomic inline elements lack their own layout box: they are
+        // flattened into the containing inline root's text layout as style spans.
+        if !node.is_element() || node.flags.is_inline_root() {
+            return None;
+        }
+        let display = node.primary_styles()?.clone_display();
+        if !(display.outside() == DisplayOutside::Inline && display.inside() == DisplayInside::Flow)
+        {
+            return None;
+        }
+
+        let inline_root = node.inline_root_ancestor()?;
+        let inline_layout = inline_root.element_data()?.inline_layout_data.as_ref()?;
+        let layout = &inline_layout.layout;
+        let scale = layout.scale() as f64;
+
+        // Walk up the DOM parent chain from `id` to check whether it is (or is
+        // inside) the target node, stopping at the inline root.
+        let is_in_target = |mut id: NodeId| -> bool {
+            loop {
+                if id == node_id {
+                    return true;
+                }
+                if id == inline_root.id {
+                    return false;
+                }
+                match self.get_node(id).and_then(|n| n.parent) {
+                    Some(parent) => id = parent,
+                    None => return false,
+                }
+            }
+        };
+
+        // Fragment rects are relative to the inline root's content box.
+        let root_layout = inline_root.final_layout();
+        let root_pos = inline_root.absolute_position(0.0, 0.0);
+        let origin_x = root_pos.x as f64
+            + (root_layout.padding.left + root_layout.border.left) as f64
+            - self.viewport_scroll.x;
+        let origin_y = root_pos.y as f64
+            + (root_layout.padding.top + root_layout.border.top) as f64
+            - self.viewport_scroll.y;
+
+        let mut rects: Vec<BoundingRect> = Vec::new();
+        for line in layout.lines() {
+            let line_metrics = line.metrics();
+            // Union all of the target's fragments on this line into a single rect
+            let mut line_rect: Option<(f64, f64, f64, f64)> = None;
+            let mut add = |x0: f64, y0: f64, x1: f64, y1: f64| {
+                line_rect = Some(match line_rect {
+                    Some((lx0, ly0, lx1, ly1)) => {
+                        (lx0.min(x0), ly0.min(y0), lx1.max(x1), ly1.max(y1))
+                    }
+                    None => (x0, y0, x1, y1),
+                });
+            };
+
+            for item in line.items() {
+                match item {
+                    PositionedLayoutItem::GlyphRun(glyph_run) => {
+                        if !is_in_target(glyph_run.style().brush.id) {
+                            continue;
+                        }
+                        let x0 = glyph_run.offset() as f64;
+                        let x1 = x0 + glyph_run.advance() as f64;
+                        // Use the line box's block extent rather than the
+                        // run's font ascent/descent: fonts with small
+                        // typographic metrics would otherwise produce rects
+                        // that clip the rendered glyphs. This matches the
+                        // geometry used for text selection highlights.
+                        let y0 = line_metrics.block_min_coord as f64;
+                        let y1 = line_metrics.block_max_coord as f64;
+                        add(x0, y0, x1, y1);
+                    }
+                    PositionedLayoutItem::InlineBox(inline_box) => {
+                        if !is_in_target(NodeId::from_u64(inline_box.id)) {
+                            continue;
+                        }
+                        let x0 = inline_box.x as f64;
+                        let y0 = inline_box.y as f64;
+                        add(
+                            x0,
+                            y0,
+                            x0 + inline_box.width as f64,
+                            y0 + inline_box.height as f64,
+                        );
+                    }
+                }
+            }
+
+            if let Some((x0, y0, x1, y1)) = line_rect {
+                rects.push(BoundingRect {
+                    x: origin_x + x0 / scale,
+                    y: origin_y + y0 / scale,
+                    width: (x1 - x0) / scale,
+                    height: (y1 - y0) / scale,
+                });
+            }
+        }
+
+        Some(rects)
     }
 
     pub fn find_title_node(&self) -> Option<&Node> {
@@ -2549,6 +2696,7 @@ impl BaseDocument {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BoundingRect {
     pub x: f64,
     pub y: f64,

--- a/packages/blitz-html/tests/inline_fragment_rects.rs
+++ b/packages/blitz-html/tests/inline_fragment_rects.rs
@@ -1,0 +1,123 @@
+//! `BaseDocument::node_client_rects` must return one rect per line-box
+//! fragment for non-atomic inline elements (which have no Taffy layout box of
+//! their own), and `get_client_bounding_rect` must return the union of those
+//! fragments instead of a zero-sized rect.
+
+use blitz_dom::{BaseDocument, DocumentConfig, NodeId};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+const HTML: &str = r#"<!DOCTYPE html>
+<html><head><style>
+    body { margin: 0; font-size: 16px; line-height: 20px; }
+    #para { width: 100px; }
+    #box { display: inline-block; width: 30px; height: 10px; }
+</style></head>
+<body>
+<p id="para">aaaa aaaa <span id="wrapped">bbbb bbbb <b id="nested">cccc</b> <span id="box"></span> bbbb</span> aaaa</p>
+</body></html>
+"#;
+
+fn make_doc() -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        HTML,
+        DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+fn node(doc: &BaseDocument, selector: &str) -> NodeId {
+    doc.query_selector(selector).unwrap().unwrap()
+}
+
+#[test]
+fn wrapped_span_has_one_rect_per_line() {
+    let doc = make_doc();
+    let span = node(&doc, "#wrapped");
+
+    let rects = doc.node_client_rects(span);
+    assert!(
+        rects.len() >= 2,
+        "span wrapped across a 100px-wide paragraph should fragment, got {rects:?}"
+    );
+    for rect in &rects {
+        assert!(rect.width > 0.0, "fragment has zero width: {rect:?}");
+        assert!(rect.height > 0.0, "fragment has zero height: {rect:?}");
+    }
+    // Fragments are on distinct line boxes, in document order
+    for pair in rects.windows(2) {
+        assert!(
+            pair[1].y > pair[0].y,
+            "fragments should be on successive lines: {rects:?}"
+        );
+    }
+}
+
+#[test]
+fn bounding_rect_is_union_of_fragments() {
+    let doc = make_doc();
+    let span = node(&doc, "#wrapped");
+
+    let rects = doc.node_client_rects(span);
+    let bounding = doc.get_client_bounding_rect(span).unwrap();
+
+    assert!(bounding.width > 0.0);
+    assert!(bounding.height > 0.0);
+    for rect in &rects {
+        assert!(rect.x >= bounding.x - 0.01);
+        assert!(rect.y >= bounding.y - 0.01);
+        assert!(rect.x + rect.width <= bounding.x + bounding.width + 0.01);
+        assert!(rect.y + rect.height <= bounding.y + bounding.height + 0.01);
+    }
+}
+
+#[test]
+fn fragments_include_nested_inline_and_atomic_children() {
+    let doc = make_doc();
+    let span = node(&doc, "#wrapped");
+    let nested = node(&doc, "#nested");
+    let atomic = node(&doc, "#box");
+
+    let span_bounding = doc.get_client_bounding_rect(span).unwrap();
+
+    // The nested <b> is itself a non-atomic inline: it gets fragment rects
+    // that lie within the outer span's bounding rect
+    let nested_rects = doc.node_client_rects(nested);
+    assert!(!nested_rects.is_empty());
+    for rect in &nested_rects {
+        assert!(rect.x >= span_bounding.x - 0.01);
+        assert!(rect.x + rect.width <= span_bounding.x + span_bounding.width + 0.01);
+    }
+
+    // The atomic inline-block has its own layout box (single rect) and is
+    // included in the span's fragments
+    let atomic_rects = doc.node_client_rects(atomic);
+    assert_eq!(atomic_rects.len(), 1);
+    let atomic_rect = &atomic_rects[0];
+    assert_eq!(atomic_rect.width, 30.0);
+    assert_eq!(atomic_rect.height, 10.0);
+    assert!(atomic_rect.x >= span_bounding.x - 0.01);
+    assert!(atomic_rect.x + atomic_rect.width <= span_bounding.x + span_bounding.width + 0.01);
+    assert!(atomic_rect.y + atomic_rect.height <= span_bounding.y + span_bounding.height + 0.01);
+}
+
+#[test]
+fn block_elements_return_single_rect() {
+    let doc = make_doc();
+    let para = node(&doc, "#para");
+
+    let rects = doc.node_client_rects(para);
+    assert_eq!(rects.len(), 1);
+    let bounding = doc.get_client_bounding_rect(para).unwrap();
+    assert_eq!(rects[0].x, bounding.x);
+    assert_eq!(rects[0].y, bounding.y);
+    assert_eq!(rects[0].width, bounding.width);
+    assert_eq!(rects[0].height, bounding.height);
+    assert_eq!(bounding.width, 100.0);
+}

--- a/packages/blitz-paint/src/debug_overlay.rs
+++ b/packages/blitz-paint/src/debug_overlay.rs
@@ -14,6 +14,25 @@ pub(crate) fn render_debug_overlay(
     initial_x: f64,
     initial_y: f64,
 ) {
+    // Non-atomic inline elements have no layout box of their own: they are laid
+    // out as style spans within an inline root's text layout and may fragment
+    // across multiple line boxes. Highlight each fragment's content box.
+    if let Some(rects) = dom.as_ref().inline_fragment_rects(node_id) {
+        let fill_color = Color::from_rgba8(66, 144, 245, 128); // blue
+        for r in rects {
+            let rect = Rect::new(0.0, 0.0, r.width * scale, r.height * scale);
+            let translation = Vec2::new(r.x * scale + initial_x, r.y * scale + initial_y);
+            scene.fill(
+                peniko::Fill::NonZero,
+                Affine::translate(translation),
+                fill_color,
+                None,
+                &rect,
+            );
+        }
+        return;
+    }
+
     let viewport_scroll = dom.as_ref().viewport_scroll();
     let mut node = &dom.as_ref().tree()[node_id];
 


### PR DESCRIPTION
## Summary

Split out of #564 so the core inline highlighting improvements can land independently of the Firefox devtools work.

Non-atomic inline elements (`display: inline` spans) aren't Taffy nodes — they're flattened into an inline root's Parley layout as style spans — so `final_layout` is zero and both the built-in highlight overlay (`highlight_hover` / `highlight_node`) and `get_client_bounding_rect` reported a 0×0 box for them.

New primitive in blitz-dom (CSSOM `getClientRects()` semantics):

```rust
impl BaseDocument {
    /// One rect per box fragment; inline elements return one rect per line box
    pub fn node_client_rects(&self, node_id: NodeId) -> Vec<BoundingRect>;
    pub fn inline_fragment_rects(&self, node_id: NodeId) -> Option<Vec<BoundingRect>>;
}
```

`inline_fragment_rects` walks the containing inline root's Parley layout lines and, per line, unions the glyph runs whose brush id is the target or a DOM descendant of it, plus atomic `InlineBox` children. Fragment rects are sized to the line's block extent (`block_min_coord..block_max_coord`, the same geometry text selection uses) rather than the run's font ascent/descent — fonts with small typographic metrics would otherwise produce rects that clip the rendered glyphs.

Consumers:
- `render_debug_overlay` (blitz-paint): draws one content-box highlight per fragment for inline elements, so hover-highlight works for spans that wrap across lines.
- `get_client_bounding_rect`: returns the union of fragments for inline elements instead of a zero rect.

Tests: new `blitz-html` integration test covering fragmentation across lines, union bounding rect, and nested inline + atomic inline-block children.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a297018e1b9d4cef96d3628aed9b8384
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30516497517).</sub>
<!-- wpt-results-end -->
