### PR TITLE
Clear IS_IN_DOCUMENT when a subtree is moved out of the document

### DIFF
--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -624,8 +624,10 @@ impl DocumentMutator<'_> {
             let child_was_in_doc = child.flags.is_in_document();
             child.parent = Some(parent_id);
 
-            if new_parent_is_in_document != child_was_in_doc {
+            if new_parent_is_in_document && !child_was_in_doc {
                 self.process_added_subtree(child_id);
+            } else if !new_parent_is_in_document && child_was_in_doc {
+                self.process_removed_subtree(child_id);
             }
         }
 
@@ -1292,6 +1294,70 @@ mod test {
             mutator.append_children(detached_target_id, &[child_id]);
         }
         assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn moving_subtree_out_of_document_clears_in_document_flag() {
+        let shell = Arc::new(RedrawShell::default());
+        let mut document = BaseDocument::new(DocumentConfig {
+            shell_provider: Some(shell.clone()),
+            ..Default::default()
+        });
+        let root_id = document.root_node().id;
+        let (child_id, grandchild_id, detached_parent_id) = {
+            let mut mutator = document.mutate();
+            let in_document_parent_id = mutator.create_element(qual_name!("div"), vec![]);
+            let child_id = mutator.create_element(qual_name!("div"), vec![]);
+            let grandchild_id = mutator.create_element(qual_name!("span"), vec![]);
+            let detached_parent_id = mutator.create_element(qual_name!("section"), vec![]);
+            mutator.append_children(root_id, &[in_document_parent_id]);
+            mutator.append_children(in_document_parent_id, &[child_id]);
+            mutator.append_children(child_id, &[grandchild_id]);
+            (child_id, grandchild_id, detached_parent_id)
+        };
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 1);
+        assert!(document.get_node(child_id).unwrap().flags.is_in_document());
+        assert!(
+            document
+                .get_node(grandchild_id)
+                .unwrap()
+                .flags
+                .is_in_document()
+        );
+
+        {
+            let mut mutator = document.mutate();
+            mutator.append_children(detached_parent_id, &[child_id]);
+        }
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 2);
+        assert!(!document.get_node(child_id).unwrap().flags.is_in_document());
+        assert!(
+            !document
+                .get_node(grandchild_id)
+                .unwrap()
+                .flags
+                .is_in_document()
+        );
+
+        {
+            let mut mutator = document.mutate();
+            mutator.set_attribute(child_id, qual_name!("id"), "detached");
+        }
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 2);
+
+        {
+            let mut mutator = document.mutate();
+            mutator.append_children(root_id, &[child_id]);
+        }
+        assert_eq!(shell.redraw_requests.load(Ordering::Relaxed), 3);
+        assert!(document.get_node(child_id).unwrap().flags.is_in_document());
+        assert!(
+            document
+                .get_node(grandchild_id)
+                .unwrap()
+                .flags
+                .is_in_document()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Moving an in-document node under a detached parent left `IS_IN_DOCUMENT` set on the moved subtree, because `add_children_to_parent` ran the *added* path whenever the parent and child flags differed in either direction:

```rust
-if new_parent_is_in_document != child_was_in_doc {
+if new_parent_is_in_document && !child_was_in_doc {
     self.process_added_subtree(child_id);
+} else if !new_parent_is_in_document && child_was_in_doc {
+    self.process_removed_subtree(child_id);
 }
```

Consequences of the stale flag were mild but real: later mutations on a detached-but-still-flagged node requested spurious frames, defeating the detached-churn gating added in #580.

The detach-from-old-parent loop earlier in the function only clears the parent link and does no subtree processing, so the move-out path is processed exactly once; `remove_node` is unchanged. Test covers the flag clearing recursively, the move itself still requesting a redraw, no redraw for a subsequent mutation while detached, and re-attachment restoring both.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9182cbcf055d48618cb8e1d697f6b33f
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30660754646).</sub>
<!-- wpt-results-end -->
