### PR TITLE
Propagate dirty-descendants when a style property is updated

### DIFF
--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -1094,7 +1094,7 @@ mod test {
         atomic::{AtomicUsize, Ordering},
     };
 
-    use blitz_traits::shell::ShellProvider;
+    use blitz_traits::shell::{ColorScheme, ShellProvider, Viewport};
 
     use crate::{Attribute, BaseDocument, DocumentConfig, ElementData, NodeData, qual_name};
 
@@ -1292,5 +1292,56 @@ mod test {
             mutator.append_children(detached_target_id, &[child_id]);
         }
         assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn style_property_updates_nested_layout() {
+        let mut document = BaseDocument::new(DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        });
+        let root_id = document.root_node().id;
+
+        let mover_id = {
+            let mut mutator = document.mutate();
+            let parent_id = mutator.create_element(qual_name!("div"), vec![]);
+            let mover_id = mutator.create_element(qual_name!("div"), vec![]);
+            mutator.set_style_property(parent_id, "position", "relative");
+            mutator.set_style_property(parent_id, "width", "800px");
+            mutator.set_style_property(parent_id, "height", "600px");
+            mutator.set_style_property(mover_id, "position", "absolute");
+            mutator.set_style_property(mover_id, "left", "0px");
+            mutator.set_style_property(mover_id, "top", "0px");
+            mutator.append_children(parent_id, &[mover_id]);
+            mutator.append_children(root_id, &[parent_id]);
+            mover_id
+        };
+
+        document.resolve(0.0);
+        assert_eq!(
+            document
+                .get_node(mover_id)
+                .unwrap()
+                .final_layout()
+                .location
+                .x,
+            0.0
+        );
+
+        {
+            let mut mutator = document.mutate();
+            mutator.set_style_property(mover_id, "left", "120px");
+        }
+
+        document.resolve(0.0);
+        assert_eq!(
+            document
+                .get_node(mover_id)
+                .unwrap()
+                .final_layout()
+                .location
+                .x,
+            120.0
+        );
     }
 }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -443,6 +443,7 @@ impl Node {
             }
         }
         self.set_dirty_descendants();
+        self.mark_ancestors_dirty();
     }
 
     /// Marks all ancestors of this node as having dirty descendants.


### PR DESCRIPTION
## Summary
Dynamic style-property updates (`element.style.left = ...`, i.e. what Dioxus Native emits for inline style changes) could be silently skipped by the Stylo traversal, so the element kept its old geometry even though a redraw was requested and painted. This is the remaining half of the "programmatic mutations don't update the screen" report from #580.

`Node::mark_style_attr_updated` set `RESTYLE_STYLE_ATTRIBUTE` and its *own* `dirty_descendants` flag, but never propagated the flag up the ancestor chain — and the traversal uses `dirty_descendants` on ancestors to decide which subtrees to visit, so the pending hint was never processed:

```rust
 fn mark_style_attr_updated(&mut self) {
     ... data.hint |= RestyleHint::RESTYLE_STYLE_ATTRIBUTE;
     self.set_dirty_descendants();
+    self.mark_ancestors_dirty();
 }
```

The `set_attribute("style", ...)` path happened to work because `set_attribute` separately calls `mark_ancestors_dirty()`; the `set_style_property` path had no such compensation.

Verified against the original repro with a real window (CPU renderer, X11 pointer input): the absolutely-positioned div now follows the pointer, with the painted bounding box tracking each move. Added a regression test that mutates `left` on a node nested below the root and asserts the resolved layout position actually changes.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9182cbcf055d48618cb8e1d697f6b33f
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30658466455).</sub>
<!-- wpt-results-end -->
