### PR TITLE
Map iframe/embed/video width/height attributes to CSS dimension properties

### DIFF
--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -965,6 +965,25 @@ impl<'a> TElement for BlitzNode<'a> {
                 }
             }
 
+            // https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images
+            // The width/height attributes on iframe, embed and video map to
+            // the corresponding dimension properties (percentages allowed).
+            if (*name == local_name!("width") || *name == local_name!("height"))
+                && (*tag == local_name!("iframe")
+                    || *tag == local_name!("embed")
+                    || *tag == local_name!("video"))
+            {
+                if let Some(size) = parse_size_attr(value, |_| true) {
+                    use style::values::generics::{NonNegative, length::Size};
+                    let size = Size::LengthPercentage(NonNegative(size));
+                    push_style(if *name == local_name!("width") {
+                        PropertyDeclaration::Width(size)
+                    } else {
+                        PropertyDeclaration::Height(size)
+                    });
+                }
+            }
+
             // https://svgwg.org/svg2-draft/geometry.html#Sizing
             // The `width` and `height` attributes on an `<svg>` element are
             // presentation attributes that map to the CSS `width`/`height`

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -932,51 +932,39 @@ impl<'a> TElement for BlitzNode<'a> {
                 }
             }
 
+            // The width/height attributes on these elements map to the
+            // corresponding dimension properties (percentages allowed):
             // https://html.spec.whatwg.org/multipage/rendering.html#dimRendering
-            if *name == local_name!("width")
-                && (*tag == local_name!("table")
+            // https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images
+            let is_width = *name == local_name!("width");
+            let is_height = *name == local_name!("height");
+            let is_embedded = *tag == local_name!("iframe")
+                || *tag == local_name!("embed")
+                || *tag == local_name!("video");
+            let maps_to_dimension = if is_width {
+                is_embedded
+                    || *tag == local_name!("table")
                     || *tag == local_name!("col")
                     || *tag == local_name!("tr")
                     || *tag == local_name!("td")
                     || *tag == local_name!("th")
-                    || *tag == local_name!("hr"))
-            {
-                let is_table = *tag == local_name!("table");
-                if let Some(width) = parse_size_attr(value, |v| !is_table || *v != 0.0) {
-                    use style::values::generics::{NonNegative, length::Size};
-
-                    push_style(PropertyDeclaration::Width(Size::LengthPercentage(
-                        NonNegative(width),
-                    )));
-                }
-            }
-
-            if *name == local_name!("height")
-                && (*tag == local_name!("table")
+                    || *tag == local_name!("hr")
+            } else if is_height {
+                is_embedded
+                    || *tag == local_name!("table")
                     || *tag == local_name!("thead")
                     || *tag == local_name!("tbody")
-                    || *tag == local_name!("tfoot"))
-            {
-                if let Some(height) = parse_size_attr(value, |_| true) {
-                    use style::values::generics::{NonNegative, length::Size};
-                    push_style(PropertyDeclaration::Height(Size::LengthPercentage(
-                        NonNegative(height),
-                    )));
-                }
-            }
-
-            // https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images
-            // The width/height attributes on iframe, embed and video map to
-            // the corresponding dimension properties (percentages allowed).
-            if (*name == local_name!("width") || *name == local_name!("height"))
-                && (*tag == local_name!("iframe")
-                    || *tag == local_name!("embed")
-                    || *tag == local_name!("video"))
-            {
-                if let Some(size) = parse_size_attr(value, |_| true) {
+                    || *tag == local_name!("tfoot")
+            } else {
+                false
+            };
+            if maps_to_dimension {
+                let is_table = *tag == local_name!("table");
+                if let Some(size) = parse_size_attr(value, |v| !(is_table && is_width) || *v != 0.0)
+                {
                     use style::values::generics::{NonNegative, length::Size};
                     let size = Size::LengthPercentage(NonNegative(size));
-                    push_style(if *name == local_name!("width") {
+                    push_style(if is_width {
                         PropertyDeclaration::Width(size)
                     } else {
                         PropertyDeclaration::Height(size)


### PR DESCRIPTION
## Summary

Follow-up to #607 (companion to the abspos static-position fix in #608).

Per [HTML rendering](https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images), the `width`/`height` attributes on `iframe`, `embed` and `video` map to the corresponding CSS dimension properties, including percentages (`<iframe height="50%">`). Previously they were only consumed as pixel intrinsic sizes in the replaced layout path, so percentage values were ignored. This adds the mapping in `synthesize_presentational_hints_for_legacy_attributes` (same pattern as the existing table/svg dimension mappings).

## WPT results

Newly passing vs main (no regressions in css-flexbox, css/CSS2/normal-flow, css/CSS2/positioning):

- `css/CSS2/positioning/absolute-replaced-height-005/007/012/014/019/026/033.xht`

Together with #608 this also fixes `inline-replaced-height-005.xht` and `inline-block-replaced-height-005.xht`.

Link to Devin session: https://app.devin.ai/sessions/0f8547b7fbb949e28e9acdbedb1ca8d2
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**10** newly passing, **0** newly failing (net +10).

<details>
<summary>Full diff (10 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/floats-clear/float-replaced-height-005.xht
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-height-005.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-height-005.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-005.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-007.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-012.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-014.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-019.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-026.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-033.xht
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30930595868).</sub>
<!-- wpt-results-end -->
