### PR TITLE
Store comment contents in the DOM

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -915,7 +915,7 @@ pub(crate) fn find_inline_layout_embedded_boxes(
                     }
                 };
             }
-            NodeData::Comment | NodeData::Text(_) => {
+            NodeData::Comment { .. } | NodeData::Text(_) => {
                 node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
             }
             NodeData::Document(_) => unreachable!(),
@@ -1199,7 +1199,7 @@ pub(crate) fn build_inline_layout_into(
                     }
                 }
             }
-            NodeData::Comment => {
+            NodeData::Comment { .. } => {
                 // node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
             }
             NodeData::Document(_) => unreachable!(),

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -462,7 +462,7 @@ impl PrintTree for BaseDocument {
             NodeData::Document(_) => "DOCUMENT",
             // NodeData::Doctype { .. } => return "DOCTYPE",
             NodeData::Text { .. } => node.node_debug_str().leak(),
-            NodeData::Comment => "COMMENT",
+            NodeData::Comment { .. } => "COMMENT",
             NodeData::AnonymousBlock(_) => "ANONYMOUS BLOCK",
             NodeData::Element(_) => {
                 let style = node.style();

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -123,8 +123,10 @@ impl DocumentMutator<'_> {
 
     // Node creation methods
 
-    pub fn create_comment_node(&mut self) -> NodeId {
-        self.doc.create_node(NodeData::Comment)
+    pub fn create_comment_node(&mut self, contents: &str) -> NodeId {
+        self.doc.create_node(NodeData::Comment {
+            contents: contents.to_string(),
+        })
     }
 
     pub fn create_text_node(&mut self, text: &str) -> NodeId {

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -667,9 +667,10 @@ pub enum NodeData {
     Text(TextNodeData),
 
     /// A comment.
-    Comment,
-    // Comment { contents: String },
-
+    Comment {
+        /// The textual content of the comment
+        contents: String,
+    },
     // /// A `DOCTYPE` with name, public id, and system id. See
     // /// [document type declaration on wikipedia][https://en.wikipedia.org/wiki/Document_type_declaration]
     // Doctype { name: String, public_id: String, system_id: String },
@@ -721,7 +722,7 @@ impl NodeData {
             NodeData::Element(_) => NodeKind::Element,
             NodeData::AnonymousBlock(_) => NodeKind::AnonymousBlock,
             NodeData::Text(_) => NodeKind::Text,
-            NodeData::Comment => NodeKind::Comment,
+            NodeData::Comment { .. } => NodeKind::Comment,
         }
     }
 }
@@ -879,11 +880,7 @@ impl Node {
                         .unwrap_or("INVALID UTF8")
                 )
             }
-            NodeData::Comment => write!(
-                s,
-                "COMMENT",
-                // &std::str::from_utf8(data.contents.as_bytes().split_at(10).0).unwrap_or("INVALID UTF8")
-            ),
+            NodeData::Comment { .. } => write!(s, "COMMENT"),
             NodeData::AnonymousBlock(_) => write!(s, "AnonymousBlock"),
             NodeData::Element(data) => {
                 let name = &data.name;
@@ -960,7 +957,7 @@ impl Node {
 
         match &self.data {
             NodeData::Document(_) => {}
-            NodeData::Comment => {}
+            NodeData::Comment { .. } => {}
             NodeData::AnonymousBlock(_) => {}
             // NodeData::Doctype { name, .. } => write!(s, "DOCTYPE {name}"),
             NodeData::Text(data) => {

--- a/packages/blitz-dom/src/util.rs
+++ b/packages/blitz-dom/src/util.rs
@@ -120,7 +120,7 @@ pub fn walk_tree(indent: usize, node: &Node) {
             }
         }
 
-        NodeData::Comment => println!("<!-- COMMENT {id} -->"),
+        NodeData::Comment { .. } => println!("<!-- COMMENT {id} -->"),
 
         NodeData::AnonymousBlock(_) => println!("{id} AnonymousBlock"),
 

--- a/packages/blitz-html/src/html_sink.rs
+++ b/packages/blitz-html/src/html_sink.rs
@@ -192,12 +192,12 @@ impl<'m, 'doc> TreeSink for DocumentHtmlParser<'m, 'doc> {
         self.mutr().create_element(name, attrs)
     }
 
-    fn create_comment(&self, _text: StrTendril) -> Self::Handle {
-        self.mutr().create_comment_node()
+    fn create_comment(&self, text: StrTendril) -> Self::Handle {
+        self.mutr().create_comment_node(&text)
     }
 
     fn create_pi(&self, _target: StrTendril, _data: StrTendril) -> Self::Handle {
-        self.mutr().create_comment_node()
+        self.mutr().create_comment_node("")
     }
 
     fn append(&self, parent_id: &Self::Handle, child: NodeOrText<Self::Handle>) {

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -483,7 +483,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             }
             NodeData::Document(_) => {}
             // NodeData::Doctype => {}
-            NodeData::Comment => {} // NodeData::ProcessingInstruction { .. } => {}
+            NodeData::Comment { .. } => {} // NodeData::ProcessingInstruction { .. } => {}
         }
     }
 

--- a/packages/dioxus-native-dom/src/mutation_writer.rs
+++ b/packages/dioxus-native-dom/src/mutation_writer.rs
@@ -142,7 +142,7 @@ impl WriteMutations for MutationWriter<'_> {
 
     fn create_placeholder(&mut self, id: ElementId) {
         trace!("create_placeholder id:{}", id.0);
-        let node_id = self.docm.create_comment_node();
+        let node_id = self.docm.create_comment_node("");
         self.map_new_node(node_id, id);
     }
 
@@ -373,7 +373,7 @@ fn create_template_node(docm: &mut DocumentMutator<'_>, node: &TemplateNode) -> 
             node_id
         }
         TemplateNode::Text { text } => docm.create_text_node(text),
-        TemplateNode::Dynamic { .. } => docm.create_comment_node(),
+        TemplateNode::Dynamic { .. } => docm.create_comment_node(""),
     }
 }
 


### PR DESCRIPTION
## Summary

Blitz was discarding comment text at parse time, so tooling (e.g. devtools inspectors) could only render comments as an empty `<!---->`.

`NodeData::Comment` is now a struct variant carrying the text:

```rust
NodeData::Comment { contents: String }
```

- `DocumentMutator::create_comment_node` takes `contents: &str`; the html5ever sink passes the comment token's text through (processing instructions and dioxus dynamic-node placeholders pass `""`).
- All `NodeData::Comment` match sites updated to `Comment { .. }`.

Split out of #572 so it can land first; the CDP server there uses the contents as the comment node's `nodeValue`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f46cbcd2db8548f5a54c1fe02a0e7eea
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30579089512).</sub>
<!-- wpt-results-end -->
