### PR TITLE
blitz-test-harness: paint inspection, structured event traces, JSON scenario fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,6 @@ version = "0.0.0"
 dependencies = [
  "blitz-test-harness",
  "blitz-traits",
- "keyboard-types 0.7.0",
  "serde",
  "serde_json",
 ]
@@ -1040,6 +1039,8 @@ dependencies = [
  "keyboard-types 0.7.0",
  "peniko",
  "png 0.18.1",
+ "serde",
+ "serde_json",
  "smol_str",
 ]
 
@@ -1060,6 +1061,7 @@ dependencies = [
  "dioxus-native-dom",
  "keyboard-types 0.7.0",
  "markup5ever",
+ "peniko",
  "usvg",
 ]
 

--- a/apps/blitz-drive/Cargo.toml
+++ b/apps/blitz-drive/Cargo.toml
@@ -9,6 +9,5 @@ publish = false
 [dependencies]
 blitz-test-harness = { workspace = true }
 blitz-traits = { workspace = true }
-keyboard-types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1"

--- a/apps/blitz-drive/src/main.rs
+++ b/apps/blitz-drive/src/main.rs
@@ -20,8 +20,7 @@ use std::io::{BufRead, Write};
 use std::path::Path;
 use std::sync::Arc;
 
-use blitz_test_harness::{FileNetProvider, Harness, HarnessOptions};
-use keyboard_types::Key;
+use blitz_test_harness::{FileNetProvider, Harness, HarnessOptions, parse_key};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -59,6 +58,8 @@ enum Command {
     },
     /// Dump the DOM tree (with layout geometry) as text
     DumpDom,
+    /// Dump the document's paint commands as text (one per line)
+    DumpPaint,
     /// Get the layout rect of the first element matching `selector`
     Layout { selector: String },
     /// Get the text content of the first element matching `selector`
@@ -77,16 +78,6 @@ enum Command {
     SetViewport { width: u32, height: u32 },
     /// Advance the animation clock by `seconds` and re-resolve
     Tick { seconds: f64 },
-}
-
-fn parse_key(key: &str) -> Key {
-    let mut chars = key.chars();
-    let first = chars.next();
-    if first.is_some() && chars.next().is_none() {
-        return Key::Character(key.to_string());
-    }
-    key.parse::<Key>()
-        .unwrap_or_else(|_| Key::Character(key.to_string()))
 }
 
 struct Driver {
@@ -183,6 +174,10 @@ impl Driver {
             Command::DumpDom => {
                 let dom = self.harness()?.dom_string();
                 Ok(json!({ "ok": true, "dom": dom }))
+            }
+            Command::DumpPaint => {
+                let paint = self.harness()?.paint_string();
+                Ok(json!({ "ok": true, "paint": paint }))
             }
             Command::Layout { selector } => {
                 let harness = self.harness()?;

--- a/packages/blitz-test-harness/Cargo.toml
+++ b/packages/blitz-test-harness/Cargo.toml
@@ -30,4 +30,6 @@ png = { workspace = true }
 # Other dependencies
 data-url = { workspace = true }
 keyboard-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = "1"
 smol_str = { workspace = true }

--- a/packages/blitz-test-harness/src/harness.rs
+++ b/packages/blitz-test-harness/src/harness.rs
@@ -50,6 +50,15 @@ impl HarnessOptions {
     }
 }
 
+/// A DOM event captured by [`Harness::dispatch_traced`]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TracedEvent {
+    /// The event name (e.g. "click", "keydown", "input")
+    pub name: String,
+    /// The event's target node
+    pub target: blitz_traits::node_id::NodeId,
+}
+
 /// A headless wrapper around a [`Document`] for driving it programmatically in tests.
 pub struct Harness<D: Document = HtmlDocument> {
     pub doc: D,
@@ -136,6 +145,22 @@ impl<D: Document> Harness<D> {
     /// so document-specific event handling (e.g. forwarding to a Dioxus VirtualDom) is
     /// bypassed. Does not [`pump`](Self::pump).
     pub fn dispatch_recorded(&mut self, events: impl IntoIterator<Item = UiEvent>) -> Vec<String> {
+        self.dispatch_traced(events)
+            .into_iter()
+            .map(|event| event.name)
+            .collect()
+    }
+
+    /// Dispatch raw [`UiEvent`]s, capturing every DOM event dispatched to application
+    /// code as a [`TracedEvent`] (name and target node).
+    ///
+    /// The events are driven directly against the underlying [`blitz_dom::BaseDocument`],
+    /// so document-specific event handling (e.g. forwarding to a Dioxus VirtualDom) is
+    /// bypassed. Does not [`pump`](Self::pump).
+    pub fn dispatch_traced(
+        &mut self,
+        events: impl IntoIterator<Item = UiEvent>,
+    ) -> Vec<TracedEvent> {
         use blitz_dom::{EventDriver, EventHandler};
         use blitz_traits::events::{DomEvent, EventState};
         use std::cell::RefCell;
@@ -143,7 +168,7 @@ impl<D: Document> Harness<D> {
 
         #[derive(Clone, Default)]
         struct RecordingHandler {
-            events: Rc<RefCell<Vec<String>>>,
+            events: Rc<RefCell<Vec<TracedEvent>>>,
         }
 
         impl EventHandler for RecordingHandler {
@@ -154,7 +179,10 @@ impl<D: Document> Harness<D> {
                 _doc: &mut dyn Document,
                 _event_state: &mut EventState,
             ) {
-                self.events.borrow_mut().push(event.name().to_string());
+                self.events.borrow_mut().push(TracedEvent {
+                    name: event.name().to_string(),
+                    target: event.target,
+                });
             }
         }
 

--- a/packages/blitz-test-harness/src/input.rs
+++ b/packages/blitz-test-harness/src/input.rs
@@ -92,6 +92,19 @@ pub fn key_event(key: Key, state: KeyState, modifiers: Modifiers) -> BlitzKeyEve
     }
 }
 
+/// Parse a key name into a [`Key`]: single characters become [`Key::Character`],
+/// multi-character strings are parsed as named keys (e.g. "Enter", "ArrowDown"),
+/// falling back to [`Key::Character`] if unrecognized.
+pub fn parse_key(key: &str) -> Key {
+    let mut chars = key.chars();
+    let first = chars.next();
+    if first.is_some() && chars.next().is_none() {
+        return Key::Character(key.to_string());
+    }
+    key.parse::<Key>()
+        .unwrap_or_else(|_| Key::Character(key.to_string()))
+}
+
 impl<D: Document> Harness<D> {
     /// Click (pointer down + up) the center of the first element matching `selector`
     pub fn click(&mut self, selector: &str) {

--- a/packages/blitz-test-harness/src/input.rs
+++ b/packages/blitz-test-harness/src/input.rs
@@ -222,6 +222,22 @@ impl<D: Document> Harness<D> {
             KeyState::Pressed,
             modifiers,
         )));
+
+        // On macOS some text-editing keys are handled via the Apple standard
+        // keybindings (dispatched by AppKit in a windowed shell) rather than
+        // the keydown event, so synthesize the corresponding command here.
+        #[cfg(target_os = "macos")]
+        if key == Key::Backspace {
+            let command = if modifiers.contains(Modifiers::ALT) {
+                "deleteWordBackward:"
+            } else {
+                "deleteBackward:"
+            };
+            self.dispatch(UiEvent::AppleStandardKeybinding(
+                blitz_traits::SmolStr::new(command),
+            ));
+        }
+
         self.dispatch(UiEvent::KeyUp(key_event(
             key,
             KeyState::Released,

--- a/packages/blitz-test-harness/src/lib.rs
+++ b/packages/blitz-test-harness/src/lib.rs
@@ -21,13 +21,17 @@ mod harness;
 mod input;
 mod inspect;
 mod net;
+mod paint;
 mod render;
+mod scenario;
 
-pub use harness::{Harness, HarnessOptions};
-pub use input::{key_event, mouse_pointer_event, pointer_event, touch_pointer_event};
+pub use harness::{Harness, HarnessOptions, TracedEvent};
+pub use input::{key_event, mouse_pointer_event, parse_key, pointer_event, touch_pointer_event};
 pub use inspect::Rect;
 pub use net::{
     FileNetProvider, RecordReplayMode, RecordReplayProvider, RequestCounts, load_data_url,
     load_fixture_bytes,
 };
+pub use paint::paint_command_string;
 pub use render::{Screenshot, ScreenshotDiff, artifacts_dir, compare_screenshots};
+pub use scenario::{Scenario, Step, run_scenario, run_scenario_file};

--- a/packages/blitz-test-harness/src/paint.rs
+++ b/packages/blitz-test-harness/src/paint.rs
@@ -1,0 +1,113 @@
+//! Paint-command inspection: record the document's paint into a command list for
+//! assertions like "this element painted a red rect at this position", which are much
+//! more robust than pixel comparison for many paint bugs.
+
+use anyrender::Paint;
+use anyrender::recording::{RenderCommand, Scene};
+use blitz_dom::Document;
+use blitz_paint::paint_scene;
+use peniko::kurbo::Shape;
+
+use crate::Harness;
+
+fn brush_string(brush: &Paint) -> String {
+    match brush {
+        Paint::Solid(color) => {
+            let rgba = color.to_rgba8();
+            format!("rgba({},{},{},{})", rgba.r, rgba.g, rgba.b, rgba.a)
+        }
+        Paint::Gradient(_) => "gradient".to_string(),
+        Paint::Image(_) | Paint::Resource(_) => "image".to_string(),
+        Paint::Custom(_) => "custom".to_string(),
+    }
+}
+
+fn rect_string(rect: peniko::kurbo::Rect) -> String {
+    format!(
+        "({:.1},{:.1}) {:.1}x{:.1}",
+        rect.x0,
+        rect.y0,
+        rect.width(),
+        rect.height()
+    )
+}
+
+/// One line of text per command: command kind, device-space bounding box, and brush
+pub fn paint_command_string(command: &RenderCommand) -> String {
+    match command {
+        RenderCommand::PushLayer(cmd) => {
+            let bbox = cmd.transform.transform_rect_bbox(cmd.clip.bounding_box());
+            format!("push_layer clip={} alpha={}", rect_string(bbox), cmd.alpha)
+        }
+        RenderCommand::PushClipLayer(cmd) => {
+            let bbox = cmd.transform.transform_rect_bbox(cmd.clip.bounding_box());
+            format!("push_clip clip={}", rect_string(bbox))
+        }
+        RenderCommand::PopLayer => "pop_layer".to_string(),
+        RenderCommand::Stroke(cmd) => {
+            let bbox = cmd.transform.transform_rect_bbox(cmd.shape.bounding_box());
+            format!(
+                "stroke {} width={} brush={}",
+                rect_string(bbox),
+                cmd.style.width,
+                brush_string(&cmd.brush)
+            )
+        }
+        RenderCommand::Fill(cmd) => {
+            let bbox = cmd.transform.transform_rect_bbox(cmd.shape.bounding_box());
+            format!(
+                "fill {} brush={}",
+                rect_string(bbox),
+                brush_string(&cmd.brush)
+            )
+        }
+        RenderCommand::GlyphRun(cmd) => {
+            format!(
+                "glyph_run glyphs={} size={} brush={}",
+                cmd.glyphs.len(),
+                cmd.font_size,
+                brush_string(&cmd.brush)
+            )
+        }
+        RenderCommand::BoxShadow(cmd) => {
+            let bbox = cmd.transform.transform_rect_bbox(cmd.rect);
+            let rgba = cmd.brush.to_rgba8();
+            format!(
+                "box_shadow {} radius={} std_dev={} color=rgba({},{},{},{})",
+                rect_string(bbox),
+                cmd.radius,
+                cmd.std_dev,
+                rgba.r,
+                rgba.g,
+                rgba.b,
+                rgba.a
+            )
+        }
+    }
+}
+
+impl<D: Document> Harness<D> {
+    /// Paint the document into a recorded [`Scene`], returning the full command list
+    /// (`scene.commands`) for structural assertions on painting.
+    pub fn record_paint(&mut self) -> Scene {
+        self.pump();
+        let mut doc = self.doc.inner_mut();
+        let (width, height) = doc.get_viewport().window_size;
+        let scale = doc.get_viewport().scale_f64();
+        let mut scene = Scene::new();
+        paint_scene(&mut scene, &mut doc, scale, width, height, 0, 0);
+        scene
+    }
+
+    /// A text serialization of the document's paint commands (one per line):
+    /// command kind, device-space bounding box, and brush.
+    pub fn paint_string(&mut self) -> String {
+        let scene = self.record_paint();
+        let mut out = String::new();
+        for command in &scene.commands {
+            out.push_str(&paint_command_string(command));
+            out.push('\n');
+        }
+        out
+    }
+}

--- a/packages/blitz-test-harness/src/scenario.rs
+++ b/packages/blitz-test-harness/src/scenario.rs
@@ -1,0 +1,185 @@
+//! Data-driven interaction scenarios: regression tests for interactive behavior
+//! expressed as JSON fixture files rather than Rust code.
+//!
+//! A scenario is a JSON document with initial `html` (plus optional `viewport`,
+//! `base_url`, and `fixture_dir`) and a list of `steps` — interactions and assertions
+//! executed in order against a [`Harness`]:
+//!
+//! ```json
+//! {
+//!     "html": "<input id='inp'><div id='out'>ready</div>",
+//!     "steps": [
+//!         { "step": "click", "selector": "#inp" },
+//!         { "step": "type", "text": "hello" },
+//!         { "step": "assert_value", "selector": "#inp", "equals": "hello" },
+//!         { "step": "assert_text", "selector": "#out", "equals": "ready" }
+//!     ]
+//! }
+//! ```
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use crate::{FileNetProvider, Harness, HarnessOptions, parse_key};
+
+#[derive(Debug, Deserialize)]
+pub struct Scenario {
+    /// Initial HTML for the document
+    pub html: String,
+    /// Viewport size as `[width, height]` (defaults to 800x600)
+    #[serde(default)]
+    pub viewport: Option<[u32; 2]>,
+    /// Base URL for resolving relative sub-resource URLs
+    #[serde(default)]
+    pub base_url: Option<String>,
+    /// Directory to serve sub-resources from (via [`FileNetProvider`])
+    #[serde(default)]
+    pub fixture_dir: Option<String>,
+    pub steps: Vec<Step>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "step", rename_all = "snake_case")]
+pub enum Step {
+    /// Click the element matching `selector`
+    Click { selector: String },
+    /// Move the mouse to `(x, y)`
+    Move { x: f32, y: f32 },
+    /// Type text via key events (into the focused element)
+    Type { text: String },
+    /// Press and release a key (e.g. "Enter", "Tab", or a single character)
+    Key { key: String },
+    /// Dispatch a wheel event at `(x, y)`
+    Scroll {
+        x: f32,
+        y: f32,
+        #[serde(default)]
+        delta_x: f64,
+        #[serde(default)]
+        delta_y: f64,
+    },
+    /// Advance the animation clock by `seconds`
+    Tick { seconds: f64 },
+    /// Assert the text content of the element matching `selector`
+    AssertText { selector: String, equals: String },
+    /// Assert the current value of the text input matching `selector`
+    AssertValue { selector: String, equals: String },
+    /// Assert (a subset of) the layout rect of the element matching `selector`
+    AssertLayout {
+        selector: String,
+        #[serde(default)]
+        x: Option<f32>,
+        #[serde(default)]
+        y: Option<f32>,
+        #[serde(default)]
+        width: Option<f32>,
+        #[serde(default)]
+        height: Option<f32>,
+    },
+    /// Assert that the element matching `selector` is focused
+    AssertFocused { selector: String },
+    /// Assert the rendered output matches a reference PNG
+    /// (path resolved relative to the scenario file, if any)
+    AssertScreenshot { reference: String },
+}
+
+/// Run a scenario from a JSON file. Panics (with the failing step) on assertion failure.
+pub fn run_scenario_file(path: impl AsRef<Path>) {
+    let path = path.as_ref();
+    let json = std::fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("failed to read scenario {}: {err}", path.display()));
+    let scenario: Scenario = serde_json::from_str(&json)
+        .unwrap_or_else(|err| panic!("failed to parse scenario {}: {err}", path.display()));
+    run_scenario(&scenario, path.parent());
+}
+
+/// Run an already-parsed scenario. Relative reference/fixture paths are resolved
+/// against `base_dir` when provided.
+pub fn run_scenario(scenario: &Scenario, base_dir: Option<&Path>) {
+    let resolve = |p: &str| -> std::path::PathBuf {
+        let p = Path::new(p);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            base_dir.map(|dir| dir.join(p)).unwrap_or_else(|| p.into())
+        }
+    };
+
+    let (width, height) = match scenario.viewport {
+        Some([w, h]) => (w, h),
+        None => (800, 600),
+    };
+    let options = HarnessOptions {
+        width,
+        height,
+        base_url: scenario.base_url.clone(),
+        net_provider: scenario
+            .fixture_dir
+            .as_deref()
+            .map(|dir| Arc::new(FileNetProvider::new(resolve(dir))) as _),
+        ..Default::default()
+    };
+    let mut harness = Harness::from_html_with(&scenario.html, options);
+
+    for (i, step) in scenario.steps.iter().enumerate() {
+        let step_context = format!("step {i} ({step:?})");
+        match step {
+            Step::Click { selector } => harness.click(selector),
+            Step::Move { x, y } => harness.move_mouse_to(*x, *y),
+            Step::Type { text } => harness.type_text(text),
+            Step::Key { key } => harness.press(parse_key(key)),
+            Step::Scroll {
+                x,
+                y,
+                delta_x,
+                delta_y,
+            } => harness.wheel_at(*x, *y, *delta_x, *delta_y),
+            Step::Tick { seconds } => harness.tick(*seconds),
+            Step::AssertText { selector, equals } => {
+                let actual = harness.text_content(selector);
+                assert_eq!(&actual, equals, "{step_context}: text mismatch");
+            }
+            Step::AssertValue { selector, equals } => {
+                let actual = harness.input_value(selector);
+                assert_eq!(
+                    actual.as_deref(),
+                    Some(equals.as_str()),
+                    "{step_context}: value mismatch"
+                );
+            }
+            Step::AssertLayout {
+                selector,
+                x,
+                y,
+                width,
+                height,
+            } => {
+                let rect = harness.layout_rect(selector);
+                let checks = [
+                    (x, rect.x),
+                    (y, rect.y),
+                    (width, rect.width),
+                    (height, rect.height),
+                ];
+                for (expected, actual) in checks {
+                    if let Some(expected) = expected {
+                        assert_eq!(*expected, actual, "{step_context}: layout mismatch");
+                    }
+                }
+            }
+            Step::AssertFocused { selector } => {
+                let node = harness.node(selector);
+                assert_eq!(
+                    harness.focused(),
+                    Some(node),
+                    "{step_context}: focus mismatch"
+                );
+            }
+            Step::AssertScreenshot { reference } => {
+                harness.assert_screenshot_matches(resolve(reference));
+            }
+        }
+    }
+}

--- a/tests/blitz-tests/Cargo.toml
+++ b/tests/blitz-tests/Cargo.toml
@@ -20,6 +20,7 @@ blitz-paint = { workspace = true, features = ["scrollbars", "svg"] }
 dioxus-native-dom = { workspace = true }
 anyrender = { workspace = true }
 anyrender_vello_cpu = { workspace = true }
+peniko = { workspace = true }
 
 # DioxusLabs dependencies
 dioxus = { workspace = true }

--- a/tests/blitz-tests/scenarios/layout_after_viewport_tick.json
+++ b/tests/blitz-tests/scenarios/layout_after_viewport_tick.json
@@ -1,0 +1,9 @@
+{
+    "viewport": [400, 300],
+    "html": "<html><body style='margin:0'><div id='box' style='width:50%;height:40px'></div></body></html>",
+    "steps": [
+        { "step": "assert_layout", "selector": "#box", "x": 0, "y": 0, "width": 200, "height": 40 },
+        { "step": "tick", "seconds": 0.1 },
+        { "step": "assert_layout", "selector": "#box", "width": 200 }
+    ]
+}

--- a/tests/blitz-tests/scenarios/type_into_input.json
+++ b/tests/blitz-tests/scenarios/type_into_input.json
@@ -1,0 +1,11 @@
+{
+    "html": "<html><body style='margin:0'><input id='inp' style='width:200px;height:20px'><div id='label'>ready</div></body></html>",
+    "steps": [
+        { "step": "click", "selector": "#inp" },
+        { "step": "assert_focused", "selector": "#inp" },
+        { "step": "type", "text": "hello" },
+        { "step": "key", "key": "Backspace" },
+        { "step": "assert_value", "selector": "#inp", "equals": "hell" },
+        { "step": "assert_text", "selector": "#label", "equals": "ready" }
+    ]
+}

--- a/tests/blitz-tests/tests/event_trace.rs
+++ b/tests/blitz-tests/tests/event_trace.rs
@@ -1,0 +1,29 @@
+//! Tests for structured event tracing via `Harness::dispatch_traced`.
+
+use blitz_test_harness::{Harness, mouse_pointer_event};
+use blitz_traits::events::UiEvent;
+
+#[test]
+fn dispatch_traced_captures_names_and_targets() {
+    let mut harness = Harness::from_html(
+        r#"<html><body style="margin:0">
+            <button id="btn" style="width:100px; height:30px;">Click me</button>
+        </body></html>"#,
+    );
+    let button = harness.node("#btn");
+    let (x, y) = harness.center_of("#btn");
+
+    let event = mouse_pointer_event(x, y);
+    let traced = harness.dispatch_traced([
+        UiEvent::PointerDown(event.clone()),
+        UiEvent::PointerUp(event),
+    ]);
+
+    let names: Vec<&str> = traced.iter().map(|e| e.name.as_str()).collect();
+    assert!(names.contains(&"mousedown"), "traced: {names:?}");
+    assert!(names.contains(&"mouseup"), "traced: {names:?}");
+    assert!(names.contains(&"click"), "traced: {names:?}");
+
+    let click = traced.iter().find(|e| e.name == "click").unwrap();
+    assert_eq!(click.target, button);
+}

--- a/tests/blitz-tests/tests/paint_inspection.rs
+++ b/tests/blitz-tests/tests/paint_inspection.rs
@@ -1,0 +1,52 @@
+//! Tests for paint-command recording and text serialization.
+
+use anyrender::recording::RenderCommand;
+use blitz_test_harness::Harness;
+
+const HTML: &str = r#"<html><body style="margin:0">
+    <div style="width:50px; height:40px; background:rgb(255,0,0);">text</div>
+</body></html>"#;
+
+#[test]
+fn record_paint_captures_background_fill() {
+    let mut harness = Harness::from_html(HTML);
+    let scene = harness.record_paint();
+
+    let red_fill = scene.commands.iter().find_map(|cmd| match cmd {
+        RenderCommand::Fill(fill) => {
+            let bbox = fill
+                .transform
+                .transform_rect_bbox(peniko::kurbo::Shape::bounding_box(&fill.shape));
+            (bbox.width() == 50.0 && bbox.height() == 40.0).then_some(fill)
+        }
+        _ => None,
+    });
+    let red_fill = red_fill.expect("expected a 50x40 fill command");
+    match &red_fill.brush {
+        anyrender::Paint::Solid(color) => {
+            let rgba = color.to_rgba8();
+            assert_eq!((rgba.r, rgba.g, rgba.b), (255, 0, 0));
+        }
+        other => panic!("expected solid brush, got {other:?}"),
+    }
+
+    // The div's text should paint as a glyph run
+    assert!(
+        scene
+            .commands
+            .iter()
+            .any(|cmd| matches!(cmd, RenderCommand::GlyphRun(_)))
+    );
+}
+
+#[test]
+fn paint_string_is_greppable() {
+    let mut harness = Harness::from_html(HTML);
+    let paint = harness.paint_string();
+
+    assert!(
+        paint.contains("fill (0.0,0.0) 50.0x40.0 brush=rgba(255,0,0,255)"),
+        "expected red fill in paint string:\n{paint}"
+    );
+    assert!(paint.contains("glyph_run"));
+}

--- a/tests/blitz-tests/tests/scenarios.rs
+++ b/tests/blitz-tests/tests/scenarios.rs
@@ -1,0 +1,22 @@
+//! Runs every JSON scenario fixture in `tests/blitz-tests/scenarios/`.
+
+use blitz_test_harness::run_scenario_file;
+
+#[test]
+fn run_all_scenarios() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scenarios");
+    let mut count = 0;
+    for entry in std::fs::read_dir(&dir).expect("scenarios dir exists") {
+        let path = entry.unwrap().path();
+        if path.extension().is_some_and(|ext| ext == "json") {
+            println!("running scenario {}", path.display());
+            run_scenario_file(&path);
+            count += 1;
+        }
+    }
+    assert!(
+        count >= 2,
+        "expected scenario fixtures in {}",
+        dir.display()
+    );
+}


### PR DESCRIPTION
## Summary

Phase 5 of the test-harness plan (stacked on #591): the remaining agent-debugging capabilities — paint-command inspection, structured event traces, and data-driven interaction scenarios.

**Paint inspection** (`paint` module): paints into `anyrender::recording::Scene` instead of a renderer, so tests can assert "this element painted a red rect at this position" without pixel-diffing:

```rust
impl<D: Document> Harness<D> {
    fn record_paint(&mut self) -> Scene;     // full Vec<RenderCommand> for structural asserts
    fn paint_string(&mut self) -> String;    // greppable text, one command per line:
}
// fill (0.0,0.0) 50.0x40.0 brush=rgba(255,0,0,255)
// glyph_run glyphs=4 size=16 brush=rgba(0,0,0,255)
```

Also exposed in `blitz-drive` as a `dump_paint` command.

**Structured event traces**: `dispatch_traced(events) -> Vec<TracedEvent { name, target: NodeId }>` captures every DOM event dispatched to application code (with its target node); `dispatch_recorded` is now a thin name-only wrapper over it.

**Scenario fixtures** (`scenario` module): interaction regression tests as JSON data rather than Rust code — `run_scenario_file(path)` loads initial HTML (with optional viewport/base_url/fixture_dir) and executes steps:

```json
{ "html": "<input id='inp'>...",
  "steps": [
    { "step": "click", "selector": "#inp" },
    { "step": "type", "text": "hello" },
    { "step": "key", "key": "Backspace" },
    { "step": "assert_value", "selector": "#inp", "equals": "hell" },
    { "step": "assert_layout", "selector": "#box", "width": 200 },
    { "step": "assert_screenshot", "reference": "ref.png" } ] }
```

`tests/blitz-tests/scenarios/*.json` are all run by a single `scenarios.rs` test, so adding a regression test is just adding a JSON file. Step assertions cover text, input value, layout rects, focus, and reference screenshots (reusing #588's snapshot machinery).

Also extracts the key-name parsing from `blitz-drive` into a shared `parse_key` ("Enter"/"ArrowDown"/single characters), used by both the driver and scenario `key` steps.

Tested with new `paint_inspection`, `event_trace`, and `scenarios` tests in `blitz-tests`, plus full `cargo test -p blitz-tests`, `cargo check --workspace`, clippy, fmt.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9c827e1e710842de87897ad30cac374f
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30664777444).</sub>
<!-- wpt-results-end -->
