### PR TITLE
Drop renderer surface before window to fix segfault on close (Wayland)

### DIFF
--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -120,6 +120,17 @@ pub struct View<Rend: WindowRenderer> {
     pub ios_request_redraw: std::cell::Cell<bool>,
 }
 
+impl<Rend: WindowRenderer> Drop for View<Rend> {
+    fn drop(&mut self) {
+        // Release the renderer's window surface before the window is dropped.
+        // The renderer may be shared (e.g. provided as a context to user code),
+        // in which case it can outlive the `View`. A GPU surface must not
+        // outlive the window/display it is attached to: dropping it after the
+        // event loop has shut down segfaults on Wayland.
+        self.renderer.suspend();
+    }
+}
+
 impl<Rend: WindowRenderer> View<Rend> {
     pub fn init(
         config: WindowConfig<Rend>,

--- a/packages/dioxus-native/src/lib.rs
+++ b/packages/dioxus-native/src/lib.rs
@@ -233,11 +233,8 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
         base_color: config.base_color,
         alpha_mode: config.alpha_mode,
     });
-    let config = WindowConfig::with_attributes(
-        Box::new(doc) as _,
-        renderer.clone(),
-        config.window_attributes,
-    );
+    let config =
+        WindowConfig::with_attributes(Box::new(doc) as _, renderer, config.window_attributes);
 
     // Create application
     let application = DioxusNativeApplication::new(proxy, event_queue, config);


### PR DESCRIPTION
## Summary

Fixes #355 (segfault when closing the window on Linux/Wayland).

The GPU surface was outliving the window/display it was attached to. `dioxus_native::launch_cfg_with_props` kept an extra `DioxusNativeWindowRenderer` clone alive as a local:

```rust
let renderer = DioxusNativeWindowRenderer::with_options(...);
let config = WindowConfig::with_attributes(doc, renderer.clone(), attrs); // extra Rc clone
// ...
event_loop.run_app(application).unwrap();
// EventLoop (Wayland display connection) dropped here...
// ...then `renderer` (wgpu Surface referencing the dead wl_display/wl_surface) → SIGSEGV
```

Because the renderer is `Rc`-shared (and also provided as a vdom context), dropping the `View` on `CloseRequested` did not drop the inner renderer, so the wgpu `Surface` was only destroyed after `run_app` returned and the event loop / Wayland connection had been torn down — the driver then dereferences freed display memory.

Two changes:
- `blitz-shell`: `impl Drop for View` now calls `self.renderer.suspend()`, which releases the surface (`RenderState::Suspended`) while the window and event loop are still alive — robust regardless of outstanding renderer clones.
- `dioxus-native`: pass `renderer` into `WindowConfig` by value instead of keeping a stray clone alive past `run_app`.

Not reproduced locally (headless VM, no Wayland/NVIDIA); verified with `cargo check`, `cargo clippy`, and `cargo test --workspace` (all green).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0caa615da22344ffb73a7ff21bcfca0f
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/30956472936).</sub>
<!-- wpt-results-end -->
