### PR TITLE
Apply computed SVG paint properties to inline SVG

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -414,6 +414,8 @@ impl BaseDocument {
             .base_url
             .and_then(|url| DocumentUrl::from_str(&url).ok())
             .unwrap_or_default();
+        let mut nodes = nodes;
+        nodes.set_document_url(base_url.clone());
 
         let net_provider = config
             .net_provider
@@ -547,6 +549,7 @@ impl BaseDocument {
     /// Set base url for resolving linked resources (stylesheets, images, fonts, etc)
     pub fn set_base_url(&mut self, url: &str) {
         self.url = DocumentUrl::from(Url::parse(url).unwrap());
+        self.nodes.set_document_url(self.url.clone());
     }
 
     pub fn guard(&self) -> &SharedRwLock {

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -374,7 +374,7 @@ pub(crate) fn collect_layout_children(
 
         #[cfg(feature = "svg")]
         if matches!(tag_name, "svg") {
-            let mut outer_html = doc.get_node(container_node_id).unwrap().outer_html();
+            let mut outer_html = doc.get_node(container_node_id).unwrap().svg_outer_html();
 
             // HACK: usvg fails to parse SVGs that don't have the SVG xmlns set. So inject it
             // if the generated source doesn't have it.

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -27,7 +27,11 @@ use style::servo_arc::Arc as ServoArc;
 use style::shared_lock::SharedRwLock;
 use style::stylesheets::UrlExtraData;
 use style::values::computed::CSSPixelLength;
+#[cfg(feature = "svg")]
+use style::values::computed::Color as ComputedColor;
 use style::values::computed::Display as StyloDisplay;
+#[cfg(feature = "svg")]
+use style::values::computed::svg::SVGPaintKind;
 use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style_dom::ElementState;
 use style_traits::values::ToCss;
@@ -944,6 +948,13 @@ impl Node {
         self.write_outer_html_in_style(writer, OutputStyle::Normal, 0);
     }
 
+    #[cfg(feature = "svg")]
+    pub(crate) fn svg_outer_html(&self) -> String {
+        let mut output = String::new();
+        self.write_svg_outer_html(&mut output);
+        output
+    }
+
     pub fn write_outer_html_pretty(&self, writer: &mut String) {
         self.write_outer_html_in_style(writer, OutputStyle::Pretty, 0);
     }
@@ -1020,6 +1031,111 @@ impl Node {
                     if matches!(style, OutputStyle::Pretty) {
                         writer.push('\n');
                     }
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "svg")]
+    fn write_svg_outer_html(&self, writer: &mut String) {
+        const SVG_PRESENTATION_ATTRIBUTES: &[&str] = &[
+            "fill",
+            "fill-opacity",
+            "fill-rule",
+            "stroke",
+            "stroke-opacity",
+            "stroke-width",
+            "stroke-linecap",
+            "stroke-linejoin",
+            "stroke-dasharray",
+            "stroke-dashoffset",
+        ];
+
+        match &self.data {
+            NodeData::Document(_) | NodeData::Comment { .. } | NodeData::AnonymousBlock(_) => {}
+            NodeData::Text(data) => writer.push_str(data.content.as_str()),
+            NodeData::Element(data) => {
+                writer.push('<');
+                writer.push_str(&data.name.local);
+
+                let current_color = self
+                    .primary_styles()
+                    .map(|style| style.clone_color())
+                    .map(|color| color.to_css_string());
+                let computed_values = self.primary_styles().map(|style| {
+                    [
+                        (
+                            "fill",
+                            svg_paint_to_css(&style.clone_fill(), &current_color),
+                        ),
+                        ("fill-opacity", style.clone_fill_opacity().to_css_string()),
+                        ("fill-rule", style.clone_fill_rule().to_css_string()),
+                        (
+                            "stroke",
+                            svg_paint_to_css(&style.clone_stroke(), &current_color),
+                        ),
+                        (
+                            "stroke-opacity",
+                            style.clone_stroke_opacity().to_css_string(),
+                        ),
+                        ("stroke-width", style.clone_stroke_width().to_css_string()),
+                        (
+                            "stroke-linecap",
+                            style.clone_stroke_linecap().to_css_string(),
+                        ),
+                        (
+                            "stroke-linejoin",
+                            style.clone_stroke_linejoin().to_css_string(),
+                        ),
+                        (
+                            "stroke-dasharray",
+                            style.clone_stroke_dasharray().to_css_string(),
+                        ),
+                        (
+                            "stroke-dashoffset",
+                            style.clone_stroke_dashoffset().to_css_string(),
+                        ),
+                    ]
+                });
+
+                for attr in data.attrs() {
+                    if computed_values.is_some()
+                        && SVG_PRESENTATION_ATTRIBUTES.contains(&attr.name.local.as_ref())
+                    {
+                        continue;
+                    }
+                    writer.push(' ');
+                    writer.push_str(&attr.name.local);
+                    writer.push_str("=\"");
+                    if let Some(current_color) = &current_color {
+                        let value = attr.value.replace("currentColor", current_color);
+                        encode_quoted_attribute_to_string(&value, writer);
+                    } else {
+                        encode_quoted_attribute_to_string(&attr.value, writer);
+                    }
+                    writer.push('"');
+                }
+
+                if let Some(values) = computed_values {
+                    for (name, value) in values {
+                        writer.push(' ');
+                        writer.push_str(name);
+                        writer.push_str("=\"");
+                        encode_quoted_attribute_to_string(&value, writer);
+                        writer.push('"');
+                    }
+                }
+
+                if self.children.is_empty() {
+                    writer.push_str(" />");
+                } else {
+                    writer.push('>');
+                    for &child_id in &self.children {
+                        self.tree()[child_id].write_svg_outer_html(writer);
+                    }
+                    writer.push_str("</");
+                    writer.push_str(&data.name.local);
+                    writer.push('>');
                 }
             }
         }
@@ -1401,6 +1517,29 @@ impl Node {
             active_pointers: Default::default(),
         }
     }
+}
+
+#[cfg(feature = "svg")]
+fn svg_paint_to_css(
+    paint: &style::values::computed::svg::SVGPaint,
+    current_color: &Option<String>,
+) -> String {
+    if let SVGPaintKind::Color(ComputedColor::CurrentColor) = &paint.kind {
+        return current_color
+            .as_deref()
+            .unwrap_or("currentcolor")
+            .to_string();
+    }
+
+    if let SVGPaintKind::PaintServer(url) = &paint.kind {
+        if let Some(url) = url.url() {
+            if let Some(fragment) = url.fragment() {
+                return format!("url(#{fragment})");
+            }
+        }
+    }
+
+    paint.to_css_string()
 }
 
 /// It might be wrong to expose this since what does *equality* mean outside the dom?

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -9,7 +9,8 @@ use crate::StyleThreading;
 use crate::layout::damage::compute_layout_damage;
 use crate::node::Node;
 use crate::node::NodeData;
-use markup5ever::{LocalName, LocalNameStaticSet, Namespace, NamespaceStaticSet, local_name};
+use cssparser::{Parser, ParserInput};
+use markup5ever::{LocalName, LocalNameStaticSet, Namespace, NamespaceStaticSet, local_name, ns};
 use selectors::bloom::BLOOM_HASH_MASK;
 use selectors::{
     Element, OpaqueElement,
@@ -26,12 +27,14 @@ use style::color::AbsoluteColor;
 use style::data::{ElementDataMut, ElementDataRef};
 use style::global_style_data::STYLE_THREAD_POOL;
 use style::invalidation::element::restyle_hints::RestyleHint;
+use style::parser::ParserContext;
 use style::properties::ComputedValues;
-use style::properties::{Importance, PropertyDeclaration};
+use style::properties::{Importance, PropertyDeclaration, PropertyId, SourcePropertyDeclaration};
 use style::rule_tree::CascadeLevel;
 use style::rule_tree::CascadeOrigin;
 use style::selector_parser::PseudoElement;
 use style::selector_parser::RestyleDamage;
+use style::stylesheets::Origin;
 use style::stylesheets::layer_rule::LayerOrder;
 use style::stylesheets::scope_rule::ImplicitScopeRoot;
 use style::values::AtomString;
@@ -54,6 +57,7 @@ use style::{
     values::{AtomIdent, GenericAtomIdent},
 };
 use style_dom::ElementState;
+use style_traits::ParsingMode;
 
 use style::values::computed::text::TextAlign as StyloTextAlign;
 
@@ -914,6 +918,40 @@ impl<'a> TElement for BlitzNode<'a> {
             Some(LengthPercentage::Length(length))
         }
 
+        if elem.name.ns == ns!(svg) {
+            let url_extra_data = self.tree().url_extra_data();
+            let svg_parser_context = ParserContext::new(
+                Origin::Author,
+                &url_extra_data,
+                Some(style::stylesheets::CssRuleType::Style),
+                ParsingMode::ALLOW_UNITLESS_LENGTH | ParsingMode::ALLOW_ALL_NUMERIC_VALUES,
+                QuirksMode::NoQuirks,
+                Default::default(),
+                None,
+                None,
+                Default::default(),
+            );
+
+            for attr in elem.attrs() {
+                let name = &attr.name.local;
+                let value = attr.value.as_str();
+                match name.as_ref() {
+                    "fill" | "fill-opacity" | "fill-rule" | "stroke" | "stroke-opacity"
+                    | "stroke-width" | "stroke-linecap" | "stroke-linejoin"
+                    | "stroke-dasharray" | "stroke-dashoffset" => {
+                        for declaration in parse_svg_presentation_attribute(
+                            name.as_ref(),
+                            value,
+                            &svg_parser_context,
+                        ) {
+                            push_style(declaration);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
         for attr in elem.attrs() {
             let name = &attr.name.local;
             let value = attr.value.as_str();
@@ -1101,6 +1139,25 @@ impl RegisteredSpeculativePainters for RegisteredPaintersImpl {
     fn get(&self, _name: &Atom) -> Option<&dyn RegisteredSpeculativePainter> {
         None
     }
+}
+
+fn parse_svg_presentation_attribute(
+    name: &str,
+    value: &str,
+    context: &ParserContext,
+) -> Vec<PropertyDeclaration> {
+    let Ok(property_id) = PropertyId::parse(name, context) else {
+        return Vec::new();
+    };
+    let mut declarations = SourcePropertyDeclaration::default();
+    let mut input = ParserInput::new(value);
+    let mut parser = Parser::new(&mut input);
+    if PropertyDeclaration::parse_into(&mut declarations, property_id, context, &mut parser)
+        .is_err()
+    {
+        return Vec::new();
+    }
+    declarations.drain().declarations.collect()
 }
 
 use style::traversal::recalc_style_at;

--- a/packages/blitz-dom/src/tree.rs
+++ b/packages/blitz-dom/src/tree.rs
@@ -6,6 +6,7 @@ use blitz_traits::node_id::NodeId;
 use slotmap::{Key as _, KeyData, SlotMap};
 
 use crate::Node;
+use crate::url::DocumentUrl;
 
 slotmap::new_key_type! {
     /// The internal [`slotmap`] key for node storage. Only used at the
@@ -30,55 +31,69 @@ fn to_id(key: NodeKey) -> NodeId {
 /// addition to its index: when a node is dropped and its slot reused, ids
 /// referring to the dropped node no longer resolve ([`NodeTree::get`] returns
 /// `None`, and indexing panics) instead of aliasing the new occupant.
-pub struct NodeTree(SlotMap<NodeKey, Node>);
+pub struct NodeTree {
+    nodes: SlotMap<NodeKey, Node>,
+    document_url: DocumentUrl,
+}
 
 impl NodeTree {
     pub(crate) fn new() -> Self {
-        Self(SlotMap::with_key())
+        Self {
+            nodes: SlotMap::with_key(),
+            document_url: DocumentUrl::default(),
+        }
+    }
+
+    pub(crate) fn set_document_url(&mut self, url: DocumentUrl) {
+        self.document_url = url;
+    }
+
+    pub(crate) fn url_extra_data(&self) -> style::stylesheets::UrlExtraData {
+        self.document_url.url_extra_data()
     }
 
     /// The number of live nodes in the map.
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.nodes.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.nodes.is_empty()
     }
 
     /// Whether `id` resolves to a live node.
     pub fn contains_key(&self, id: NodeId) -> bool {
-        self.0.contains_key(to_key(id))
+        self.nodes.contains_key(to_key(id))
     }
 
     /// Get a reference to the node with the given id, if it is still live.
     pub fn get(&self, id: NodeId) -> Option<&Node> {
-        self.0.get(to_key(id))
+        self.nodes.get(to_key(id))
     }
 
     /// Get a mutable reference to the node with the given id, if it is still live.
     pub fn get_mut(&mut self, id: NodeId) -> Option<&mut Node> {
-        self.0.get_mut(to_key(id))
+        self.nodes.get_mut(to_key(id))
     }
 
     /// Insert a node constructed with knowledge of its own id.
     pub(crate) fn insert_with_key(&mut self, f: impl FnOnce(NodeId) -> Node) -> NodeId {
-        to_id(self.0.insert_with_key(|key| f(to_id(key))))
+        to_id(self.nodes.insert_with_key(|key| f(to_id(key))))
     }
 
     /// Remove the node with the given id, returning it if it was still live.
     pub(crate) fn remove(&mut self, id: NodeId) -> Option<Node> {
-        self.0.remove(to_key(id))
+        self.nodes.remove(to_key(id))
     }
 
     /// Iterate over all live `(NodeId, &Node)` pairs.
     pub fn iter(&self) -> impl Iterator<Item = (NodeId, &Node)> {
-        self.0.iter().map(|(key, node)| (to_id(key), node))
+        self.nodes.iter().map(|(key, node)| (to_id(key), node))
     }
 
     /// Iterate over all live `(NodeId, &mut Node)` pairs.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (NodeId, &mut Node)> {
-        self.0.iter_mut().map(|(key, node)| (to_id(key), node))
+        self.nodes.iter_mut().map(|(key, node)| (to_id(key), node))
     }
 }
 
@@ -88,7 +103,7 @@ impl Index<NodeId> for NodeTree {
     #[track_caller]
     #[inline]
     fn index(&self, id: NodeId) -> &Node {
-        &self.0[to_key(id)]
+        &self.nodes[to_key(id)]
     }
 }
 
@@ -96,6 +111,6 @@ impl IndexMut<NodeId> for NodeTree {
     #[track_caller]
     #[inline]
     fn index_mut(&mut self, id: NodeId) -> &mut Node {
-        &mut self.0[to_key(id)]
+        &mut self.nodes[to_key(id)]
     }
 }

--- a/packages/blitz-html/tests/svg_presentation.rs
+++ b/packages/blitz-html/tests/svg_presentation.rs
@@ -1,0 +1,152 @@
+//! CSS and presentation-attribute SVG paint properties must reach usvg.
+
+use anyrender::render_to_buffer;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_paint::paint_scene;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn pixel(html: &str, x: usize, y: usize) -> [u8; 3] {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(100, 100, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
+        |scene| paint_scene(scene, doc.as_mut(), 1.0, 100, 100, 0, 0),
+        100,
+        100,
+    );
+    let index = (y * 100 + x) * 4;
+    [buffer[index], buffer[index + 1], buffer[index + 2]]
+}
+
+#[test]
+fn css_currentcolor_fill_is_serialized() {
+    let px = pixel(
+        r##"<html><head><style>
+            #icon { display:block; width:100px; height:100px; color:#0071f1; fill:currentcolor; }
+        </style></head><body style="margin:0">
+            <svg id="icon" viewBox="0 0 100 100">
+                <path d="M50 10 L90 90 L10 90 Z"/>
+            </svg>
+        </body></html>"##,
+        50,
+        50,
+    );
+    assert_eq!(px, [0, 113, 241]);
+}
+
+#[test]
+fn css_fill_overrides_presentation_attribute() {
+    let px = pixel(
+        r##"<html><head><style>
+            #icon { display:block; width:100px; height:100px; fill:#00ff00; }
+        </style></head><body style="margin:0">
+            <svg id="icon" fill="#ff0000" viewBox="0 0 100 100">
+                <path d="M50 10 L90 90 L10 90 Z"/>
+            </svg>
+        </body></html>"##,
+        50,
+        50,
+    );
+    assert_eq!(px, [0, 255, 0]);
+}
+
+#[test]
+fn fill_none_is_preserved() {
+    let px = pixel(
+        r##"<html><body style="margin:0; background:#0000ff">
+            <svg id="icon" style="display:block; width:100px; height:100px" fill="none" viewBox="0 0 100 100">
+                <path d="M50 10 L90 90 L10 90 Z"/>
+            </svg>
+        </body></html>"##,
+        50,
+        50,
+    );
+    assert_eq!(px, [0, 0, 255]);
+}
+
+#[test]
+fn stroke_and_stroke_width_are_serialized() {
+    let px = pixel(
+        r##"<html><body style="margin:0">
+            <svg id="icon" style="display:block; width:100px; height:100px" fill="none"
+                stroke="#0000ff" stroke-width="10" viewBox="0 0 100 100">
+                <path d="M10 10 H90 V90 H10 Z"/>
+            </svg>
+        </body></html>"##,
+        6,
+        50,
+    );
+    assert_eq!(px, [0, 0, 255]);
+    assert_eq!(
+        pixel(
+            r##"<html><body style="margin:0">
+                <svg style="display:block; width:100px; height:100px" fill="none"
+                    stroke="#0000ff" stroke-width="1" viewBox="0 0 100 100">
+                    <path d="M10 10 H90 V90 H10 Z"/>
+                </svg>
+            </body></html>"##,
+            8,
+            50,
+        ),
+        [0, 0, 0],
+        "the 10-unit stroke must extend beyond the 1-unit default stroke"
+    );
+}
+
+#[test]
+fn css_paint_server_fragment_stays_local() {
+    let px = pixel(
+        r##"<html><head><style>
+            #icon { display:block; width:100px; height:100px; fill:url(#gradient); }
+        </style></head><body style="margin:0">
+            <svg id="icon" viewBox="0 0 100 100">
+                <defs>
+                    <linearGradient id="gradient">
+                        <stop offset="0" stop-color="#ff0000"/>
+                        <stop offset="1" stop-color="#0000ff"/>
+                    </linearGradient>
+                </defs>
+                <path d="M0 0 H100 V100 H0 Z"/>
+            </svg>
+        </body></html>"##,
+        1,
+        50,
+    );
+    assert!(
+        px[0] > px[2],
+        "local CSS paint server should resolve to red"
+    );
+}
+
+#[test]
+fn presentation_paint_server_fragment_stays_local() {
+    let px = pixel(
+        r##"<html><body style="margin:0">
+            <svg style="display:block; width:100px; height:100px"
+                fill="url(#gradient)" viewBox="0 0 100 100">
+                <defs>
+                    <linearGradient id="gradient">
+                        <stop offset="0" stop-color="#ff0000"/>
+                        <stop offset="1" stop-color="#0000ff"/>
+                    </linearGradient>
+                </defs>
+                <path d="M0 0 H100 V100 H0 Z"/>
+            </svg>
+        </body></html>"##,
+        1,
+        50,
+    );
+    assert!(
+        px[0] > px[2],
+        "local presentation paint server should resolve to red"
+    );
+}


### PR DESCRIPTION
## Summary

Inline `<svg>` is rendered by serializing the DOM subtree back to markup and handing it to usvg. That serialization only emitted the *raw attributes*, so any SVG paint property coming from CSS never reached usvg and it fell back to its initial `fill: black`. On https://bbc.co.uk the header icons are styled with

```css
.icon { fill: currentcolor }   /* wrapper sets color: #0071F1 */
```

so they rendered solid black instead of blue — and black-on-dark makes them look like they aren't rendering at all.

The fix makes the computed style the source of truth for the SVG properties stylo supports (`fill`, `stroke`, and their `-opacity`/`-rule`/`-width`/`-linecap`/`-linejoin`/`-dasharray`/`-dashoffset` friends), which needs two halves:

1. **`stylo.rs`** — SVG presentation attributes on elements in `ns!(svg)` are now parsed into declarations and pushed as presentation hints, so the cascade sees them at their proper (lowest) precedence. Parsing uses `ALLOW_UNITLESS_LENGTH | ALLOW_ALL_NUMERIC_VALUES` since `stroke-width="10"` is not valid strict CSS, and the document's real `UrlExtraData` so `fill="url(#grad)"` resolves.
2. **`node.rs`** — a separate `svg_outer_html()` serializer used only by `collect_layout_children`; `outer_html()` (a public DOM API) is unchanged. For each element it emits the computed value of each of those properties as a presentation attribute and drops the element's own raw attribute of that name, so nothing is emitted twice. `currentcolor` is resolved against the element's own computed `color`, and paint servers are re-serialized as `url(#fragment)` rather than the absolutised url that usvg can't resolve locally.

Without part 1, part 2 would regress every SVG that paints via attributes: the computed value wouldn't know about `fill="red"` and would overwrite it with the initial value.

`NodeTree` gained a `document_url` field so the styling path can reach the document's url extra data (`BlitzNode` can get to the tree, but not to the `BaseDocument`).

## Result

BBC header before / after:

![before](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvOTJiNGUzYjMtNjM5MC00ZTRlLWE1MGUtZTllNDhjZTg2OWRhIiwiaWF0IjoxNzg1NTI5Mjc4LCJleHAiOjE3ODYxMzQwNzgsImZpbGVuYW1lIjoiYmJjX2JlZm9yZS5wbmcifQ.gplnKjJymdqf5cJR7PAXs7QaVXjpYyLtuikfywzEEpY)

![after](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvMmUwMzYxNDEtMmE1Ni00YTZiLTgyZmItYTk2OTRlOTliMjVjIiwiaWF0IjoxNzg1NTI5Mjc4LCJleHAiOjE3ODYxMzQwNzgsImZpbGVuYW1lIjoiYmJjX2FmdGVyLnBuZyJ9.abNUsMuf27j-w3jZLNSGy2X1PLN2Un4PLKptevpzQ2Y)

## Tests

`packages/blitz-html/tests/svg_presentation.rs` renders and samples pixels for: CSS `fill: currentcolor`, CSS `fill` overriding a `fill=` attribute, `fill="none"`, `stroke` + a `stroke-width="10"` case with a negative control at a pixel only a 10-unit stroke can reach, and local paint-server references from both CSS and an attribute.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/db067c6d753649c7952b3aa35f112993
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**2** newly passing, **5** newly failing (net -3).

<details>
<summary>Full diff (7 changed tests)</summary>

```diff
+ Fail => Pass css/css-borders/border-shape/border-shape-shadow-negative-spread.html
- Pass => Fail css/css-masking/clip-path/animations/clip-path-animation-neutral-keyframe-svg-smil.html
- Pass => Fail css/css-viewport/zoom/stroke.html
- Pass => Fail css/css-viewport/zoom/svg-font-relative-units.html
- Pass => Fail css/css-viewport/zoom/svg-path.html
- Pass => Fail css/css-viewport/zoom/svg-stroke-width.html
+ Fail => Pass css/selectors/sharing-in-svg-use.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30662560097).</sub>
<!-- wpt-results-end -->
