### PR TITLE
Clip scrollable_overflow to border box for overflow:hidden/clip

### DIFF
--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -181,6 +181,18 @@ impl BaseDocument {
             overflow = overflow.union(child_rect_in_self);
         }
 
+        if let Some(style) = self.nodes[node_id].primary_styles() {
+            use style::values::computed::Overflow;
+            if matches!(style.clone_overflow_x(), Overflow::Hidden | Overflow::Clip) {
+                overflow.x0 = overflow.x0.max(0.0);
+                overflow.x1 = overflow.x1.min(w);
+            }
+            if matches!(style.clone_overflow_y(), Overflow::Hidden | Overflow::Clip) {
+                overflow.y0 = overflow.y0.max(0.0);
+                overflow.y1 = overflow.y1.min(h);
+            }
+        }
+
         *self.nodes[node_id].scrollable_overflow_mut() = overflow;
         *self.nodes[node_id].layout_children.get_mut() = layout_children;
 


### PR DESCRIPTION
When an element has overflow:hidden or overflow:clip on an axis, its scrollable_overflow now gets clipped to the border box on that axis. This prevents hit testing from matching children that are visually clipped, which caused incorrect cursor and hover state when a child with a transform escaped its parent's overflow:hidden clipping.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30903210500).</sub>
<!-- wpt-results-end -->
