### PR TITLE
Add a ByteFetcher abstraction underneath NetProvider

### DIFF
--- a/packages/blitz-net/Cargo.toml
+++ b/packages/blitz-net/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 [features]
 http2 = ["reqwest/http2"]
 cookies = ["reqwest/cookies"]
-multipart = ["reqwest/multipart", "reqwest/stream"]
+multipart = ["reqwest/multipart", "reqwest/stream", "reqwest-middleware?/multipart"]
 cache = ["dep:reqwest-middleware", "dep:http-cache-reqwest", "dep:directories", "dep:http-cache"]
 tracing = ["dep:tracing"]
 

--- a/packages/blitz-net/src/lib.rs
+++ b/packages/blitz-net/src/lib.rs
@@ -2,7 +2,10 @@
 //!
 //! Provides an implementation of the [`blitz_traits::net::NetProvider`] trait.
 
-use blitz_traits::net::{AbortSignal, Body, Bytes, NetHandler, NetProvider, NetWaker, Request};
+use blitz_traits::net::{
+    AbortSignal, Body, ByteFetcher, Bytes, FetchError, FetcherProvider, NetHandler, NetProvider,
+    NetWaker, Request, RequestObserver,
+};
 use data_url::DataUrl;
 use std::{
     collections::HashMap,
@@ -63,15 +66,14 @@ where
     tokio::spawn(fut);
 }
 
-pub struct Provider {
+pub struct HttpFetcher {
     client: Client,
-    waker: Arc<dyn NetWaker>,
     per_host_limits: HostLimits,
     #[cfg(feature = "cache")]
     cache_manager: CACacheManager,
 }
-impl Provider {
-    pub fn new(waker: Option<Arc<dyn NetWaker>>) -> Self {
+impl HttpFetcher {
+    pub fn new() -> Self {
         let builder = reqwest::Client::builder();
         #[cfg(feature = "cookies")]
         let builder = builder.cookie_store(true);
@@ -103,25 +105,13 @@ impl Provider {
             }))
             .build();
 
-        let waker = waker.unwrap_or(Arc::new(DummyNetWaker));
         Self {
             client,
-            waker,
             per_host_limits: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(feature = "cache")]
             cache_manager,
         }
     }
-    pub fn shared(waker: Option<Arc<dyn NetWaker>>) -> Arc<dyn NetProvider> {
-        Arc::new(Self::new(waker))
-    }
-    pub fn is_empty(&self) -> bool {
-        Arc::strong_count(&self.waker) == 1
-    }
-    pub fn count(&self) -> usize {
-        Arc::strong_count(&self.waker) - 1
-    }
-
     #[cfg(feature = "cache")]
     pub async fn clear_cache(&self) {
         if let Err(e) = self.cache_manager.clear().await {
@@ -132,7 +122,43 @@ impl Provider {
         }
     }
 }
+
+impl Default for HttpFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct Provider {
+    fetcher: Arc<HttpFetcher>,
+    inner: FetcherProvider<Arc<HttpFetcher>>,
+}
 impl Provider {
+    pub fn new(waker: Option<Arc<dyn NetWaker>>) -> Self {
+        let fetcher = Arc::new(HttpFetcher::new());
+        let inner = FetcherProvider::new(fetcher.clone(), waker);
+        Self { fetcher, inner }
+    }
+    pub fn shared(waker: Option<Arc<dyn NetWaker>>) -> Arc<dyn NetProvider> {
+        Arc::new(Self::new(waker))
+    }
+    pub fn is_empty(&self) -> bool {
+        Arc::strong_count(self.inner.waker()) == 1
+    }
+    pub fn count(&self) -> usize {
+        Arc::strong_count(self.inner.waker()) - 1
+    }
+
+    #[cfg(feature = "cache")]
+    pub async fn clear_cache(&self) {
+        self.fetcher.clear_cache().await;
+    }
+
+    pub fn set_observer(&self, observer: Arc<dyn RequestObserver>) {
+        self.inner.set_observer(observer);
+    }
+}
+impl HttpFetcher {
     async fn fetch_inner(
         client: Client,
         request: Request,
@@ -255,48 +281,66 @@ impl Provider {
     }
 }
 
-impl NetProvider for Provider {
-    fn fetch(&self, doc_id: usize, mut request: Request, handler: Box<dyn NetHandler>) {
+impl ByteFetcher for HttpFetcher {
+    fn fetch_bytes(
+        &self,
+        request: Request,
+        on_done: Box<dyn FnOnce(Result<(String, Bytes), FetchError>) + Send>,
+    ) {
+        #[cfg(feature = "tracing")]
+        let url = request.url.to_string();
+
         let client = self.client.clone();
         let per_host_limits = self.per_host_limits.clone();
-
-        #[cfg(feature = "tracing")]
-        tracing::info!(url = request.url.as_str(), "Fetching");
-
-        let waker = self.waker.clone();
+        let signal = request.signal.clone();
         spawn(async move {
-            #[cfg(feature = "tracing")]
-            let url = request.url.to_string();
-
-            let signal = request.signal.take();
             let result = if let Some(signal) = signal {
                 AbortFetch::new(
                     signal,
-                    Box::pin(
-                        async move { Self::fetch_inner(client, request, per_host_limits).await },
-                    ),
+                    Box::pin(async move {
+                        HttpFetcher::fetch_inner(client, request, per_host_limits).await
+                    }),
                 )
                 .await
             } else {
-                Self::fetch_inner(client, request, per_host_limits).await
+                HttpFetcher::fetch_inner(client, request, per_host_limits).await
             };
 
-            waker.wake(doc_id);
+            #[cfg(feature = "tracing")]
+            if let Err(e) = &result {
+                tracing::error!(url = url.as_str(), error = ?e, "Fetching");
+            } else {
+                tracing::info!(url = url.as_str(), "Success fetching");
+            }
 
-            match result {
-                Ok((response_url, bytes)) => {
-                    handler.bytes(response_url, bytes);
-                    #[cfg(feature = "tracing")]
-                    tracing::info!(url = url.as_str(), "Success fetching");
-                }
-                Err(e) => {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!(url = url.as_str(), error = ?e, "Error fetching");
-                    #[cfg(not(feature = "tracing"))]
-                    let _ = e;
-                }
-            };
+            on_done(result.map_err(|error| match error {
+                ProviderError::Abort => FetchError::Aborted,
+                error => FetchError::new(error),
+            }));
         });
+    }
+}
+
+impl Provider {
+    #[allow(clippy::type_complexity)]
+    pub fn fetch_with_callback(
+        &self,
+        request: Request,
+        callback: Box<dyn FnOnce(Result<(String, Bytes), ProviderError>) + Send + Sync + 'static>,
+    ) {
+        self.fetcher.fetch_with_callback(request, callback);
+    }
+
+    pub async fn fetch_async(&self, request: Request) -> Result<(String, Bytes), ProviderError> {
+        self.fetcher.fetch_async(request).await
+    }
+}
+
+impl NetProvider for Provider {
+    fn fetch(&self, doc_id: usize, request: Request, handler: Box<dyn NetHandler>) {
+        #[cfg(feature = "tracing")]
+        tracing::info!(url = request.url.as_str(), "Fetching");
+        self.inner.fetch(doc_id, request, handler);
     }
 }
 
@@ -437,9 +481,4 @@ impl ReqwestExt for RequestBuilder {
             Body::Empty => self,
         }
     }
-}
-
-struct DummyNetWaker;
-impl NetWaker for DummyNetWaker {
-    fn wake(&self, _client_id: usize) {}
 }

--- a/packages/blitz-traits/src/net.rs
+++ b/packages/blitz-traits/src/net.rs
@@ -10,7 +10,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
-use std::{ops::Deref, path::PathBuf};
+use std::{fmt, ops::Deref, path::PathBuf, sync::RwLock};
 pub use url::Url;
 
 /// A type that fetches resources for a Document.
@@ -26,6 +26,155 @@ pub trait NetHandler: Send + Sync + 'static {
     fn bytes(self: Box<Self>, resolved_url: String, bytes: Bytes);
 }
 
+/// An error produced while fetching bytes.
+#[derive(Debug, Clone)]
+pub enum FetchError {
+    /// The request was aborted before or during fetching.
+    Aborted,
+    /// The fetcher reported an error message.
+    Message(String),
+}
+
+impl FetchError {
+    /// Creates an error from any displayable error or message.
+    pub fn new(message: impl fmt::Display) -> Self {
+        Self::Message(message.to_string())
+    }
+
+    /// Returns whether this error represents an aborted request.
+    pub fn is_aborted(&self) -> bool {
+        matches!(self, Self::Aborted)
+    }
+}
+
+impl fmt::Display for FetchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Aborted => f.write_str("request aborted"),
+            Self::Message(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for FetchError {}
+
+/// A callback-based source of fetched bytes.
+pub trait ByteFetcher: Send + Sync + 'static {
+    /// Fetches bytes and invokes `on_done` when the operation completes.
+    #[allow(clippy::type_complexity)]
+    fn fetch_bytes(
+        &self,
+        request: Request,
+        on_done: Box<dyn FnOnce(Result<(String, Bytes), FetchError>) + Send>,
+    );
+}
+
+impl<F: ByteFetcher> ByteFetcher for Arc<F> {
+    fn fetch_bytes(
+        &self,
+        request: Request,
+        on_done: Box<dyn FnOnce(Result<(String, Bytes), FetchError>) + Send>,
+    ) {
+        (**self).fetch_bytes(request, on_done);
+    }
+}
+
+/// Observes requests and responses handled by a [`FetcherProvider`].
+pub trait RequestObserver: Send + Sync + 'static {
+    /// Called before a request is dispatched.
+    fn on_request(&self, doc_id: usize, request: &Request);
+    /// Called when a request completes, including when it fails.
+    fn on_response(&self, doc_id: usize, url: &str, result: Result<&Bytes, &FetchError>);
+}
+
+/// Adapts a [`ByteFetcher`] to the [`NetProvider`] interface.
+///
+/// The waker fires before the [`NetHandler`] is invoked. Requests already
+/// aborted at dispatch time are reported to the observer, but are not
+/// dispatched or woken. The observer receives errors that cannot be delivered
+/// through the [`NetHandler`] path.
+pub struct FetcherProvider<F: ByteFetcher> {
+    fetcher: F,
+    waker: Arc<dyn NetWaker>,
+    observer: RwLock<Option<Arc<dyn RequestObserver>>>,
+}
+
+impl<F: ByteFetcher> FetcherProvider<F> {
+    /// Creates a provider with an optional request-completion waker.
+    pub fn new(fetcher: F, waker: Option<Arc<dyn NetWaker>>) -> Self {
+        Self {
+            fetcher,
+            waker: waker.unwrap_or_else(|| Arc::new(DummyNetWaker)),
+            observer: RwLock::new(None),
+        }
+    }
+
+    /// Returns the underlying byte fetcher.
+    pub fn fetcher(&self) -> &F {
+        &self.fetcher
+    }
+
+    /// Returns the provider's request-completion waker.
+    pub fn waker(&self) -> &Arc<dyn NetWaker> {
+        &self.waker
+    }
+
+    /// Installs the observer used for subsequent requests and responses.
+    pub fn set_observer(&self, observer: Arc<dyn RequestObserver>) {
+        *self
+            .observer
+            .write()
+            .unwrap_or_else(|error| error.into_inner()) = Some(observer);
+    }
+}
+
+/// Dispatches byte fetches, waking before invoking the handler and exposing
+/// failures through the observer.
+impl<F: ByteFetcher> NetProvider for FetcherProvider<F> {
+    fn fetch(&self, doc_id: usize, request: Request, handler: Box<dyn NetHandler>) {
+        let signal = request.signal.clone();
+        let url = request.url.to_string();
+        let observer = self
+            .observer
+            .read()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
+        if let Some(observer) = &observer {
+            observer.on_request(doc_id, &request);
+        }
+
+        if signal.as_ref().is_some_and(AbortSignal::aborted) {
+            if let Some(observer) = observer {
+                let error = FetchError::Aborted;
+                observer.on_response(doc_id, &url, Err(&error));
+            }
+            return;
+        }
+
+        let waker = self.waker.clone();
+        self.fetcher.fetch_bytes(
+            request,
+            Box::new(move |mut result| {
+                if signal.as_ref().is_some_and(AbortSignal::aborted) {
+                    result = Err(FetchError::Aborted);
+                }
+                waker.wake(doc_id);
+                if let Some(observer) = observer {
+                    match &result {
+                        Ok((response_url, bytes)) => {
+                            observer.on_response(doc_id, response_url, Ok(bytes));
+                        }
+                        Err(error) => observer.on_response(doc_id, &url, Err(error)),
+                    }
+                }
+                if let Ok((response_url, bytes)) = result {
+                    handler.bytes(response_url, bytes);
+                }
+            }),
+        );
+    }
+}
+
 /// A callback which gets called every time a network request completes
 // Q: Should we use std::task::Waker for this?
 pub trait NetWaker: Send + Sync + 'static {
@@ -36,6 +185,11 @@ impl<F: Fn(usize) + Send + Sync + 'static> NetWaker for F {
     fn wake(&self, doc_id: usize) {
         self(doc_id)
     }
+}
+
+struct DummyNetWaker;
+impl NetWaker for DummyNetWaker {
+    fn wake(&self, _client_id: usize) {}
 }
 
 #[non_exhaustive]
@@ -196,5 +350,108 @@ impl AbortSignal {
     /// <https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/aborted>
     pub fn aborted(&self) -> bool {
         self.0.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, atomic::AtomicUsize};
+
+    struct SyncFetcher {
+        result: Result<(String, Bytes), FetchError>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl ByteFetcher for SyncFetcher {
+        fn fetch_bytes(
+            &self,
+            _request: Request,
+            on_done: Box<dyn FnOnce(Result<(String, Bytes), FetchError>) + Send>,
+        ) {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            on_done(self.result.clone());
+        }
+    }
+
+    struct Handler(Arc<AtomicBool>);
+    impl NetHandler for Handler {
+        fn bytes(self: Box<Self>, _resolved_url: String, _bytes: Bytes) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    struct Observer {
+        responses: Mutex<Vec<bool>>,
+    }
+
+    impl RequestObserver for Observer {
+        fn on_request(&self, _doc_id: usize, _request: &Request) {}
+
+        fn on_response(&self, _doc_id: usize, _url: &str, result: Result<&Bytes, &FetchError>) {
+            self.responses
+                .lock()
+                .unwrap()
+                .push(result.is_err() && result.unwrap_err().is_aborted());
+        }
+    }
+
+    fn request() -> Request {
+        Request::get(Url::parse("https://example.com/").unwrap())
+    }
+
+    #[test]
+    fn synchronous_fetcher_completes_before_fetch_returns() {
+        let ran = Arc::new(AtomicBool::new(false));
+        let fetcher = SyncFetcher {
+            result: Ok(("https://example.com/".into(), Bytes::from_static(b"ok"))),
+            calls: Arc::new(AtomicUsize::new(0)),
+        };
+        let provider = FetcherProvider::new(fetcher, None);
+        provider.fetch(1, request(), Box::new(Handler(ran.clone())));
+        assert!(ran.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn fetch_error_reaches_observer() {
+        let observer = Arc::new(Observer {
+            responses: Mutex::new(Vec::new()),
+        });
+        let fetcher = SyncFetcher {
+            result: Err(FetchError::new("failed")),
+            calls: Arc::new(AtomicUsize::new(0)),
+        };
+        let provider = FetcherProvider::new(fetcher, None);
+        provider.set_observer(observer.clone());
+        provider.fetch(
+            1,
+            request(),
+            Box::new(Handler(Arc::new(AtomicBool::new(false)))),
+        );
+        assert_eq!(*observer.responses.lock().unwrap(), vec![false]);
+    }
+
+    #[test]
+    fn aborted_request_reaches_observer_without_calling_handler() {
+        let observer = Arc::new(Observer {
+            responses: Mutex::new(Vec::new()),
+        });
+        let calls = Arc::new(AtomicUsize::new(0));
+        let fetcher = SyncFetcher {
+            result: Ok(("https://example.com/".into(), Bytes::from_static(b"ok"))),
+            calls: calls.clone(),
+        };
+        let provider = FetcherProvider::new(fetcher, None);
+        provider.set_observer(observer.clone());
+        let controller = AbortController::default();
+        let signal = controller.signal.clone();
+        controller.abort();
+        provider.fetch(
+            1,
+            request().signal(signal),
+            Box::new(Handler(Arc::new(AtomicBool::new(false)))),
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(*observer.responses.lock().unwrap(), vec![true]);
     }
 }


### PR DESCRIPTION
## Summary

Every `NetProvider` impl duplicates the same orchestration (waker notification, abort handling, error logging) around a different byte source. This splits that apart: a new low-level `ByteFetcher` trait only turns a `Request` into bytes, and a generic `FetcherProvider<F>` adapter owns the shared orchestration and implements `NetProvider`. `NetProvider`/`NetHandler` are unchanged as the doc-facing boundary.

```rust
// blitz-traits
pub trait ByteFetcher: Send + Sync + 'static {
    fn fetch_bytes(&self, request: Request,
                   on_done: Box<dyn FnOnce(Result<(String, Bytes), FetchError>) + Send>);
}
pub enum FetchError { Aborted, Message(String) }   // no reqwest types in blitz-traits
impl<F: ByteFetcher> NetProvider for FetcherProvider<F> { ... }
```

Callback-based rather than `async fn`, so a synchronous fetcher completes inline during `fetch` with no runtime dependency, while an async fetcher completes from a spawned task. The adapter lives in blitz-traits since it needs no dependencies. There is also a blanket `impl<F: ByteFetcher> ByteFetcher for Arc<F>` so one fetcher can be shared between the adapter and direct callers.

Adapter semantics (documented on `FetcherProvider`): the waker fires *before* the handler (as today); a request whose signal is already aborted at dispatch time is reported to the observer and never dispatched or woken; a result that completes after the signal fired is converted to `FetchError::Aborted`.

`FetcherProvider` also carries a runtime-settable `RequestObserver` (`on_request` / `on_response`, the latter including errors) — the motivating use case is devtools request recording, which the `NetHandler`-only path could not support because errors never reach the handler. `Provider::set_observer` forwards to it. No devtools consumer is wired up here.

`blitz_net::Provider` becomes a thin composition, with the client, per-host semaphores and cache manager moving to a new public `HttpFetcher`:

```rust
pub struct Provider { fetcher: Arc<HttpFetcher>, inner: FetcherProvider<Arc<HttpFetcher>> }
```

The fetch logic itself (`fetch_inner`/`fetch_http`, `AbortFetch`, `ProviderError`, feature gating) is unchanged, and `fetch_async`/`fetch_with_callback` still call the raw path directly, so their behaviour (no abort wrapping) is preserved. One subtlety: `is_empty`/`count` are derived from `Arc::strong_count` of the waker, so `Provider` deliberately keeps no second clone and reads it via `self.inner.waker()`.

Unrelated one-line fix needed to build the combined feature set: `multipart` now enables `reqwest-middleware?/multipart`, without which `cargo check -p blitz-net --features cache,multipart` fails on `no method named multipart found for reqwest_middleware::RequestBuilder`.

Unit tests in blitz-traits cover the sync-completes-inline, error-reaches-observer, and pre-aborted paths. The harness net providers (`FileNetProvider`/`RecordReplayProvider`) and the WPT provider are untouched — the former only exist in the unmerged harness stack; both can be converted to fetchers as follow-ups.

Verified with `cargo fmt --all`, `cargo clippy --workspace --all-targets`, `cargo check --workspace`, `cargo test --workspace`, plus `cargo check -p blitz-net --features cache,cookies,multipart,tracing`.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/6f80c95255464ec08dee5e5080864be7
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30665574876).</sub>
<!-- wpt-results-end -->
