### PR TITLE
Split blitz-headless crate out of blitz-test-harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "anyrender_vello_hybrid",
  "blitz",
  "blitz-dom",
+ "blitz-headless",
  "blitz-html",
  "blitz-net",
  "blitz-paint",
@@ -950,6 +951,20 @@ dependencies = [
  "reqwest",
  "tokio",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "blitz-headless"
+version = "0.3.0-beta.1"
+dependencies = [
+ "anyrender",
+ "anyrender_vello_cpu",
+ "blitz-dom",
+ "blitz-html",
+ "blitz-paint",
+ "blitz-traits",
+ "peniko",
+ "png 0.18.1",
 ]
 
 [[package]]
@@ -1028,8 +1043,8 @@ name = "blitz-test-harness"
 version = "0.3.0-beta.1"
 dependencies = [
  "anyrender",
- "anyrender_vello_cpu",
  "blitz-dom",
+ "blitz-headless",
  "blitz-html",
  "blitz-paint",
  "blitz-traits",
@@ -1038,7 +1053,6 @@ dependencies = [
  "dioxus-native-dom",
  "keyboard-types 0.7.0",
  "peniko",
- "png 0.18.1",
  "serde",
  "serde_json",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "packages/blitz-traits",
     "packages/blitz-dom",
     "packages/blitz-html",
+    "packages/blitz-headless",
     "packages/blitz-net",
     "packages/blitz-paint",
     "packages/blitz-shell",
@@ -44,6 +45,7 @@ rust-version = "1.89.0"
 blitz = { version = "=0.3.0-beta.1", path = "./packages/blitz" }
 blitz-dom = { version = "=0.3.0-beta.1", path = "./packages/blitz-dom", default-features = false }
 blitz-html = { version = "=0.3.0-beta.1", path = "./packages/blitz-html", default-features = false }
+blitz-headless = { version = "=0.3.0-beta.1", path = "./packages/blitz-headless" }
 blitz-net = { version = "=0.3.0-beta.1", path = "./packages/blitz-net", default-features = false }
 blitz-paint = { version = "=0.3.0-beta.1", path = "./packages/blitz-paint", default-features = false }
 blitz-shell = { version = "=0.3.0-beta.1", path = "./packages/blitz-shell", default-features = false }
@@ -249,6 +251,7 @@ anyrender_vello_cpu = { workspace = true, features = ["multithreading"] }
 anyrender_vello_hybrid = { workspace = true }
 blitz-dom = { workspace = true, features = ["default"] }
 blitz-html = { workspace = true }
+blitz-headless = { workspace = true }
 blitz-traits = { workspace = true }
 blitz-paint = { workspace = true }
 blitz-shell = { workspace = true }

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,19 +1,10 @@
 //! Load first CLI argument as a url. Fallback to google.com if no CLI argument is provided.
 
-use anyrender::{PaintScene as _, render_to_buffer};
-use anyrender_vello_cpu::VelloCpuImageRenderer;
-use blitz_dom::{DocumentConfig, util::Color};
-use blitz_html::HtmlDocument;
+use blitz_headless::{HeadlessDocument, HeadlessOptions};
 use blitz_net::Provider;
-use blitz_paint::paint_scene;
-use blitz_traits::shell::{ColorScheme, Viewport};
-use peniko::Fill;
-use peniko::kurbo::Rect;
 use reqwest::Url;
 use std::sync::Arc;
 use std::{
-    fs::File,
-    io::Write,
     path::{Path, PathBuf},
     time::Instant,
 };
@@ -56,8 +47,8 @@ async fn main() {
     timer.time("Fetched HTML");
 
     // Setup viewport. TODO: make configurable.
-    let scale = 2.0;
-    let height = 800;
+    let scale: f64 = 2.0;
+    let height: u32 = 800;
     let width: u32 = std::env::args()
         .nth(2)
         .and_then(|arg| arg.parse().ok())
@@ -67,78 +58,41 @@ async fn main() {
 
     timer.time("Setup document prerequisites");
 
-    // Create HtmlDocument
-    let mut document = HtmlDocument::from_html(
+    // Create document
+    let mut document = HeadlessDocument::from_html_with(
         &html,
-        DocumentConfig {
+        HeadlessOptions {
+            width: width * (scale as u32),
+            height: height * (scale as u32),
+            scale: scale as f32,
             base_url: Some(url_string.clone()),
             net_provider: Some(Arc::clone(&net) as _),
-            viewport: Some(Viewport::new(
-                width * (scale as u32),
-                height * (scale as u32),
-                scale as f32,
-                ColorScheme::Light,
-            )),
             ..Default::default()
         },
     );
 
     timer.time("Parsed document");
 
-    loop {
-        document.resolve(0.0);
-        if net.is_empty() {
-            break;
-        }
-    }
+    // Resolve style/layout, waiting for sub-resources (stylesheets, images, fonts) to load
+    document.resolve_until_network_idle();
 
-    timer.time("Fetched assets");
+    timer.time("Fetched assets and resolved styles and layout");
 
-    // Compute style, layout, etc for HtmlDocument
-    document.as_mut().resolve(0.0);
-
-    timer.time("Resolved styles and layout");
-
-    // Determine height to render
-    let computed_height = document.as_ref().root_element().final_layout().size.height;
+    // Determine height to render: the content height, clamped between the viewport
+    // height and 4000px
     let render_width = (width as f64 * scale) as u32;
-    let render_height = ((computed_height as f64).max(height as f64).min(4000.0) * scale) as u32;
+    let render_height = (document.content_height() as f64)
+        .max(height as f64 * scale)
+        .min(4000.0 * scale) as u32;
 
-    // Render document to RGBA buffer
-    let buffer = render_to_buffer::<VelloCpuImageRenderer, _>(
-        |scene| {
-            // Render white background
-            scene.fill(
-                Fill::NonZero,
-                Default::default(),
-                Color::WHITE,
-                Default::default(),
-                &Rect::new(0.0, 0.0, render_width as f64, render_height as f64),
-            );
-
-            // Render document
-            paint_scene(
-                scene,
-                document.as_mut(),
-                scale,
-                render_width,
-                render_height,
-                0,
-                0,
-            );
-        },
-        render_width,
-        render_height,
-    );
+    // Render document to RGBA screenshot
+    let screenshot = document.screenshot_with_size(render_width, render_height);
 
     timer.time("Rendered to buffer");
 
-    // Determine output path, and open a file at that path. TODO: make configurable.
+    // Determine output path and write PNG to it. TODO: make configurable.
     let out_path = compute_filename(&url_string);
-    let mut file = File::create(&out_path).unwrap();
-
-    // Encode buffer as PNG and write it to a file
-    write_png(&mut file, &buffer, render_width, render_height);
+    screenshot.save_png(&out_path);
 
     timer.time("Wrote out png");
 
@@ -146,26 +100,6 @@ async fn main() {
     timer.total_time("\nDone");
     println!("Screenshot is ({width}x{render_height})");
     println!("Written to {}", out_path.display());
-}
-
-fn write_png<W: Write>(writer: W, buffer: &[u8], width: u32, height: u32) {
-    // Set pixels-per-meter. TODO: make configurable.
-    const PPM: u32 = (144.0 * 39.3701) as u32;
-
-    // Create PNG encoder
-    let mut encoder = png::Encoder::new(writer, width, height);
-    encoder.set_color(png::ColorType::Rgba);
-    encoder.set_depth(png::BitDepth::Eight);
-    encoder.set_pixel_dims(Some(png::PixelDimensions {
-        xppu: PPM,
-        yppu: PPM,
-        unit: png::Unit::Meter,
-    }));
-
-    // Write PNG data to writer
-    let mut writer = encoder.write_header().unwrap();
-    writer.write_image_data(buffer).unwrap();
-    writer.finish().unwrap();
 }
 
 fn compute_filename(url: &str) -> PathBuf {

--- a/packages/blitz-headless/Cargo.toml
+++ b/packages/blitz-headless/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "blitz-headless"
+description = "Headless document setup and rendering for Blitz"
+documentation = "https://docs.rs/blitz-headless"
+version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+# Blitz dependencies
+blitz-dom = { workspace = true, features = ["system-fonts"] }
+blitz-html = { workspace = true }
+blitz-paint = { workspace = true, features = ["default"] }
+blitz-traits = { workspace = true }
+
+# Rendering dependencies
+anyrender = { workspace = true }
+anyrender_vello_cpu = { workspace = true }
+peniko = { workspace = true }
+png = { workspace = true }

--- a/packages/blitz-headless/src/document.rs
+++ b/packages/blitz-headless/src/document.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+
+use blitz_dom::{DocGuard, DocGuardMut, Document, DocumentConfig};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::net::NetProvider;
+use blitz_traits::shell::{ColorScheme, Viewport};
+
+use crate::render::{Screenshot, screenshot_document, screenshot_document_with_size};
+
+/// Options controlling document construction for a [`HeadlessDocument`].
+pub struct HeadlessOptions {
+    /// Viewport width in physical pixels
+    pub width: u32,
+    /// Viewport height in physical pixels
+    pub height: u32,
+    pub scale: f32,
+    pub color_scheme: ColorScheme,
+    /// Base url which relative URLs are resolved against
+    pub base_url: Option<String>,
+    /// Net provider used to fetch sub-resources (stylesheets, images, fonts, etc)
+    pub net_provider: Option<Arc<dyn NetProvider>>,
+}
+
+impl Default for HeadlessOptions {
+    fn default() -> Self {
+        Self {
+            width: 800,
+            height: 600,
+            scale: 1.0,
+            color_scheme: ColorScheme::Light,
+            base_url: None,
+            net_provider: None,
+        }
+    }
+}
+
+impl HeadlessOptions {
+    /// Convert into a [`DocumentConfig`] (with HTML parsing enabled)
+    pub fn into_config(self) -> DocumentConfig {
+        DocumentConfig {
+            viewport: Some(Viewport::new(
+                self.width,
+                self.height,
+                self.scale,
+                self.color_scheme,
+            )),
+            base_url: self.base_url,
+            net_provider: self.net_provider,
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        }
+    }
+}
+
+/// A headless wrapper around a [`Document`] for resolving and rendering it
+/// without a window.
+pub struct HeadlessDocument<D: Document = HtmlDocument> {
+    doc: D,
+    net_provider: Option<Arc<dyn NetProvider>>,
+}
+
+impl HeadlessDocument<HtmlDocument> {
+    /// Parse `html` into a document with default options (800x600 viewport, scale 1, light mode)
+    pub fn from_html(html: &str) -> Self {
+        Self::from_html_with(html, HeadlessOptions::default())
+    }
+
+    pub fn from_html_with(html: &str, options: HeadlessOptions) -> Self {
+        let net_provider = options.net_provider.clone();
+        let doc = HtmlDocument::from_html(html, options.into_config());
+        Self { doc, net_provider }
+    }
+}
+
+impl<D: Document> HeadlessDocument<D> {
+    /// Wrap an already-constructed document, optionally with the [`NetProvider`] it
+    /// fetches sub-resources through (used by
+    /// [`resolve_until_network_idle`](Self::resolve_until_network_idle))
+    pub fn wrap(doc: D, net_provider: Option<Arc<dyn NetProvider>>) -> Self {
+        Self { doc, net_provider }
+    }
+
+    pub fn into_inner(self) -> D {
+        self.doc
+    }
+
+    pub fn doc(&self) -> &D {
+        &self.doc
+    }
+
+    pub fn doc_mut(&mut self) -> &mut D {
+        &mut self.doc
+    }
+
+    /// Read access to the underlying [`blitz_dom::BaseDocument`]
+    pub fn base(&self) -> DocGuard<'_> {
+        self.doc.inner()
+    }
+
+    /// Write access to the underlying [`blitz_dom::BaseDocument`]
+    pub fn base_mut(&mut self) -> DocGuardMut<'_> {
+        self.doc.inner_mut()
+    }
+
+    /// Poll pending async work and resolve style/layout at animation time `time` (in seconds)
+    pub fn resolve(&mut self, time: f64) {
+        self.doc.poll(None);
+        self.doc.inner_mut().resolve(time);
+    }
+
+    /// Repeatedly [`resolve`](Self::resolve) until the document's [`NetProvider`] reports
+    /// no pending requests, so that sub-resources (stylesheets, images, fonts) and any
+    /// resources they in turn trigger are loaded and reflected in style/layout.
+    pub fn resolve_until_network_idle(&mut self) {
+        loop {
+            self.resolve(0.0);
+            let pending = self
+                .net_provider
+                .as_ref()
+                .map(|net| net.pending_requests())
+                .unwrap_or(0);
+            if pending == 0 {
+                break;
+            }
+        }
+    }
+
+    /// The height of the document's root element in physical pixels (once laid out)
+    pub fn content_height(&self) -> f32 {
+        let doc = self.base();
+        let scale = doc.get_viewport().scale();
+        doc.root_element().final_layout().size.height * scale
+    }
+
+    /// Render the document to an RGBA screenshot at the viewport's physical size,
+    /// on a white background, using the CPU renderer.
+    ///
+    /// Styles and layout must already be resolved (e.g. via
+    /// [`resolve_until_network_idle`](Self::resolve_until_network_idle)).
+    pub fn screenshot(&mut self) -> Screenshot {
+        screenshot_document(&mut self.doc.inner_mut())
+    }
+
+    /// Render the document to an RGBA screenshot at the given physical size,
+    /// on a white background, using the CPU renderer.
+    ///
+    /// Styles and layout must already be resolved (e.g. via
+    /// [`resolve_until_network_idle`](Self::resolve_until_network_idle)).
+    pub fn screenshot_with_size(&mut self, width: u32, height: u32) -> Screenshot {
+        screenshot_document_with_size(&mut self.doc.inner_mut(), width, height)
+    }
+}

--- a/packages/blitz-headless/src/lib.rs
+++ b/packages/blitz-headless/src/lib.rs
@@ -1,0 +1,22 @@
+//! Headless document setup and rendering for Blitz.
+//!
+//! [`HeadlessDocument`] wraps any [`blitz_dom::Document`] (e.g.
+//! [`blitz_html::HtmlDocument`]) and provides:
+//!
+//! - Document construction with configurable viewport, scale, color scheme, base url,
+//!   and a pluggable [`NetProvider`](blitz_traits::net::NetProvider)
+//!   ([`HeadlessDocument::from_html`], [`HeadlessDocument::from_html_with`])
+//! - Style/layout resolution, including waiting for pending network requests to drain
+//!   ([`HeadlessDocument::resolve_until_network_idle`])
+//! - CPU rendering to RGBA buffers/PNGs ([`HeadlessDocument::screenshot`], [`Screenshot`])
+//!
+//! No window, GPU, or compositor is required.
+
+mod document;
+mod render;
+
+pub use document::{HeadlessDocument, HeadlessOptions};
+pub use render::{
+    Screenshot, ScreenshotDiff, compare_screenshots, screenshot_document,
+    screenshot_document_with_size,
+};

--- a/packages/blitz-headless/src/render.rs
+++ b/packages/blitz-headless/src/render.rs
@@ -1,0 +1,180 @@
+//! CPU rendering of documents to RGBA buffers/PNGs.
+
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+use anyrender::{PaintScene as _, render_to_buffer};
+use anyrender_vello_cpu::VelloCpuImageRenderer;
+use blitz_dom::BaseDocument;
+use blitz_dom::util::Color;
+use blitz_paint::paint_scene;
+use peniko::Fill;
+use peniko::kurbo::Rect;
+
+/// An RGBA8 image rendered from a document (or loaded from a PNG)
+#[derive(Clone, PartialEq, Eq)]
+pub struct Screenshot {
+    pub width: u32,
+    pub height: u32,
+    /// RGBA8 pixel data, row-major
+    pub data: Vec<u8>,
+}
+
+impl std::fmt::Debug for Screenshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Screenshot")
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Screenshot {
+    /// Get the RGBA value of the pixel at `(x, y)`
+    pub fn pixel(&self, x: u32, y: u32) -> [u8; 4] {
+        assert!(x < self.width && y < self.height, "pixel out of bounds");
+        let idx = ((y * self.width + x) * 4) as usize;
+        self.data[idx..idx + 4].try_into().unwrap()
+    }
+
+    /// Encode as PNG and write to `path`, creating parent directories as needed
+    pub fn save_png(&self, path: impl AsRef<Path>) {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let file = File::create(path)
+            .unwrap_or_else(|err| panic!("failed to create {}: {err}", path.display()));
+        self.write_png(file);
+    }
+
+    /// Encode as PNG to an arbitrary writer
+    pub fn write_png<W: Write>(&self, writer: W) {
+        let mut encoder = png::Encoder::new(writer, self.width, self.height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().unwrap();
+        writer.write_image_data(&self.data).unwrap();
+        writer.finish().unwrap();
+    }
+
+    /// Load a PNG file as a screenshot
+    pub fn load_png(path: impl AsRef<Path>) -> Result<Self, String> {
+        let path = path.as_ref();
+        let file = File::open(path).map_err(|err| format!("open {}: {err}", path.display()))?;
+        let decoder = png::Decoder::new(std::io::BufReader::new(file));
+        let mut reader = decoder
+            .read_info()
+            .map_err(|err| format!("decode {}: {err}", path.display()))?;
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
+        let info = reader
+            .next_frame(&mut buf)
+            .map_err(|err| format!("decode {}: {err}", path.display()))?;
+        if info.color_type != png::ColorType::Rgba || info.bit_depth != png::BitDepth::Eight {
+            return Err(format!(
+                "{}: expected 8-bit RGBA png, got {:?} {:?}",
+                path.display(),
+                info.color_type,
+                info.bit_depth
+            ));
+        }
+        buf.truncate(info.buffer_size());
+        Ok(Self {
+            width: info.width,
+            height: info.height,
+            data: buf,
+        })
+    }
+}
+
+/// The result of comparing two same-sized screenshots that differ
+pub struct ScreenshotDiff {
+    /// Number of pixels differing by more than the tolerance in some channel
+    pub differing_pixels: usize,
+    /// Copy of the "actual" image with differing pixels highlighted in red
+    pub diff_image: Screenshot,
+}
+
+/// Compare two screenshots pixel-by-pixel with a per-channel `tolerance` (0 for exact).
+///
+/// Returns `None` if the images match, and `Some(ScreenshotDiff)` (or an `Err` on
+/// dimension mismatch) otherwise.
+pub fn compare_screenshots(
+    actual: &Screenshot,
+    expected: &Screenshot,
+    tolerance: u8,
+) -> Result<Option<ScreenshotDiff>, String> {
+    if actual.width != expected.width || actual.height != expected.height {
+        return Err(format!(
+            "size mismatch: actual {}x{}, expected {}x{}",
+            actual.width, actual.height, expected.width, expected.height
+        ));
+    }
+
+    let mut differing_pixels = 0;
+    let mut diff_image = actual.clone();
+    for (i, (a, e)) in actual
+        .data
+        .chunks_exact(4)
+        .zip(expected.data.chunks_exact(4))
+        .enumerate()
+    {
+        let differs = a
+            .iter()
+            .zip(e.iter())
+            .any(|(a, e)| a.abs_diff(*e) > tolerance);
+        if differs {
+            differing_pixels += 1;
+            diff_image.data[i * 4..i * 4 + 4].copy_from_slice(&[255, 0, 0, 255]);
+        }
+    }
+
+    if differing_pixels == 0 {
+        return Ok(None);
+    }
+    Ok(Some(ScreenshotDiff {
+        differing_pixels,
+        diff_image,
+    }))
+}
+
+/// Render `doc` to an RGBA [`Screenshot`] at the viewport's physical size, on a white
+/// background, using the CPU renderer.
+///
+/// Styles and layout must already be resolved.
+pub fn screenshot_document(doc: &mut BaseDocument) -> Screenshot {
+    let (width, height) = doc.get_viewport().window_size;
+    screenshot_document_with_size(doc, width, height)
+}
+
+/// Render `doc` to an RGBA [`Screenshot`] at the given physical size, on a white
+/// background, using the CPU renderer.
+///
+/// Styles and layout must already be resolved.
+pub fn screenshot_document_with_size(
+    doc: &mut BaseDocument,
+    width: u32,
+    height: u32,
+) -> Screenshot {
+    let scale = doc.get_viewport().scale_f64();
+    let data = render_to_buffer::<VelloCpuImageRenderer, _>(
+        |scene| {
+            scene.fill(
+                Fill::NonZero,
+                Default::default(),
+                Color::WHITE,
+                Default::default(),
+                &Rect::new(0.0, 0.0, width as f64, height as f64),
+            );
+            paint_scene(scene, doc, scale, width, height, 0, 0);
+        },
+        width,
+        height,
+    );
+    Screenshot {
+        width,
+        height,
+        data,
+    }
+}

--- a/packages/blitz-net/src/lib.rs
+++ b/packages/blitz-net/src/lib.rs
@@ -256,6 +256,10 @@ impl Provider {
 }
 
 impl NetProvider for Provider {
+    fn pending_requests(&self) -> usize {
+        self.count()
+    }
+
     fn fetch(&self, doc_id: usize, mut request: Request, handler: Box<dyn NetHandler>) {
         let client = self.client.clone();
         let per_host_limits = self.per_host_limits.clone();

--- a/packages/blitz-test-harness/Cargo.toml
+++ b/packages/blitz-test-harness/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 [dependencies]
 # Blitz dependencies
 blitz-dom = { workspace = true, features = ["accessibility", "system-fonts"] }
+blitz-headless = { workspace = true }
 blitz-html = { workspace = true }
 blitz-paint = { workspace = true, features = ["default"] }
 blitz-traits = { workspace = true }
@@ -23,9 +24,7 @@ dioxus-core = { workspace = true }
 
 # Rendering dependencies
 anyrender = { workspace = true }
-anyrender_vello_cpu = { workspace = true }
 peniko = { workspace = true }
-png = { workspace = true }
 
 # Other dependencies
 data-url = { workspace = true }

--- a/packages/blitz-test-harness/src/harness.rs
+++ b/packages/blitz-test-harness/src/harness.rs
@@ -1,54 +1,12 @@
-use std::sync::Arc;
-
-use blitz_dom::{DocGuard, DocGuardMut, Document, DocumentConfig};
-use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_dom::{DocGuard, DocGuardMut, Document};
+use blitz_html::HtmlDocument;
 use blitz_traits::events::UiEvent;
-use blitz_traits::net::NetProvider;
-use blitz_traits::shell::{ColorScheme, Viewport};
+use blitz_traits::shell::Viewport;
 use dioxus_core::{Element, VirtualDom};
 use dioxus_native_dom::DioxusDocument;
 
 /// Options controlling document construction for a [`Harness`].
-pub struct HarnessOptions {
-    pub width: u32,
-    pub height: u32,
-    pub scale: f32,
-    pub color_scheme: ColorScheme,
-    /// Base url which relative URLs are resolved against
-    pub base_url: Option<String>,
-    /// Net provider used to fetch sub-resources (stylesheets, images, fonts, etc)
-    pub net_provider: Option<Arc<dyn NetProvider>>,
-}
-
-impl Default for HarnessOptions {
-    fn default() -> Self {
-        Self {
-            width: 800,
-            height: 600,
-            scale: 1.0,
-            color_scheme: ColorScheme::Light,
-            base_url: None,
-            net_provider: None,
-        }
-    }
-}
-
-impl HarnessOptions {
-    fn into_config(self) -> DocumentConfig {
-        DocumentConfig {
-            viewport: Some(Viewport::new(
-                self.width,
-                self.height,
-                self.scale,
-                self.color_scheme,
-            )),
-            base_url: self.base_url,
-            net_provider: self.net_provider,
-            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
-            ..Default::default()
-        }
-    }
-}
+pub use blitz_headless::HeadlessOptions as HarnessOptions;
 
 /// A DOM event captured by [`Harness::dispatch_traced`]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/blitz-test-harness/src/lib.rs
+++ b/packages/blitz-test-harness/src/lib.rs
@@ -33,5 +33,8 @@ pub use net::{
     load_fixture_bytes,
 };
 pub use paint::paint_command_string;
-pub use render::{Screenshot, ScreenshotDiff, artifacts_dir, compare_screenshots};
+pub use render::artifacts_dir;
+
+// Re-exported from `blitz-headless` for backwards compatibility
+pub use blitz_headless::{Screenshot, ScreenshotDiff, compare_screenshots};
 pub use scenario::{Scenario, Step, run_scenario, run_scenario_file};

--- a/packages/blitz-test-harness/src/net.rs
+++ b/packages/blitz-test-harness/src/net.rs
@@ -246,6 +246,13 @@ impl NetHandler for RecordingHandler {
 }
 
 impl NetProvider for RecordReplayProvider {
+    fn pending_requests(&self) -> usize {
+        self.inner
+            .as_ref()
+            .map(|inner| inner.pending_requests())
+            .unwrap_or(0)
+    }
+
     fn fetch(&self, doc_id: usize, request: Request, handler: Box<dyn NetHandler>) {
         let url = request.url.to_string();
 

--- a/packages/blitz-test-harness/src/render.rs
+++ b/packages/blitz-test-harness/src/render.rs
@@ -1,146 +1,13 @@
-//! CPU rendering of documents to RGBA buffers/PNGs, plus screenshot
-//! comparison and snapshot assertions with on-disk failure artifacts.
+//! Screenshot comparison and snapshot assertions with on-disk failure artifacts.
+//!
+//! CPU rendering itself (the [`Screenshot`] type) lives in [`blitz_headless`].
 
-use std::fs::File;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use anyrender::{PaintScene as _, render_to_buffer};
-use anyrender_vello_cpu::VelloCpuImageRenderer;
 use blitz_dom::Document;
-use blitz_dom::util::Color;
-use blitz_paint::paint_scene;
-use peniko::Fill;
-use peniko::kurbo::Rect;
+use blitz_headless::{Screenshot, compare_screenshots, screenshot_document};
 
 use crate::Harness;
-
-/// An RGBA8 image rendered from a document (or loaded from a PNG)
-#[derive(Clone, PartialEq, Eq)]
-pub struct Screenshot {
-    pub width: u32,
-    pub height: u32,
-    /// RGBA8 pixel data, row-major
-    pub data: Vec<u8>,
-}
-
-impl std::fmt::Debug for Screenshot {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Screenshot")
-            .field("width", &self.width)
-            .field("height", &self.height)
-            .finish_non_exhaustive()
-    }
-}
-
-impl Screenshot {
-    /// Get the RGBA value of the pixel at `(x, y)`
-    pub fn pixel(&self, x: u32, y: u32) -> [u8; 4] {
-        assert!(x < self.width && y < self.height, "pixel out of bounds");
-        let idx = ((y * self.width + x) * 4) as usize;
-        self.data[idx..idx + 4].try_into().unwrap()
-    }
-
-    /// Encode as PNG and write to `path`, creating parent directories as needed
-    pub fn save_png(&self, path: impl AsRef<Path>) {
-        let path = path.as_ref();
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).unwrap();
-        }
-        let file = File::create(path)
-            .unwrap_or_else(|err| panic!("failed to create {}: {err}", path.display()));
-        self.write_png(file);
-    }
-
-    /// Encode as PNG to an arbitrary writer
-    pub fn write_png<W: Write>(&self, writer: W) {
-        let mut encoder = png::Encoder::new(writer, self.width, self.height);
-        encoder.set_color(png::ColorType::Rgba);
-        encoder.set_depth(png::BitDepth::Eight);
-        let mut writer = encoder.write_header().unwrap();
-        writer.write_image_data(&self.data).unwrap();
-        writer.finish().unwrap();
-    }
-
-    /// Load a PNG file as a screenshot
-    pub fn load_png(path: impl AsRef<Path>) -> Result<Self, String> {
-        let path = path.as_ref();
-        let file = File::open(path).map_err(|err| format!("open {}: {err}", path.display()))?;
-        let decoder = png::Decoder::new(std::io::BufReader::new(file));
-        let mut reader = decoder
-            .read_info()
-            .map_err(|err| format!("decode {}: {err}", path.display()))?;
-        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
-        let info = reader
-            .next_frame(&mut buf)
-            .map_err(|err| format!("decode {}: {err}", path.display()))?;
-        if info.color_type != png::ColorType::Rgba || info.bit_depth != png::BitDepth::Eight {
-            return Err(format!(
-                "{}: expected 8-bit RGBA png, got {:?} {:?}",
-                path.display(),
-                info.color_type,
-                info.bit_depth
-            ));
-        }
-        buf.truncate(info.buffer_size());
-        Ok(Self {
-            width: info.width,
-            height: info.height,
-            data: buf,
-        })
-    }
-}
-
-/// The result of comparing two same-sized screenshots that differ
-pub struct ScreenshotDiff {
-    /// Number of pixels differing by more than the tolerance in some channel
-    pub differing_pixels: usize,
-    /// Copy of the "actual" image with differing pixels highlighted in red
-    pub diff_image: Screenshot,
-}
-
-/// Compare two screenshots pixel-by-pixel with a per-channel `tolerance` (0 for exact).
-///
-/// Returns `None` if the images match, and `Some(ScreenshotDiff)` (or an `Err` on
-/// dimension mismatch) otherwise.
-pub fn compare_screenshots(
-    actual: &Screenshot,
-    expected: &Screenshot,
-    tolerance: u8,
-) -> Result<Option<ScreenshotDiff>, String> {
-    if actual.width != expected.width || actual.height != expected.height {
-        return Err(format!(
-            "size mismatch: actual {}x{}, expected {}x{}",
-            actual.width, actual.height, expected.width, expected.height
-        ));
-    }
-
-    let mut differing_pixels = 0;
-    let mut diff_image = actual.clone();
-    for (i, (a, e)) in actual
-        .data
-        .chunks_exact(4)
-        .zip(expected.data.chunks_exact(4))
-        .enumerate()
-    {
-        let differs = a
-            .iter()
-            .zip(e.iter())
-            .any(|(a, e)| a.abs_diff(*e) > tolerance);
-        if differs {
-            differing_pixels += 1;
-            diff_image.data[i * 4..i * 4 + 4].copy_from_slice(&[255, 0, 0, 255]);
-        }
-    }
-
-    if differing_pixels == 0 {
-        return Ok(None);
-    }
-    Ok(Some(ScreenshotDiff {
-        differing_pixels,
-        diff_image,
-    }))
-}
 
 /// Directory failure artifacts (actual/diff PNGs and DOM dumps) are written to.
 ///
@@ -162,28 +29,7 @@ impl<D: Document> Harness<D> {
     /// The image is rendered at the viewport's physical size on a white background.
     pub fn screenshot(&mut self) -> Screenshot {
         self.pump();
-        let mut doc = self.doc.inner_mut();
-        let (width, height) = doc.get_viewport().window_size;
-        let scale = doc.get_viewport().scale_f64();
-        let data = render_to_buffer::<VelloCpuImageRenderer, _>(
-            |scene| {
-                scene.fill(
-                    Fill::NonZero,
-                    Default::default(),
-                    Color::WHITE,
-                    Default::default(),
-                    &Rect::new(0.0, 0.0, width as f64, height as f64),
-                );
-                paint_scene(scene, &mut doc, scale, width, height, 0, 0);
-            },
-            width,
-            height,
-        );
-        Screenshot {
-            width,
-            height,
-            data,
-        }
+        screenshot_document(&mut self.doc.inner_mut())
     }
 
     /// Render the document and save it as a PNG at `path`

--- a/packages/blitz-traits/src/net.rs
+++ b/packages/blitz-traits/src/net.rs
@@ -18,6 +18,14 @@ pub use url::Url;
 /// This may be over the network via http(s), via the filesystem, or some other method.
 pub trait NetProvider: Send + Sync + 'static {
     fn fetch(&self, doc_id: usize, request: Request, handler: Box<dyn NetHandler>);
+
+    /// The number of in-flight requests. Consumers may poll this to wait for
+    /// "network idle" before rendering. Providers which complete all requests
+    /// synchronously during [`fetch`](Self::fetch) can rely on the default
+    /// implementation, which returns `0`.
+    fn pending_requests(&self) -> usize {
+        0
+    }
 }
 
 /// A type that parses raw bytes from a network request into a Data and then calls


### PR DESCRIPTION
## Summary

Extracts the production-grade headless pipeline out of `blitz-test-harness` (which is `publish = false`) into a new *published* `packages/blitz-headless` crate, so production consumers (e.g. `examples/screenshot.rs`, external projects like hyper-render) can do "HTML in → PNG out" without depending on the test harness or dioxus.

`blitz-headless` contains:
- `HeadlessOptions` (viewport/scale/color-scheme/base-url/pluggable `NetProvider`) — moved from `HarnessOptions`, with `into_config()` now public
- `HeadlessDocument<D: Document = HtmlDocument>`: `from_html[_with]`, `resolve(time)`, `resolve_until_network_idle()`, `content_height()`, `screenshot[_with_size]()`
- `Screenshot`/`ScreenshotDiff`/`compare_screenshots` plus free fns `screenshot_document[_with_size]` — moved from the harness's `render.rs`

"Resolve until network idle" (the `loop { resolve; if pending == 0 break }` pattern from `examples/screenshot.rs`) is enabled by a new defaulted trait method:

```rust
// blitz-traits
pub trait NetProvider {
    fn fetch(...);
    fn pending_requests(&self) -> usize { 0 } // new; default fine for synchronous providers
}
// blitz-net: impl returns self.count(); harness RecordReplayProvider delegates to inner
```

No live-networking deps in `blitz-headless` — the net provider stays caller-supplied.

Consumers refactored on top:
- `blitz-test-harness` now depends on `blitz-headless` and keeps only the test-flavored layer (input synthesis, inspection, snapshot assertions/blessing, scenarios, test net providers, dioxus support). Public API is backward compatible: `pub use HeadlessOptions as HarnessOptions` and re-exported `Screenshot`/`ScreenshotDiff`/`compare_screenshots`; `tests/blitz-tests`, `apps/blitz-drive`, and the WPT runner compile unchanged.
- `examples/screenshot.rs` shrinks to fetch HTML + `HeadlessDocument::from_html_with` + `resolve_until_network_idle` + `screenshot_with_size` (same auto-height-from-content-layout behavior, clamped to [viewport, 4000px]).

Based on the harness stack; targets `devin/1785530895-harness-phase5`.

## Validation

- `cargo fmt --all`, `cargo clippy --workspace`, `cargo check --workspace` clean
- `cargo test -p blitz-tests` all green
- `cargo run --example screenshot -- file:///tmp/test.html` and `-- https://example.com` work
- WPT smoke: `css/css-flexbox/flexbox_align-items-center.html` PASS

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/bd9fbfcc69914870bef9b62f171d0f1d
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30669108091).</sub>
<!-- wpt-results-end -->
