### PR TITLE
Fix replaced flex item measurement sizing

### DIFF
--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -225,7 +225,8 @@ impl BaseDocument {
                         inputs.available_space,
                         &replaced_context,
                         node.style(),
-                        false,
+                        inputs.sizing_mode,
+                        inputs.axis,
                     );
 
                     return taffy::LayoutOutput {

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -1,6 +1,7 @@
 use style::Atom;
 use taffy::{
-    AvailableSpace, BoxSizing, CoreStyle as _, MaybeMath, MaybeResolve, ResolveOrZero as _, Size,
+    AvailableSpace, BoxSizing, CoreStyle as _, MaybeMath, MaybeResolve, RequestedAxis,
+    ResolveOrZero as _, Size, SizingMode,
 };
 
 use crate::layout::resolve_calc_value;
@@ -29,7 +30,8 @@ pub fn replaced_measure_function(
     available_space: taffy::Size<AvailableSpace>,
     image_context: &ReplacedContext,
     style: &taffy::Style<Atom>,
-    _debug: bool,
+    sizing_mode: SizingMode,
+    requested_axis: RequestedAxis,
 ) -> taffy::Size<f32> {
     let inherent_size = image_context.inherent_size;
 
@@ -73,9 +75,8 @@ pub fn replaced_measure_function(
     let style_size = style
         .size
         .maybe_resolve(basis_for_max_and_preferred, resolve_calc_value)
-        .maybe_apply_aspect_ratio(Some(aspect_ratio))
         .maybe_sub(box_sizing_adjustment);
-    let min_size = style
+    let mut min_size = style
         .min_size
         .maybe_resolve(parent_size, resolve_calc_value)
         .maybe_sub(box_sizing_adjustment);
@@ -86,16 +87,51 @@ pub fn replaced_measure_function(
         .maybe_min(available_space.into_options())
         .maybe_max(min_size)
         .maybe_sub(box_sizing_adjustment);
+
+    // For ContentSize mode, ignore preferred/min size styles in the axis being measured: the
+    // parent layout algorithm applies them itself, and content-based measurement should return
+    // the content size (the intrinsic size for replaced elements). Constraints in the opposite
+    // axis are retained as they transfer through the aspect ratio (transferred size suggestion).
+    let mut style_size = style_size;
+    if sizing_mode == SizingMode::ContentSize {
+        match requested_axis {
+            RequestedAxis::Horizontal => {
+                style_size.width = None;
+                min_size.width = None;
+            }
+            RequestedAxis::Vertical => {
+                style_size.height = None;
+                min_size.height = None;
+            }
+            RequestedAxis::Both => {}
+        }
+    }
     let attr_size = image_context.attr_size;
 
-    let unclamped_size = 'size: {
-        if known_dimensions.width.is_some() | known_dimensions.height.is_some() {
-            let content_box_known_dimensions = known_dimensions.maybe_sub(pb_sum);
-            break 'size content_box_known_dimensions
-                .maybe_apply_aspect_ratio(Some(aspect_ratio))
-                .map(|s| s.unwrap());
-        }
+    // Known dimensions are output directly: they have already been sized by the parent
+    // layout algorithm (including min/max clamping), so no further clamping should occur.
+    if known_dimensions.width.is_some() | known_dimensions.height.is_some() {
+        let content_box_known_dimensions = known_dimensions.maybe_sub(pb_sum);
+        let size = content_box_known_dimensions
+            .maybe_apply_aspect_ratio(Some(aspect_ratio))
+            .map(|s| s.unwrap());
 
+        let clamped_size = Size {
+            width: if known_dimensions.width.is_some() {
+                size.width
+            } else {
+                size.width.maybe_clamp(min_size.width, max_size.width)
+            },
+            height: if known_dimensions.height.is_some() {
+                size.height
+            } else {
+                size.height.maybe_clamp(min_size.height, max_size.height)
+            },
+        };
+        return clamped_size.map(|s| s.max(0.0)) + pb_sum;
+    }
+
+    let unclamped_size = 'size: {
         if style_size.width.is_some() | style_size.height.is_some() {
             break 'size style_size
                 .maybe_apply_aspect_ratio(Some(aspect_ratio))

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -120,32 +120,15 @@ pub fn replaced_measure_function(
             .maybe_max(min_size);
 
         let content_box_known_dimensions = known_dimensions.maybe_sub(pb_sum);
-        let clamped_known_dimensions = Size {
-            width: content_box_known_dimensions
-                .width
-                .maybe_clamp(min_size.width, style_max_size.width),
-            height: content_box_known_dimensions
-                .height
-                .maybe_clamp(min_size.height, style_max_size.height),
-        };
-        let transferred = clamped_known_dimensions
+        let transferred = content_box_known_dimensions
+            .maybe_clamp(min_size, style_max_size)
             .maybe_apply_aspect_ratio(Some(aspect_ratio))
             .map(|s| s.unwrap());
 
         // Known axes are authoritative (already resolved by the parent); only the axis
         // derived via aspect-ratio transfer is clamped by this element's min/max sizes.
-        let size = Size {
-            width: content_box_known_dimensions.width.unwrap_or_else(|| {
-                transferred
-                    .width
-                    .maybe_clamp(min_size.width, style_max_size.width)
-            }),
-            height: content_box_known_dimensions.height.unwrap_or_else(|| {
-                transferred
-                    .height
-                    .maybe_clamp(min_size.height, style_max_size.height)
-            }),
-        };
+        let size = content_box_known_dimensions
+            .unwrap_or(transferred.maybe_clamp(min_size, style_max_size));
 
         return size.map(|s| s.max(0.0)) + pb_sum;
     }

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -108,27 +108,23 @@ pub fn replaced_measure_function(
     }
     let attr_size = image_context.attr_size;
 
-    // Known dimensions are output directly: they have already been sized by the parent
-    // layout algorithm (including min/max clamping), so no further clamping should occur.
+    // Known dimensions are the parent's current sizing inputs. Clamp them before transferring
+    // an aspect ratio so provisional cross-axis sizes do not bypass replaced-element limits.
     if known_dimensions.width.is_some() | known_dimensions.height.is_some() {
         let content_box_known_dimensions = known_dimensions.maybe_sub(pb_sum);
-        let size = content_box_known_dimensions
+        let clamped_known_dimensions = Size {
+            width: content_box_known_dimensions
+                .width
+                .maybe_clamp(min_size.width, max_size.width),
+            height: content_box_known_dimensions
+                .height
+                .maybe_clamp(min_size.height, max_size.height),
+        };
+        let size = clamped_known_dimensions
             .maybe_apply_aspect_ratio(Some(aspect_ratio))
             .map(|s| s.unwrap());
 
-        let clamped_size = Size {
-            width: if known_dimensions.width.is_some() {
-                size.width
-            } else {
-                size.width.maybe_clamp(min_size.width, max_size.width)
-            },
-            height: if known_dimensions.height.is_some() {
-                size.height
-            } else {
-                size.height.maybe_clamp(min_size.height, max_size.height)
-            },
-        };
-        return clamped_size.map(|s| s.max(0.0)) + pb_sum;
+        return size.map(|s| s.max(0.0)) + pb_sum;
     }
 
     let unclamped_size = 'size: {

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -111,18 +111,41 @@ pub fn replaced_measure_function(
     // Known dimensions are the parent's current sizing inputs. Clamp them before transferring
     // an aspect ratio so provisional cross-axis sizes do not bypass replaced-element limits.
     if known_dimensions.width.is_some() | known_dimensions.height.is_some() {
+        // Style max sizes without the available-space fallback: available space must not
+        // constrain the aspect-ratio transfer of parent-resolved dimensions.
+        let style_max_size = style
+            .max_size
+            .maybe_resolve(basis_for_max_and_preferred, resolve_calc_value)
+            .maybe_sub(box_sizing_adjustment)
+            .maybe_max(min_size);
+
         let content_box_known_dimensions = known_dimensions.maybe_sub(pb_sum);
         let clamped_known_dimensions = Size {
             width: content_box_known_dimensions
                 .width
-                .maybe_clamp(min_size.width, max_size.width),
+                .maybe_clamp(min_size.width, style_max_size.width),
             height: content_box_known_dimensions
                 .height
-                .maybe_clamp(min_size.height, max_size.height),
+                .maybe_clamp(min_size.height, style_max_size.height),
         };
-        let size = clamped_known_dimensions
+        let transferred = clamped_known_dimensions
             .maybe_apply_aspect_ratio(Some(aspect_ratio))
             .map(|s| s.unwrap());
+
+        // Known axes are authoritative (already resolved by the parent); only the axis
+        // derived via aspect-ratio transfer is clamped by this element's min/max sizes.
+        let size = Size {
+            width: content_box_known_dimensions.width.unwrap_or_else(|| {
+                transferred
+                    .width
+                    .maybe_clamp(min_size.width, style_max_size.width)
+            }),
+            height: content_box_known_dimensions.height.unwrap_or_else(|| {
+                transferred
+                    .height
+                    .maybe_clamp(min_size.height, style_max_size.height)
+            }),
+        };
 
         return size.map(|s| s.max(0.0)) + pb_sum;
     }


### PR DESCRIPTION
## Summary

Fix replaced-element measurement so flex layout can pass through dimensions it has already resolved instead of reapplying the image's natural/style constraints.

`replaced_measure_function` now receives `SizingMode` and `RequestedAxis` from the layout input. During `ContentSize` measurement, constraints in the requested axis are left to the parent flex algorithm while opposite-axis constraints remain available for aspect-ratio transfer. When known dimensions are supplied by the parent, those dimensions are preserved; only an unspecified aspect-ratio-derived axis is clamped.

This prevents flexed or stretched replaced items from collapsing back to their intrinsic size and fixes the automatic-minimum/aspect-ratio sizing path without changing the WPT runner or intrinsic asset handling.

Link to Devin session: https://app.devin.ai/sessions/0f8547b7fbb949e28e9acdbedb1ca8d2
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**43** newly passing, **1** newly failing (net +42).

<details>
<summary>Full diff (44 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-003.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-010.xht
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-001.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-002.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-003.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-011.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-012.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-017.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-001.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-002.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-003.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-007.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-013.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-017.html
+ Fail => Pass css/css-flexbox/flex-minimum-height-flex-items-004.xht
+ Fail => Pass css/css-flexbox/flex-minimum-height-flex-items-005.xht
+ Fail => Pass css/css-flexbox/flex-minimum-height-flex-items-006.xht
+ Fail => Pass css/css-flexbox/flex-minimum-height-flex-items-007.xht
+ Fail => Pass css/css-flexbox/flex-minimum-height-flex-items-008.xht
+ Fail => Pass css/css-flexbox/flex-minimum-height-flex-items-020.html
+ Fail => Pass css/css-flexbox/flex-minimum-height-flex-items-021.html
+ Fail => Pass css/css-flexbox/flex-minimum-height-flex-items-022.html
+ Fail => Pass css/css-flexbox/flex-minimum-height-flex-items-023.html
+ Fail => Pass css/css-flexbox/flex-minimum-size-003.html
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-004.xht
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-005.xht
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-006.xht
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-007.xht
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-008.xht
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-009.html
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-010.html
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-011.html
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-012.html
+ Fail => Pass css/css-flexbox/flex-minimum-width-flex-items-013.html
+ Fail => Pass css/css-flexbox/flex-svg-no-intrinsic-column-001.html
+ Fail => Pass css/css-flexbox/flexbox-min-height-auto-002a.html
+ Fail => Pass css/css-flexbox/flexbox-min-height-auto-002b.html
+ Fail => Pass css/css-flexbox/flexbox-min-height-auto-002c.html
+ Fail => Pass css/css-flexbox/flexbox-min-width-auto-002a.html
+ Fail => Pass css/css-flexbox/flexbox-min-width-auto-002b.html
+ Fail => Pass css/css-flexbox/flexbox-min-width-auto-002c.html
+ Fail => Pass css/css-flexbox/image-items-flake-001.html
- Pass => Fail css/css-flexbox/svg-root-as-flex-item-002.html
+ Fail => Pass css/css-position/position-absolute-replaced-intrinsic-size.tentative.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30922120808).</sub>
<!-- wpt-results-end -->
