### PR TITLE
Draw position-inside list markers in the bullet font

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -29,7 +29,11 @@ use crate::{
     traversal::{iter_children, iter_children_and_pseudos},
 };
 
-use super::{damage::ALL_DAMAGE, list::collect_list_item_children, table::build_table_context};
+use super::{
+    damage::ALL_DAMAGE,
+    list::{BULLET_FONT_FAMILY, collect_list_item_children},
+    table::build_table_context,
+};
 
 const DUMMY_NAME: QualName = qual_name!("div", html);
 
@@ -971,7 +975,17 @@ pub(crate) fn build_inline_layout_into(
         .and_then(|el| el.list_item_data.as_deref())
     {
         match marker {
-            Marker::Char(char) => builder.push_text(&format!("{char} ")),
+            // Bullet glyphs live in the bundled bullet font. The position-outside
+            // path already asks for it; without the same span here a marker like
+            // disclosure-closed (U+25B8) falls back to the element's own font and
+            // renders as a missing glyph.
+            Marker::Char(char) => {
+                let mut marker_style = parley_style.clone();
+                marker_style.font_family = BULLET_FONT_FAMILY.into();
+                builder.push_style_span(marker_style);
+                builder.push_text(&format!("{char} "));
+                builder.pop_style_span();
+            }
             Marker::String(str) => builder.push_text(str),
         }
     };

--- a/packages/blitz-dom/src/layout/list.rs
+++ b/packages/blitz-dom/src/layout/list.rs
@@ -12,6 +12,8 @@ use crate::{
     stylo_to_parley,
 };
 
+pub(super) const BULLET_FONT_FAMILY: &str = "Bullet, monospace, sans-serif";
+
 pub(super) fn collect_list_item_children(
     doc: &mut BaseDocument,
     index: &mut usize,
@@ -158,7 +160,7 @@ fn marker_for_style(list_style_type: ListStyleType, index: usize) -> Option<Mark
 // Override the font to our specific bullet font when rendering bullets
 fn font_for_bullet_style(list_style_type: ListStyleType) -> Option<FontFamily<'static>> {
     if list_style_type.0.is_bullet() {
-        return Some("Bullet, monospace, sans-serif".into());
+        return Some(BULLET_FONT_FAMILY.into());
     }
 
     None


### PR DESCRIPTION
`font_for_bullet_style` gives position-**outside** markers the bundled bullet font. The position-**inside** path in `build_inline_layout_into` pushes the marker straight into the inline builder using the element's own style, so it never asks for that font.

Bullet glyphs are not in a typical text font, so an inside marker falls through to system fallback — and can land on nothing.

## Where it shows

`details > summary`. The UA sheet styles it `list-style: disclosure-closed inside`, so every disclosure triangle takes the inside path. On a machine whose fallback chain has no font covering U+25B8, the triangle renders as a missing-glyph box instead — reproducible on macOS 15 with any page containing a plain `<details>`.

The glyph is not missing from the machine — naming Menlo, Arial Unicode MS or STIXGeneral explicitly renders `▸ ▾ ✓` fine. Fallback simply does not reach them, which is a separate question; the marker should not be depending on fallback in the first place when the bullet font is bundled for exactly this.

## The change

Push a style span requesting the same family the outside path asks for, around the char marker only. `Marker::String` markers — `decimal`, `lower-alpha` and friends — are ordinary text and keep the element's font, which is what you want.

The family string moves into one `BULLET_FONT_FAMILY` constant so the two paths cannot drift apart again.

## Checking it

Built against the published `blitz-dom` `0.3.0-beta.1` with this patch applied and rendered a page with `<details>` through [Kiln](https://github.com/marshallshelly/kiln): the missing-glyph box becomes a triangle. `cargo fmt --all --check` and `cargo clippy -p blitz-dom --all-features` are clean.

I have not added a test. Marker rendering lands in a Parley layout rather than the DOM tree, so asserting it means asserting on shaped glyph runs, and I could not see an existing seam for that — happy to add one if you can point me at the right place.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30767394396).</sub>
<!-- wpt-results-end -->
