### PR TITLE
Implement position:static and position:fixed with containing-block-aware abspos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -293,7 +293,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1456,7 +1456,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2431,7 +2431,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2691,7 +2691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4697,7 +4697,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6176,7 +6176,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6743,7 +6743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7131,6 +7131,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
+source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1785479063-position-static-fixed#68e0159ebb4bc52fa527d12507866c9aa4b3b630"
 dependencies = [
  "arrayvec",
  "grid",
@@ -7165,7 +7166,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7719,7 +7720,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8610,7 +8611,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,7 +7131,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
-source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1785479063-position-static-fixed#68e0159ebb4bc52fa527d12507866c9aa4b3b630"
+source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1785479063-position-static-fixed#c564e04ac38e922b87249c7819bafe95cb7eb3fb"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,8 +7131,6 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340a09581f29809fc0df82a3955501dc7f2a21f887e5d1c13dbe288fe1c0bef4"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,7 +7131,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
-source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1785479063-position-static-fixed#c564e04ac38e922b87249c7819bafe95cb7eb3fb"
+source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1785479063-position-static-fixed#b7eadd93f68ffd994d68df97acb5591679ddef8c"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,8 +291,8 @@ tracing-subscriber = "0.3"
 # selectors = { path = "../stylo/selectors", package = "selectors" }
 
 # [patch.crates-io]
-# [patch."https://github.com/dioxuslabs/taffy"]
-# taffy = { path = "../taffy" }
+[patch.crates-io]
+taffy = { path = "../taffy" }
 
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,8 +291,9 @@ tracing-subscriber = "0.3"
 # selectors = { path = "../stylo/selectors", package = "selectors" }
 
 # [patch.crates-io]
+# taffy = { path = "../taffy" }
 [patch.crates-io]
-taffy = { path = "../taffy" }
+taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "devin/1785479063-position-static-fixed" }
 
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -669,14 +669,6 @@ impl BaseDocument {
             paint_children.clear();
             paint_children.reserve(children.len());
 
-            // Whether this node is the containing block for its absolutely positioned children
-            let is_absolute_containing_block = self
-                .nodes[node_id]
-                .primary_styles()
-                .map(|s| s.clone_position() != Position::Static)
-                .unwrap_or(false)
-                || self.nodes[node_id].establishes_fixed_containing_block();
-
             // Push children to either paint_children or layout_children depending on
             for &child_id in children.iter() {
                 let child = &self.nodes[child_id];
@@ -694,10 +686,12 @@ impl BaseDocument {
                 // (css-flexbox-1 §painting, css-grid-1 §z-order).
                 let z_index_hoisted =
                     z_index != 0 && (position != Position::Static || is_flex_or_grid);
-                // Out-of-flow children whose containing block is not their layout parent are
-                // hoisted so that the parent's scrolling and clipping do not apply to them.
-                let out_of_flow_hoisted = position == Position::Fixed
-                    || (position == Position::Absolute && !is_absolute_containing_block);
+                // Fixed position children are hoisted so that the scrolling and clipping of
+                // ancestors between them and their containing block do not apply to them.
+                // TODO: also hoist absolutely positioned children whose containing block is
+                // not their layout parent (needs paint-order interleaving with in-tree
+                // positioned siblings).
+                let out_of_flow_hoisted = position == Position::Fixed;
                 if z_index_hoisted || out_of_flow_hoisted {
                     stacking_context.children.push(HoistedPaintChild {
                         node_id: child_id,

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -395,6 +395,57 @@ impl HoistedPaintChildren {
 }
 
 impl BaseDocument {
+    /// Recompute the offsets of hoisted paint children relative to their stacking context
+    /// root, using the final (post-layout) positions of the intervening nodes.
+    ///
+    /// The offsets initially recorded by `flush_styles_to_layout` are computed *before*
+    /// layout runs and may therefore be stale.
+    pub(crate) fn refresh_hoisted_paint_positions(&mut self) {
+        let root_ids: Vec<NodeId> = self
+            .nodes
+            .iter()
+            .filter(|(_, node)| node.stacking_context.is_some())
+            .map(|(id, _)| id)
+            .collect();
+
+        for root_id in root_ids {
+            let Some(mut stacking_context) = self.nodes[root_id].stacking_context.take() else {
+                continue;
+            };
+
+            for hoisted in stacking_context.children.iter_mut() {
+                if !self.nodes.contains_key(hoisted.node_id) {
+                    continue;
+                }
+                // Fixed position children do not scroll with their ancestors
+                let is_fixed =
+                    self.nodes[hoisted.node_id].style().position == taffy::Position::Fixed;
+
+                let mut position = taffy::Point::ZERO;
+                let mut current = self.nodes[hoisted.node_id].layout_parent.get();
+                while let Some(ancestor_id) = current {
+                    if ancestor_id == root_id || !self.nodes.contains_key(ancestor_id) {
+                        break;
+                    }
+                    let ancestor = &self.nodes[ancestor_id];
+                    let location = ancestor.final_layout().location;
+                    position.x += location.x;
+                    position.y += location.y;
+                    if !is_fixed {
+                        let scroll_offset = *ancestor.scroll_offset();
+                        position.x -= scroll_offset.x as f32;
+                        position.y -= scroll_offset.y as f32;
+                    }
+                    current = ancestor.layout_parent.get();
+                }
+                hoisted.position = position;
+            }
+
+            stacking_context.compute_content_size(self);
+            self.nodes[root_id].stacking_context = Some(stacking_context);
+        }
+    }
+
     pub(crate) fn invalidate_inline_contexts(&mut self) {
         let scale = self.viewport.scale();
 
@@ -618,6 +669,14 @@ impl BaseDocument {
             paint_children.clear();
             paint_children.reserve(children.len());
 
+            // Whether this node is the containing block for its absolutely positioned children
+            let is_absolute_containing_block = self
+                .nodes[node_id]
+                .primary_styles()
+                .map(|s| s.clone_position() != Position::Static)
+                .unwrap_or(false)
+                || self.nodes[node_id].establishes_fixed_containing_block();
+
             // Push children to either paint_children or layout_children depending on
             for &child_id in children.iter() {
                 let child = &self.nodes[child_id];
@@ -633,7 +692,13 @@ impl BaseDocument {
                 // TODO: more complete hoisting detection
                 // z-index applies to static flex/grid items too
                 // (css-flexbox-1 §painting, css-grid-1 §z-order).
-                if z_index != 0 && (position != Position::Static || is_flex_or_grid) {
+                let z_index_hoisted =
+                    z_index != 0 && (position != Position::Static || is_flex_or_grid);
+                // Out-of-flow children whose containing block is not their layout parent are
+                // hoisted so that the parent's scrolling and clipping do not apply to them.
+                let out_of_flow_hoisted = position == Position::Fixed
+                    || (position == Position::Absolute && !is_absolute_containing_block);
+                if z_index_hoisted || out_of_flow_hoisted {
                     stacking_context.children.push(HoistedPaintChild {
                         node_id: child_id,
                         z_index,

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -313,6 +313,10 @@ pub struct HoistedPaintChild {
     pub node_id: NodeId,
     pub z_index: i32,
     pub position: taffy::Point<f32>,
+    /// The overflow clip applied by ancestors between this box and its stacking context
+    /// root, in the coordinate space of the stacking context root. `None` means unclipped.
+    /// Out-of-flow boxes are only clipped by ancestors from their containing block outwards.
+    pub clip: Option<taffy::Rect<f32>>,
 }
 
 #[derive(Debug)]
@@ -417,10 +421,16 @@ impl BaseDocument {
                 if !self.nodes.contains_key(hoisted.node_id) {
                     continue;
                 }
-                // Fixed position children do not scroll with their ancestors
-                let is_fixed =
-                    self.nodes[hoisted.node_id].style().position == taffy::Position::Fixed;
+                // Out-of-flow boxes do not scroll with the ancestors between them and
+                // their containing block: only apply scroll offsets from the containing
+                // block outwards.
+                let hoisted_position = self.nodes[hoisted.node_id].style().position;
 
+                // Overflow clips from clipping ancestors, recorded as (offset of the box
+                // relative to the ancestor, clip rect relative to the ancestor's border box)
+                let mut clips: Vec<(taffy::Point<f32>, taffy::Rect<f32>)> = Vec::new();
+
+                let mut past_cb = false;
                 let mut position = taffy::Point::ZERO;
                 let mut current = self.nodes[hoisted.node_id].layout_parent.get();
                 while let Some(ancestor_id) = current {
@@ -428,17 +438,79 @@ impl BaseDocument {
                         break;
                     }
                     let ancestor = &self.nodes[ancestor_id];
+                    let is_cb = match hoisted_position {
+                        taffy::Position::Fixed => ancestor.establishes_fixed_containing_block(),
+                        taffy::Position::Absolute => {
+                            ancestor.style().position != taffy::Position::Static
+                                || ancestor.establishes_fixed_containing_block()
+                        }
+                        // z-index hoisted in-flow boxes scroll with all their ancestors
+                        _ => true,
+                    };
+                    // Ancestors clip this box only from its containing block outwards
+                    let mut pushed_clip = false;
+                    if is_cb || past_cb {
+                        let style = ancestor.style();
+                        if style.overflow.x != taffy::Overflow::Visible
+                            || style.overflow.y != taffy::Overflow::Visible
+                        {
+                            let layout = ancestor.final_layout();
+                            clips.push((
+                                position,
+                                taffy::Rect {
+                                    left: layout.border.left,
+                                    right: layout.size.width
+                                        - layout.border.right
+                                        - layout.scrollbar_size.width,
+                                    top: layout.border.top,
+                                    bottom: layout.size.height
+                                        - layout.border.bottom
+                                        - layout.scrollbar_size.height,
+                                },
+                            ));
+                            pushed_clip = true;
+                        }
+                    }
                     let location = ancestor.final_layout().location;
                     position.x += location.x;
                     position.y += location.y;
-                    if !is_fixed {
+                    if is_cb || past_cb {
                         let scroll_offset = *ancestor.scroll_offset();
                         position.x -= scroll_offset.x as f32;
                         position.y -= scroll_offset.y as f32;
+                        // An ancestor's scroll offset moves its content (including this box)
+                        // but not its own clip box: cancel it out of the clip's offset.
+                        if pushed_clip {
+                            let (offset, _) = clips.last_mut().unwrap();
+                            offset.x -= scroll_offset.x as f32;
+                            offset.y -= scroll_offset.y as f32;
+                        }
                     }
+                    past_cb |= is_cb;
                     current = ancestor.layout_parent.get();
                 }
                 hoisted.position = position;
+
+                // Convert the recorded clips into the stacking context root's coordinate
+                // space and intersect them
+                hoisted.clip = None;
+                for (offset, rect) in clips {
+                    let clip = taffy::Rect {
+                        left: position.x - offset.x + rect.left,
+                        right: position.x - offset.x + rect.right,
+                        top: position.y - offset.y + rect.top,
+                        bottom: position.y - offset.y + rect.bottom,
+                    };
+                    hoisted.clip = Some(match hoisted.clip {
+                        Some(existing) => taffy::Rect {
+                            left: existing.left.max(clip.left),
+                            right: existing.right.min(clip.right),
+                            top: existing.top.max(clip.top),
+                            bottom: existing.bottom.min(clip.bottom),
+                        },
+                        None => clip,
+                    });
+                }
             }
 
             stacking_context.compute_content_size(self);
@@ -640,17 +712,6 @@ impl BaseDocument {
         if let Some(mut children) = children {
             let is_flex_or_grid = matches!(display, taffy::Display::Flex | taffy::Display::Grid);
 
-            // Recursively call flush_styles_to_layout on each child
-            for &child in children.iter() {
-                self.flush_styles_to_layout_impl(
-                    child,
-                    match self.nodes[child].is_stacking_context_root(is_flex_or_grid) {
-                        true => None,
-                        false => Some(stacking_context),
-                    },
-                );
-            }
-
             // Sort layout_children
             if is_flex_or_grid {
                 children.sort_by(|left, right| {
@@ -660,56 +721,68 @@ impl BaseDocument {
                 });
             }
 
-            // Reserve space for paint_children
-            let mut paint_children = self.nodes[node_id].paint_children.borrow_mut();
-            if paint_children.is_none() {
-                *paint_children = Some(ThinVec::new());
-            }
-            let paint_children = paint_children.as_mut().unwrap();
-            paint_children.clear();
-            paint_children.reserve(children.len());
+            let mut new_paint_children: ThinVec<NodeId> = ThinVec::with_capacity(children.len());
 
-            // Push children to either paint_children or layout_children depending on
+            // Push children to either paint_children or the stacking context, then recurse.
+            // Hoisted entries are pushed before recursing into the child so that the hoisted
+            // list is in tree (pre-)order: CSS 2.1 Appendix E step 8 paints positioned
+            // descendants with z-index: auto at the same level, in tree order.
             for &child_id in children.iter() {
-                let child = &self.nodes[child_id];
+                let hoisted = 'hoisted: {
+                    let child = &self.nodes[child_id];
 
-                let Some(style) = child.primary_styles() else {
-                    paint_children.push(child_id);
-                    continue;
+                    let Some(style) = child.primary_styles() else {
+                        break 'hoisted false;
+                    };
+
+                    let position = style.clone_position();
+                    let z_index = style.clone_z_index().integer_or(0);
+
+                    // Positioned descendants are painted at the level of their stacking
+                    // context root rather than at the level of their layout parent
+                    // (CSS 2.1 Appendix E steps 8-9): hoist them. This also ensures that
+                    // out-of-flow boxes whose containing block is not their layout parent
+                    // (fixed children, and absolute children of non-positioned parents)
+                    // escape the scrolling and clipping of the ancestors between them and
+                    // their containing block.
+                    //
+                    // z-index also applies to static flex/grid items
+                    // (css-flexbox-1 §painting, css-grid-1 §z-order).
+                    position != Position::Static || (z_index != 0 && is_flex_or_grid)
                 };
 
-                let position = style.clone_position();
-                let z_index = style.clone_z_index().integer_or(0);
-
-                // TODO: more complete hoisting detection
-                // z-index applies to static flex/grid items too
-                // (css-flexbox-1 §painting, css-grid-1 §z-order).
-                let z_index_hoisted =
-                    z_index != 0 && (position != Position::Static || is_flex_or_grid);
-                // Fixed position children are hoisted so that the scrolling and clipping of
-                // ancestors between them and their containing block do not apply to them.
-                // TODO: also hoist absolutely positioned children whose containing block is
-                // not their layout parent (needs paint-order interleaving with in-tree
-                // positioned siblings).
-                let out_of_flow_hoisted = position == Position::Fixed;
-                if z_index_hoisted || out_of_flow_hoisted {
+                if hoisted {
+                    let z_index = self.nodes[child_id]
+                        .primary_styles()
+                        .map(|style| style.clone_z_index().integer_or(0))
+                        .unwrap_or(0);
                     stacking_context.children.push(HoistedPaintChild {
                         node_id: child_id,
                         z_index,
                         position: taffy::Point::ZERO,
+                        clip: None,
                     })
                 } else {
-                    paint_children.push(child_id);
+                    new_paint_children.push(child_id);
                 }
+
+                self.flush_styles_to_layout_impl(
+                    child_id,
+                    match self.nodes[child_id].is_stacking_context_root(is_flex_or_grid) {
+                        true => None,
+                        false => Some(stacking_context),
+                    },
+                );
             }
 
             // Sort paint_children
-            paint_children.sort_by(|left, right| {
+            new_paint_children.sort_by(|left, right| {
                 let left_node = self.nodes.get(*left).unwrap();
                 let right_node = self.nodes.get(*right).unwrap();
                 node_to_paint_order(left_node, is_flex_or_grid)
                     .cmp(&node_to_paint_order(right_node, is_flex_or_grid))
             });
+            *self.nodes[node_id].paint_children.borrow_mut() = Some(new_paint_children);
 
             // Put children back
             *self.nodes[node_id].layout_children.borrow_mut() = Some(children);

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -673,7 +673,7 @@ impl BaseDocument {
             // Compute the owned taffy style and display in an inner scope so the
             // immutable borrow of `node` (held by the stylo element data guard)
             // is released before we mutably access `node` below.
-            let (taffy_style, display_constructed_as) = {
+            let (mut taffy_style, display_constructed_as) = {
                 let stylo_element_data = node.stylo_element_data_opt().and_then(|s| s.get());
                 let primary_styles = stylo_element_data
                     .as_ref()
@@ -685,6 +685,10 @@ impl BaseDocument {
 
                 (stylo_taffy::to_taffy_style(style), style.clone_display())
             };
+            taffy_style.item_is_replaced = node
+                .data
+                .downcast_element()
+                .is_some_and(|el| matches!(&*el.name.local, "img" | "canvas"));
 
             // if damage.intersects(RestyleDamage::RELAYOUT | CONSTRUCT_BOX) {
             *node.style_mut() = taffy_style;

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -699,6 +699,15 @@ impl BaseDocument {
                     if node.style().position.is_absolutely_positioned() {
                         let child_position = node.style().position;
                         let direction = node.style().direction;
+                        // The static position of an inline-level abspos box: the inline
+                        // offset is the box's resolved position in the line, and the block
+                        // offset is the top of the line box it would have been placed in
+                        // (parley anchors the zero-sized placeholder box to the baseline,
+                        // which is not what we want here).
+                        let static_position = taffy::Point {
+                            x: (ibox.x / scale) + container_pb.left,
+                            y: (line.metrics().block_min_coord / scale) + container_pb.top,
+                        };
                         // If a positioned inline box (e.g. a `position: relative` span) sits
                         // between this box and the inline root then that inline box is the
                         // containing block. We don't yet support inline containing blocks, so
@@ -725,6 +734,7 @@ impl BaseDocument {
                                 ibox,
                                 final_size,
                                 taffy::Point::ZERO,
+                                static_position,
                                 direction,
                             );
                         } else if child_position == Position::Fixed
@@ -732,12 +742,7 @@ impl BaseDocument {
                         {
                             // This inline container is not the child's containing block: hand
                             // the child back to be laid out against its actual containing block
-                            // after the main layout pass. The static position is the position
-                            // the box would have had in the inline flow.
-                            let static_position = taffy::Point {
-                                x: (ibox.x / scale) + container_pb.left,
-                                y: (ibox.y / scale) + container_pb.top,
-                            };
+                            // after the main layout pass.
                             // `ibox.x` is a resolved left edge, so LTR semantics apply.
                             self.defer_absolute_child(
                                 taffy::NodeId::from(ibox.id),
@@ -751,6 +756,7 @@ impl BaseDocument {
                                 ibox,
                                 final_size,
                                 taffy::Point::ZERO,
+                                static_position,
                                 direction,
                             );
                         }
@@ -828,6 +834,7 @@ fn layout_abspos_child(
     item: PositionedInlineBox,
     area_size: Size<f32>,
     area_offset: Point<f32>,
+    static_position: Point<f32>,
     direction: taffy::Direction,
 ) {
     let area_width = area_size.width;
@@ -1017,51 +1024,53 @@ fn layout_abspos_child(
                 - non_auto_margin.vertical_axis_sum(),
         };
 
-        let auto_margin_size = Size {
-            // If all three of 'left', 'width', and 'right' are 'auto': First set any 'auto' values for 'margin-left' and 'margin-right' to 0.
-            // Then, if the 'direction' property of the element establishing the static-position containing block is 'ltr' set 'left' to the
-            // static position and apply rule number three below; otherwise, set 'right' to the static position and apply rule number one below.
-            //
-            // If none of the three is 'auto': If both 'margin-left' and 'margin-right' are 'auto', solve the equation under the extra constraint
-            // that the two margins get equal values, unless this would make them negative, in which case when direction of the containing block is
-            // 'ltr' ('rtl'), set 'margin-left' ('margin-right') to zero and solve for 'margin-right' ('margin-left'). If one of 'margin-left' or
-            // 'margin-right' is 'auto', solve the equation for that value. If the values are over-constrained, ignore the value for 'left' (in case
-            // the 'direction' property of the containing block is 'rtl') or 'right' (in case 'direction' is 'ltr') and solve for that value.
-            width: {
-                let auto_margin_count = margin.left.is_none() as u8 + margin.right.is_none() as u8;
-                if auto_margin_count == 2
-                    && (style_size.width.is_none() || style_size.width.unwrap() >= free_space.width)
-                {
-                    0.0
-                } else if auto_margin_count > 0 {
-                    free_space.width / auto_margin_count as f32
+        // If both 'margin-left' and 'margin-right' are 'auto', solve the equation under the
+        // extra constraint that the two margins get equal values, unless this would make them
+        // negative, in which case when direction of the containing block is 'ltr' ('rtl'), set
+        // 'margin-left' ('margin-right') to zero and solve for 'margin-right' ('margin-left').
+        // Auto margins in an axis only resolve to non-zero values when both insets in that
+        // axis are set; otherwise they resolve to zero.
+        let (auto_margin_left, auto_margin_right) = {
+            let auto_margin_count = if left.is_some() && right.is_some() {
+                margin.left.is_none() as u8 + margin.right.is_none() as u8
+            } else {
+                0
+            };
+            if auto_margin_count == 2 && free_space.width < 0.0 {
+                if direction == Direction::Rtl {
+                    (free_space.width, 0.0)
                 } else {
-                    0.0
+                    (0.0, free_space.width)
                 }
-            },
-            height: {
-                let auto_margin_count = margin.top.is_none() as u8 + margin.bottom.is_none() as u8;
-                if auto_margin_count == 2
-                    && (style_size.height.is_none()
-                        || style_size.height.unwrap() >= free_space.height)
-                {
-                    0.0
-                } else if auto_margin_count > 0 {
-                    free_space.height / auto_margin_count as f32
-                } else {
-                    0.0
-                }
-            },
+            } else if auto_margin_count > 0 {
+                let share = free_space.width / auto_margin_count as f32;
+                (share, share)
+            } else {
+                (0.0, 0.0)
+            }
+        };
+
+        // If both 'margin-top' and 'margin-bottom' are 'auto', solve the equation under the
+        // extra constraint that the two margins get equal values (no non-negativity constraint
+        // applies in the vertical axis).
+        let auto_margin_height = {
+            let auto_margin_count = if top.is_some() && bottom.is_some() {
+                margin.top.is_none() as u8 + margin.bottom.is_none() as u8
+            } else {
+                0
+            };
+            if auto_margin_count > 0 {
+                free_space.height / auto_margin_count as f32
+            } else {
+                0.0
+            }
         };
 
         taffy::Rect {
-            left: margin.left.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-            right: margin.right.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-            top: margin.top.map(|_| 0.0).unwrap_or(auto_margin_size.height),
-            bottom: margin
-                .bottom
-                .map(|_| 0.0)
-                .unwrap_or(auto_margin_size.height),
+            left: margin.left.map(|_| 0.0).unwrap_or(auto_margin_left),
+            right: margin.right.map(|_| 0.0).unwrap_or(auto_margin_right),
+            top: margin.top.map(|_| 0.0).unwrap_or(auto_margin_height),
+            bottom: margin.bottom.map(|_| 0.0).unwrap_or(auto_margin_height),
         }
     };
 
@@ -1084,9 +1093,9 @@ fn layout_abspos_child(
         (None, Some(right)) => area_size.width - final_size.width - right - resolved_margin.right,
         (None, None) => {
             if direction == Direction::Rtl {
-                item.x - final_size.width - resolved_margin.right - area_offset.x
+                static_position.x - final_size.width - resolved_margin.right - area_offset.x
             } else {
-                item.x + resolved_margin.left - area_offset.x
+                static_position.x + resolved_margin.left - area_offset.x
             }
         }
     };
@@ -1098,7 +1107,7 @@ fn layout_abspos_child(
                 area_size.height - final_size.height - bottom - resolved_margin.bottom
             }))
             .maybe_add(area_offset.y)
-            .unwrap_or(item.y + resolved_margin.top),
+            .unwrap_or(static_position.y + resolved_margin.top),
     };
     // Note: axis intentionally switched here as scrollbars take up space in the opposite axis
     // to the axis in which scrolling is enabled.

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -151,6 +151,7 @@ impl BaseDocument {
             .unwrap();
 
         let style = self.nodes[node_id].style();
+        let container_position = style.position;
 
         // Note: both horizontal and vertical percentage padding/borders are resolved against the container's inline size (i.e. width).
         // This is not a bug, but is how CSS is specified (see: https://developer.mozilla.org/en-US/docs/Web/CSS/padding#values)
@@ -186,7 +187,7 @@ impl BaseDocument {
         let has_styles_preventing_being_collapsed_through = !style.is_block()
             || style.overflow().x.is_scroll_container()
             || style.overflow().y.is_scroll_container()
-            || style.position() == Position::Absolute
+            || style.position().is_absolutely_positioned()
             || padding.top > 0.0
             || padding.bottom > 0.0
             || border.top > 0.0
@@ -296,7 +297,7 @@ impl BaseDocument {
             #[cfg(not(feature = "floats"))]
             let is_floated = false;
 
-            if style.position == Position::Absolute || is_floated {
+            if style.position.is_absolutely_positioned() || is_floated {
                 ibox.width = 0.0;
                 ibox.height = 0.0;
             } else {
@@ -695,9 +696,32 @@ impl BaseDocument {
                     #[cfg(not(feature = "floats"))]
                     let is_floated = false;
 
-                    if node.style().position == Position::Absolute {
+                    if node.style().position.is_absolutely_positioned() {
+                        let child_position = node.style().position;
                         let direction = node.style().direction;
-                        layout_abspos_child(self, ibox, final_size, taffy::Point::ZERO, direction);
+                        if child_position == Position::Fixed || container_position == Position::Static {
+                            // This inline container is not the child's containing block: hand
+                            // the child back to be laid out against its actual containing block
+                            // after the main layout pass. The static position is the position
+                            // the box would have had in the inline flow.
+                            let static_position = taffy::Point {
+                                x: (ibox.x / scale) + container_pb.left,
+                                y: (ibox.y / scale) + container_pb.top,
+                            };
+                            self.defer_absolute_child(
+                                taffy::NodeId::from(ibox.id),
+                                0,
+                                static_position,
+                            );
+                        } else {
+                            layout_abspos_child(
+                                self,
+                                ibox,
+                                final_size,
+                                taffy::Point::ZERO,
+                                direction,
+                            );
+                        }
                     } else if is_floated {
                         let layout = self.nodes[NodeId::from_u64(ibox.id)].unrounded_layout_mut();
                         layout.padding = padding; //.map(|p| p / scale);
@@ -782,7 +806,7 @@ fn layout_abspos_child(
 
     // Skip items that are display:none or are not position:absolute
     if child_style.box_generation_mode() == taffy::BoxGenerationMode::None
-        || child_style.position() != taffy::Position::Absolute
+        || !child_style.position().is_absolutely_positioned()
     {
         return;
     }

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -699,7 +699,37 @@ impl BaseDocument {
                     if node.style().position.is_absolutely_positioned() {
                         let child_position = node.style().position;
                         let direction = node.style().direction;
-                        if child_position == Position::Fixed || container_position == Position::Static {
+                        // If a positioned inline box (e.g. a `position: relative` span) sits
+                        // between this box and the inline root then that inline box is the
+                        // containing block. We don't yet support inline containing blocks, so
+                        // approximate them with the inline root by laying out directly.
+                        let has_positioned_inline_ancestor = {
+                            let mut ancestor = self.nodes[NodeId::from_u64(ibox.id)].parent;
+                            let mut found = false;
+                            while let Some(ancestor_id) = ancestor {
+                                if ancestor_id == node_id {
+                                    break;
+                                }
+                                if self.nodes[ancestor_id].style().position != Position::Static {
+                                    found = true;
+                                    break;
+                                }
+                                ancestor = self.nodes[ancestor_id].parent;
+                            }
+                            found
+                        };
+                        if child_position == Position::Absolute && has_positioned_inline_ancestor {
+                            *self.nodes[NodeId::from_u64(ibox.id)].deferred_position_mut() = None;
+                            layout_abspos_child(
+                                self,
+                                ibox,
+                                final_size,
+                                taffy::Point::ZERO,
+                                direction,
+                            );
+                        } else if child_position == Position::Fixed
+                            || container_position == Position::Static
+                        {
                             // This inline container is not the child's containing block: hand
                             // the child back to be laid out against its actual containing block
                             // after the main layout pass. The static position is the position
@@ -708,10 +738,12 @@ impl BaseDocument {
                                 x: (ibox.x / scale) + container_pb.left,
                                 y: (ibox.y / scale) + container_pb.top,
                             };
+                            // `ibox.x` is a resolved left edge, so LTR semantics apply.
                             self.defer_absolute_child(
                                 taffy::NodeId::from(ibox.id),
                                 0,
                                 static_position,
+                                taffy::Direction::Ltr,
                             );
                         } else {
                             layout_abspos_child(

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -342,6 +342,16 @@ impl LayoutPartialTree for BaseDocument {
             tree.compute_child_layout_internal(node_id, inputs, None)
         })
     }
+
+    #[inline(always)]
+    fn defer_absolute_child(
+        &mut self,
+        child_id: NodeId,
+        order: u32,
+        static_position: taffy::Point<f32>,
+    ) {
+        *self.node_from_id_mut(child_id).deferred_position_mut() = Some((order, static_position));
+    }
 }
 
 impl taffy::CacheTree for BaseDocument {

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -183,13 +183,23 @@ impl BaseDocument {
                     //
                     // TODO: smarter sizing using these (depending on object-fit, they shouldn't
                     // necessarily just override the native size)
+                    // HTML dimension attribute values may be a number of pixels or a
+                    // percentage of the parent's corresponding dimension
+                    let parse_dimension_attr = |val: &str, parent: Option<f32>| -> Option<f32> {
+                        match val.strip_suffix('%') {
+                            Some(percent) => {
+                                Some(percent.trim().parse::<f32>().ok()? / 100.0 * parent?)
+                            }
+                            None => val.parse::<f32>().ok(),
+                        }
+                    };
                     let attr_size = taffy::Size {
                         width: element_data
                             .attr(local_name!("width"))
-                            .and_then(|val| val.parse::<f32>().ok()),
+                            .and_then(|val| parse_dimension_attr(val, inputs.parent_size.width)),
                         height: element_data
                             .attr(local_name!("height"))
-                            .and_then(|val| val.parse::<f32>().ok()),
+                            .and_then(|val| parse_dimension_attr(val, inputs.parent_size.height)),
                     };
 
                     // Get image's native sizespecial_data

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -349,8 +349,10 @@ impl LayoutPartialTree for BaseDocument {
         child_id: NodeId,
         order: u32,
         static_position: taffy::Point<f32>,
+        static_position_direction: taffy::Direction,
     ) {
-        *self.node_from_id_mut(child_id).deferred_position_mut() = Some((order, static_position));
+        *self.node_from_id_mut(child_id).deferred_position_mut() =
+            Some((order, static_position, static_position_direction));
     }
 }
 

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -79,11 +79,19 @@ pub fn replaced_measure_function(
         .min_size
         .maybe_resolve(parent_size, resolve_calc_value)
         .maybe_sub(box_sizing_adjustment);
+    // Available space acts as a max-size constraint for in-flow replaced elements,
+    // but absolutely positioned ones size to their intrinsic size regardless of the
+    // size of their containing block.
+    let available_space_max = if style.position.is_absolutely_positioned() {
+        Size::NONE
+    } else {
+        available_space.into_options()
+    };
     let max_size = style
         .max_size
         .maybe_resolve(basis_for_max_and_preferred, resolve_calc_value)
-        .or(available_space.into_options())
-        .maybe_min(available_space.into_options())
+        .or(available_space_max)
+        .maybe_min(available_space_max)
         .maybe_max(min_size)
         .maybe_sub(box_sizing_adjustment);
     let attr_size = image_context.attr_size;

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -70,6 +70,7 @@ pub mod util;
 #[cfg(feature = "accessibility")]
 mod accessibility;
 
+pub use crate::layout::damage::{HoistedPaintChild, HoistedPaintChildren};
 #[cfg(feature = "custom-widget")]
 pub use crate::node::Widget;
 

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -112,6 +112,9 @@ pub struct ElementData {
     pub cache: Cache,
     pub unrounded_layout: Layout,
     pub final_layout: Layout,
+    /// The static position recorded when this node was deferred by its layout parent during
+    /// layout (because that parent was not its containing block). `(order, static_position)`.
+    pub deferred_position: Option<(u32, taffy::Point<f32>)>,
     pub scroll_offset: crate::Point<f64>,
     pub scrollable_overflow: KurboRect,
     pub transform: Option<Affine>,
@@ -137,6 +140,9 @@ pub struct DocumentData {
     pub cache: Cache,
     pub unrounded_layout: Layout,
     pub final_layout: Layout,
+    /// The static position recorded when this node was deferred by its layout parent during
+    /// layout (because that parent was not its containing block). `(order, static_position)`.
+    pub deferred_position: Option<(u32, taffy::Point<f32>)>,
     pub scroll_offset: crate::Point<f64>,
     pub scrollable_overflow: KurboRect,
     pub transform: Option<Affine>,
@@ -156,6 +162,7 @@ impl DocumentData {
             cache: Cache::new(),
             unrounded_layout: Layout::new(),
             final_layout: Layout::new(),
+            deferred_position: None,
             scroll_offset: crate::Point::ZERO,
             scrollable_overflow: KurboRect::ZERO,
             transform: None,
@@ -236,6 +243,7 @@ impl Clone for ElementData {
             cache: Cache::new(),
             unrounded_layout: Layout::new(),
             final_layout: Layout::new(),
+            deferred_position: None,
             scroll_offset: crate::Point::ZERO,
             scrollable_overflow: KurboRect::ZERO,
             transform: None,
@@ -347,6 +355,7 @@ impl ElementData {
             cache: Cache::new(),
             unrounded_layout: Layout::new(),
             final_layout: Layout::new(),
+            deferred_position: None,
             scroll_offset: crate::Point::ZERO,
             scrollable_overflow: KurboRect::ZERO,
             transform: None,

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -114,7 +114,7 @@ pub struct ElementData {
     pub final_layout: Layout,
     /// The static position recorded when this node was deferred by its layout parent during
     /// layout (because that parent was not its containing block). `(order, static_position)`.
-    pub deferred_position: Option<(u32, taffy::Point<f32>)>,
+    pub deferred_position: Option<(u32, taffy::Point<f32>, taffy::Direction)>,
     pub scroll_offset: crate::Point<f64>,
     pub scrollable_overflow: KurboRect,
     pub transform: Option<Affine>,
@@ -142,7 +142,7 @@ pub struct DocumentData {
     pub final_layout: Layout,
     /// The static position recorded when this node was deferred by its layout parent during
     /// layout (because that parent was not its containing block). `(order, static_position)`.
-    pub deferred_position: Option<(u32, taffy::Point<f32>)>,
+    pub deferred_position: Option<(u32, taffy::Point<f32>, taffy::Direction)>,
     pub scroll_offset: crate::Point<f64>,
     pub scrollable_overflow: KurboRect,
     pub transform: Option<Affine>,

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -191,7 +191,7 @@ universal_accessors! {
     cache / cache_mut: Cache,
     unrounded_layout / unrounded_layout_mut: Layout,
     final_layout / final_layout_mut: Layout,
-    deferred_position / deferred_position_mut: Option<(u32, taffy::Point<f32>)>,
+    deferred_position / deferred_position_mut: Option<(u32, taffy::Point<f32>, taffy::Direction)>,
     scroll_offset / scroll_offset_mut: crate::Point<f64>,
     scrollable_overflow / scrollable_overflow_mut: KurboRect,
     transform / transform_mut: Option<Affine>,
@@ -345,8 +345,14 @@ impl Node {
                 let box_style = s.get_box();
                 let effects = s.get_effects();
                 !box_style.transform.0.is_empty()
-                    || !matches!(box_style.scale, style::values::generics::transform::Scale::None)
-                    || !matches!(box_style.rotate, style::values::generics::transform::Rotate::None)
+                    || !matches!(
+                        box_style.scale,
+                        style::values::generics::transform::Scale::None
+                    )
+                    || !matches!(
+                        box_style.rotate,
+                        style::values::generics::transform::Rotate::None
+                    )
                     || !matches!(
                         box_style.translate,
                         style::values::generics::transform::Translate::None

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -191,6 +191,7 @@ universal_accessors! {
     cache / cache_mut: Cache,
     unrounded_layout / unrounded_layout_mut: Layout,
     final_layout / final_layout_mut: Layout,
+    deferred_position / deferred_position_mut: Option<(u32, taffy::Point<f32>)>,
     scroll_offset / scroll_offset_mut: crate::Point<f64>,
     scrollable_overflow / scrollable_overflow_mut: KurboRect,
     transform / transform_mut: Option<Affine>,
@@ -331,6 +332,33 @@ impl Node {
 
         *self.transform_mut() = transform;
         transform
+    }
+
+    /// Whether this node establishes a containing block for `position: fixed` descendants
+    /// (and, along with positioned-ness, for `position: absolute` descendants).
+    ///
+    /// See: <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Containing_block>
+    pub fn establishes_fixed_containing_block(&self) -> bool {
+        use style::values::computed::Perspective;
+        self.primary_styles()
+            .map(|s| {
+                let box_style = s.get_box();
+                let effects = s.get_effects();
+                !box_style.transform.0.is_empty()
+                    || !matches!(box_style.scale, style::values::generics::transform::Scale::None)
+                    || !matches!(box_style.rotate, style::values::generics::transform::Rotate::None)
+                    || !matches!(
+                        box_style.translate,
+                        style::values::generics::transform::Translate::None
+                    )
+                    || !matches!(box_style.perspective, Perspective::None)
+                    || !effects.filter.0.is_empty()
+                    || box_style.will_change.bits.intersects(
+                        style::values::specified::box_::WillChangeBits::TRANSFORM
+                            | style::values::specified::box_::WillChangeBits::PERSPECTIVE,
+                    )
+            })
+            .unwrap_or(false)
     }
 
     pub fn pe_by_index(&self, index: usize) -> Option<NodeId> {

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -91,6 +91,9 @@ impl BaseDocument {
         self.resolve_layout();
         timer.record_time("layout");
 
+        // Refresh hoisted paint child positions now that layout is final
+        self.refresh_hoisted_paint_positions();
+
         // Resolve transforms
         self.resolve_transforms(root_node_id);
         timer.record_time("transform");
@@ -169,7 +172,13 @@ impl BaseDocument {
         if let Some(ref children) = layout_children {
             for &child_id in children {
                 let child_rect_in_self = self.resolve_transforms(child_id);
-                overflow = overflow.union(child_rect_in_self);
+                // Fixed position children do not contribute to their ancestors'
+                // scrollable overflow
+                let child_is_fixed =
+                    self.nodes[child_id].style().position == taffy::Position::Fixed;
+                if !child_is_fixed {
+                    overflow = overflow.union(child_rect_in_self);
+                }
             }
         }
         if let Some(before) = self.nodes[node_id].before() {
@@ -398,9 +407,190 @@ impl BaseDocument {
         // println!("\n\nRESOLVE LAYOUT\n===========\n");
 
         taffy::compute_root_layout(self, root_element_id, available_space);
+        self.position_deferred_children();
         taffy::round_layout(self, root_element_id);
 
         // println!("\n\n");
         // taffy::print_tree(self, root_node_id)
+    }
+
+    /// Lay out out-of-flow children which were deferred during the main layout pass (via
+    /// [`taffy::LayoutPartialTree::defer_absolute_child`]) against their actual containing block:
+    ///
+    /// - `position: absolute` children of non-positioned containers are positioned against
+    ///   their nearest positioned (or transformed) ancestor, falling back to the initial
+    ///   containing block (the viewport).
+    /// - `position: fixed` children are positioned against their nearest transformed ancestor,
+    ///   falling back to the initial containing block (the viewport).
+    ///
+    /// This runs after `compute_root_layout` (so all in-flow layout and static positions are
+    /// resolved) and before `round_layout` (so the final positions get rounded normally).
+    fn position_deferred_children(&mut self) {
+        use taffy::{Point, Position};
+
+        /// A containing block for out-of-flow boxes, described relative to the border box of
+        /// the node establishing it.
+        #[derive(Copy, Clone)]
+        struct Cb {
+            node_id: NodeId,
+            area_size: taffy::Size<f32>,
+            area_offset: taffy::Point<f32>,
+        }
+
+        fn cb_from_node(doc: &BaseDocument, node_id: NodeId) -> Cb {
+            let layout = *doc.nodes[node_id].unrounded_layout();
+            let is_rtl = doc.nodes[node_id].style().direction.is_rtl();
+            let area_size = taffy::Size {
+                width: layout.size.width
+                    - layout.border.left
+                    - layout.border.right
+                    - layout.scrollbar_size.width,
+                height: layout.size.height
+                    - layout.border.top
+                    - layout.border.bottom
+                    - layout.scrollbar_size.height,
+            };
+            let area_offset = taffy::Point {
+                x: if is_rtl {
+                    layout.border.left + layout.scrollbar_size.width
+                } else {
+                    layout.border.left
+                },
+                y: layout.border.top,
+            };
+            Cb {
+                node_id,
+                area_size,
+                area_offset,
+            }
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        fn recurse(
+            doc: &mut BaseDocument,
+            node_id: NodeId,
+            fixed_cb: Cb,
+            abs_cb: Cb,
+            offset_from_fixed_cb: taffy::Point<f32>,
+            offset_from_abs_cb: taffy::Point<f32>,
+        ) {
+            let node_position = doc.nodes[node_id].style().position;
+
+            let layout_children = doc.nodes[node_id].layout_children.borrow().clone();
+            let mut child_ids: Vec<NodeId> = layout_children.map(|c| c.to_vec()).unwrap_or_default();
+            if let Some(before) = doc.nodes[node_id].before() {
+                child_ids.push(before);
+            }
+            if let Some(after) = doc.nodes[node_id].after() {
+                child_ids.push(after);
+            }
+
+            for child_id in child_ids {
+                if !doc.nodes.contains_key(child_id) {
+                    continue;
+                }
+                let child_position = doc.nodes[child_id].style().position;
+
+                let is_deferred = child_position == Position::Fixed
+                    || (child_position == Position::Absolute && node_position == Position::Static);
+
+                if is_deferred {
+                    if let Some((order, static_position)) = *doc.nodes[child_id].deferred_position()
+                    {
+                        let (cb, parent_offset) = if child_position == Position::Fixed {
+                            (fixed_cb, offset_from_fixed_cb)
+                        } else {
+                            (abs_cb, offset_from_abs_cb)
+                        };
+                        let direction = doc.nodes[cb.node_id].style().direction;
+                        let static_position_in_cb = Point {
+                            x: static_position.x + parent_offset.x,
+                            y: static_position.y + parent_offset.y,
+                        };
+                        let result = taffy::compute_absolute_child_layout(
+                            doc,
+                            crate::taffy_node_id(child_id),
+                            order,
+                            cb.area_size,
+                            cb.area_offset,
+                            static_position_in_cb,
+                            direction,
+                        );
+                        // `compute_absolute_child_layout` writes a location relative to the
+                        // containing block's border box. Convert it to be relative to the layout
+                        // parent's border box (the coordinate space layouts are stored in).
+                        let mut layout = result.layout;
+                        layout.location.x -= parent_offset.x;
+                        layout.location.y -= parent_offset.y;
+                        *doc.nodes[child_id].unrounded_layout_mut() = layout;
+                    }
+                }
+
+                // Compute the containing blocks and offsets that apply to the child's descendants
+                let child_layout = *doc.nodes[child_id].unrounded_layout();
+                let child_establishes_fixed_cb =
+                    doc.nodes[child_id].establishes_fixed_containing_block();
+                let child_is_positioned =
+                    child_position != Position::Static || child_establishes_fixed_cb;
+
+                let child_fixed_cb;
+                let child_offset_from_fixed_cb;
+                if child_establishes_fixed_cb {
+                    child_fixed_cb = cb_from_node(doc, child_id);
+                    child_offset_from_fixed_cb = Point::ZERO;
+                } else {
+                    child_fixed_cb = fixed_cb;
+                    child_offset_from_fixed_cb = Point {
+                        x: offset_from_fixed_cb.x + child_layout.location.x,
+                        y: offset_from_fixed_cb.y + child_layout.location.y,
+                    };
+                }
+
+                let child_abs_cb;
+                let child_offset_from_abs_cb;
+                if child_is_positioned {
+                    child_abs_cb = cb_from_node(doc, child_id);
+                    child_offset_from_abs_cb = Point::ZERO;
+                } else {
+                    child_abs_cb = abs_cb;
+                    child_offset_from_abs_cb = Point {
+                        x: offset_from_abs_cb.x + child_layout.location.x,
+                        y: offset_from_abs_cb.y + child_layout.location.y,
+                    };
+                }
+
+                recurse(
+                    doc,
+                    child_id,
+                    child_fixed_cb,
+                    child_abs_cb,
+                    child_offset_from_fixed_cb,
+                    child_offset_from_abs_cb,
+                );
+            }
+        }
+
+        let viewport_size = self.stylist.device().au_viewport_size();
+        let root_id = self.root_element().id;
+
+        // The initial containing block: the viewport. Offsets are tracked relative to the root
+        // element's border box, which is positioned at the viewport origin.
+        let viewport_cb = Cb {
+            node_id: root_id,
+            area_size: taffy::Size {
+                width: viewport_size.width.to_f32_px(),
+                height: viewport_size.height.to_f32_px(),
+            },
+            area_offset: taffy::Point::ZERO,
+        };
+
+        recurse(
+            self,
+            root_id,
+            viewport_cb,
+            viewport_cb,
+            Point::ZERO,
+            Point::ZERO,
+        );
     }
 }

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -465,6 +465,112 @@ impl BaseDocument {
             }
         }
 
+        /// Convert a 1-based (possibly negative) grid line index into a boundary offset,
+        /// relative to the start content edge of the track axis. Returns `None` for lines
+        /// which fall outside the laid-out tracks.
+        fn grid_line_offset(tracks: &taffy::DetailedGridTracksInfo, line: i16) -> Option<f32> {
+            let track_count = tracks.sizes.len() as i16;
+            let explicit_start = tracks.negative_implicit_tracks as i16;
+            // Convert to a 0-based boundary index into the full (implicit + explicit) track list
+            let boundary = if line > 0 {
+                explicit_start + (line - 1)
+            } else if line < 0 {
+                explicit_start + tracks.explicit_tracks as i16 + 1 + line
+            } else {
+                return None;
+            };
+            if boundary < 0 || boundary > track_count {
+                return None;
+            }
+            let boundary = boundary as usize;
+            // Track layout along an axis is: gutter, track, gutter, track, ..., gutter.
+            // The offset of boundary `b` is the sum of the first `b` tracks and `b + 1` gutters.
+            let mut offset = 0.0;
+            for i in 0..boundary {
+                offset += tracks.gutters.get(i).copied().unwrap_or(0.0);
+                offset += tracks.sizes[i];
+            }
+            offset += tracks.gutters.get(boundary).copied().unwrap_or(0.0);
+            Some(offset)
+        }
+
+        /// Resolve a grid placement (for one axis) to start/end boundary offsets relative to
+        /// the start content edge. Only handles numeric lines (+ spans); named lines and
+        /// auto-placement resolve to `None` (= the padding box edge, per css-grid §9.1).
+        fn resolve_grid_axis<S: taffy::CheapCloneStr>(
+            tracks: &taffy::DetailedGridTracksInfo,
+            placement: &taffy::Line<taffy::GridPlacement<S>>,
+        ) -> (Option<f32>, Option<f32>) {
+            use taffy::GridPlacement::*;
+            let (start_line, end_line): (Option<i16>, Option<i16>) =
+                match (&placement.start, &placement.end) {
+                    (Line(s), Line(e)) => (Some(s.as_i16()), Some(e.as_i16())),
+                    (Line(s), Span(n)) => (Some(s.as_i16()), Some(s.as_i16() + *n as i16)),
+                    (Span(n), Line(e)) => (Some(e.as_i16() - *n as i16), Some(e.as_i16())),
+                    (Line(s), _) => (Some(s.as_i16()), None),
+                    (_, Line(e)) => (None, Some(e.as_i16())),
+                    _ => (None, None),
+                };
+            (
+                start_line.and_then(|line| grid_line_offset(tracks, line)),
+                end_line.and_then(|line| grid_line_offset(tracks, line)),
+            )
+        }
+
+        /// If the containing block is a grid container and the child has explicit grid
+        /// placement then the child's containing block is the corresponding grid area
+        /// rather than the grid container's padding box (css-grid-1 §9.1).
+        fn grid_area_for_child(
+            doc: &BaseDocument,
+            cb: &Cb,
+            child_id: NodeId,
+        ) -> Option<(taffy::Size<f32>, taffy::Point<f32>)> {
+            let cb_node = &doc.nodes[cb.node_id];
+            if cb_node.style().display != taffy::Display::Grid {
+                return None;
+            }
+            let info = cb_node
+                .data
+                .downcast_element()?
+                .detailed_grid_info
+                .as_deref()?;
+
+            let child_style = doc.nodes[child_id].style();
+            let (col_start, col_end) = resolve_grid_axis(&info.columns, &child_style.grid_column);
+            let (row_start, row_end) = resolve_grid_axis(&info.rows, &child_style.grid_row);
+            if col_start.is_none() && col_end.is_none() && row_start.is_none() && row_end.is_none()
+            {
+                return None;
+            }
+
+            let layout = cb_node.unrounded_layout();
+            let content_offset = taffy::Point {
+                x: layout.border.left + layout.padding.left,
+                y: layout.border.top + layout.padding.top,
+            };
+            // Auto lines resolve to the padding box edges
+            let left = col_start
+                .map(|o| content_offset.x + o)
+                .unwrap_or(cb.area_offset.x);
+            let right = col_end
+                .map(|o| content_offset.x + o)
+                .unwrap_or(cb.area_offset.x + cb.area_size.width);
+            let top = row_start
+                .map(|o| content_offset.y + o)
+                .unwrap_or(cb.area_offset.y);
+            let bottom = row_end
+                .map(|o| content_offset.y + o)
+                .unwrap_or(cb.area_offset.y + cb.area_size.height);
+
+            Some((
+                taffy::Size {
+                    width: (right - left).max(0.0),
+                    height: (bottom - top).max(0.0),
+                },
+                taffy::Point { x: left, y: top },
+            ))
+        }
+
         #[allow(clippy::too_many_arguments)]
         fn recurse(
             doc: &mut BaseDocument,
@@ -477,7 +583,8 @@ impl BaseDocument {
             let node_position = doc.nodes[node_id].style().position;
 
             let layout_children = doc.nodes[node_id].layout_children.borrow().clone();
-            let mut child_ids: Vec<NodeId> = layout_children.map(|c| c.to_vec()).unwrap_or_default();
+            let mut child_ids: Vec<NodeId> =
+                layout_children.map(|c| c.to_vec()).unwrap_or_default();
             if let Some(before) = doc.nodes[node_id].before() {
                 child_ids.push(before);
             }
@@ -495,7 +602,8 @@ impl BaseDocument {
                     || (child_position == Position::Absolute && node_position == Position::Static);
 
                 if is_deferred {
-                    if let Some((order, static_position)) = *doc.nodes[child_id].deferred_position()
+                    if let Some((order, static_position, static_position_direction)) =
+                        *doc.nodes[child_id].deferred_position()
                     {
                         let (cb, parent_offset) = if child_position == Position::Fixed {
                             (fixed_cb, offset_from_fixed_cb)
@@ -507,13 +615,16 @@ impl BaseDocument {
                             x: static_position.x + parent_offset.x,
                             y: static_position.y + parent_offset.y,
                         };
+                        let (area_size, area_offset) = grid_area_for_child(doc, &cb, child_id)
+                            .unwrap_or((cb.area_size, cb.area_offset));
                         let result = taffy::compute_absolute_child_layout(
                             doc,
                             crate::taffy_node_id(child_id),
                             order,
-                            cb.area_size,
-                            cb.area_offset,
+                            area_size,
+                            area_offset,
                             static_position_in_cb,
+                            static_position_direction,
                             direction,
                         );
                         // `compute_absolute_child_layout` writes a location relative to the

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -883,19 +883,9 @@ impl ElementCx<'_, '_> {
         clip_rect: Rect,
     ) {
         // Negative z_index hoisted nodes
-
         if let Some(hoisted) = &self.node.stacking_context {
             for hoisted_child in hoisted.neg_z_hoisted_children() {
-                let pos = kurbo::Vec2 {
-                    x: hoisted_child.position.x as f64 * self.scale,
-                    y: hoisted_child.position.y as f64 * self.scale,
-                };
-                self.render_node(
-                    scene,
-                    hoisted_child.node_id,
-                    parent_style_transform.pre_translate(pos),
-                    clip_rect,
-                );
+                self.draw_hoisted_child(scene, hoisted_child, parent_style_transform, clip_rect);
             }
         }
 
@@ -909,17 +899,52 @@ impl ElementCx<'_, '_> {
         // Positive z_index hoisted nodes
         if let Some(hoisted) = &self.node.stacking_context {
             for hoisted_child in hoisted.pos_z_hoisted_children() {
-                let pos = kurbo::Vec2 {
-                    x: hoisted_child.position.x as f64 * self.scale,
-                    y: hoisted_child.position.y as f64 * self.scale,
-                };
-                self.render_node(
+                self.draw_hoisted_child(scene, hoisted_child, parent_style_transform, clip_rect);
+            }
+        }
+    }
+
+    fn draw_hoisted_child(
+        &self,
+        scene: &mut impl PaintScene,
+        hoisted_child: &blitz_dom::HoistedPaintChild,
+        parent_style_transform: Affine,
+        clip_rect: Rect,
+    ) {
+        let pos = kurbo::Vec2 {
+            x: hoisted_child.position.x as f64 * self.scale,
+            y: hoisted_child.position.y as f64 * self.scale,
+        };
+        let transform = parent_style_transform.pre_translate(pos);
+        match hoisted_child.clip {
+            Some(clip) => {
+                // Hoisted boxes are painted outside the tree position where ancestor
+                // overflow clips are applied, so apply the applicable clips here.
+                let clip_shape = Rect::new(
+                    clip.left as f64 * self.scale,
+                    clip.top as f64 * self.scale,
+                    clip.right as f64 * self.scale,
+                    clip.bottom as f64 * self.scale,
+                );
+                let clip_rect =
+                    clip_rect.intersect(parent_style_transform.transform_rect_bbox(clip_shape));
+                if clip_rect.width() <= 0.0 || clip_rect.height() <= 0.0 {
+                    return;
+                }
+                self.layer_manager.maybe_with_layer(
                     scene,
-                    hoisted_child.node_id,
-                    parent_style_transform.pre_translate(pos),
-                    clip_rect,
+                    true,
+                    1.0,
+                    parent_style_transform,
+                    &clip_shape,
+                    None,
+                    None,
+                    |scene| {
+                        self.render_node(scene, hoisted_child.node_id, transform, clip_rect);
+                    },
                 );
             }
+            None => self.render_node(scene, hoisted_child.node_id, transform, clip_rect),
         }
     }
 

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -222,13 +222,12 @@ pub fn box_sizing(input: stylo::BoxSizing) -> taffy::BoxSizing {
 #[inline]
 pub fn position(input: stylo::Position) -> taffy::Position {
     match input {
-        // TODO: support position:static
         stylo::Position::Relative => taffy::Position::Relative,
-        stylo::Position::Static => taffy::Position::Relative,
+        stylo::Position::Static => taffy::Position::Static,
 
-        // TODO: support position:fixed and sticky
+        // TODO: support position:sticky
         stylo::Position::Absolute => taffy::Position::Absolute,
-        stylo::Position::Fixed => taffy::Position::Absolute,
+        stylo::Position::Fixed => taffy::Position::Fixed,
         stylo::Position::Sticky => taffy::Position::Relative,
     }
 }


### PR DESCRIPTION
## Summary

Implements real `position: static` and `position: fixed` semantics: absolutely positioned boxes now resolve against their nearest *positioned* ancestor (not just their direct layout parent), and fixed boxes against the viewport or nearest transformed/perspective/filter/`will-change` ancestor. Built on the companion Taffy PR DioxusLabs/taffy#1009 (`Position::Static`/`Fixed`, `defer_absolute_child` hook, public `compute_absolute_child_layout`); `Cargo.toml` temporarily patches `taffy` to that branch.

How it fits together:

- `stylo_taffy` now maps `static → Static` and `fixed → Fixed` instead of collapsing them into `Relative`/`Absolute`.
- During Taffy layout, containers call `defer_absolute_child` for abspos children they aren't the CB of; Blitz stores `(order, static_position, direction)` on the node (`deferred_position`).
- A new `BaseDocument::position_deferred_children` pass runs between `compute_root_layout` and `round_layout`: it walks the layout tree with independent absolute-CB and fixed-CB stacks (viewport fallback) and lays deferred nodes out via `taffy::compute_absolute_child_layout`, converting between CB-relative and layout-parent-relative coordinates.
- If the actual CB is a grid container and the child has numeric `grid-row`/`grid-column` placement, the positioning area is the corresponding grid area, reconstructed from `DetailedGridInfo` track sizes/gutters (css-grid-1 §9.1). Named lines fall back to the padding box.
- Static positions are alignment-aware (computed by the direct parent per spec): flex `justify-content`/`align-self` fallback and grid sole-item content-box alignment come from the Taffy side; inline static positions come from the inline layout's hypothetical box position.
- Positioned *inline* boxes (e.g. a `position:relative` span) as containing blocks aren't supported yet; those children keep the previous inline-root approximation (see `nested-inline-abspos-child*` WPT tests).
- Painting: fixed nodes are hoisted into their stacking context via the existing `HoistedPaintChild` machinery so ancestor scroll/clip doesn't apply (`refresh_hoisted_paint_positions` recomputes hoisted positions post-layout, skipping scroll offsets for fixed). Fixed nodes are also excluded from ancestors' scrollable overflow. Absolute nodes keep in-tree paint order (hoisting them broke Appendix-E interleaving with in-flow positioned siblings; noted as TODO).

WPT results (this branch + Taffy PR vs main):

| Suite | main | this PR |
|---|---|---|
| css/CSS2/positioning | 325 | 366 |
| css/css-position | 49 | 51 |
| css/css-grid/abspos | 70 | 92 |
| css/css-flexbox/abspos | 29 | 30 |

One regression: `grid-abspos-staticpos-align-self-safe-outer-cb-003.tentative.html` (vertical writing modes + `safe` alignment + single-axis static position; tentative test tracking csswg-drafts#11934).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/222d77e67e0947fcb4cec72499eed49c
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**403** newly passing, **72** newly failing (net +331), **1** other status change.

<details>
<summary>Full diff (476 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/abspos/abspos-containing-block-initial-009f.xht
+ Fail => Pass css/CSS2/abspos/static-inside-float-inside-inline.html
+ Fail => Pass css/CSS2/abspos/static-inside-inline-001.html
+ Fail => Pass css/CSS2/abspos/static-inside-inline-003.html
+ Fail => Pass css/CSS2/backgrounds/background-001.xht
+ Fail => Pass css/CSS2/backgrounds/background-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-003.xht
+ Fail => Pass css/CSS2/backgrounds/background-006.xht
+ Fail => Pass css/CSS2/backgrounds/background-007.xht
+ Fail => Pass css/CSS2/backgrounds/background-008.xht
+ Fail => Pass css/CSS2/backgrounds/background-009.xht
+ Fail => Pass css/CSS2/backgrounds/background-010.xht
+ Fail => Pass css/CSS2/backgrounds/background-014.xht
+ Fail => Pass css/CSS2/backgrounds/background-018.xht
+ Fail => Pass css/CSS2/backgrounds/background-022.xht
+ Fail => Pass css/CSS2/backgrounds/background-087.xht
+ Fail => Pass css/CSS2/backgrounds/background-182.xht
+ Fail => Pass css/CSS2/backgrounds/background-bg-pos-204.xht
- Pass => Fail css/CSS2/backgrounds/background-bg-pos-206.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-cover-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-cover-004.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-cover-attachment-001.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-transparency-001.xht
- Pass => Fail css/CSS2/backgrounds/background-position-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-001.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-003.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-005.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-023.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-003.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-025.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-058.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-069.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-080.xht
+ Fail => Pass css/CSS2/borders/border-right-width-095.xht
+ Fail => Pass css/CSS2/borders/border-top-width-003.xht
+ Fail => Pass css/CSS2/borders/border-top-width-025.xht
+ Fail => Pass css/CSS2/borders/border-top-width-058.xht
+ Fail => Pass css/CSS2/borders/border-top-width-069.xht
+ Fail => Pass css/CSS2/borders/border-top-width-080.xht
+ Fail => Pass css/CSS2/borders/border-width-shorthand-001.xht
+ Fail => Pass css/CSS2/borders/border-width-shorthand-002.xht
+ Fail => Pass css/CSS2/borders/border-width-shorthand-003.xht
+ Fail => Pass css/CSS2/borders/border-width-shorthand-004.xht
+ Fail => Pass css/CSS2/box-display/containing-block-007.xht
+ Fail => Pass css/CSS2/box-display/containing-block-009.xht
+ Fail => Pass css/CSS2/box-display/containing-block-023.xht
+ Fail => Pass css/CSS2/css1/c43-rpl-bbx-002.xht
+ Fail => Pass css/CSS2/css1/c5501-mrgn-t-000.xht
+ Fail => Pass css/CSS2/css1/c5503-mrgn-b-000.xht
+ Fail => Pass css/CSS2/css1/c62-percent-000.xht
+ Fail => Pass css/CSS2/floats-clear/clear-after-top-margin.html
+ Fail => Pass css/CSS2/floats-clear/clear-applies-to-012.xht
+ Fail => Pass css/CSS2/floats-clear/clear-applies-to-014.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-001.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-002.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-004.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-005.xht
+ Fail => Pass css/CSS2/floats-clear/clear-on-parent-with-margins-no-clearance.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-replaced-element.html
- Pass => Fail css/CSS2/floats-clear/clearance-006.xht
+ Fail => Pass css/CSS2/floats-clear/float-005.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-008a.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-013.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-014.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-007.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-008.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-009.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-010.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-011.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-012.xht
+ Fail => Pass css/CSS2/floats-clear/float-replaced-width-011.xht
+ Fail => Pass css/CSS2/floats-clear/floats-005.xht
+ Fail => Pass css/CSS2/floats-clear/floats-015.xht
+ Fail => Pass css/CSS2/floats-clear/floats-019.xht
+ Fail => Pass css/CSS2/floats-clear/floats-118.xht
+ Fail => Pass css/CSS2/floats-clear/floats-119.xht
+ Fail => Pass css/CSS2/floats-clear/floats-120.xht
+ Fail => Pass css/CSS2/floats-clear/floats-138.xht
+ Crash => Pass css/CSS2/floats-clear/floats-146.xht
+ Fail => Pass css/CSS2/floats-clear/floats-154.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-023.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-027.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-123.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-165.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-015.xht
- Pass => Fail css/CSS2/floats-clear/no-clearance-adjoining-opposite-float.html
- Pass => Fail css/CSS2/floats-clear/no-clearance-due-to-large-margin-after-left-right.html
+ Fail => Pass css/CSS2/floats-clear/second-float-inside-empty-cleared-block-after-margin.html
+ Fail => Pass css/CSS2/floats-clear/second-float-inside-empty-cleared-block.html
+ Fail => Pass css/CSS2/floats/floats-placement-003.html
+ Fail => Pass css/CSS2/generated-content/before-after-positioned-002.html
+ Fail => Pass css/CSS2/generated-content/before-after-positioned-003.html
+ Fail => Pass css/CSS2/linebox/line-height-128.xht
+ Fail => Pass css/CSS2/lists/list-style-image-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-037.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-039.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-040.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-041.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-clear-011.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-016.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-017.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-018.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-028.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-029.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-030.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-040.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-041.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-042.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-052.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-053.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-054.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-064.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-065.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-066.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-076.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-077.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-078.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-088.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-089.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-090.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-109.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-110.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-111.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-112.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-014.xht
+ Fail => Pass css/CSS2/normal-flow/block-formatting-contexts-011.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-001.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-002.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-width-006.xht
+ Fail => Pass css/CSS2/normal-flow/height-percentage-003.xht
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-width-006.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-width-006.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-applies-to-018.html
+ Fail => Pass css/CSS2/normal-flow/max-width-106.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-110.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-applies-to-018.html
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-height-003.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-height-013.html
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-max-height-011.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-width-025.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-width-026.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-width-027.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-002.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-003.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-009.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-010.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-001.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-006.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-008.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-013.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-015.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-020.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-027.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-034.xht
+ Fail => Pass css/CSS2/positioning/abspos-009.xht
+ Fail => Pass css/CSS2/positioning/abspos-014.xht
+ Fail => Pass css/CSS2/positioning/abspos-015.xht
+ Fail => Pass css/CSS2/positioning/abspos-016.xht
+ Fail => Pass css/CSS2/positioning/abspos-017.xht
+ Fail => Pass css/CSS2/positioning/abspos-018.xht
+ Fail => Pass css/CSS2/positioning/abspos-022.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-001.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-002.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-003.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-004.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-005.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-006.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-007.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-008.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-009.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-010.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-001.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-002.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-003.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-004.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-005.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-006.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-007.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-008.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-009.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-012.xht
+ Fail => Pass css/CSS2/positioning/bottom-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/bottom-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/bottom-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/bottom-applies-to-014.xht
+ Fail => Pass css/CSS2/positioning/dynamic-top-change-003.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-014.xht
+ Fail => Pass css/CSS2/positioning/position-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/position-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/position-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/position-applies-to-014.xht
+ Fail => Pass css/CSS2/positioning/position-fixed-007.xht
+ Fail => Pass css/CSS2/positioning/position-relative-018.xht
+ Fail => Pass css/CSS2/positioning/position-static-001.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-014.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-014.xht
+ Fail => Pass css/CSS2/tables/separated-border-model-007.xht
+ Fail => Pass css/CSS2/tables/separated-border-model-008.xht
+ Fail => Pass css/CSS2/tables/separated-border-model-009.xht
+ Fail => Pass css/CSS2/text/text-indent-013.xht
+ Fail => Pass css/CSS2/text/white-space-mixed-003.xht
+ Fail => Pass css/CSS2/values/units-004.xht
+ Fail => Pass css/CSS2/visuren/anonymous-boxes-001b.xht
+ Fail => Pass css/CSS2/visuren/inherit-static-offset-001.xht
+ Fail => Pass css/CSS2/visuren/inherit-static-offset-003.xht
+ Fail => Pass css/CSS2/visuren/position-absolute-percentage-inherit-001.xht
+ Fail => Pass css/css-align/abspos/align-self-with-flex-grid-parent.html
- Pass => Fail css/css-anchor-position/anchor-position-dynamic-005.html
- Pass => Fail css/css-anchor-position/anchor-scroll-fixedpos-003.html
- Pass => Fail css/css-anchor-position/anchor-scroll-fixedpos-004.html
- Pass => Fail css/css-anchor-position/anchor-scroll-nested.html
- Pass => Fail css/css-anchor-position/position-visibility-anchors-visible-in-overflow.html
+ Fail => Pass css/css-backgrounds/background-image-001.html
+ Fail => Pass css/css-backgrounds/background-image-002.html
+ Fail => Pass css/css-backgrounds/background-image-003.html
+ Fail => Pass css/css-backgrounds/background-image-004.html
+ Fail => Pass css/css-backgrounds/background-image-005.html
+ Fail => Pass css/css-backgrounds/background-image-006.html
+ Fail => Pass css/css-backgrounds/background-rounded-image-clip-001.html
+ Fail => Pass css/css-backgrounds/background-size-percentage-root.html
+ Fail => Pass css/css-backgrounds/border-left-width-medium.html
+ Fail => Pass css/css-backgrounds/border-left-width-thick.html
+ Fail => Pass css/css-backgrounds/border-left-width-thin.html
+ Fail => Pass css/css-backgrounds/border-right-width-medium.html
+ Fail => Pass css/css-backgrounds/border-right-width-thick.html
+ Fail => Pass css/css-backgrounds/border-right-width-thin.html
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-002.html
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-003.html
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-004.html
- Pass => Fail css/css-break/grid/grid-item-oof-012.html
+ Fail => Pass css/css-break/out-of-flow-in-multicolumn-091.html
+ Fail => Pass css/css-break/out-of-flow-in-multicolumn-092.html
+ Fail => Pass css/css-break/out-of-flow-in-multicolumn-104.html
+ Fail => Pass css/css-cascade/all-prop-002.html
+ Fail => Pass css/css-conditional/container-queries/no-layout-containment-abspos.html
- Pass => Fail css/css-contain/contain-content-003.html
- Pass => Fail css/css-contain/contain-layout-006.html
- Pass => Fail css/css-contain/contain-layout-007.html
+ Fail => Pass css/css-contain/contain-layout-009.html
+ Fail => Pass css/css-contain/contain-layout-010.html
+ Fail => Pass css/css-contain/contain-layout-011.html
+ Fail => Pass css/css-contain/contain-layout-012.html
- Pass => Fail css/css-contain/contain-layout-013.html
- Pass => Fail css/css-contain/contain-layout-014.html
- Pass => Fail css/css-contain/contain-layout-containing-block-absolute-001.html
- Pass => Fail css/css-contain/contain-layout-containing-block-fixed-001.html
+ Fail => Pass css/css-contain/contain-layout-flexbox-001.html
+ Fail => Pass css/css-contain/contain-layout-grid-001.html
- Pass => Fail css/css-contain/contain-paint-009.html
- Pass => Fail css/css-contain/contain-paint-010.html
- Pass => Fail css/css-contain/contain-paint-containing-block-absolute-001.html
- Pass => Fail css/css-contain/contain-paint-containing-block-fixed-001.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-058.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-064.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-margin-001.html
+ Fail => Pass css/css-flexbox/align-items-baseline-overflow-non-visible.html
+ Fail => Pass css/css-flexbox/aspect-ratio-transferred-max-size.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-006.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-007.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-009.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-004.html
+ Fail => Pass css/css-flexbox/flex-flow-001.html
+ Fail => Pass css/css-flexbox/flex-flow-004.html
+ Fail => Pass css/css-flexbox/flex-item-position-relative-001.html
+ Fail => Pass css/css-flexbox/flexbox-paint-ordering-001.xhtml
+ Fail => Pass css/css-flexbox/intrinsic-size/row-002.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-003.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-004.html
+ Fail => Pass css/css-flexbox/order/order-abs-children-painting-order.html
- Pass => Fail css/css-flexbox/table-as-item-large-intrinsic-size.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-002.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-003.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-004.html
- Pass => Fail css/css-grid/abspos/grid-abspos-staticpos-align-self-safe-outer-cb-003.tentative.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-last-baseline-003.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-last-baseline-004.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-justify-self-002.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-004.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-006.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-007.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-008.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-012.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-014.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-015.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-016.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-items-019.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-001.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-002.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-003.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-004.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-005.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-001.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-002.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-003.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-004.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-005.html
+ Fail => Pass css/css-grid/grid-items/grid-inline-z-axis-ordering-overlapped-items-006.html
+ Fail => Pass css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/column-subgrid-abs-pos-001.html
+ Fail => Pass css/css-grid/grid-model/grid-floats-no-intrude-001.html
+ Fail => Pass css/css-grid/grid-model/grid-inline-floats-no-intrude-001.html
- Pass => Fail css/css-grid/layout-algorithm/grid-percent-cols-filled-shrinkwrap-001.html
- Pass => Fail css/css-grid/layout-algorithm/grid-percent-cols-spanned-shrinkwrap-001.html
+ Fail => Pass css/css-grid/subgrid/line-names-007.html
- Pass => Fail css/css-images/image-orientation/image-orientation-img-object-fit.html
- Pass => Fail css/css-masking/clip-path/animations/clip-path-animation-geometry-box-delay.html
- Pass => Fail css/css-masking/clip-path/clip-path-blending-offset.html
- Pass => Fail css/css-masking/clip-path/clip-path-fixed-scroll.html
- Pass => Fail css/css-masking/clip-path/clip-path-reference-box-003.html
+ Fail => Pass css/css-masking/mask-image/mask-clip-7.html
+ Fail => Pass css/css-multicol/multicol-contained-absolute.html
+ Fail => Pass css/css-overflow/overflow-clip-margin-021.html
+ Fail => Pass css/css-overflow/overflow-clip-margin-022.html
+ Fail => Pass css/css-overflow/scrollbar-gutter-root.html
+ Fail => Pass css/css-page/fixedpos-001-print.html
+ Fail => Pass css/css-page/fixedpos-002-print.html
+ Fail => Pass css/css-page/fixedpos-003-print.html
+ Fail => Pass css/css-page/fixedpos-004-print.html
+ Fail => Pass css/css-page/fixedpos-005-print.html
+ Fail => Pass css/css-page/fixedpos-006-print.html
+ Fail => Pass css/css-page/fixedpos-007-print.html
+ Fail => Pass css/css-page/fixedpos-008-print.html
! Crash => Fail css/css-page/page-size-007-print.html
+ Fail => Pass css/css-position/position-absolute-center-003.html
+ Fail => Pass css/css-position/position-absolute-center-004.html
+ Fail => Pass css/css-position/position-absolute-margin-auto-001.html
+ Fail => Pass css/css-position/position-absolute-replaced-intrinsic-size.tentative.html
+ Fail => Pass css/css-position/position-fixed-overflow-print.html
+ Fail => Pass css/css-position/position-static-001.html
+ Fail => Pass css/css-position/sticky/position-sticky-large-top.tentative.html
- Pass => Fail css/css-pseudo/first-letter-width-2.html
+ Fail => Pass css/css-rhythm/block-step-size-none-does-not-establish-block-formatting-context.html
+ Fail => Pass css/css-rhythm/block-step-size-none-does-not-establish-indepdendent-formatting-context.html
- Pass => Fail css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size.html
# ... and 76 more (see the workflow logs)
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30614977725).</sub>
<!-- wpt-results-end -->
