### PR TITLE
Request a redraw after programmatic DOM mutations

### DIFF
--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -578,6 +578,7 @@ impl DocumentMutator<'_> {
         for child_id in child_ids.iter().copied() {
             let child = &mut self.doc.nodes[child_id];
             let child_was_in_doc = child.flags.is_in_document();
+            self.mutations_occurred |= child_was_in_doc;
             let Some(old_parent_id) = child.parent.take() else {
                 continue;
             };
@@ -603,10 +604,9 @@ impl DocumentMutator<'_> {
 
         let new_parent = &mut self.doc.nodes[parent_id];
         new_parent.insert_damage(ALL_DAMAGE);
-        let new_parent_is_in_doc = new_parent_is_in_document;
 
         // TODO: make this fine grained / conditional based on ElementSelectorFlags
-        if new_parent_is_in_doc {
+        if new_parent_is_in_document {
             if let Some(mut data) = new_parent
                 .stylo_element_data_opt_mut()
                 .and_then(|s| s.get_mut())
@@ -624,7 +624,7 @@ impl DocumentMutator<'_> {
             let child_was_in_doc = child.flags.is_in_document();
             child.parent = Some(parent_id);
 
-            if new_parent_is_in_doc != child_was_in_doc {
+            if new_parent_is_in_document != child_was_in_doc {
                 self.process_added_subtree(child_id);
             }
         }
@@ -1254,6 +1254,7 @@ mod test {
             let child_id = mutator.create_element(qual_name!("span"), vec![]);
             mutator.append_children(parent_id, &[child_id]);
             mutator.remove_and_drop_all_children(parent_id);
+            mutator.set_attribute(parent_id, qual_name!("id"), "detached");
         }
         assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 0);
 
@@ -1264,12 +1265,32 @@ mod test {
 
         {
             let mut mutator = document.mutate();
+            let node_id = mutator.create_element(qual_name!("div"), vec![]);
+            mutator.append_children(root_id, &[node_id]);
+            mutator.set_attribute(node_id, qual_name!("id"), "in-document");
+        }
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 1);
+
+        {
+            let mut mutator = document.mutate();
             let parent_id = mutator.create_element(qual_name!("div"), vec![]);
             let child_id = mutator.create_element(qual_name!("span"), vec![]);
             mutator.append_children(root_id, &[parent_id]);
             mutator.append_children(parent_id, &[child_id]);
             mutator.remove_and_drop_all_children(parent_id);
         }
-        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 2);
+
+        {
+            let mut mutator = document.mutate();
+            let parent_id = mutator.create_element(qual_name!("div"), vec![]);
+            let child_id = mutator.create_element(qual_name!("span"), vec![]);
+            let detached_target_id = mutator.create_element(qual_name!("div"), vec![]);
+            mutator.append_children(root_id, &[parent_id]);
+            mutator.append_children(parent_id, &[child_id]);
+            assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 2);
+            mutator.append_children(detached_target_id, &[child_id]);
+        }
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 3);
     }
 }

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -163,6 +163,7 @@ impl DocumentMutator<'_> {
     // Node mutation methods
 
     pub fn set_node_text(&mut self, node_id: NodeId, value: &str) {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         let node = &mut self.doc.nodes[node_id];
 
         let text = match node.data {
@@ -173,7 +174,7 @@ impl DocumentMutator<'_> {
 
         let changed = text.content != value;
         if changed {
-            self.mutations_occurred = true;
+            self.mutations_occurred |= node_is_in_document;
             text.content.clear();
             text.content.push_str(value);
             node.insert_damage(ALL_DAMAGE);
@@ -198,13 +199,14 @@ impl DocumentMutator<'_> {
         node_id: NodeId,
         text: &str,
     ) -> Result<(), AppendTextErr> {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         let node = &mut self.doc.nodes[node_id];
         node.insert_damage(ALL_DAMAGE);
         node.mark_ancestors_dirty();
         match node.text_data_mut() {
             Some(data) => {
                 data.content += text;
-                self.mutations_occurred = true;
+                self.mutations_occurred |= node_is_in_document;
                 Ok(())
             }
             None => Err(AppendTextErr::NotTextNode),
@@ -265,7 +267,7 @@ impl DocumentMutator<'_> {
             return;
         };
 
-        self.mutations_occurred = true;
+        self.mutations_occurred |= node_is_in_document;
         // If element is a CustomWidget, then Ccall attribute_changed on it
         #[cfg(feature = "custom-widget")]
         if let SpecialElementData::CustomWidget(widget_data) = &mut element.special_data {
@@ -352,7 +354,7 @@ impl DocumentMutator<'_> {
         if !had_attr {
             return;
         }
-        self.mutations_occurred = true;
+        self.mutations_occurred |= node_is_in_document;
 
         // If element is a CustomWidget, then call attribute_changed on it
         #[cfg(feature = "custom-widget")]
@@ -397,39 +399,46 @@ impl DocumentMutator<'_> {
     }
 
     pub fn set_style_property(&mut self, node_id: NodeId, name: &str, value: &str) {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         self.doc.set_style_property(node_id, name, value);
-        self.mutations_occurred = true;
+        self.mutations_occurred |= node_is_in_document;
     }
 
     pub fn remove_style_property(&mut self, node_id: NodeId, name: &str) {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         self.doc.remove_style_property(node_id, name);
-        self.mutations_occurred = true;
+        self.mutations_occurred |= node_is_in_document;
     }
 
     pub fn set_sub_document(&mut self, node_id: NodeId, sub_document: Box<dyn Document>) {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         self.doc.set_sub_document(node_id, sub_document);
-        self.mutations_occurred = true;
+        self.mutations_occurred |= node_is_in_document;
     }
 
     pub fn remove_sub_document(&mut self, node_id: NodeId) {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         self.doc.remove_sub_document(node_id);
-        self.mutations_occurred = true;
+        self.mutations_occurred |= node_is_in_document;
     }
 
     #[cfg(feature = "custom-widget")]
     pub fn set_custom_widget(&mut self, node_id: NodeId, widget: Box<dyn crate::Widget>) {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         self.doc.set_custom_widget(node_id, widget);
-        self.mutations_occurred = true;
+        self.mutations_occurred |= node_is_in_document;
     }
 
     #[cfg(feature = "custom-widget")]
     pub fn remove_custom_widget(&mut self, node_id: NodeId) {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         self.doc.remove_custom_widget(node_id);
-        self.mutations_occurred = true;
+        self.mutations_occurred |= node_is_in_document;
     }
 
     /// Remove the node from it's parent but don't drop it
     pub fn remove_node(&mut self, node_id: NodeId) {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         // Process the subtree *before* severing the parent link so that
         // interaction state referencing removed nodes can retarget to the
         // nearest surviving ancestor.
@@ -439,7 +448,7 @@ impl DocumentMutator<'_> {
 
         // Update child_idx values
         if let Some(parent_id) = node.parent.take() {
-            self.mutations_occurred = true;
+            self.mutations_occurred |= node_is_in_document;
             let parent = &mut self.doc.nodes[parent_id];
             parent.insert_damage(ALL_DAMAGE);
             // Mark ancestors dirty so the style traversal visits this subtree.
@@ -460,12 +469,11 @@ impl DocumentMutator<'_> {
         node_id: NodeId,
         on_drop: &mut dyn FnMut(NodeId),
     ) -> Option<Node> {
+        let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         self.process_removed_subtree(node_id);
 
         let node = self.doc.drop_node_ignoring_parent_with(node_id, on_drop);
-        if node.is_some() {
-            self.mutations_occurred = true;
-        }
+        self.mutations_occurred |= node_is_in_document;
 
         // Update child_idx values
         if let Some(parent_id) = node.as_ref().and_then(|node| node.parent) {
@@ -509,9 +517,7 @@ impl DocumentMutator<'_> {
         }
 
         let children = mem::take(&mut parent.children);
-        if !children.is_empty() {
-            self.mutations_occurred = true;
-        }
+        self.mutations_occurred |= parent_is_in_doc && !children.is_empty();
         for child_id in children {
             self.process_removed_subtree(child_id);
             let _ = self.doc.drop_node_ignoring_parent(child_id);
@@ -561,9 +567,8 @@ impl DocumentMutator<'_> {
         child_ids: &[NodeId],
         insert_children_fn: &dyn Fn(&mut Node, &[NodeId]),
     ) {
-        if !child_ids.is_empty() {
-            self.mutations_occurred = true;
-        }
+        let new_parent_is_in_document = self.doc.nodes[parent_id].flags.is_in_document();
+        self.mutations_occurred |= new_parent_is_in_document && !child_ids.is_empty();
         // Detach the children from their old parents *before* inserting them into
         // the new parent (matching DOM `insertBefore` semantics). If a child is
         // being moved within the same parent then detaching it after insertion
@@ -598,7 +603,7 @@ impl DocumentMutator<'_> {
 
         let new_parent = &mut self.doc.nodes[parent_id];
         new_parent.insert_damage(ALL_DAMAGE);
-        let new_parent_is_in_doc = new_parent.flags.is_in_document();
+        let new_parent_is_in_doc = new_parent_is_in_document;
 
         // TODO: make this fine grained / conditional based on ElementSelectorFlags
         if new_parent_is_in_doc {
@@ -1241,20 +1246,29 @@ mod test {
             shell_provider: Some(shell.clone()),
             ..Default::default()
         });
-        let node_id = document.create_node(NodeData::Element(Box::new(ElementData::new(
-            qual_name!("div"),
-            vec![],
-        ))));
+        let root_id = document.root_node().id;
 
         {
             let mut mutator = document.mutate();
-            mutator.set_attribute(node_id, qual_name!("id"), "value");
+            let parent_id = mutator.create_element(qual_name!("div"), vec![]);
+            let child_id = mutator.create_element(qual_name!("span"), vec![]);
+            mutator.append_children(parent_id, &[child_id]);
+            mutator.remove_and_drop_all_children(parent_id);
         }
-        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 0);
 
         {
             let mutator = document.mutate();
-            assert!(!mutator.node_has_parent(node_id));
+            assert_eq!(mutator.child_ids(root_id).len(), 0);
+        }
+
+        {
+            let mut mutator = document.mutate();
+            let parent_id = mutator.create_element(qual_name!("div"), vec![]);
+            let child_id = mutator.create_element(qual_name!("span"), vec![]);
+            mutator.append_children(root_id, &[parent_id]);
+            mutator.append_children(parent_id, &[child_id]);
+            mutator.remove_and_drop_all_children(parent_id);
         }
         assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 1);
     }

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -57,6 +57,9 @@ pub struct DocumentMutator<'doc> {
     /// Whether an element/attribute that affect animation status has been seen
     recompute_is_animating: bool,
 
+    /// Whether any mutation that affects rendered output has been performed
+    mutations_occurred: bool,
+
     /// The (latest) node which has been mounted in and had autofocus=true, if any
     #[cfg(feature = "autofocus")]
     node_to_autofocus: Option<NodeId>,
@@ -65,6 +68,9 @@ pub struct DocumentMutator<'doc> {
 impl Drop for DocumentMutator<'_> {
     fn drop(&mut self) {
         self.flush(); // Defined at bottom of file
+        if self.mutations_occurred {
+            self.doc.shell_provider.request_redraw();
+        }
     }
 }
 
@@ -77,6 +83,7 @@ impl DocumentMutator<'_> {
             style_nodes: HashSet::new(),
             form_nodes: HashSet::new(),
             recompute_is_animating: false,
+            mutations_occurred: false,
             #[cfg(feature = "autofocus")]
             node_to_autofocus: None,
         }
@@ -166,6 +173,7 @@ impl DocumentMutator<'_> {
 
         let changed = text.content != value;
         if changed {
+            self.mutations_occurred = true;
             text.content.clear();
             text.content.push_str(value);
             node.insert_damage(ALL_DAMAGE);
@@ -196,6 +204,7 @@ impl DocumentMutator<'_> {
         match node.text_data_mut() {
             Some(data) => {
                 data.content += text;
+                self.mutations_occurred = true;
                 Ok(())
             }
             None => Err(AppendTextErr::NotTextNode),
@@ -256,6 +265,7 @@ impl DocumentMutator<'_> {
             return;
         };
 
+        self.mutations_occurred = true;
         // If element is a CustomWidget, then Ccall attribute_changed on it
         #[cfg(feature = "custom-widget")]
         if let SpecialElementData::CustomWidget(widget_data) = &mut element.special_data {
@@ -342,6 +352,7 @@ impl DocumentMutator<'_> {
         if !had_attr {
             return;
         }
+        self.mutations_occurred = true;
 
         // If element is a CustomWidget, then call attribute_changed on it
         #[cfg(feature = "custom-widget")]
@@ -386,29 +397,35 @@ impl DocumentMutator<'_> {
     }
 
     pub fn set_style_property(&mut self, node_id: NodeId, name: &str, value: &str) {
-        self.doc.set_style_property(node_id, name, value)
+        self.doc.set_style_property(node_id, name, value);
+        self.mutations_occurred = true;
     }
 
     pub fn remove_style_property(&mut self, node_id: NodeId, name: &str) {
-        self.doc.remove_style_property(node_id, name)
+        self.doc.remove_style_property(node_id, name);
+        self.mutations_occurred = true;
     }
 
     pub fn set_sub_document(&mut self, node_id: NodeId, sub_document: Box<dyn Document>) {
-        self.doc.set_sub_document(node_id, sub_document)
+        self.doc.set_sub_document(node_id, sub_document);
+        self.mutations_occurred = true;
     }
 
     pub fn remove_sub_document(&mut self, node_id: NodeId) {
-        self.doc.remove_sub_document(node_id)
+        self.doc.remove_sub_document(node_id);
+        self.mutations_occurred = true;
     }
 
     #[cfg(feature = "custom-widget")]
     pub fn set_custom_widget(&mut self, node_id: NodeId, widget: Box<dyn crate::Widget>) {
-        self.doc.set_custom_widget(node_id, widget)
+        self.doc.set_custom_widget(node_id, widget);
+        self.mutations_occurred = true;
     }
 
     #[cfg(feature = "custom-widget")]
     pub fn remove_custom_widget(&mut self, node_id: NodeId) {
-        self.doc.remove_custom_widget(node_id)
+        self.doc.remove_custom_widget(node_id);
+        self.mutations_occurred = true;
     }
 
     /// Remove the node from it's parent but don't drop it
@@ -422,6 +439,7 @@ impl DocumentMutator<'_> {
 
         // Update child_idx values
         if let Some(parent_id) = node.parent.take() {
+            self.mutations_occurred = true;
             let parent = &mut self.doc.nodes[parent_id];
             parent.insert_damage(ALL_DAMAGE);
             // Mark ancestors dirty so the style traversal visits this subtree.
@@ -445,6 +463,9 @@ impl DocumentMutator<'_> {
         self.process_removed_subtree(node_id);
 
         let node = self.doc.drop_node_ignoring_parent_with(node_id, on_drop);
+        if node.is_some() {
+            self.mutations_occurred = true;
+        }
 
         // Update child_idx values
         if let Some(parent_id) = node.as_ref().and_then(|node| node.parent) {
@@ -488,6 +509,9 @@ impl DocumentMutator<'_> {
         }
 
         let children = mem::take(&mut parent.children);
+        if !children.is_empty() {
+            self.mutations_occurred = true;
+        }
         for child_id in children {
             self.process_removed_subtree(child_id);
             let _ = self.doc.drop_node_ignoring_parent(child_id);
@@ -537,6 +561,9 @@ impl DocumentMutator<'_> {
         child_ids: &[NodeId],
         insert_children_fn: &dyn Fn(&mut Node, &[NodeId]),
     ) {
+        if !child_ids.is_empty() {
+            self.mutations_occurred = true;
+        }
         // Detach the children from their old parents *before* inserting them into
         // the new parent (matching DOM `insertBefore` semantics). If a child is
         // being moved within the same parent then detaching it after insertion
@@ -1057,6 +1084,13 @@ mod test {
     use style::media_queries::MediaType;
     use style_dom::ElementState;
 
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use blitz_traits::shell::ShellProvider;
+
     use crate::{Attribute, BaseDocument, DocumentConfig, ElementData, NodeData, qual_name};
 
     #[test]
@@ -1187,5 +1221,41 @@ mod test {
             !node.element_state().contains(ElementState::ENABLED),
             "form node is enabled"
         );
+    }
+
+    #[derive(Default)]
+    struct RedrawShell {
+        redraw_requests: AtomicUsize,
+    }
+
+    impl ShellProvider for RedrawShell {
+        fn request_redraw(&self) {
+            self.redraw_requests.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn mutator_requests_redraw_only_after_mutation() {
+        let shell = Arc::new(RedrawShell::default());
+        let mut document = BaseDocument::new(DocumentConfig {
+            shell_provider: Some(shell.clone()),
+            ..Default::default()
+        });
+        let node_id = document.create_node(NodeData::Element(Box::new(ElementData::new(
+            qual_name!("div"),
+            vec![],
+        ))));
+
+        {
+            let mut mutator = document.mutate();
+            mutator.set_attribute(node_id, qual_name!("id"), "value");
+        }
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 1);
+
+        {
+            let mutator = document.mutate();
+            assert!(!mutator.node_has_parent(node_id));
+        }
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
## Summary
Programmatic DOM mutations (e.g. from Dioxus Native state updates) updated the document but never asked the shell for a new frame, so the window only repainted when something else happened to trigger a redraw.

`DocumentMutator` now tracks whether it performed any mutation that can affect rendered output, and requests a redraw on drop:

```rust
impl Drop for DocumentMutator<'_> {
    fn drop(&mut self) {
        self.flush();
        if self.mutations_occurred {
            self.doc.shell_provider.request_redraw();
        }
    }
}
```

The flag is set in the lowest-level mutation paths (text/attribute/style changes, node removal, and the shared `add_children_to_parent`), and only when a change actually occurred (e.g. `clear_attribute` on a missing attribute, or a no-op `set_node_text`, don't set it). Creating detached nodes (`create_element`/`create_text_node`/`deep_clone_node`) deliberately does not set it, since an unparented node changes nothing visible. The redraw lives in `Drop` rather than `flush()`, which is public and may be called mid-transaction.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9182cbcf055d48618cb8e1d697f6b33f
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30656431503).</sub>
<!-- wpt-results-end -->
