### PR TITLE
Generalise replaced element intrinsic sizing (canvas, video, embed, iframe)

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -32,6 +32,7 @@ use crate::{
 use super::{
     damage::ALL_DAMAGE,
     list::{BULLET_FONT_FAMILY, collect_list_item_children},
+    replaced::is_replaced_element,
     table::build_table_context,
 };
 
@@ -892,9 +893,7 @@ pub(crate) fn find_inline_layout_embedded_boxes(
                     (DisplayOutside::Inline, DisplayInside::Flow) => {
                         let tag_name = &element_data.name.local;
 
-                        if *tag_name == local_name!("img")
-                            || *tag_name == local_name!("svg")
-                            || *tag_name == local_name!("canvas")
+                        if is_replaced_element(tag_name)
                             || *tag_name == local_name!("input")
                             || *tag_name == local_name!("textarea")
                             || *tag_name == local_name!("button")
@@ -1099,9 +1098,7 @@ pub(crate) fn build_inline_layout_into(
                     (DisplayOutside::Inline, DisplayInside::Flow) => {
                         let tag_name = &element_data.name.local;
 
-                        if *tag_name == local_name!("img")
-                            || *tag_name == local_name!("svg")
-                            || *tag_name == local_name!("canvas")
+                        if is_replaced_element(tag_name)
                             || *tag_name == local_name!("input")
                             || *tag_name == local_name!("textarea")
                             || *tag_name == local_name!("button")

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -894,6 +894,7 @@ pub(crate) fn find_inline_layout_embedded_boxes(
 
                         if *tag_name == local_name!("img")
                             || *tag_name == local_name!("svg")
+                            || *tag_name == local_name!("canvas")
                             || *tag_name == local_name!("input")
                             || *tag_name == local_name!("textarea")
                             || *tag_name == local_name!("button")
@@ -1100,6 +1101,7 @@ pub(crate) fn build_inline_layout_into(
 
                         if *tag_name == local_name!("img")
                             || *tag_name == local_name!("svg")
+                            || *tag_name == local_name!("canvas")
                             || *tag_name == local_name!("input")
                             || *tag_name == local_name!("textarea")
                             || *tag_name == local_name!("button")

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -26,7 +26,7 @@ pub(crate) mod list;
 pub(crate) mod replaced;
 pub(crate) mod table;
 
-use self::replaced::{ReplacedContext, replaced_measure_function};
+use self::replaced::{ReplacedContext, is_replaced_element, replaced_measure_function};
 use self::table::TableTreeWrapper;
 
 pub(crate) fn resolve_calc_value(calc_ptr: *const (), parent_size: f32) -> f32 {
@@ -175,10 +175,7 @@ impl BaseDocument {
                     }
                 }
 
-                if *element_data.name.local == *"img"
-                    || *element_data.name.local == *"canvas"
-                    || (cfg!(feature = "svg") && *element_data.name.local == *"svg")
-                {
+                if is_replaced_element(&element_data.name.local) {
                     // Get width and height attributes on image element
                     //
                     // TODO: smarter sizing using these (depending on object-fit, they shouldn't
@@ -192,42 +189,52 @@ impl BaseDocument {
                             .and_then(|val| val.parse::<f32>().ok()),
                     };
 
-                    // Get image's native sizespecial_data
-                    let inherent_size = match &element_data.special_data {
+                    // Get the element's intrinsic size and aspect ratio
+                    let (inherent_size, inherent_ratio) = match &element_data.special_data {
                         SpecialElementData::Image(image_data) => match &**image_data {
-                            ImageData::Raster(image) => taffy::Size {
-                                width: image.width as f32,
-                                height: image.height as f32,
-                            },
+                            ImageData::Raster(image) => {
+                                let size = taffy::Size {
+                                    width: image.width as f32,
+                                    height: image.height as f32,
+                                };
+                                (size, Some(size.width / size.height))
+                            }
                             #[cfg(feature = "svg")]
                             ImageData::Svg(svg) => {
                                 let size = svg.tree.size();
-                                taffy::Size {
+                                let size = taffy::Size {
                                     width: size.width(),
                                     height: size.height(),
-                                }
+                                };
+                                (size, Some(size.width / size.height))
                             }
-                            ImageData::None => taffy::Size::ZERO,
+                            ImageData::None => (taffy::Size::ZERO, None),
                         },
-                        // A canvas's intrinsic size is given by its width/height attributes,
-                        // defaulting to 300x150
-                        SpecialElementData::Canvas(_) => taffy::Size {
-                            width: attr_size.width.unwrap_or(300.0),
-                            height: attr_size.height.unwrap_or(150.0),
-                        },
-                        SpecialElementData::None if *element_data.name.local == *"canvas" => {
-                            taffy::Size {
-                                width: attr_size.width.unwrap_or(300.0),
-                                height: attr_size.height.unwrap_or(150.0),
+                        // Canvas has an intrinsic size and aspect ratio given by its
+                        // width/height attributes, defaulting to 300x150. Other replaced
+                        // elements without intrinsic dimensions (video, iframe, embed) use
+                        // the 300x150 default object size but have no intrinsic ratio.
+                        SpecialElementData::Canvas(_) | SpecialElementData::None => {
+                            let tag_name = &element_data.name.local;
+                            if *tag_name == local_name!("img") || *tag_name == local_name!("svg") {
+                                (taffy::Size::ZERO, None)
+                            } else {
+                                let size = taffy::Size {
+                                    width: attr_size.width.unwrap_or(300.0),
+                                    height: attr_size.height.unwrap_or(150.0),
+                                };
+                                let ratio = (*tag_name == local_name!("canvas"))
+                                    .then(|| size.width / size.height);
+                                (size, ratio)
                             }
                         }
-                        SpecialElementData::None => taffy::Size::ZERO,
                         _ => unreachable!(),
                     };
 
                     let replaced_context = ReplacedContext {
                         inherent_size,
                         attr_size,
+                        inherent_ratio,
                     };
 
                     let computed = replaced_measure_function(

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -209,7 +209,18 @@ impl BaseDocument {
                             }
                             ImageData::None => taffy::Size::ZERO,
                         },
-                        SpecialElementData::Canvas(_) => taffy::Size::ZERO,
+                        // A canvas's intrinsic size is given by its width/height attributes,
+                        // defaulting to 300x150
+                        SpecialElementData::Canvas(_) => taffy::Size {
+                            width: attr_size.width.unwrap_or(300.0),
+                            height: attr_size.height.unwrap_or(150.0),
+                        },
+                        SpecialElementData::None if *element_data.name.local == *"canvas" => {
+                            taffy::Size {
+                                width: attr_size.width.unwrap_or(300.0),
+                                height: attr_size.height.unwrap_or(150.0),
+                            }
+                        }
                         SpecialElementData::None => taffy::Size::ZERO,
                         _ => unreachable!(),
                     };

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -1,3 +1,4 @@
+use markup5ever::{LocalName, local_name};
 use style::Atom;
 use taffy::{
     AvailableSpace, BoxSizing, CoreStyle as _, MaybeMath, MaybeResolve, RequestedAxis,
@@ -6,10 +7,26 @@ use taffy::{
 
 use crate::layout::resolve_calc_value;
 
+/// Whether an element is a replaced element laid out as a leaf box with an
+/// intrinsic size. Note: `<object>` is deliberately excluded as its fallback
+/// children should render when no resource is loaded.
+pub(crate) fn is_replaced_element(tag_name: &LocalName) -> bool {
+    *tag_name == local_name!("img")
+        || *tag_name == local_name!("svg")
+        || *tag_name == local_name!("canvas")
+        || *tag_name == local_name!("video")
+        || *tag_name == local_name!("embed")
+        || *tag_name == local_name!("iframe")
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ReplacedContext {
     pub inherent_size: taffy::Size<f32>,
     pub attr_size: taffy::Size<Option<f32>>,
+    /// The element's intrinsic aspect ratio, if it has one. Some replaced elements
+    /// (iframe, embed, video without loaded media) have a default object size but
+    /// no intrinsic aspect ratio.
+    pub inherent_ratio: Option<f32>,
 }
 
 /// Whether a height/width value is violating it's min- and max- constraints
@@ -52,10 +69,8 @@ pub fn replaced_measure_function(
         Size::ZERO
     };
 
-    // Use aspect_ratio from style, fall back to inherent aspect ratio
-    let s_aspect_ratio = style.aspect_ratio;
-    let aspect_ratio = s_aspect_ratio.unwrap_or_else(|| inherent_size.width / inherent_size.height);
-    let inv_aspect_ratio = 1.0 / aspect_ratio;
+    // Use aspect_ratio from style, fall back to inherent aspect ratio (if any)
+    let aspect_ratio: Option<f32> = style.aspect_ratio.or(image_context.inherent_ratio);
 
     // See https://www.w3.org/TR/css-sizing-3/#replaced-percentage-min-contribution
     let basis_for_max_and_preferred = Size {
@@ -122,11 +137,12 @@ pub fn replaced_measure_function(
         let content_box_known_dimensions = known_dimensions.maybe_sub(pb_sum);
         let transferred = content_box_known_dimensions
             .maybe_clamp(min_size, style_max_size)
-            .maybe_apply_aspect_ratio(Some(aspect_ratio))
-            .map(|s| s.unwrap());
+            .maybe_apply_aspect_ratio(aspect_ratio)
+            .unwrap_or(inherent_size);
 
         // Known axes are authoritative (already resolved by the parent); only the axis
-        // derived via aspect-ratio transfer is clamped by this element's min/max sizes.
+        // derived via aspect-ratio transfer (or falling back to the intrinsic size) is
+        // clamped by this element's min/max sizes.
         let size = content_box_known_dimensions
             .unwrap_or(transferred.maybe_clamp(min_size, style_max_size));
 
@@ -136,14 +152,14 @@ pub fn replaced_measure_function(
     let unclamped_size = 'size: {
         if style_size.width.is_some() | style_size.height.is_some() {
             break 'size style_size
-                .maybe_apply_aspect_ratio(Some(aspect_ratio))
-                .map(|s| s.unwrap());
+                .maybe_apply_aspect_ratio(aspect_ratio)
+                .unwrap_or(inherent_size);
         }
 
         if attr_size.width.is_some() | attr_size.height.is_some() {
             break 'size attr_size
-                .maybe_apply_aspect_ratio(Some(aspect_ratio))
-                .map(|s| s.unwrap());
+                .maybe_apply_aspect_ratio(aspect_ratio)
+                .unwrap_or(inherent_size);
         }
 
         inherent_size
@@ -168,6 +184,13 @@ pub fn replaced_measure_function(
     } else {
         Violation::None
     };
+
+    // Without an intrinsic aspect ratio, each axis is clamped independently
+    let Some(aspect_ratio) = aspect_ratio else {
+        let size = size.maybe_clamp(min_size, max_size);
+        return size + pb_sum;
+    };
+    let inv_aspect_ratio = 1.0 / aspect_ratio;
 
     // Clamp following rules in table at
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-widths


### PR DESCRIPTION
## Summary

Replaced elements other than `img`/`svg` were not treated as replaced at all: `<canvas>`, `<video>`, `<embed>`, and `<iframe>` were laid out as ordinary (empty, zero-sized) boxes both in flow and inline layout.

This PR generalises replaced-element handling:

- New `is_replaced_element(tag_name)` predicate (`img`, `svg`, `canvas`, `video`, `embed`, `iframe`) shared by the leaf-layout path in `layout/mod.rs` and the inline-box construction paths in `layout/construct.rs`. `<object>` is deliberately excluded since its fallback children should render when no resource is loaded.
- Intrinsic sizing per CSS: elements without intrinsic dimensions use their `width`/`height` attributes, falling back to the 300x150 default object size. `canvas` additionally has an intrinsic aspect ratio derived from those dimensions; `video`/`embed`/`iframe` (and unloaded images) have **no** intrinsic ratio.
- `ReplacedContext` gains `inherent_ratio: Option<f32>`, and `replaced_measure_function` now handles ratio-less replaced elements: no aspect-ratio transfer, min/max clamping applied to each axis independently instead of the CSS2 ratio-preserving min/max table.

```rust
// layout/mod.rs
let (inherent_size, inherent_ratio) = match &element_data.special_data { ... };
let replaced_context = ReplacedContext { inherent_size, attr_size, inherent_ratio };
```

WPT `css/css-flexbox` suite: +10 tests vs main (canvas, video, and iframe basic flexbox tests, aspect-ratio-intrinsic-size-001, flex-item-percentage-height-img-001, flexbox-flex-basis-content-003a/b, relayout-intrinsic-block-size, canvas-contain-size), no regressions (verified via wptreport.json PASS-set diff, including flexbox-iframe-intrinsic-size-001 which requires iframes to have no intrinsic ratio).

Link to Devin session: https://app.devin.ai/sessions/0f8547b7fbb949e28e9acdbedb1ca8d2
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**63** newly passing, **17** newly failing (net +46).

<details>
<summary>Full diff (80 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/floats-clear/float-replaced-height-004.xht
+ Fail => Pass css/CSS2/floats-clear/float-replaced-height-007.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-height-004.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-height-005.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-height-007.xht
- Pass => Fail css/CSS2/positioning/absolute-replaced-height-007.xht
- Pass => Fail css/CSS2/positioning/absolute-replaced-height-014.xht
- Pass => Fail css/css-contain/content-visibility/content-visibility-032.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-033.sub.https.html
+ Fail => Pass css/css-contain/content-visibility/content-visibility-canvas.html
+ Fail => Pass css/css-contain/content-visibility/content-visibility-video.html
+ Fail => Pass css/css-flexbox/aspect-ratio-intrinsic-size-001.html
+ Fail => Pass css/css-flexbox/canvas-contain-size.html
+ Fail => Pass css/css-flexbox/flex-item-percentage-height-img-001.html
+ Fail => Pass css/css-flexbox/flexbox-basic-canvas-horiz-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-canvas-horiz-001v.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-iframe-horiz-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-video-horiz-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-flex-basis-content-003a.html
+ Fail => Pass css/css-flexbox/flexbox-flex-basis-content-003b.html
+ Fail => Pass css/css-flexbox/relayout-intrinsic-block-size.html
- Pass => Fail css/css-grid/grid-item-percentage-quirk-001.html
+ Fail => Pass css/css-grid/grid-items/grid-item-inline-contribution-001.html
+ Fail => Pass css/css-grid/grid-items/grid-item-inline-contribution-002.html
+ Fail => Pass css/css-grid/grid-items/grid-item-inline-contribution-003.html
+ Fail => Pass css/css-grid/grid-items/grid-item-inline-contribution-004.html
+ Fail => Pass css/css-grid/grid-items/grid-item-inline-contribution-005.html
+ Fail => Pass css/css-grid/grid-items/replaced-element-011.html
+ Fail => Pass css/css-grid/grid-items/replaced-element-012.html
+ Fail => Pass css/css-grid/grid-items/replaced-element-013.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-float-intrinsic-width-percent-height-aspect-ratio-001.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-inline-grid-intrinsic-width-percent-height-aspect-ratio-001.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-track-ignores-max-size-002.html
- Pass => Fail css/css-highlight-api/painting/custom-highlight-dynamic-container-metrics-001.html
- Pass => Fail css/css-highlight-api/painting/custom-highlight-dynamic-viewport-metrics-001.html
- Pass => Fail css/css-highlight-api/painting/custom-highlight-dynamic-viewport-metrics-first-line-001.html
+ Fail => Pass css/css-images/object-view-box-fit-contain-canvas.html
+ Fail => Pass css/css-images/object-view-box-fit-contain-video.html
+ Fail => Pass css/css-images/object-view-box-fit-none-canvas.html
+ Fail => Pass css/css-images/object-view-box-fit-none-video.html
- Pass => Fail css/css-images/object-view-box-writing-mode-canvas.html
- Pass => Fail css/css-images/object-view-box-writing-mode-video.html
- Pass => Fail css/css-page/fixedpos-with-iframe-print.html
+ Fail => Pass css/css-paint-api/background-image-alpha.https.html
+ Fail => Pass css/css-paint-api/dynamic-import.https.html
+ Fail => Pass css/css-paint-api/paint-arguments.https.html
+ Fail => Pass css/css-paint-api/paint-function-arguments-var.https.html
+ Fail => Pass css/css-paint-api/paint-function-arguments.https.html
+ Fail => Pass css/css-paint-api/paint2d-rects.https.html
+ Fail => Pass css/css-paint-api/paint2d-roundRect.https.html
+ Fail => Pass css/css-paint-api/top-level-await.https.html
+ Fail => Pass css/css-rhythm/replaced-elements/block-level-canvas-margins-affected-by-block-step-size.html
+ Fail => Pass css/css-scrollbars/viewport-scrollbar-body.html
+ Fail => Pass css/css-scrollbars/viewport-scrollbar.html
+ Fail => Pass css/css-sizing/aspect-ratio/replaced-element-002.html
+ Fail => Pass css/css-sizing/aspect-ratio/replaced-element-003.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-005.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-007.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-008.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-019.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-025.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-027.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-029.tentative.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-031.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-032.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-dynamic-005.html
+ Fail => Pass css/css-sizing/intrinsic-size-fallback-video.html
+ Fail => Pass css/css-sizing/replaced-max-size-saturation.html
+ Fail => Pass css/css-sizing/responsive-iframe/responsive-iframe-cross-origin-no-match-element.sub.html
+ Fail => Pass css/css-sizing/responsive-iframe/responsive-iframe-cross-origin-not-embedded-sized.sub.html
+ Fail => Pass css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-append-after-body.html
+ Fail => Pass css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-name-change-after-body.html
+ Fail => Pass css/css-sizing/responsive-iframe/responsive-iframe-meta-in-body.html
+ Fail => Pass css/css-sizing/responsive-iframe/responsive-iframe-no-match-element.html
+ Fail => Pass css/css-sizing/responsive-iframe/responsive-iframe-not-embedded-sized.html
- Pass => Fail css/css-sizing/stretch/stretch-anonymous-block-001.html
- Pass => Fail css/css-sizing/stretch/stretch-quirk-002.html
+ Fail => Pass css/css-tables/percent-height-replaced-in-percent-cell-002.html
- Pass => Fail css/css-view-transitions/paint-holding-in-iframe.html
+ Fail => Pass css/css-writing-modes/abs-pos-with-replaced-child.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30924764098).</sub>
<!-- wpt-results-end -->
