### PR TITLE
Skip @font-face sources with unresolvable urls instead of panicking

### DIFF
--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -452,7 +452,14 @@ pub(crate) fn fetch_font_face(
                         return None;
                     }
 
-                    let url = url_source.url.url().unwrap().as_ref().clone();
+                    // A relative url with no base url to resolve against
+                    // yields None; skip the source instead of panicking
+                    let Some(url) = url_source.url.url() else {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!("Skipping @font-face source with unresolvable url");
+                        return None;
+                    };
+                    let url = url.as_ref().clone();
                     Some((url, format))
                 });
 


### PR DESCRIPTION
A stylesheet with a relative @font-face src url loaded into a document without a base url resolves the url to None; unwrapping it took the whole application down. Skip the source with a warning, matching how unsupported font formats are handled a few lines up.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31020309902).</sub>
<!-- wpt-results-end -->
