### PR TITLE
Node-scoped querySelector/querySelectorAll, plus matches/closest

### DIFF
--- a/packages/blitz-dom/src/query_selector.rs
+++ b/packages/blitz-dom/src/query_selector.rs
@@ -1,7 +1,10 @@
 use blitz_traits::node_id::NodeId;
 use selectors::SelectorList;
 use smallvec::SmallVec;
-use style::dom_apis::{MayUseInvalidation, QueryAll, QueryFirst, query_selector};
+use style::dom::{TDocument, TNode};
+use style::dom_apis::{
+    MayUseInvalidation, QueryAll, QueryFirst, element_closest, element_matches, query_selector,
+};
 use style::selector_parser::{SelectorImpl, SelectorParser};
 use style_traits::ParseError;
 
@@ -22,19 +25,55 @@ impl BaseDocument {
         &self,
         selector: &'input str,
     ) -> Result<Option<NodeId>, ParseError<'input>> {
-        let selector_list = self.try_parse_selector_list(selector)?;
-        Ok(self.query_selector_raw(&selector_list))
+        self.query_selector_in(self.root_node_id, selector)
     }
 
-    /// Find the first node that matches the selector(s) specified in selector_list
+    /// Find the first descendant of `scope` that matches the selector specified
+    /// as a string.
+    ///
+    /// The scope node itself is never matched. Selector parts may match nodes
+    /// outside the scope while evaluating relationships between descendants.
+    ///
+    /// Returns:
+    ///   - `Err(_)` if parsing the selector fails
+    ///   - `Ok(None)` if nothing matches
+    ///   - `Ok(Some(node_id))` with the first matching descendant ID otherwise
+    pub fn query_selector_in<'input>(
+        &self,
+        scope: NodeId,
+        selector: &'input str,
+    ) -> Result<Option<NodeId>, ParseError<'input>> {
+        let selector_list = self.try_parse_selector_list(selector)?;
+        Ok(self.query_selector_in_raw(scope, &selector_list))
+    }
+
+    /// Find the first descendant of the document root that matches the
+    /// selector(s) specified in `selector_list`.
+    ///
+    /// The document root itself is never matched. Selector parts may match
+    /// nodes outside the scope while evaluating relationships between
+    /// descendants.
     pub fn query_selector_raw(&self, selector_list: &SelectorList<SelectorImpl>) -> Option<NodeId> {
-        let root_node = self.root_node();
+        self.query_selector_in_raw(self.root_node_id, selector_list)
+    }
+
+    /// Find the first descendant of `scope` that matches the selector(s)
+    /// specified in `selector_list`.
+    ///
+    /// The scope node itself is never matched. Selector parts may match nodes
+    /// outside the scope while evaluating relationships between descendants.
+    pub fn query_selector_in_raw(
+        &self,
+        scope: NodeId,
+        selector_list: &SelectorList<SelectorImpl>,
+    ) -> Option<NodeId> {
+        let root_node = &self.nodes[scope];
         let mut result = None;
         query_selector::<&Node, QueryFirst>(
             root_node,
             selector_list,
             &mut result,
-            MayUseInvalidation::Yes,
+            self.may_use_invalidation_for(scope),
         );
 
         result.map(|node| node.id)
@@ -48,25 +87,94 @@ impl BaseDocument {
         &self,
         selector: &'input str,
     ) -> Result<SmallVec<[NodeId; 32]>, ParseError<'input>> {
-        let selector_list = self.try_parse_selector_list(selector)?;
-        Ok(self.query_selector_all_raw(&selector_list))
+        self.query_selector_all_in(self.root_node_id, selector)
     }
 
-    /// Find all nodes that match the selector(s) specified in selector_list
+    /// Find all descendants of `scope` that match the selector specified as a
+    /// string, in tree order.
+    ///
+    /// The scope node itself is never matched. Selector parts may match nodes
+    /// outside the scope while evaluating relationships between descendants.
+    ///
+    /// Returns:
+    ///   - `Err(_)` if parsing the selector fails
+    ///   - `Ok(_)` with all matching descendant IDs otherwise
+    pub fn query_selector_all_in<'input>(
+        &self,
+        scope: NodeId,
+        selector: &'input str,
+    ) -> Result<SmallVec<[NodeId; 32]>, ParseError<'input>> {
+        let selector_list = self.try_parse_selector_list(selector)?;
+        Ok(self.query_selector_all_in_raw(scope, &selector_list))
+    }
+
+    /// Find all descendants of the document root that match the selector(s)
+    /// specified in `selector_list`, in tree order.
+    ///
+    /// The document root itself is never matched. Selector parts may match
+    /// nodes outside the scope while evaluating relationships between
+    /// descendants.
     pub fn query_selector_all_raw(
         &self,
         selector_list: &SelectorList<SelectorImpl>,
     ) -> SmallVec<[NodeId; 32]> {
-        let root_node = self.root_node();
+        self.query_selector_all_in_raw(self.root_node_id, selector_list)
+    }
+
+    /// Find all descendants of `scope` that match the selector(s) specified in
+    /// `selector_list`, in tree order.
+    ///
+    /// The scope node itself is never matched. Selector parts may match nodes
+    /// outside the scope while evaluating relationships between descendants.
+    pub fn query_selector_all_in_raw(
+        &self,
+        scope: NodeId,
+        selector_list: &SelectorList<SelectorImpl>,
+    ) -> SmallVec<[NodeId; 32]> {
+        let root_node = &self.nodes[scope];
         let mut results = SmallVec::new();
         query_selector::<&Node, QueryAll>(
             root_node,
             selector_list,
             &mut results,
-            MayUseInvalidation::Yes,
+            self.may_use_invalidation_for(scope),
         );
 
         results.iter().map(|node| node.id).collect()
+    }
+
+    fn may_use_invalidation_for(&self, scope: NodeId) -> MayUseInvalidation {
+        if scope == self.root_node_id {
+            MayUseInvalidation::Yes
+        } else {
+            MayUseInvalidation::No
+        }
+    }
+
+    /// Test whether the node identified by `node_id` matches the selector
+    /// specified as a string.
+    ///
+    /// Non-element nodes never match.
+    pub fn matches_selector<'input>(
+        &self,
+        node_id: NodeId,
+        selector: &'input str,
+    ) -> Result<bool, ParseError<'input>> {
+        let selector_list = self.try_parse_selector_list(selector)?;
+        Ok(self.nodes[node_id].matches_selector_raw(&selector_list))
+    }
+
+    /// Find the closest matching element at or above the node identified by
+    /// `node_id`.
+    ///
+    /// Non-element nodes never match and return `None`.
+    pub fn closest<'input>(
+        &self,
+        node_id: NodeId,
+        selector: &'input str,
+    ) -> Result<Option<NodeId>, ParseError<'input>> {
+        let selector_list = self.try_parse_selector_list(selector)?;
+        Ok(self.nodes[node_id].closest_raw(&selector_list))
     }
 
     pub fn try_parse_selector_list<'input>(
@@ -75,5 +183,69 @@ impl BaseDocument {
     ) -> Result<SelectorList<SelectorImpl>, ParseError<'input>> {
         let url_extra_data = self.url.url_extra_data();
         SelectorParser::parse_author_origin_no_namespace(input, &url_extra_data)
+    }
+}
+
+impl Node {
+    /// Find the first descendant of this node that matches the selector(s)
+    /// specified in `selector_list`.
+    ///
+    /// The scope node itself is never matched. Selector parts may match nodes
+    /// outside the scope while evaluating relationships between descendants.
+    ///
+    /// Text and comment scope nodes return no matches.
+    pub fn query_selector_raw(&self, selector_list: &SelectorList<SelectorImpl>) -> Option<NodeId> {
+        let mut result = None;
+        query_selector::<&Node, QueryFirst>(
+            self,
+            selector_list,
+            &mut result,
+            MayUseInvalidation::No,
+        );
+        result.map(|node| node.id)
+    }
+
+    /// Find all descendants of this node that match the selector(s) specified
+    /// in `selector_list`, in tree order.
+    ///
+    /// The scope node itself is never matched. Selector parts may match nodes
+    /// outside the scope while evaluating relationships between descendants.
+    ///
+    /// Text and comment scope nodes return no matches.
+    pub fn query_selector_all_raw(
+        &self,
+        selector_list: &SelectorList<SelectorImpl>,
+    ) -> SmallVec<[NodeId; 32]> {
+        let mut results = SmallVec::new();
+        query_selector::<&Node, QueryAll>(
+            self,
+            selector_list,
+            &mut results,
+            MayUseInvalidation::No,
+        );
+        results.iter().map(|node| node.id).collect()
+    }
+
+    /// Test whether this element matches the selector(s) specified in
+    /// `selector_list`.
+    ///
+    /// Non-element nodes never match.
+    pub fn matches_selector_raw(&self, selector_list: &SelectorList<SelectorImpl>) -> bool {
+        if !self.is_element() {
+            return false;
+        }
+
+        element_matches(&self, selector_list, self.owner_doc().quirks_mode())
+    }
+
+    /// Find the closest matching element at or above this element.
+    ///
+    /// Non-element nodes never match and return `None`.
+    pub fn closest_raw(&self, selector_list: &SelectorList<SelectorImpl>) -> Option<NodeId> {
+        if !self.is_element() {
+            return None;
+        }
+
+        element_closest(self, selector_list, self.owner_doc().quirks_mode()).map(|node| node.id)
     }
 }

--- a/packages/blitz-html/tests/scoped_query_selector.rs
+++ b/packages/blitz-html/tests/scoped_query_selector.rs
@@ -1,0 +1,175 @@
+use blitz_dom::{DocumentConfig, NodeData, NodeId};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn document() -> HtmlDocument {
+    HtmlDocument::from_html(
+        r#"
+        <html>
+            <body>
+                <div id="a">
+                    <div id="b" class="target" data-scope="yes">
+                        <div id="c" class="target" data-match="yes">
+                            <span id="d" class="target" data-match="yes"></span>
+                        </div>
+                        <div id="e"></div>
+                    </div>
+                    <div id="sibling" class="target" data-match="yes"></div>
+                    <div id="text-scope">text<!-- comment --><span id="inside"></span></div>
+                </div>
+            </body>
+        </html>
+        "#,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    )
+}
+
+fn id(doc: &HtmlDocument, selector: &str) -> NodeId {
+    doc.query_selector(selector)
+        .unwrap()
+        .unwrap_or_else(|| panic!("{selector} not found"))
+}
+
+#[test]
+fn scoped_queries_exclude_scope_and_outside_nodes() {
+    let doc = document();
+    let scope = id(&doc, "#b");
+    let c = id(&doc, "#c");
+    let d = id(&doc, "#d");
+    let e = id(&doc, "#e");
+
+    assert_eq!(doc.query_selector_in(scope, ".target").unwrap(), Some(c));
+    assert_eq!(
+        doc.query_selector_all_in(scope, ".target")
+            .unwrap()
+            .as_slice(),
+        &[c, d]
+    );
+    assert_eq!(
+        doc.query_selector_all_in(scope, "#a").unwrap().as_slice(),
+        &[]
+    );
+    assert_eq!(
+        doc.query_selector_all_in(scope, "#sibling")
+            .unwrap()
+            .as_slice(),
+        &[]
+    );
+    assert_eq!(
+        doc.query_selector_all_in(scope, "div").unwrap().as_slice(),
+        &[c, e]
+    );
+}
+
+#[test]
+fn scoped_selectors_can_match_ancestors_while_returning_descendants() {
+    let doc = document();
+    let scope = id(&doc, "#b");
+    let c = id(&doc, "#c");
+    let e = id(&doc, "#e");
+
+    assert_eq!(
+        doc.query_selector_all_in(scope, "#a div")
+            .unwrap()
+            .as_slice(),
+        &[c, e]
+    );
+}
+
+#[test]
+fn scoped_query_all_covers_fast_and_slow_paths_in_tree_order() {
+    let doc = document();
+    let scope = id(&doc, "#b");
+    let c = id(&doc, "#c");
+    let d = id(&doc, "#d");
+    let e = id(&doc, "#e");
+
+    assert_eq!(
+        doc.query_selector_all_in(scope, ".target")
+            .unwrap()
+            .as_slice(),
+        &[c, d]
+    );
+    assert_eq!(
+        doc.query_selector_all_in(scope, "div").unwrap().as_slice(),
+        &[c, e]
+    );
+    assert_eq!(
+        doc.query_selector_all_in(scope, "[data-match]")
+            .unwrap()
+            .as_slice(),
+        &[c, d]
+    );
+    assert_eq!(
+        doc.query_selector_all_in(scope, "#c").unwrap().as_slice(),
+        &[c]
+    );
+    assert_eq!(
+        doc.query_selector_all_in(scope, "div > span")
+            .unwrap()
+            .as_slice(),
+        &[d]
+    );
+    assert_eq!(
+        doc.query_selector_all_in(scope, ":is(div > span)")
+            .unwrap()
+            .as_slice(),
+        &[d]
+    );
+}
+
+#[test]
+fn non_element_scopes_return_no_matches() {
+    let doc = document();
+    let text_scope = id(&doc, "#text-scope");
+    let text = doc.get_node(text_scope).unwrap().children[0];
+    let comment = doc
+        .get_node(text_scope)
+        .unwrap()
+        .children
+        .iter()
+        .copied()
+        .find(|node_id| {
+            matches!(
+                doc.get_node(*node_id).unwrap().data,
+                NodeData::Comment { .. }
+            )
+        })
+        .expect("comment not found");
+
+    assert!(doc.query_selector_in(text, "span").unwrap().is_none());
+    assert!(doc.query_selector_all_in(text, "*").unwrap().is_empty());
+    assert!(doc.query_selector_in(comment, "span").unwrap().is_none());
+    assert!(doc.query_selector_all_in(comment, "*").unwrap().is_empty());
+}
+
+#[test]
+fn matches_and_closest_include_self_then_ancestors() {
+    let doc = document();
+    let b = id(&doc, "#b");
+    let c = id(&doc, "#c");
+    let d = id(&doc, "#d");
+
+    assert!(doc.matches_selector(c, ".target").unwrap());
+    assert!(!doc.matches_selector(d, "#c").unwrap());
+    assert_eq!(doc.closest(c, "#c").unwrap(), Some(c));
+    assert_eq!(doc.closest(d, "#b").unwrap(), Some(b));
+    assert_eq!(doc.closest(c, "#a").unwrap(), Some(id(&doc, "#a")));
+    assert_eq!(doc.closest(c, "#missing").unwrap(), None);
+
+    let parsed = doc.try_parse_selector_list(".target").unwrap();
+    assert_eq!(
+        doc.get_node(c)
+            .unwrap()
+            .query_selector_all_raw(&parsed)
+            .as_slice(),
+        &[d]
+    );
+    assert!(doc.get_node(c).unwrap().matches_selector_raw(&parsed));
+    assert_eq!(doc.get_node(c).unwrap().closest_raw(&parsed), Some(c));
+}


### PR DESCRIPTION
## Summary

Adds `Element.querySelector`-style scoped queries (plus `matches` / `closest`) to `blitz-dom`. Previously every query was rooted at the document node.

Stylo's `dom_apis::query_selector` already implements the scoped semantics — it sets `matching_context.scope_element` from `root.as_element()`, walks `root.dom_descendants()` (which excludes the root itself), and skips the invalidation machinery entirely when the root is an element — so this is plumbing: the four existing `BaseDocument` methods gain a `scope: NodeId` parameter and the old signatures become wrappers passing `self.root_node_id`.

Semantics that fall out of stylo and are now documented on each method: the scope node is never itself a match, but selector *parts* may match outside the scope, so for `<div id=a><div id=b><div id=c>`, `query_selector_all_in(b, "#a div")` returns `c` (and `e`) — matching the DOM spec.

One non-obvious bit, `may_use_invalidation_for`:

```rust
if scope == self.root_node_id { MayUseInvalidation::Yes } else { MayUseInvalidation::No }
```

Stylo ignores the flag for element roots, but for a root that is neither an element nor the document (a text or comment node) it would take the invalidation branch and trip `debug_assert!(element.parent_element().is_none())` in `QuerySelectorProcessor::collect_invalidations`. Restricting `Yes` to the document root makes the API total at no cost to the existing path.

New API surface:

```rust
// BaseDocument
query_selector_in(scope, &str)          query_selector_in_raw(scope, &SelectorList)
query_selector_all_in(scope, &str)      query_selector_all_in_raw(scope, &SelectorList)
matches_selector(node_id, &str)         closest(node_id, &str)

// Node — `&Node` holds its tree pointer, so these need no document borrow.
// String parsing stays on BaseDocument since it needs `url.url_extra_data()`.
query_selector_raw    query_selector_all_raw    matches_selector_raw    closest_raw
```

`matches`/`closest` are backed by `dom_apis::element_matches`/`element_closest`; non-element nodes return `false`/`None` rather than panicking.

Not covered: the scope of a non-element node can't be expressed as an `OpaqueElement`, so `:scope` there still falls back to stylo's "matches the root element" behaviour instead of matching nothing. Deliberately left alone.

Tests in `packages/blitz-html/tests/scoped_query_selector.rs` cover scope exclusion, ancestor-reaching selectors, tree order across stylo's id/class/tag/attr fast paths and the combinator slow path, non-element scopes, and `matches`/`closest`. `:has()` would have been the natural slow-path case but blitz's `SelectorParser` has `parse_has()` disabled, so the test uses `:is(div > span)`.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/316ca1c9158c4e0ba86ae35cdf54e5c0
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30588445887).</sub>
<!-- wpt-results-end -->
