### PR TITLE
fix: scale CSS transform translate by viewport scale factor

### DIFF
--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -326,7 +326,7 @@ impl Node {
                 Point2D::new(CSSPixelLength::new(0.0), CSSPixelLength::new(0.0)),
                 Size2D::new(CSSPixelLength::new(w), CSSPixelLength::new(h)),
             );
-            crate::resolve_2d_transform(s.get_box(), reference_box)
+            crate::resolve_2d_transform(s.get_box(), reference_box, scale as f64)
         });
 
         *self.transform_mut() = transform;

--- a/packages/blitz-dom/src/stylo_to_kurbo.rs
+++ b/packages/blitz-dom/src/stylo_to_kurbo.rs
@@ -25,12 +25,13 @@ use style::{
 pub fn resolve_2d_transform(
     box_styles: &BoxStyleStruct,
     reference_box: Rect<CSSPixelLength>,
+    scale: f64,
 ) -> Option<Affine> {
     let translate = match &box_styles.translate {
         Translate::None => None,
         Translate::Translate(x, y, _z) => Some(Vec2 {
-            x: x.resolve(reference_box.width()).px() as f64,
-            y: y.resolve(reference_box.height()).px() as f64,
+            x: x.resolve(reference_box.width()).px() as f64 * scale,
+            y: y.resolve(reference_box.height()).px() as f64 * scale,
         }),
     };
 
@@ -60,7 +61,16 @@ pub fn resolve_2d_transform(
             .map(|(t, _has_3d)| {
                 // See: https://drafts.csswg.org/css-transforms-2/#two-dimensional-subset
                 // And https://docs.rs/kurbo/latest/kurbo/struct.Affine.html#method.new
-                Affine::new([t.m11, t.m12, t.m21, t.m22, t.m41, t.m42].map(|v| v as f64))
+                // Scale the translation components by the viewport scale factor;
+                // scale factors and rotation angles are unitless and need no scaling.
+                Affine::new([
+                    t.m11 as f64,
+                    t.m12 as f64,
+                    t.m21 as f64,
+                    t.m22 as f64,
+                    t.m41 as f64 * scale,
+                    t.m42 as f64 * scale,
+                ])
             })
     };
 
@@ -80,11 +90,13 @@ pub fn resolve_2d_transform(
         x: transform_origin
             .horizontal
             .resolve(reference_box.width())
-            .px() as f64,
+            .px() as f64
+            * scale,
         y: transform_origin
             .vertical
             .resolve(reference_box.height())
-            .px() as f64,
+            .px() as f64
+            * scale,
     });
 
     let mut resolved = Affine::IDENTITY;

--- a/tests/blitz-tests/tests/transform_viewport_scale.rs
+++ b/tests/blitz-tests/tests/transform_viewport_scale.rs
@@ -1,0 +1,123 @@
+//! Verify that CSS `transform: translate(...)` is correctly scaled by the
+//! viewport scale factor (hidpi_scale * zoom).
+//!
+//! Per the CSS spec, transform values are in CSS pixels and should be multiplied
+//! by the device pixel ratio when rendering to physical pixels. If the
+//! transform is not scaled, a `translate(100px)` on a hidpi-2 screen moves
+//! 100 physical pixels instead of 200, causing misalignment between layout
+//! (which IS scaled) and transforms (which are not).
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+const HTML: &str = r#"<!DOCTYPE html>
+<html><head><style>
+    html, body { margin: 0; }
+    #box {
+        width: 100px;
+        height: 100px;
+        transform: translate(100px, 50px);
+        background: red;
+    }
+</style></head>
+<body><div id="box"></div></body></html>
+"#;
+
+fn make_doc(width: u32, height: u32, scale: f32) -> HtmlDocument {
+    HtmlDocument::from_html(
+        HTML,
+        DocumentConfig {
+            viewport: Some(Viewport::new(width, height, scale, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    )
+}
+
+/// Read the resolved CSS transform coefficients for `#box`.
+/// Returns `Some([m11, m12, m21, m22, m31, m32])` or `None` if no transform.
+fn box_transform_coeffs(doc: &HtmlDocument) -> Option<[f64; 6]> {
+    let box_id = doc.query_selector("#box").unwrap().unwrap();
+    let node = doc.get_node(box_id).unwrap();
+    node.transform().map(|t| t.as_coeffs())
+}
+
+/// Layout location of `#box` (before transform).
+fn box_layout_location(doc: &HtmlDocument) -> (f32, f32) {
+    let box_id = doc.query_selector("#box").unwrap().unwrap();
+    let layout = &doc.get_node(box_id).unwrap().final_layout();
+    (layout.location.x, layout.location.y)
+}
+
+#[test]
+fn transform_translate_at_scale_1() {
+    let mut doc = make_doc(400, 400, 1.0);
+    doc.resolve(0.0);
+
+    let t = box_transform_coeffs(&doc).expect("box should have a transform");
+    // translate(100px, 50px) => Affine([1, 0, 0, 1, 100, 50])
+    assert_eq!(t, [1.0, 0.0, 0.0, 1.0, 100.0, 50.0]);
+}
+
+#[test]
+fn transform_translate_at_scale_2() {
+    let mut doc = make_doc(400, 400, 2.0);
+    doc.resolve(0.0);
+
+    let (lx, ly) = box_layout_location(&doc);
+    // Layout is in CSS pixels, unscaled by the viewport scale.
+    assert_eq!(lx, 0.0);
+    assert_eq!(ly, 0.0);
+
+    let t = box_transform_coeffs(&doc).expect("box should have a transform");
+    // At hidpi_scale=2, translate(100px, 50px) in CSS pixels should become
+    // translate(200px, 100px) in device pixels.
+    //
+    // If this assertion fails with [1, 0, 0, 1, 100, 50], it means the
+    // transform was NOT scaled by the viewport factor -- a bug.
+    assert_eq!(
+        t,
+        [1.0, 0.0, 0.0, 1.0, 200.0, 100.0],
+        "transform translate should be scaled by viewport scale factor"
+    );
+}
+
+#[test]
+fn transform_scale_at_scale_2() {
+    // At hidpi_scale=2, a CSS scale(0.5) should still be scale(0.5) --
+    // scale factors are unitless and should NOT change with viewport scale.
+    // But the *effect* on screen should be as if applied after the
+    // viewport scale, so the combined scale is 2.0 * 0.5 = 1.0.
+    let html = r#"<html><head><style>
+        html, body { margin: 0; }
+        #box { width: 100px; height: 100px; transform: scale(0.5); background: red; }
+    </style></head><body><div id="box"></div></body></html>"#;
+
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(400, 400, 2.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+
+    let box_id = doc.query_selector("#box").unwrap().unwrap();
+    let node = doc.get_node(box_id).unwrap();
+    let t = node.transform().expect("box should have a transform");
+
+    // The CSS transform matrix itself: scale(0.5) => [0.5, 0, 0, 0.5, 0, 0]
+    // This is the raw CSS transform without viewport scaling applied.
+    let coeffs = t.as_coeffs();
+    eprintln!("scale(0.5) at hidpi=2: coeffs = {:?}", coeffs);
+    // We expect the matrix to represent 0.5 scale (unscaled by viewport)
+    // because scale is unitless. The viewport scaling should be applied
+    // separately at paint time.
+    assert!(
+        (coeffs[0] - 0.5).abs() < 1e-6 && (coeffs[3] - 0.5).abs() < 1e-6,
+        "scale factor should be 0.5 regardless of viewport scale"
+    );
+}


### PR DESCRIPTION
CSS transform values (translate, transform-origin) are in CSS pixels and must be multiplied by the viewport scale factor (hidpi_scale * zoom) when rendering to device pixels. Previously only layout positions were scaled while transform matrices were not, causing misalignment between layout coordinates and transformed elements on hidpi screens.

Pass the viewport scale into resolve_2d_transform and multiply the translation components (translate property, transform function m41/m42, and transform-origin) by it. Scale factors and rotation angles are unitless and remain unchanged.

Test: transform_viewport_scale.rs verifies translate is scaled at hidpi_scale=2 while scale(0.5) is not.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31186432999).</sub>
<!-- wpt-results-end -->
