### PR TITLE
Move focus backwards on Shift+Tab

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1459,6 +1459,14 @@ impl BaseDocument {
         Some(id)
     }
 
+    /// Move focus to the previous focussable node in the document
+    pub fn focus_prev_node(&mut self) -> Option<NodeId> {
+        let focussed_node_id = self.get_focussed_node_id()?;
+        let id = self.prev_node(&self.nodes[focussed_node_id], |node| node.is_focussable())?;
+        self.set_focus_to(id);
+        Some(id)
+    }
+
     /// Clear the focussed node
     pub fn clear_focus(&mut self) {
         if let Some(id) = self.focus_node_id {

--- a/packages/blitz-dom/src/events/keyboard.rs
+++ b/packages/blitz-dom/src/events/keyboard.rs
@@ -4,7 +4,7 @@ use blitz_traits::{
     SmolStr,
     events::{BlitzInputEvent, BlitzKeyEvent, DomEvent, DomEventData},
 };
-use keyboard_types::Key;
+use keyboard_types::{Key, Modifiers};
 use markup5ever::local_name;
 
 pub(super) enum KeyboardOrTextInputEvent {
@@ -20,7 +20,11 @@ pub(crate) fn handle_key_or_input_event<F: FnMut(DomEvent)>(
 ) {
     if let KeyboardOrTextInputEvent::KeyPress(event) = &event {
         if event.key == Key::Tab {
-            doc.focus_next_node();
+            if event.modifiers.contains(Modifiers::SHIFT) {
+                doc.focus_prev_node();
+            } else {
+                doc.focus_next_node();
+            }
             return;
         }
 

--- a/packages/blitz-dom/src/traversal.rs
+++ b/packages/blitz-dom/src/traversal.rs
@@ -262,6 +262,50 @@ impl BaseDocument {
         }
     }
 
+    /// The node that comes last within `node`'s subtree in document order,
+    /// which is what precedes `node`'s successor in reverse order.
+    fn deepest_last_descendant<'a>(&'a self, mut node: &'a Node) -> &'a Node {
+        while let Some(last_child_id) = node.children.last() {
+            node = &self.nodes[*last_child_id];
+        }
+        node
+    }
+
+    /// Mirror of [`Self::next_node`]: walks the tree in reverse document
+    /// order, wrapping around to the end of the document.
+    pub fn prev_node(&self, start: &Node, mut filter: impl FnMut(&Node) -> bool) -> Option<NodeId> {
+        let start_id = start.id;
+        let mut node = start;
+        loop {
+            let prev = if let Some(parent) = node.parent_node() {
+                let self_idx = parent
+                    .children
+                    .iter()
+                    .position(|id| *id == node.id)
+                    .unwrap();
+                // Previous is the deepest last descendant of the previous
+                // sibling, or the parent when there is no previous sibling
+                if self_idx > 0 {
+                    self.deepest_last_descendant(&self.nodes[parent.children[self_idx - 1]])
+                } else {
+                    parent
+                }
+            }
+            // Continue the search from the end of the document
+            else {
+                self.deepest_last_descendant(self.root_node())
+            };
+
+            if filter(prev) {
+                return Some(prev.id);
+            } else if prev.id == start_id {
+                return None;
+            }
+
+            node = prev;
+        }
+    }
+
     pub fn node_layout_ancestors(&self, node_id: NodeId) -> Vec<NodeId> {
         let mut ancestors = Vec::with_capacity(12);
         let mut maybe_id = Some(node_id);


### PR DESCRIPTION
The Tab handler always called focus_next_node, so Shift+Tab moved focus forwards like a plain Tab and there was no way to reach the previous control from the keyboard.

Add prev_node, the reverse-document-order mirror of next_node (step to the deepest last descendant of the preceding sibling, or up to the parent, wrapping around at the start of the document), expose it as focus_prev_node, and dispatch to it when the shift modifier is set.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31020443570).</sub>
<!-- wpt-results-end -->
