### PR TITLE
Map display:flow-root to taffy item_is_flow_root (BFC beside floats)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7188,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
-source = "git+https://github.com/DioxusLabs/taffy?rev=8391c0903648448cf0a78d7983cb9b49b5f200a3#8391c0903648448cf0a78d7983cb9b49b5f200a3"
+source = "git+https://github.com/DioxusLabs/taffy?rev=6e811a8b72a8dc00d4765a927632606d9a2208af#6e811a8b72a8dc00d4765a927632606d9a2208af"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "8391c0903648448cf0a78d7983cb9b49b5f200a3", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "6e811a8b72a8dc00d4765a927632606d9a2208af", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -159,6 +159,11 @@ pub fn is_block(input: stylo::Display) -> bool {
 }
 
 #[inline]
+pub fn is_flow_root(input: stylo::Display) -> bool {
+    matches!(input.inside(), stylo::DisplayInside::FlowRoot)
+}
+
+#[inline]
 pub fn is_table(input: stylo::Display) -> bool {
     matches!(input.inside(), stylo::DisplayInside::Table)
 }
@@ -613,6 +618,7 @@ pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style<Atom> {
         box_sizing: self::box_sizing(style.clone_box_sizing()),
         item_is_table: display.inside() == stylo::DisplayInside::Table,
         item_is_replaced: false,
+        item_is_flow_root: self::is_flow_root(display),
         position: self::position(style.clone_position()),
         overflow: taffy::Point {
             x: self::overflow(style.clone_overflow_x()),

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -45,6 +45,11 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
     }
 
     #[inline]
+    fn is_flow_root(&self) -> bool {
+        convert::is_flow_root(self.0.get_box().display)
+    }
+
+    #[inline]
     fn box_sizing(&self) -> taffy::BoxSizing {
         convert::box_sizing(self.0.get_position().box_sizing)
     }


### PR DESCRIPTION
## Summary

Map `display: flow-root` to Taffy's new `Style::item_is_flow_root` / `CoreStyle::is_flow_root` (DioxusLabs/taffy#1060) so that flow-root boxes establish a new Block Formatting Context: they avoid floats (CSS2 §9.5) and don't collapse margins with their parent's BFC. Previously `DisplayInside::FlowRoot` was converted to a plain `Display::Block` that participated in the parent's BFC, so `display:flow-root` boxes overlapped floats.

```rust
// stylo_taffy::convert
pub fn is_flow_root(input: stylo::Display) -> bool {
    matches!(input.inside(), stylo::DisplayInside::FlowRoot)
}
// TaffyStyloStyle CoreStyle impl + to_taffy_style: item_is_flow_root wired up
```

Also bumps the pinned taffy rev to `6e811a8b` (the DioxusLabs/taffy#1060 branch), which additionally fixes BFC-beside-float full-height overlap, negative-margin, and negative-inset edge cases. Once taffy#1060 merges to main the rev should be bumped to the merge commit.

Based on #625. WPT `css/CSS2/floats` + `css/CSS2/floats-clear` vs #625: 195 → 211 PASS (16 newly passing, incl. floats-wrap-bfc-004, floats-wrap-bfc-with-margin-004/005/010, floats-bfc-003, floats-wrap-top-below-bfc-001–003 l/r), 0 regressions, 0 crashes.


Link to Devin session: https://app.devin.ai/sessions/bd32f9420a3346a0be428cc02c532d0d
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**270** newly passing, **12** newly failing (net +258), **1** other status change.

<details>
<summary>Full diff (283 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/borders/border-right-width-095.xht
+ Fail => Pass css/CSS2/css1/c5501-mrgn-t-000.xht
+ Fail => Pass css/CSS2/css1/c5503-mrgn-b-000.xht
+ Fail => Pass css/CSS2/css1/c62-percent-000.xht
+ Fail => Pass css/CSS2/floats-clear/adjoining-float-before-clearance.html
+ Fail => Pass css/CSS2/floats-clear/adjoining-float-nested-forced-clearance.html
+ Fail => Pass css/CSS2/floats-clear/adjoining-float-new-fc.html
+ Fail => Pass css/CSS2/floats-clear/clear-after-top-margin.html
+ Fail => Pass css/CSS2/floats-clear/clear-applies-to-013.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-001.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-002.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-003.xht
+ Fail => Pass css/CSS2/floats-clear/clear-on-child-with-margins-2.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-child-with-margins.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-parent-with-margins-no-clearance.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-parent-with-margins.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-replaced-element.html
+ Fail => Pass css/CSS2/floats-clear/float-005.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-008a.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-013.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-014.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-007.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-008.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-009.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-010.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-011.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-012.xht
+ Fail => Pass css/CSS2/floats-clear/float-replaced-height-001.xht
+ Fail => Pass css/CSS2/floats-clear/float-replaced-height-002.xht
+ Fail => Pass css/CSS2/floats-clear/float-replaced-height-003.xht
+ Fail => Pass css/CSS2/floats-clear/floats-005.xht
+ Fail => Pass css/CSS2/floats-clear/floats-015.xht
+ Fail => Pass css/CSS2/floats-clear/floats-101.xht
+ Fail => Pass css/CSS2/floats-clear/floats-118.xht
+ Fail => Pass css/CSS2/floats-clear/floats-119.xht
+ Fail => Pass css/CSS2/floats-clear/floats-120.xht
+ Fail => Pass css/CSS2/floats-clear/floats-138.xht
+ Fail => Pass css/CSS2/floats-clear/floats-145.xht
+ Crash => Pass css/CSS2/floats-clear/floats-146.xht
+ Fail => Pass css/CSS2/floats-clear/floats-154.xht
+ Fail => Pass css/CSS2/floats-clear/floats-bfc-001.xht
+ Fail => Pass css/CSS2/floats-clear/floats-bfc-003.html
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-018.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-023.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-027.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-122.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-123.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-125.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-135.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-142.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-165.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-012.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-013.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-015.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-016.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-017.xht
+ Fail => Pass css/CSS2/floats-clear/negative-clearance-after-adjoining-float.html
+ Fail => Pass css/CSS2/floats-clear/negative-clearance-after-bottom-margin.html
+ Fail => Pass css/CSS2/floats-clear/nested-clearance-new-formatting-context.html
+ Fail => Pass css/CSS2/floats-clear/no-clearance-due-to-large-margin.html
+ Fail => Pass css/CSS2/floats-clear/second-float-inside-empty-cleared-block-after-margin.html
+ Fail => Pass css/CSS2/floats-clear/second-float-inside-empty-cleared-block.html
+ Fail => Pass css/CSS2/floats/floats-placement-003.html
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-003-left-table.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-003-right-table.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-004.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-005.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-007.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-008.html
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-with-margin-004.html
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-with-margin-005.html
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-with-margin-006.tentative.html
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-with-margin-007.tentative.html
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-with-margin-008.tentative.html
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-with-margin-009.tentative.html
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-with-margin-010.html
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-001l.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-001r.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-002l.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-002r.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-003l.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-003r.xht
+ Fail => Pass css/CSS2/floats/new-fc-beside-adjoining-float-2.html
+ Fail => Pass css/CSS2/floats/new-fc-beside-adjoining-float.html
+ Fail => Pass css/CSS2/floats/new-fc-separates-from-float-2.html
+ Fail => Pass css/CSS2/floats/new-fc-separates-from-float-3.html
+ Fail => Pass css/CSS2/floats/zero-space-between-floats-003.html
+ Fail => Pass css/CSS2/floats/zero-space-between-floats-004.html
+ Fail => Pass css/CSS2/floats/zero-width-floats-positioning.tentative.html
+ Fail => Pass css/CSS2/linebox/line-height-128.xht
+ Fail => Pass css/CSS2/lists/list-style-image-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-bottom-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-bottom-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-039.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-040.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-041.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-113.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-114.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-clear-011.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-016.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-017.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-018.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-028.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-029.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-030.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-040.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-041.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-042.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-052.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-053.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-054.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-064.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-065.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-066.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-076.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-077.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-078.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-088.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-089.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-090.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-109.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-110.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-111.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-112.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-016.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-023.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-024.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-026.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-027.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-034.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-035.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-037.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-038.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-045.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-046.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-048.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-049.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-056.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-057.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-059.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-060.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-067.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-068.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-070.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-071.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-078.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-079.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-081.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-082.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-100.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-101.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-102.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-014.xht
+ Fail => Pass css/CSS2/normal-flow/block-formatting-contexts-011.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-applies-to-018.html
+ Fail => Pass css/CSS2/normal-flow/max-width-106.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-110.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-applies-to-018.html
+ Fail => Pass css/CSS2/normal-flow/min-height-106.xht
+ Fail => Pass css/CSS2/positioning/abspos-008.xht
+ Fail => Pass css/CSS2/positioning/position-relative-018.xht
+ Fail => Pass css/CSS2/text/white-space-mixed-003.xht
+ Fail => Pass css/CSS2/values/units-004.xht
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-002.html
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-003.html
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-004.html
+ Fail => Pass css/css-box/margin-trim/block-container-block-end-start-margin.html
+ Fail => Pass css/css-box/margin-trim/multicol-spanner-003.html
+ Fail => Pass css/css-break/box-decoration-break-clone-013.html
+ Fail => Pass css/css-break/ink-overflow-002.html
- Pass => Fail css/css-break/tall-float-pushed-to-next-fragmentainer-000.html
+ Fail => Pass css/css-break/truncated-margin-at-fragmentainer-end-001.html
+ Fail => Pass css/css-flexbox/align-items-baseline-overflow-non-visible.html
+ Fail => Pass css/css-flexbox/aspect-ratio-transferred-max-size.html
+ Fail => Pass css/css-flexbox/column-flex-child-with-max-width.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-006.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-007.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-009.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-004.html
+ Fail => Pass css/css-flexbox/flex-flow-001.html
+ Fail => Pass css/css-flexbox/flex-flow-004.html
- Pass => Fail css/css-flexbox/flexbox-min-height-auto-002b.html
+ Fail => Pass css/css-flexbox/flexbox-paint-ordering-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox_box-clear.html
+ Fail => Pass css/css-flexbox/flexbox_fbfc.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-002.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-003.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-004.html
+ Fail => Pass css/css-grid/alignment/grid-content-alignment-and-self-alignment-002.html
+ Fail => Pass css/css-grid/alignment/grid-gutters-016.html
+ Fail => Pass css/css-grid/grid-model/grid-box-sizing-001.html
+ Fail => Pass css/css-grid/grid-model/grid-floats-no-intrude-001.html
+ Fail => Pass css/css-grid/grid-model/grid-inline-floats-no-intrude-001.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-find-fr-size-restart-algorithm.html
- Pass => Fail css/css-grid/layout-algorithm/grid-percent-cols-filled-shrinkwrap-001.html
- Pass => Fail css/css-grid/layout-algorithm/grid-percent-cols-spanned-shrinkwrap-001.html
- Pass => Fail css/css-multicol/inline-block-and-column-span-all.html
- Pass => Fail css/css-multicol/multicol-nested-029.html
+ Fail => Pass css/css-overflow/scrollable-overflow-padding-inline.html
! Crash => Fail css/css-page/page-size-007-print.html
+ Fail => Pass css/css-rhythm/block-step-size-none-does-not-establish-block-formatting-context.html
+ Fail => Pass css/css-rhythm/block-step-size-none-does-not-establish-indepdendent-formatting-context.html
+ Fail => Pass css/css-sizing/aspect-ratio/block-aspect-ratio-025.html
+ Fail => Pass css/css-sizing/aspect-ratio/floats-aspect-ratio-001.html
+ Fail => Pass css/css-sizing/fit-content-contribution-001.html
- Pass => Fail css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-001.html
- Pass => Fail css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-002.html
- Pass => Fail css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-003.html
- Pass => Fail css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-004.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-001.html
+ Fail => Pass css/css-sizing/replaced-aspect-ratio-intrinsic-size-002.html
+ Fail => Pass css/css-sizing/stretch/bfc-next-to-float-1.html
+ Fail => Pass css/css-tables/min-height-table.html
+ Fail => Pass css/css-text/overflow-wrap/overflow-wrap-min-content-size-003.html
+ Fail => Pass css/css-text/white-space/break-spaces-051.html
+ Fail => Pass css/css-text/white-space/pre-line-051.html
+ Fail => Pass css/css-text/white-space/pre-wrap-051.html
+ Fail => Pass css/css-text/white-space/white-space-pre-051.html
+ Fail => Pass css/css-transforms/transform-origin-013.html
+ Fail => Pass css/css-values/ic-unit-001.html
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vlr-007.xht
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vlr-009.xht
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vrl-006.xht
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vrl-008.xht
+ Fail => Pass css/css-writing-modes/inline-box-orthogonal-child-with-margins.html
+ Fail => Pass css/css-writing-modes/percent-margin-vlr-003.xht
+ Fail => Pass css/css-writing-modes/percent-margin-vrl-002.xht
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31210667005).</sub>
<!-- wpt-results-end -->
