### PR TITLE
Prerequisite APIs for remote devtools inspectors

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1084,6 +1084,22 @@ impl BaseDocument {
         }
     }
 
+    /// The document's base URL
+    pub fn url(&self) -> &url::Url {
+        &self.url
+    }
+
+    /// Iterate over the author stylesheets (from `<style>` and `<link>` nodes)
+    /// currently associated with this document
+    pub fn author_stylesheets(&self) -> impl Iterator<Item = &DocumentStyleSheet> {
+        self.nodes_to_stylesheet.values()
+    }
+
+    /// Iterate over the user-agent stylesheets currently associated with this document
+    pub fn useragent_stylesheets(&self) -> impl Iterator<Item = &DocumentStyleSheet> {
+        self.ua_stylesheets.values()
+    }
+
     pub fn add_user_agent_stylesheet(&mut self, css: &str) {
         let sheet = self.make_stylesheet(css, Origin::UserAgent);
         self.ua_stylesheets.insert(css.to_string(), sheet.clone());

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -442,6 +442,17 @@ impl taffy::LayoutGridContainer for BaseDocument {
     fn get_grid_child_style(&self, child_node_id: NodeId) -> Self::GridItemStyle<'_> {
         self.get_core_container_style(child_node_id)
     }
+
+    fn set_detailed_grid_info(
+        &mut self,
+        node_id: NodeId,
+        detailed_grid_info: taffy::DetailedGridInfo,
+    ) {
+        let node = self.node_from_id_mut(node_id);
+        if let Some(element) = node.element_data_mut() {
+            element.detailed_grid_info = Some(Box::new(detailed_grid_info));
+        }
+    }
 }
 
 impl RoundTree for BaseDocument {

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -102,6 +102,10 @@ pub struct ElementData {
     pub before: Option<NodeId>,
     pub after: Option<NodeId>,
 
+    /// Detailed grid track sizing information from the most recent layout
+    /// (grid containers only). Used by devtools grid inspection.
+    pub detailed_grid_info: Option<Box<taffy::DetailedGridInfo>>,
+
     // Taffy layout data:
     pub style: Style<Atom>,
     pub display_constructed_as: StyloDisplay,
@@ -226,6 +230,7 @@ impl Clone for ElementData {
             dirty_descendants: AtomicBool::new(true),
             before: None,
             after: None,
+            detailed_grid_info: None,
             style: Default::default(),
             display_constructed_as: StyloDisplay::Block,
             cache: Cache::new(),
@@ -336,6 +341,7 @@ impl ElementData {
             dirty_descendants: AtomicBool::new(true),
             before: None,
             after: None,
+            detailed_grid_info: None,
             style: Default::default(),
             display_constructed_as: StyloDisplay::Block,
             cache: Cache::new(),

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -189,6 +189,24 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                 );
             }
         }
+        if let Some(node_id) = self.dom.devtools().highlight_node {
+            // Only nodes with element data have a layout to visualise
+            if self
+                .dom
+                .as_ref()
+                .get_node(node_id)
+                .is_some_and(|node| node.element_data().is_some())
+            {
+                render_debug_overlay(
+                    scene,
+                    self.dom,
+                    node_id,
+                    self.scale,
+                    self.initial_x,
+                    self.initial_y,
+                );
+            }
+        }
     }
 
     /// Renders a node, but is guaranteed that the node is an element

--- a/packages/blitz-traits/src/devtools.rs
+++ b/packages/blitz-traits/src/devtools.rs
@@ -1,5 +1,7 @@
 //! Types configure developer inspection and debug tools
 
+use crate::node_id::NodeId;
+
 /// Configuration for debug overlays and other debugging tools
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DevtoolSettings {
@@ -9,6 +11,14 @@ pub struct DevtoolSettings {
     /// Render browser-style colored overlay showing the content-box,
     /// padding, border, and margin of the hovered element
     pub highlight_hover: bool,
+    /// Render browser-style colored overlay showing the content-box,
+    /// padding, border, and margin of a specific node (set by e.g. a
+    /// remote devtools inspector)
+    pub highlight_node: Option<NodeId>,
+    /// Element picker mode: mouse events are intercepted (not delivered to
+    /// the page) and reported to a remote devtools inspector so the user
+    /// can pick an element by hovering/clicking it
+    pub element_picker: bool,
 }
 
 impl DevtoolSettings {


### PR DESCRIPTION
## Summary

Split out of #557/#558 so the generic (protocol-independent) parts of the devtools work can merge separately from the FDP server crate. No behavior change without a devtools server driving it. Useful for any remote inspector backend (Firefox DevTools Protocol now, potentially Chrome DevTools Protocol later).

- `blitz-traits`: `DevtoolSettings` gains
  ```rust
  pub highlight_node: Option<NodeId>, // overlay a specific node (set by a remote inspector)
  pub element_picker: bool,           // shell intercepts input and reports hover/click to the inspector
  ```
- `blitz-paint`: render the box-model debug overlay for `highlight_node` (element nodes only), alongside the existing `highlight_hover` path.
- `blitz-dom`:
  - `BaseDocument::url()` and `author_stylesheets()` / `useragent_stylesheets()` accessors (used to report rule origins/hrefs).
  - Implement taffy's `set_detailed_grid_info` and store `DetailedGridInfo` on grid container elements after layout (`ElementData::detailed_grid_info`), for grid track inspection.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a297018e1b9d4cef96d3628aed9b8384
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30579946655).</sub>
<!-- wpt-results-end -->
