### PR TITLE
Defer mid-line floats that don't fit to below the current line

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -484,6 +484,18 @@ impl BaseDocument {
         // Perform inline layout
         #[cfg(feature = "floats")]
         {
+            // Floats that are encountered mid-line but do not fit in the remaining space on
+            // the current line. Their placement is deferred until the line has been completed
+            // (and thus its height is known) as they must be placed *below* the current line.
+            struct PendingFloat {
+                node_id: NodeId,
+                size: taffy::Size<f32>,
+                margin: taffy::Rect<f32>,
+                direction: taffy::FloatDirection,
+                clear: Clear,
+            }
+            let mut pending_floats: Vec<PendingFloat> = Vec::new();
+
             let mut breaker = inline_layout.layout.break_lines();
             let initial_slot = block_ctx.find_content_slot(0.0, Clear::None, None);
             let mut has_active_floats = initial_slot.segment_id.is_some();
@@ -504,6 +516,27 @@ impl BaseDocument {
                 match yield_data {
                     YieldData::LineBreak(_line_break_data) => {
                         let state = breaker.state_mut();
+
+                        // Place any floats whose placement was deferred because they did not
+                        // fit next to the just-completed line. They are placed below that
+                        // line (`state.line_y()` is the top of the next line at this point).
+                        if !pending_floats.is_empty() {
+                            let min_y = (state.line_y() / scale as f64) as f32;
+                            for float in pending_floats.drain(..) {
+                                let margin_sum = float.margin.sum_axes();
+                                let pos = block_ctx.place_floated_box(
+                                    float.size + margin_sum,
+                                    min_y,
+                                    float.direction,
+                                    float.clear,
+                                );
+                                let layout = self.nodes[float.node_id].unrounded_layout_mut();
+                                layout.size = float.size;
+                                layout.location.x = pos.x + float.margin.left + container_pb.left;
+                                layout.location.y = pos.y + float.margin.top + container_pb.top;
+                            }
+                            has_active_floats = true;
+                        }
 
                         if has_active_floats {
                             // TODO: revert state and retry layout if a line doesn't fit
@@ -529,7 +562,6 @@ impl BaseDocument {
                         continue;
                     }
                     YieldData::InlineBoxBreak(box_break_data) => {
-                        let state = breaker.state_mut();
                         let node_id = NodeId::from_u64(box_break_data.inline_box_id);
                         let node = &mut self.nodes[node_id];
 
@@ -551,6 +583,32 @@ impl BaseDocument {
                             crate::taffy_node_id(node_id),
                             float_child_inputs,
                         );
+
+                        // A float encountered mid-line may only be placed alongside the current
+                        // line if it fits in the line's remaining space. Otherwise its placement
+                        // is deferred until the line is complete (and its height is known), and
+                        // it is placed below the line. Exception: if the line's existing content
+                        // already overflows the available space (e.g. `white-space: nowrap`) then
+                        // pushing the float down cannot help, so it is placed alongside anyway.
+                        let state = breaker.state_mut();
+                        let line_advance = box_break_data.advance;
+                        let max_advance = state.line_max_advance();
+                        let fits_on_line = line_advance == 0.0
+                            || line_advance > max_advance
+                            || line_advance + (output.size.width + margin_sum.width) * scale
+                                <= max_advance;
+                        if !fits_on_line {
+                            pending_floats.push(PendingFloat {
+                                node_id,
+                                size: output.size,
+                                margin,
+                                direction,
+                                clear,
+                            });
+                            state.append_inline_box_to_line(box_break_data.advance, 0.0);
+                            continue;
+                        }
+
                         let min_y = state.line_y() as f32 / scale;
 
                         // Note: `pos` is content-box relative


### PR DESCRIPTION
## Summary

Fixes the avatar on https://github.com/nicoburns rendering ~100% of its width too far to the right.

Root cause: in float-aware inline layout (`compute_inline_layout_inner`), when the breaker yields an `InlineBoxBreak` for a float mid-line, the float was always placed at the top of the *current* line (`min_y = state.line_y()`), and the resulting content slot was applied to the current line via `set_line_x`/`set_line_max_advance`. When the float doesn't fit next to the line's existing content (GitHub's `float: left; width: 100%` names container following the inline-block avatar), the float was placed beside the line anyway and the whole line got shifted right by the float's width — pushing the avatar out of the profile column.

Fix: a mid-line float that doesn't fit in the line's remaining space is now queued in `pending_floats` and placed at the `LineBreak` yield for that line (Parley yields one for every line, including the last), using the line's bottom as `min_y` — i.e. the float is placed *below* the line, matching browser behavior:

```rust
let fits_on_line = line_advance == 0.0
    || line_advance > max_advance   // line already overflows (e.g. nowrap): pushing down can't help
    || line_advance + float_margin_box_width * scale <= max_advance;
```

The `line_advance > max_advance` exception preserves the expected behavior for overflowing `white-space: nowrap` lines (WPT `float-nowrap-3`/`float-nowrap-9` regress without it).

After (`https://github.com/nicoburns` via the screenshot example — avatar correctly at the top of the left profile column):

![after](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvYjdiNTlkMzgtYmM1Zi00MmJiLTkzOWQtZGIxNjE4MWE5Y2ZjIiwiaWF0IjoxNzg1NDgzMzg0LCJleHAiOjE3ODYwODgxODQsImZpbGVuYW1lIjoiZ2gzLnBuZyJ9.znwQSmz1SGaScq3Clp0sT2tADt7Bpq7hgxm0Jo-3IjA)

## Testing

- `cargo fmt` / `cargo clippy --workspace` / `cargo test --workspace` clean
- WPT `css/CSS2/floats` and `css/CSS2/floats-clear`: identical per-test results to `main` (no regressions; 42 and 82 passes respectively)
- Verified the GitHub profile page and a minimal repro (inline-block `width:100%` image followed by a `float:left; width:100%` block) both render correctly with the CPU renderer


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/180fec81522a418390c56ca9be06c7b3
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**1** newly passing, **1** newly failing (net 0).

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
- Pass => Fail css/css-flexbox/flexbox-baseline-multi-line-vert-002.html
+ Fail => Pass css/css-shapes/shape-outside/shape-box/shape-outside-border-box-002.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30613373000).</sub>
<!-- wpt-results-end -->
