### PR TITLE
Fix static position of block-level abspos elements in inline layout

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -1,5 +1,6 @@
 use blitz_traits::node_id::NodeId;
-use parley::{AlignmentOptions, IndentOptions, PositionedInlineBox};
+use parley::{AlignmentOptions, IndentOptions};
+use style::values::specified::box_::DisplayOutside;
 use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
 use taffy::{
     AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
@@ -697,7 +698,36 @@ impl BaseDocument {
 
                     if node.style().position == Position::Absolute {
                         let direction = node.style().direction;
-                        layout_abspos_child(self, ibox, final_size, taffy::Point::ZERO, direction);
+
+                        // The static position of an absolutely positioned box depends on the
+                        // display its hypothetical box would have had (the display specified
+                        // before position:absolute blockified it): inline-level boxes sit at
+                        // their position within the line, while block-level boxes start at the
+                        // content-box left edge of their containing block.
+                        let is_inline_level = node
+                            .primary_styles()
+                            .map(|s| {
+                                s.get_box().original_display.outside() == DisplayOutside::Inline
+                            })
+                            .unwrap_or(true);
+                        let static_position = taffy::Point {
+                            x: if is_inline_level {
+                                ibox.x
+                            } else {
+                                container_pb.left
+                            },
+                            y: ibox.y,
+                        };
+
+                        layout_abspos_child(
+                            self,
+                            ibox.id,
+                            static_position,
+                            is_inline_level,
+                            final_size,
+                            taffy::Point::ZERO,
+                            direction,
+                        );
                     } else if is_floated {
                         let layout = self.nodes[NodeId::from_u64(ibox.id)].unrounded_layout_mut();
                         layout.padding = padding; //.map(|p| p / scale);
@@ -769,7 +799,9 @@ fn f32_max(a: f32, b: f32) -> f32 {
 #[inline]
 fn layout_abspos_child(
     tree: &mut impl taffy::LayoutBlockContainer,
-    item: PositionedInlineBox,
+    item_id: u64,
+    static_position: Point<f32>,
+    is_inline_level: bool,
     area_size: Size<f32>,
     area_offset: Point<f32>,
     direction: taffy::Direction,
@@ -777,7 +809,7 @@ fn layout_abspos_child(
     let area_width = area_size.width;
     let area_height = area_size.height;
 
-    let node_id = taffy::NodeId::from(item.id);
+    let node_id = taffy::NodeId::from(item_id);
     let child_style = tree.get_block_child_style(node_id);
 
     // Skip items that are display:none or are not position:absolute
@@ -1027,10 +1059,10 @@ fn layout_abspos_child(
         (Some(left), None) => left + resolved_margin.left,
         (None, Some(right)) => area_size.width - final_size.width - right - resolved_margin.right,
         (None, None) => {
-            if direction == Direction::Rtl {
-                item.x - final_size.width - resolved_margin.right - area_offset.x
+            if direction == Direction::Rtl && is_inline_level {
+                static_position.x - final_size.width - resolved_margin.right - area_offset.x
             } else {
-                item.x + resolved_margin.left - area_offset.x
+                static_position.x + resolved_margin.left - area_offset.x
             }
         }
     };
@@ -1042,7 +1074,7 @@ fn layout_abspos_child(
                 area_size.height - final_size.height - bottom - resolved_margin.bottom
             }))
             .maybe_add(area_offset.y)
-            .unwrap_or(item.y + resolved_margin.top),
+            .unwrap_or(static_position.y + resolved_margin.top),
     };
     // Note: axis intentionally switched here as scrollbars take up space in the opposite axis
     // to the axis in which scrolling is enabled.


### PR DESCRIPTION
## Summary

Follow-up to #607 (split into two PRs per review; the companion iframe/embed/video dimension-attribute fix is a separate PR).

`layout_abspos_child` in inline layout used the inline box's line position (`ibox.x`/`ibox.y`) as the static position for *every* abspos element with auto insets. That's only correct for elements whose hypothetical box is inline-level. A `div { position: absolute }` sibling of an inline replaced element was being placed beside it on the line instead of at the containing block's content-box left edge. The call site now checks `original_display.outside() == DisplayOutside::Inline` (the display before abspos blockification) and passes an explicit static position:

```rust
let static_position = Point {
    x: if is_inline_level { ibox.x } else { container_pb.left },
    y: ibox.y,
};
```

The RTL inline static-position adjustment also only applies when the box is inline-level.

## WPT results

Newly passing vs main (no regressions in css-flexbox, css/CSS2/normal-flow, css/CSS2/positioning):

- `css/CSS2/normal-flow/inline-replaced-height-004/007.xht`
- `css/CSS2/normal-flow/inline-block-replaced-height-004/007.xht`

The `*-005` variants and `absolute-replaced-height-*` tests additionally need the percentage dimension attribute mapping from the companion PR.

Link to Devin session: https://app.devin.ai/sessions/0f8547b7fbb949e28e9acdbedb1ca8d2
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**5** newly passing, **1** newly failing (net +4).

<details>
<summary>Full diff (6 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/floats/floats-placement-008.html
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-height-004.xht
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-height-007.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-height-004.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-height-007.xht
- Pass => Fail css/css-fonts/variations/font-weight-metrics.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30929564845).</sub>
<!-- wpt-results-end -->
