### PR TITLE
Measure both axes so width-only measurements are safe to cache

### DIFF
--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -13,10 +13,10 @@ use style::Atom;
 use style::values::computed::CSSPixelLength;
 use style::values::computed::length_percentage::CalcLengthPercentage;
 use taffy::{
-    BlockContext, CollapsibleMarginSet, FlexDirection, LayoutPartialTree, NodeId, ResolveOrZero,
-    RoundTree, Style, TraversePartialTree, TraverseTree, compute_block_layout,
-    compute_cached_layout, compute_flexbox_layout, compute_grid_layout, compute_leaf_layout,
-    prelude::*,
+    BlockContext, CollapsibleMarginSet, FlexDirection, LayoutPartialTree, NodeId, RequestedAxis,
+    ResolveOrZero, RoundTree, RunMode, Style, TraversePartialTree, TraverseTree,
+    compute_block_layout, compute_cached_layout, compute_flexbox_layout, compute_grid_layout,
+    compute_leaf_layout, prelude::*,
 };
 
 pub(crate) mod construct;
@@ -384,6 +384,21 @@ impl LayoutPartialTree for BaseDocument {
         node_id: NodeId,
         inputs: taffy::LayoutInput,
     ) -> taffy::LayoutOutput {
+        // A width-only measurement short-circuits with a height of zero once
+        // the width is determined, and the measurement cache does not key on
+        // the requested axis, so storing such an answer would poison the cache
+        // for a later height query: a table cell came out shorter than its
+        // contents. Keeping those answers out of the cache instead recomputed
+        // the subtree for every width probe a parent issues, and a deeply
+        // nested page paid for shaping its text dozens of times over. So ask
+        // for both axes: the height at the resolved width is computed once per
+        // cache key, every stored entry answers any axis, and repeated probes
+        // hit the cache.
+        let mut inputs = inputs;
+        if inputs.run_mode == RunMode::ComputeSize && inputs.axis == RequestedAxis::Horizontal {
+            inputs.axis = RequestedAxis::Both;
+        }
+
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
             tree.compute_child_layout_internal(node_id, inputs, None)
         })

--- a/tests/blitz-tests/tests/table_cell_content_height.rs
+++ b/tests/blitz-tests/tests/table_cell_content_height.rs
@@ -1,0 +1,109 @@
+//! A table row is as tall as its tallest cell's contents, whatever else in the
+//! row specifies a height.
+//!
+//! A cell whose width is already known is measured width-only first, and that
+//! measurement reports no height. It must not stand in for the cell's real
+//! height afterwards, or the row collapses onto whatever height is specified
+//! elsewhere in it and the text spills out of its cell.
+
+use blitz_test_harness::{Harness, HarnessOptions};
+
+/// The content cell holds a 20px line box and 10px of vertical padding, so it
+/// needs 30px whatever the sibling cell says.
+fn table(cell_style: &str, sibling_style: &str) -> Harness {
+    let html = format!(
+        "<html><head><style>body {{ margin: 0; font-size: 14px; line-height: 20px }}\
+         </style></head><body>\
+         <div style='display: table'><div style='display: table-row'>\
+         <div id=content style='display: table-cell; padding: 5px 10px; {cell_style}'>\
+         <div id=inner>Entry 0</div></div>\
+         <div id=sibling style='display: table-cell; {sibling_style}'></div>\
+         </div></div></body></html>"
+    );
+    Harness::from_html_with(
+        &html,
+        HarnessOptions {
+            width: 600,
+            height: 400,
+            ..Default::default()
+        },
+    )
+}
+
+#[test]
+fn a_cell_with_a_definite_width_still_contributes_its_content_height() {
+    let harness = table("width: 256px", "");
+    assert_eq!(harness.layout_rect("#content").height, 30.0);
+    assert_eq!(harness.layout_rect("#inner").height, 20.0);
+}
+
+/// What a data table widget commonly does: every row carries a zero-width spacer cell with
+/// the row height it wants. A specified height is a minimum, so the taller
+/// content wins.
+///
+/// The spacer keeps its own specified height rather than stretching to the
+/// row, which a browser would do. That is invisible for a zero-width cell, so
+/// this only pins down the cell that holds the text.
+#[test]
+fn a_shorter_specified_height_elsewhere_in_the_row_does_not_win() {
+    let harness = table("width: 256px", "vertical-align: top; height: 22px");
+    assert_eq!(harness.layout_rect("#content").height, 30.0);
+}
+
+/// A taller specified height still stretches the row.
+#[test]
+fn a_taller_specified_height_stretches_the_row() {
+    let harness = table("width: 256px", "height: 50px");
+    assert_eq!(harness.layout_rect("#content").height, 50.0);
+}
+
+/// The content of a cell laid out at its content-based width was always
+/// accounted for; keep it that way.
+#[test]
+fn a_cell_with_an_automatic_width_is_unchanged() {
+    let harness = table("", "vertical-align: top; height: 22px");
+    assert_eq!(harness.layout_rect("#content").height, 30.0);
+}
+
+/// A cell's specified height is a content-box height, so a spacer that also
+/// has padding asks for more of the row than its `height` alone suggests.
+#[test]
+fn a_spacer_cells_own_padding_counts_toward_the_row() {
+    // 22px of content plus 10px of padding beats the 30px content cell
+    let harness = table("width: 256px", "height: 22px; padding: 5px 10px");
+    assert_eq!(harness.layout_rect("#content").height, 32.0);
+
+    // ... unless the spacer measures its height as a border box
+    let harness = table(
+        "width: 256px",
+        "height: 22px; padding: 5px 10px; box-sizing: border-box",
+    );
+    assert_eq!(harness.layout_rect("#content").height, 30.0);
+}
+
+/// The same shape as a data table widget: fixed column widths from a leading
+/// sizing row, and an unpadded spacer cell carrying the row height.
+#[test]
+fn a_datatable_shaped_row_is_as_tall_as_its_text() {
+    let html = "<html><head><style>body { margin: 0; font-size: 14px; line-height: 20px }\
+         .content { display: table; table-layout: fixed; width: 1px; border-collapse: collapse }\
+         .content .datatable-cell { padding: 5px 10px }\
+         .content td { overflow: hidden; white-space: nowrap }\
+         </style></head><body>\
+         <table class=content>\
+         <tr><td style='width: 256px; height: 0px'></td><td style='width: 242px; height: 0px'></td>\
+             <td style='width: 0px; height: 0px'></td></tr>\
+         <tr><td id=cell class=datatable-cell><div>Entry 0</div></td>\
+             <td class=datatable-cell><div>Value 0</div></td>\
+             <td style='vertical-align: top; height: 22px'></td></tr>\
+         </table></body></html>";
+    let harness = Harness::from_html_with(
+        html,
+        HarnessOptions {
+            width: 600,
+            height: 400,
+            ..Default::default()
+        },
+    );
+    assert_eq!(harness.layout_rect("#cell").height, 30.0);
+}


### PR DESCRIPTION
Asking a box only for its width, when its width is already known, gets a height of zero back: taffy's block layout short-circuits, because the caller said it did not want the height. The measurement cache keys on the known dimensions and treats the requested axis as irrelevant, so that answer is stored where a later height query for the same box finds it, and the box reports no content at all.

Table cells are laid out at the width of their column, which is what makes them ask for this. A row then falls back to whatever height is specified elsewhere in it: a data table row carrying a spacer cell of `height: 22px` came out 22 tall around a 30px cell, clipping the text against the bottom of every row, and a row with no specified height anywhere collapsed onto its padding.

Answer width-only requests from the cache when a full measurement is already there, and otherwise measure without storing the result. The height a later query needs is computed once either way, so this trades no work for the correct answer.

<!-- wpt-results-start -->
## WPT results

**22** newly passing, **8** newly failing (net +14).

<details>
<summary>Full diff (30 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/backgrounds/background-position-applies-to-013d.xht
- Pass => Fail css/CSS2/margin-padding-clear/margin-collapse-101.xht
- Pass => Fail css/CSS2/margin-padding-clear/margin-collapse-105.xht
- Pass => Fail css/CSS2/margin-padding-clear/margin-collapse-113.xht
- Pass => Fail css/CSS2/margin-padding-clear/margin-collapse-115.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b01.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b02.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b03.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b04.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b05.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b06.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b07.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b08.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b09.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b10.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b11.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b12.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c01.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c02.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c03.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c04.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c05.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c06.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c07.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c08.xht
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-column-011.html
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-row-007.html
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-row-017.html
- Pass => Fail css/css-flexbox/flexbox-min-width-auto-002b.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-find-fr-size-gutters-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31247339875).</sub>
<!-- wpt-results-end -->
