### PR TITLE
Hit-testing misses `position: fixed` elements with `transform` when nested inside a non-stacking-context parent

### DIFF
--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -7,6 +7,7 @@ use crate::node::NodeFlags;
 use crate::{
     BaseDocument, net::ImageHandler, node::ImageResourceData, node::Status, util::ImageLayerKind,
 };
+use kurbo::Affine;
 use style::properties::ComputedValues;
 use style::properties::generated::longhands::position::computed_value::T as Position;
 use style::selector_parser::RestyleDamage;
@@ -434,6 +435,109 @@ impl BaseDocument {
 
     pub fn flush_styles_to_layout(&mut self, node_id: NodeId) {
         self.flush_styles_to_layout_impl(node_id, None);
+    }
+
+    /// Recompute `content_area` for all stacking context roots after layout
+    /// has been resolved. During `flush_styles_to_layout`, `compute_content_size`
+    /// runs before `resolve_layout`, so the cached `content_area` is stale.
+    pub fn recompute_stacking_context_content_area(&mut self, node_id: NodeId) {
+        let scale = self.viewport.scale_f64();
+        let has_sc = self
+            .nodes
+            .get(node_id)
+            .map(|n| n.stacking_context.is_some())
+            .unwrap_or(false);
+        if has_sc {
+            // Gather hoisted child data without holding a borrow on self
+            let children_data: Vec<(NodeId, taffy::Point<f32>)> = {
+                let node = &self.nodes[node_id];
+                node.stacking_context
+                    .as_ref()
+                    .map(|sc| {
+                        sc.children
+                            .iter()
+                            .map(|hc| (hc.node_id, hc.position))
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            };
+
+            if !children_data.is_empty() {
+                let mut content_area = taffy::Rect::ZERO;
+                for (i, (child_id, child_pos)) in children_data.iter().enumerate() {
+                    let node = &self.nodes[*child_id];
+                    let layout = node.final_layout();
+
+                    // Build the full transform: translate to layout position, then apply CSS transform.
+                    // This gives us the rendered position of the child's border box.
+                    let scaled_x = layout.location.x as f64 * scale;
+                    let scaled_y = layout.location.y as f64 * scale;
+                    let full = if let Some(t) = *node.transform() {
+                        Affine::translate((scaled_x, scaled_y)) * t
+                    } else {
+                        Affine::translate((scaled_x, scaled_y))
+                    };
+
+                    // Transform the four corners of the child's border box (in device pixels)
+                    let w = layout.size.width as f64 * scale;
+                    let h = layout.size.height as f64 * scale;
+                    let corners = [
+                        full * kurbo::Point::new(0.0, 0.0),
+                        full * kurbo::Point::new(w, 0.0),
+                        full * kurbo::Point::new(0.0, h),
+                        full * kurbo::Point::new(w, h),
+                    ];
+
+                    // Add hoisted position offset and convert back to CSS pixels
+                    let px = child_pos.x as f64;
+                    let py = child_pos.y as f64;
+                    let left = corners
+                        .iter()
+                        .map(|p| p.x / scale + px)
+                        .fold(f64::INFINITY, f64::min) as f32;
+                    let top = corners
+                        .iter()
+                        .map(|p| p.y / scale + py)
+                        .fold(f64::INFINITY, f64::min) as f32;
+                    let right = corners
+                        .iter()
+                        .map(|p| p.x / scale + px)
+                        .fold(f64::NEG_INFINITY, f64::max) as f32;
+                    let bottom = corners
+                        .iter()
+                        .map(|p| p.y / scale + py)
+                        .fold(f64::NEG_INFINITY, f64::max) as f32;
+
+                    if i == 0 {
+                        content_area = Rect {
+                            left,
+                            top,
+                            right,
+                            bottom,
+                        };
+                    } else {
+                        content_area.left = content_area.left.min(left);
+                        content_area.top = content_area.top.min(top);
+                        content_area.right = content_area.right.max(right);
+                        content_area.bottom = content_area.bottom.max(bottom);
+                    }
+                }
+                let node = &mut self.nodes[node_id];
+                if let Some(sc) = node.stacking_context.as_mut() {
+                    sc.content_area = content_area;
+                }
+            }
+        }
+
+        // Recurse into children
+        let children: Vec<NodeId> = self
+            .nodes
+            .get(node_id)
+            .and_then(|n| n.layout_children.borrow().as_ref().map(|c| c.to_vec()))
+            .unwrap_or_default();
+        for child_id in children {
+            self.recompute_stacking_context_content_area(child_id);
+        }
     }
 
     /// Flush a CSS image layer list (`background-image` or `mask-image`) from style

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -763,8 +763,16 @@ impl BaseDocument {
             let position = self.nodes[node_id].final_layout().location;
             let scroll_offset = *self.nodes[node_id].scroll_offset();
             for hoisted in stacking_context.children.iter_mut() {
-                hoisted.position.x += position.x - scroll_offset.x as f32;
-                hoisted.position.y += position.y - scroll_offset.y as f32;
+                // Fixed-position elements are positioned relative to the
+                // viewport, not the parent's content box. Do not add the
+                // parent's layout offset to their hoisted position.
+                let is_fixed = self.nodes[hoisted.node_id]
+                    .primary_styles()
+                    .is_some_and(|s| s.clone_position() == Position::Fixed);
+                if !is_fixed {
+                    hoisted.position.x += position.x - scroll_offset.x as f32;
+                    hoisted.position.y += position.y - scroll_offset.y as f32;
+                }
             }
             parent_stacking_context
                 .children

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -95,6 +95,14 @@ impl BaseDocument {
         self.resolve_transforms(root_node_id);
         timer.record_time("transform");
 
+        // Recompute stacking context content_area now that layout and transforms
+        // are resolved. During flush_styles_to_layout, compute_content_size runs
+        // before layout, so content_area is stale (all zeros). We recompute it
+        // here using transform-adjusted positions so hit-testing can correctly
+        // gate hoisted-child traversal.
+        self.recompute_stacking_context_content_area(root_node_id);
+        timer.record_time("recompute_sc");
+
         // Clear all damage and dirty flags
         if self.incremental_layout {
             for (_, node) in self.nodes.iter_mut() {

--- a/tests/blitz-tests/tests/fixed_transform_hit_test.rs
+++ b/tests/blitz-tests/tests/fixed_transform_hit_test.rs
@@ -1,0 +1,588 @@
+//! Regression test: a `position: fixed` element with `transform: translate(-50%, -50%)`
+//! centered on screen must be hit-testable. A full-screen overlay (`mask-overlay`)
+//! with lower z-index must not intercept clicks meant for the centered content.
+//!
+//! This mirrors the YearMonthModal layout: a `mask-overlay` (fixed, full-screen,
+//! z-index via CSS var) and a `mask-content` (fixed, full-screen, higher z-index)
+//! wrapping a `modal-content` (fixed, top:50%, left:50%, translate(-50%,-50%)).
+
+use blitz_test_harness::{Harness, HarnessOptions};
+
+fn harness(html: &str) -> Harness {
+    Harness::from_html_with(
+        html,
+        HarnessOptions {
+            width: 400,
+            height: 400,
+            ..Default::default()
+        },
+    )
+}
+
+#[test]
+fn fixed_transformed_centered_content_is_hittable() {
+    // 400×400 viewport. Content is 100×100, centered via top:50%/left:50% +
+    // translate(-50%,-50%), so it paints at (150,150)-(250,250).
+    // The overlay covers the full viewport at a lower z-index.
+    let harness = harness(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            .overlay {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: 10;
+                background: rgba(0,0,0,0.2);
+            }
+            .content {
+                position: fixed;
+                top: 50%; left: 50%;
+                transform: translate(-50%, -50%);
+                z-index: 20;
+                width: 100px;
+                height: 100px;
+                background: #fff;
+            }
+        </style></head><body>
+            <div class="overlay" id="overlay"></div>
+            <div class="content" id="content"></div>
+        </body></html>"#,
+    );
+
+    let overlay = harness.node("#overlay");
+    let content = harness.node("#content");
+
+    // Click the center of the content (200, 200).
+    let hit = harness.hit(200.0, 200.0);
+    assert!(hit.is_some(), "expected a hit at center");
+    let hit = hit.unwrap();
+    assert_ne!(
+        hit.node_id, overlay,
+        "click at center should not hit the overlay"
+    );
+    assert_eq!(
+        hit.node_id, content,
+        "click at center should hit the transformed centered content"
+    );
+
+    // Click near the top-left corner of the content (155, 155).
+    let hit = harness.hit(155.0, 155.0);
+    assert!(hit.is_some(), "expected a hit at (155, 155)");
+    let hit = hit.unwrap();
+    assert_eq!(
+        hit.node_id, content,
+        "click at (155, 155) should hit the content, not the overlay"
+    );
+}
+
+#[test]
+fn fixed_transformed_centered_content_with_css_var_zindex() {
+    // Same as above but z-index uses CSS custom properties + calc(),
+    // matching the Mask component's pattern. Blitz's stylo engine
+    // correctly resolves var() in z-index to integer values.
+    let harness = harness(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            :root { --mask-z: 1000; }
+            .overlay {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: var(--mask-z);
+                background: rgba(0,0,0,0.2);
+            }
+            .content {
+                position: fixed;
+                top: 50%; left: 50%;
+                transform: translate(-50%, -50%);
+                z-index: calc(var(--mask-z) + 1);
+                width: 100px;
+                height: 100px;
+                background: #fff;
+            }
+        </style></head><body>
+            <div class="overlay" id="overlay"></div>
+            <div class="content" id="content"></div>
+        </body></html>"#,
+    );
+
+    let overlay = harness.node("#overlay");
+    let content = harness.node("#content");
+
+    // Verify CSS var() resolves to integer z-index values
+    {
+        let doc = harness.base();
+        if let Some(n) = doc.get_node(overlay) {
+            assert_eq!(
+                n.z_index(),
+                1000,
+                "overlay z_index should resolve var(--mask-z) to 1000"
+            );
+        }
+        if let Some(n) = doc.get_node(content) {
+            assert_eq!(
+                n.z_index(),
+                1001,
+                "content z_index should resolve calc(var(--mask-z) + 1) to 1001"
+            );
+        }
+    }
+
+    let hit = harness.hit(200.0, 200.0);
+    assert!(hit.is_some(), "expected a hit at center");
+    let hit = hit.unwrap();
+    assert_ne!(
+        hit.node_id, overlay,
+        "click at center should not hit the overlay"
+    );
+    assert_eq!(
+        hit.node_id, content,
+        "click at center should hit the content"
+    );
+}
+
+#[test]
+fn fixed_transformed_centered_content_nested_in_wrapper() {
+    // Mirrors the actual structure: body > mask-overlay (sibling) +
+    // mask-content (fixed, full-screen wrapper) > modal-content (fixed, centered).
+    let harness = harness(
+        r#"<html><head><style>
+            .mask-overlay {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: 10;
+                background: rgba(0,0,0,0.2);
+            }
+            .mask-content {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: 12;
+            }
+            .modal-content {
+                position: fixed;
+                top: 50%; left: 50%;
+                transform: translate(-50%, -50%);
+                z-index: 12;
+                width: 100px;
+                height: 100px;
+                background: #fff;
+            }
+        </style></head><body style="margin:0">
+            <div class="mask-overlay" id="overlay"></div>
+            <div class="mask-content">
+                <div class="modal-content" id="content"></div>
+            </div>
+        </body></html>"#,
+    );
+
+    let overlay = harness.node("#overlay");
+    let content = harness.node("#content");
+
+    let hit = harness.hit(200.0, 200.0);
+    assert!(hit.is_some(), "expected a hit at center");
+    let hit = hit.unwrap();
+    assert_ne!(
+        hit.node_id, overlay,
+        "click at center should not hit the overlay"
+    );
+    assert_eq!(
+        hit.node_id, content,
+        "click at center should hit the nested centered content"
+    );
+}
+
+#[test]
+fn mask_content_does_not_intercept_clicks_on_nested_modal_content() {
+    // Exact mirror of the real app:
+    // - modal-content has NO explicit width/height (shrinks to content)
+    // - modal-content contains a panel with its own width
+    // - modal-content has overflow:auto, transform, top:50%/left:50%
+    // - mask-content and modal-content both use CSS var z-index = calc(var(--mask-z)+1)
+    let harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; }
+            :root { --mask-z: 1000; }
+            .app-root {
+                height: calc(100vh - 2px);
+                padding: 20px;
+                overflow: auto;
+                background: #f0f2f5;
+            }
+            .mask-overlay {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: var(--mask-z);
+                background: rgba(0,0,0,0.2);
+            }
+            .mask-content {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: calc(var(--mask-z) + 1);
+            }
+            .modal-content {
+                position: fixed;
+                top: 50%; left: 50%;
+                transform: translate(-50%, -50%);
+                z-index: calc(var(--mask-z) + 1);
+                background: #fff;
+                border-radius: 12px;
+                overflow: auto;
+            }
+            .panel {
+                width: 220px;
+                background: #fff;
+            }
+            .panel-columns {
+                display: flex;
+                height: 180px;
+            }
+            .panel-footer {
+                display: flex;
+                gap: 8px;
+                padding: 10px 16px;
+            }
+            .panel-btn {
+                flex: 1;
+                height: 30px;
+            }
+        </style></head><body>
+            <div class="app-root">
+                <h1>Hisdata Export Tool</h1>
+            </div>
+            <div class="mask-overlay" id="overlay"></div>
+            <div class="mask-content" id="mask-content">
+                <div class="modal-content" id="content">
+                    <div class="panel">
+                        <div class="panel-columns">
+                            <div style="flex:1; height:180px; overflow:hidden;">Col1</div>
+                            <div style="flex:1; height:180px; overflow:hidden;">Col2</div>
+                        </div>
+                        <div class="panel-footer">
+                            <div class="panel-btn" id="cancel-btn" style="background:#e5e7eb;">Cancel</div>
+                            <div class="panel-btn" id="confirm-btn" style="background:#6366f1;">OK</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 780,
+            height: 600,
+            ..Default::default()
+        },
+    );
+
+    let overlay = harness.node("#overlay");
+    let mask_content = harness.node("#mask-content");
+    let content = harness.node("#content");
+    let cancel_btn = harness.node("#cancel-btn");
+
+    // Debug
+    {
+        let doc = harness.base();
+        let mut cur = doc.get_node(content);
+        while let Some(node) = cur {
+            let l = node.final_layout();
+            eprintln!(
+                "node {:?}: loc=({},{}) size=({},{}) z={} sc={} transform={:?}",
+                node.id,
+                l.location.x,
+                l.location.y,
+                l.size.width,
+                l.size.height,
+                node.z_index(),
+                node.stacking_context.is_some(),
+                node.transform()
+            );
+            if let Some(sc) = &node.stacking_context {
+                eprintln!("  sc content_area={:?}", sc.content_area);
+                for hc in &sc.children {
+                    eprintln!(
+                        "  hoisted {:?}: z={} pos=({},{})",
+                        hc.node_id, hc.z_index, hc.position.x, hc.position.y
+                    );
+                }
+            }
+            cur = node.parent.and_then(|p| doc.get_node(p));
+        }
+    }
+
+    // Click cancel button. In a 780x600 viewport, modal-content is centered at (390, 300).
+    // Panel is 220px wide. Footer is at the bottom. Cancel button is at left of footer.
+    let hit = harness.hit(390.0, 300.0);
+    assert!(hit.is_some(), "expected a hit");
+    let hit = hit.unwrap();
+    eprintln!("hit: {:?}", hit.node_id);
+    assert_ne!(hit.node_id, overlay, "should not hit overlay");
+    assert_ne!(hit.node_id, mask_content, "should not hit mask-content");
+}
+
+#[test]
+fn mask_modal_structure_with_css_var_zindex_and_child_button() {
+    // Exact mirror of the YearMonthModal structure:
+    // - mask-overlay: fixed, full-screen, z=var(--mask-z)=1000
+    // - mask-content: fixed, full-screen, z=calc(var(--mask-z)+1)=1002,
+    //                 wrapping modal-content
+    // - modal-content: fixed, top:50%/left:50%, translate(-50%,-50%),
+    //                  z=calc(var(--mask-z)+1)=1002, contains a button
+    // Clicking the button must hit the button, not mask-content or mask-overlay.
+    let harness = harness(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            :root { --mask-z: 1000; }
+            .mask-overlay {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: var(--mask-z);
+                background: rgba(0,0,0,0.2);
+            }
+            .mask-content {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: calc(var(--mask-z) + 1);
+            }
+            .modal-content {
+                position: fixed;
+                top: 50%; left: 50%;
+                transform: translate(-50%, -50%);
+                z-index: calc(var(--mask-z) + 1);
+                width: 100px;
+                height: 100px;
+                background: #fff;
+            }
+        </style></head><body>
+            <div class="mask-overlay" id="overlay"></div>
+            <div class="mask-content" id="mask-content">
+                <div class="modal-content" id="content">
+                    <button id="btn" style="width:80px; height:30px;">Cancel</button>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+
+    let overlay = harness.node("#overlay");
+    let mask_content = harness.node("#mask-content");
+    let content = harness.node("#content");
+    let btn = harness.node("#btn");
+
+    // Click center of modal-content (200, 200) - should hit button or content
+    let hit = harness.hit(200.0, 200.0);
+    assert!(hit.is_some(), "expected a hit at center");
+    let hit = hit.unwrap();
+    assert_ne!(hit.node_id, overlay, "click should not hit mask-overlay");
+    assert_ne!(
+        hit.node_id, mask_content,
+        "click should not hit mask-content, should reach content or button"
+    );
+    // Hit should be content or button (button is inside content)
+    assert!(
+        hit.node_id == content || hit.node_id == btn,
+        "click should hit content or button, got {:?}",
+        hit.node_id
+    );
+}
+
+#[test]
+fn dynamically_inserted_modal_content_is_hittable() {
+    // Reproduces the real bug: modal-content is inserted AFTER initial render
+    // (Vue v-if). The incremental layout path must correctly hoist modal-content
+    // into mask-content's stacking context.
+    use blitz_dom::{Attribute, DocumentMutator};
+    use markup5ever::{QualName, ns};
+
+    let mut harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            :root { --mask-z: 1000; }
+            .mask-overlay {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: var(--mask-z);
+                background: rgba(0,0,0,0.2);
+            }
+            .mask-content {
+                position: fixed;
+                top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: calc(var(--mask-z) + 1);
+            }
+            .modal-content {
+                position: fixed;
+                top: 50%; left: 50%;
+                transform: translate(-50%, -50%);
+                z-index: calc(var(--mask-z) + 1);
+                background: #fff;
+                overflow: auto;
+            }
+            .panel { width: 220px; }
+            .panel-btn { width: 100px; height: 30px; }
+        </style></head><body>
+            <div class="app-root">
+                <h1>App</h1>
+            </div>
+            <div class="mask-overlay" id="overlay"></div>
+            <div class="mask-content" id="mask-content">
+            </div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 780,
+            height: 600,
+            ..Default::default()
+        },
+    );
+
+    // First pump: render with empty mask-content
+    harness.pump();
+
+    let mask_content = harness.node("#mask-content");
+
+    // Now dynamically insert modal-content into mask-content (simulating Vue v-if)
+    {
+        let mut doc = harness.base_mut();
+        let doc = &mut *doc;
+        let mut m = DocumentMutator::new(doc);
+
+        // Create modal-content
+        let modal = m.create_element(
+            QualName::new(None, ns!(html), "div".into()),
+            vec![Attribute {
+                name: QualName::new(None, ns!(), "class".into()),
+                value: "modal-content".into(),
+            }],
+        );
+
+        // Create panel inside modal-content
+        let panel = m.create_element(
+            QualName::new(None, ns!(html), "div".into()),
+            vec![Attribute {
+                name: QualName::new(None, ns!(), "class".into()),
+                value: "panel".into(),
+            }],
+        );
+
+        // Create cancel button
+        let btn = m.create_element(
+            QualName::new(None, ns!(html), "div".into()),
+            vec![Attribute {
+                name: QualName::new(None, ns!(), "class".into()),
+                value: "panel-btn".into(),
+            }],
+        );
+
+        let btn_text = m.create_text_node("Cancel");
+
+        // Assemble: mask-content > modal-content > panel > btn > "Cancel"
+        m.append_children(modal, &[panel]);
+        m.append_children(panel, &[btn]);
+        m.append_children(btn, &[btn_text]);
+        m.append_children(mask_content, &[modal]);
+    }
+
+    // Second pump: resolve with the newly inserted modal-content
+    harness.pump();
+
+    // Click center of viewport (390, 300) - modal-content is centered there
+    let hit = harness.hit(390.0, 300.0);
+    assert!(hit.is_some(), "expected a hit at modal center");
+    let hit = hit.unwrap();
+    eprintln!("hit: {:?}", hit.node_id);
+    assert_ne!(
+        hit.node_id,
+        harness.node("#overlay"),
+        "should not hit overlay"
+    );
+    assert_ne!(hit.node_id, mask_content, "should not hit mask-content");
+}
+
+#[test]
+fn dynamically_inserted_modal_content_hittable_at_transformed_edge() {
+    // Edge case: modal-content has loc=(390,300) size=(220,30) with
+    // transform: translate(-50%, -50%) = translate(-110, -15).
+    // Rendered top-left = (280, 285). content_area (pre-transform) = (390,300,610,330).
+    // Click at (285, 290) which is INSIDE the rendered modal but OUTSIDE content_area.
+    use blitz_dom::{Attribute, DocumentMutator};
+    use markup5ever::{QualName, ns};
+
+    let mut harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            :root { --mask-z: 1000; }
+            .mask-overlay {
+                position: fixed; top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: var(--mask-z);
+            }
+            .mask-content {
+                position: fixed; top: 0; left: 0;
+                width: 100vw; height: 100vh;
+                z-index: calc(var(--mask-z) + 1);
+            }
+            .modal-content {
+                position: fixed; top: 50%; left: 50%;
+                transform: translate(-50%, -50%);
+                z-index: calc(var(--mask-z) + 1);
+                background: #fff;
+            }
+            .panel { width: 220px; }
+        </style></head><body>
+            <div class="app-root"><h1>App</h1></div>
+            <div class="mask-overlay" id="overlay"></div>
+            <div class="mask-content" id="mask-content"></div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 780,
+            height: 600,
+            ..Default::default()
+        },
+    );
+
+    harness.pump();
+    let mask_content = harness.node("#mask-content");
+
+    {
+        let mut doc = harness.base_mut();
+        let doc = &mut *doc;
+        let mut m = DocumentMutator::new(doc);
+        let modal = m.create_element(
+            QualName::new(None, ns!(html), "div".into()),
+            vec![Attribute {
+                name: QualName::new(None, ns!(), "class".into()),
+                value: "modal-content".into(),
+            }],
+        );
+        let panel = m.create_element(
+            QualName::new(None, ns!(html), "div".into()),
+            vec![Attribute {
+                name: QualName::new(None, ns!(), "class".into()),
+                value: "panel".into(),
+            }],
+        );
+        let text = m.create_text_node("Content");
+        m.append_children(panel, &[text]);
+        m.append_children(modal, &[panel]);
+        m.append_children(mask_content, &[modal]);
+    }
+
+    harness.pump();
+
+    // modal-content: loc=(390,300) size=(220,30), transform translate(-110,-15)
+    // rendered: (280,285) to (500,315)
+    // Click at (285, 290) - inside rendered modal, outside pre-transform content_area
+    let hit = harness.hit(285.0, 290.0);
+    assert!(hit.is_some(), "expected a hit at modal transformed edge");
+    let hit = hit.unwrap();
+    eprintln!("edge hit: {:?}", hit.node_id);
+    assert_ne!(
+        hit.node_id,
+        harness.node("#overlay"),
+        "should not hit overlay"
+    );
+    assert_ne!(hit.node_id, mask_content, "should not hit mask-content");
+}


### PR DESCRIPTION
## Problem

A `position: fixed` element with `transform: translate(-50%, -50%)` (centered modal) nested inside a full-screen `position: fixed` wrapper is not hit-testable. Clicks land on the wrapper instead of the modal content.

This affects any structure like:

```html
<body style="margin: 8px">  <!-- any non-zero margin/offset -->
  <div class="mask-content" style="position: fixed; width: 100vw; height: 100vh; z-index: 1001">
    <div class="modal-content" style="position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 1001">
      <button>Cancel</button>
    </div>
  </div>
</body>
```

The bug is especially reproducible when the modal is dynamically inserted (e.g. Vue `v-if`) after initial render, triggering the incremental layout path.

## Root causes

### 1. Fixed-position hoisted children get incorrect parent layout offset

In `flush_styles_to_layout_impl` (`packages/blitz-dom/src/layout/damage.rs`), when a hoisted child is passed up from a non-stacking-context parent to the parent's stacking context, the parent's `final_layout().location` is added to the child's hoisted position:

```rust
hoisted.position.x += position.x - scroll_offset.x as f32;
hoisted.position.y += position.y - scroll_offset.y as f32;
```

For `position: fixed` elements this is wrong. They are positioned relative to the viewport, not the parent's content box. If `<body>` has a margin (e.g. 21px from default user-agent styles or margin collapsing), this offset is incorrectly applied to the fixed element, shifting all hit-test coordinates by that amount.

When the modal is small enough that the offset pushes the click coordinate outside the modal's transformed bounds, the modal becomes unclickable.

**Fix:** Skip adding the parent layout offset for `position: fixed` hoisted children.

### 2. `content_area` does not account for transforms on hoisted children

`compute_content_size` runs during `flush_styles_to_layout`, which executes **before** `resolve_layout` and `resolve_transforms`. At that point `final_layout()` returns zeros and transforms are not yet computed, so `content_area` is `Rect::ZERO`. This means `matches_hoisted_content` in `hit_inner` is always false for any stacking context whose children were flushed in the same pass.

Even after layout resolves, `content_area` was computed from pre-transform `final_layout().location`. A hoisted child with `transform: translate(-50%, -50%)` may be visually present at a point outside its untransformed `content_area`, causing the `matches_hoisted_content` gatekeeper to incorrectly skip it.

**Fix:** Added `recompute_stacking_context_content_area` called **after** `resolve_transforms` in `resolve.rs`. It recomputes `content_area` using transform-adjusted corner positions (applying `Affine::translate(layout_location) * transform` to the child's border box corners), so the gatekeeper correctly reflects where hoisted children are actually rendered.

## Reproduction

```rust
// Test: dynamically_inserted_modal_content_is_hittable
// 1. Render page with empty mask-content
// 2. Pump (resolve layout)
// 3. Dynamically insert modal-content into mask-content
// 4. Pump again (incremental layout)
// 5. Hit-test at center of viewport -> should hit modal content, not mask-content
```

Without the fixes, step 5 hits `mask-content` instead of `modal-content`.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31073626206).</sub>
<!-- wpt-results-end -->
