### PR TITLE
Inline float placement: line retries, deferred and revocable floats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=0e33e961c4ecd36a38d5103f57f305fbe37d749f#0e33e961c4ecd36a38d5103f57f305fbe37d749f"
+source = "git+https://github.com/DioxusLabs/taffy?rev=9d4a1305dadb5075651a5626b26bb7a3332469b8#9d4a1305dadb5075651a5626b26bb7a3332469b8"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "0e33e961c4ecd36a38d5103f57f305fbe37d749f", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "9d4a1305dadb5075651a5626b26bb7a3332469b8", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -487,49 +487,152 @@ impl BaseDocument {
 
         // Perform inline layout
         #[cfg(feature = "floats")]
+        let line_bottom_height;
+        #[cfg(feature = "floats")]
         {
+            const MAX_LINE_RETRIES: u32 = 8;
+
+            // Floats encountered mid-line that cannot be placed alongside the line's existing
+            // content: their placement is deferred until the line is committed, and they are
+            // placed below it.
+            struct PendingFloat {
+                node_id: NodeId,
+                size: taffy::Size<f32>,
+                margin: taffy::Rect<f32>,
+                direction: taffy::FloatDirection,
+                clear: Clear,
+            }
+            let mut pending_floats: Vec<PendingFloat> = Vec::new();
+
+            // Floats already handled for the current line: skipped if re-yielded after the
+            // line is reverted and re-laid out.
+            let mut line_deferred_ids: Vec<NodeId> = Vec::new();
+
             let mut breaker = inline_layout.layout.break_lines();
-            let initial_slot = block_ctx.find_content_slot(0.0, Clear::None, None);
+            let initial_slot = block_ctx.find_content_slot(0.0, 0.0, Clear::None, None);
             let mut has_active_floats = initial_slot.segment_id.is_some();
+            let mut current_slot = initial_slot;
             let state = breaker.state_mut();
             state.set_layout_max_advance(width);
-            state.set_line_max_advance(initial_slot.width * scale);
-            state.set_line_x(initial_slot.x * scale);
-            state.set_line_y((initial_slot.y * scale) as f64);
+            state.set_line_max_advance(current_slot.width * scale);
+            state.set_line_x(current_slot.x * scale);
+            state.set_line_y((current_slot.y * scale) as f64);
+            state.set_line_max_height(current_slot.height * scale);
 
-            // TODO: revert state and retry layout if a line doesn't fit
-            //
-            // Save initial state. Saved state is used to revert the layout to a previous state if needed
-            // (e.g. to revert a line that doesn't fit in the space it was laid out into)
-            //
-            // let mut saved_state = breaker.state().clone();
+            // Saved state is used to revert the layout to the start of the current line if the
+            // line doesn't fit in the space it was laid out into (e.g. because it turned out
+            // taller or wider than the float-free space at its position)
+            let mut saved_state = breaker.state().clone();
+            let mut line_retry_count = 0;
+
+            // Track the bottom edge of the lowest committed line: a line moved down below floats
+            // may end below the sum of the line heights (which is what parley reports as the
+            // layout height)
+            let mut max_line_bottom: f64 = 0.0;
 
             while let Some(yield_data) = breaker.break_next() {
                 match yield_data {
-                    YieldData::LineBreak(_line_break_data) => {
+                    YieldData::LineBreak(line_break_data) => {
+                        // If the line's content overflows a float-shortened line box then re-lay
+                        // the line out in the next available space down.
+                        if has_active_floats
+                            && line_retry_count < MAX_LINE_RETRIES
+                            && line_break_data.advance > current_slot.width * scale + 0.001
+                        {
+                            if let Some(segment_id) = current_slot.segment_id {
+                                line_retry_count += 1;
+                                let line_top = (line_break_data.line_y_start / scale as f64) as f32;
+                                let line_height = (line_break_data.line_height / scale).max(0.0);
+                                let next_slot = block_ctx.find_content_slot(
+                                    line_top,
+                                    line_height,
+                                    Clear::None,
+                                    Some(segment_id),
+                                );
+                                has_active_floats = next_slot.segment_id.is_some();
+                                current_slot = next_slot;
+
+                                breaker.revert_to(saved_state.clone());
+                                let state = breaker.state_mut();
+                                state.set_line_max_advance(current_slot.width * scale);
+                                state.set_line_x(current_slot.x * scale);
+                                state.set_line_y((current_slot.y * scale) as f64);
+                                state.set_line_max_height(current_slot.height * scale);
+                                continue;
+                            }
+                        }
+                        line_retry_count = 0;
+                        line_deferred_ids.clear();
+                        max_line_bottom = max_line_bottom.max(line_break_data.line_y_end);
+
+                        let line_bottom = (line_break_data.line_y_end / scale as f64) as f32;
+
+                        // Place floats which could not be placed alongside the line's content:
+                        // their tops may not be higher than the bottom of the line
+                        for pending in pending_floats.drain(..) {
+                            let pos = block_ctx.place_floated_box(
+                                pending.size + pending.margin.sum_axes(),
+                                line_bottom,
+                                pending.direction,
+                                pending.clear,
+                                false,
+                            );
+                            let layout = self.nodes[pending.node_id].unrounded_layout_mut();
+                            layout.size = pending.size;
+                            layout.location.x = pos.x + pending.margin.left + container_pb.left;
+                            layout.location.y = pos.y + pending.margin.top + container_pb.top;
+                        }
+
                         let state = breaker.state_mut();
 
                         if has_active_floats {
-                            // TODO: revert state and retry layout if a line doesn't fit
-                            // saved_state = state.clone();
-
                             let min_y = state.line_y() / scale as f64;
                             let next_slot =
-                                block_ctx.find_content_slot(min_y as f32, Clear::None, None);
+                                block_ctx.find_content_slot(min_y as f32, 0.0, Clear::None, None);
                             has_active_floats = next_slot.segment_id.is_some();
+                            current_slot = next_slot;
 
-                            state.set_line_max_advance(next_slot.width * scale);
-                            state.set_line_x(next_slot.x * scale);
-                            state.set_line_y((next_slot.y * scale) as f64);
+                            state.set_line_max_advance(current_slot.width * scale);
+                            state.set_line_x(current_slot.x * scale);
+                            state.set_line_y((current_slot.y * scale) as f64);
+                            state.set_line_max_height(current_slot.height * scale);
                         } else {
                             state.set_line_x(0.0);
                             state.set_line_max_advance(width);
+                            state.set_line_max_height(f32::INFINITY);
                         }
 
+                        saved_state = breaker.state().clone();
                         continue;
                     }
-                    YieldData::MaxHeightExceeded(_data) => {
-                        // TODO
+                    YieldData::MaxHeightExceeded(data) => {
+                        // The line's content is taller than the vertical extent over which its
+                        // line box width is valid: re-place the line taking account of all
+                        // floats that the line's actual height makes it adjacent to.
+                        if has_active_floats && line_retry_count < MAX_LINE_RETRIES {
+                            line_retry_count += 1;
+                            let line_top = (breaker.state().line_y() / scale as f64) as f32;
+                            let line_height = (data.line_height / scale).max(0.0);
+                            let next_slot = block_ctx.find_content_slot(
+                                line_top,
+                                line_height,
+                                Clear::None,
+                                None,
+                            );
+                            has_active_floats = next_slot.segment_id.is_some();
+                            current_slot = next_slot;
+
+                            breaker.revert_to(saved_state.clone());
+                            let state = breaker.state_mut();
+                            state.set_line_max_advance(current_slot.width * scale);
+                            state.set_line_x(current_slot.x * scale);
+                            state.set_line_y((current_slot.y * scale) as f64);
+                            state.set_line_max_height(
+                                (current_slot.height * scale).max(data.line_height),
+                            );
+                        } else {
+                            breaker.state_mut().set_line_max_height(f32::INFINITY);
+                        }
                         continue;
                     }
                     YieldData::InlineBoxBreak(box_break_data) => {
@@ -555,35 +658,63 @@ impl BaseDocument {
                             crate::taffy_node_id(node_id),
                             float_child_inputs,
                         );
-                        let min_y = state.line_y() as f32 / scale;
+                        let margin_box = output.size + margin_sum;
 
-                        // Note: `pos` is content-box relative
-                        let pos = block_ctx.place_floated_box(
-                            output.size + margin_sum,
-                            min_y,
-                            direction,
-                            clear,
-                            false,
-                        );
+                        // Skip floats already handled for this line (re-yielded after the line
+                        // was reverted and re-laid out)
+                        if line_deferred_ids.contains(&node_id) {
+                            let state = breaker.state_mut();
+                            state.append_inline_box_to_line(box_break_data.advance, 0.0);
+                            saved_state = breaker.state().clone();
+                            continue;
+                        }
 
-                        let min_y = state.line_y() / scale as f64; //.max(pos.y as f64);
-                        let next_slot =
-                            block_ctx.find_content_slot(min_y as f32, Clear::None, None);
-                        has_active_floats = next_slot.segment_id.is_some();
+                        // A float encountered mid-line can only be placed alongside the line's
+                        // existing content if there is enough space for both (the content shifts
+                        // sideways if the float is on its side). Otherwise its placement is
+                        // deferred until the line is committed, and it is placed below the line.
+                        let fits_on_line = box_break_data.advance <= 0.0
+                            || box_break_data.advance + margin_box.width * scale
+                                <= current_slot.width * scale + 0.001;
 
-                        state.set_line_max_advance(next_slot.width * scale);
-                        state.set_line_x(next_slot.x * scale);
-                        state.set_line_y((next_slot.y * scale) as f64);
+                        if fits_on_line {
+                            let min_y = state.line_y() as f32 / scale;
 
-                        let layout = self.nodes[node_id].unrounded_layout_mut();
-                        layout.size = output.size;
-                        layout.location.x = pos.x + margin.left + container_pb.left;
-                        layout.location.y = pos.y + margin.top + container_pb.top;
+                            // Note: `pos` is content-box relative
+                            let pos = block_ctx
+                                .place_floated_box(margin_box, min_y, direction, clear, false);
 
-                        // dbg!(&layout.size);
-                        // dbg!(&layout.location);
+                            let min_y = state.line_y() / scale as f64; //.max(pos.y as f64);
+                            let next_slot =
+                                block_ctx.find_content_slot(min_y as f32, 0.0, Clear::None, None);
+                            has_active_floats = next_slot.segment_id.is_some();
+                            current_slot = next_slot;
 
+                            state.set_line_max_advance(current_slot.width * scale);
+                            state.set_line_x(current_slot.x * scale);
+                            state.set_line_y((current_slot.y * scale) as f64);
+                            state.set_line_max_height(current_slot.height * scale);
+
+                            let layout = self.nodes[node_id].unrounded_layout_mut();
+                            layout.size = output.size;
+                            layout.location.x = pos.x + margin.left + container_pb.left;
+                            layout.location.y = pos.y + margin.top + container_pb.top;
+                        } else {
+                            line_deferred_ids.push(node_id);
+                            pending_floats.push(PendingFloat {
+                                node_id,
+                                size: output.size,
+                                margin,
+                                direction,
+                                clear,
+                            });
+                        }
+
+                        let state = breaker.state_mut();
                         state.append_inline_box_to_line(box_break_data.advance, 0.0);
+
+                        // Re-save state so that a line retry does not re-place this float
+                        saved_state = breaker.state().clone();
 
                         // if float.is_floated() {
                         //     println!("INLINE FLOATED BOX ({}) {:?}", ibox.id, float);
@@ -596,6 +727,23 @@ impl BaseDocument {
                 }
             }
             breaker.finish();
+
+            // Place any floats deferred from the final line
+            for pending in pending_floats.drain(..) {
+                let pos = block_ctx.place_floated_box(
+                    pending.size + pending.margin.sum_axes(),
+                    max_line_bottom as f32 / scale,
+                    pending.direction,
+                    pending.clear,
+                    false,
+                );
+                let layout = self.nodes[pending.node_id].unrounded_layout_mut();
+                layout.size = pending.size;
+                layout.location.x = pos.x + pending.margin.left + container_pb.left;
+                layout.location.y = pos.y + pending.margin.top + container_pb.top;
+            }
+
+            line_bottom_height = max_line_bottom as f32;
         }
 
         let alignment = self.nodes[node_id]
@@ -627,6 +775,10 @@ impl BaseDocument {
 
         #[allow(unused_mut)]
         let mut height = inline_layout.layout.height();
+        #[cfg(feature = "floats")]
+        {
+            height = height.max(line_bottom_height);
+        }
 
         // HACK. TODO: fix in Parley.
         //


### PR DESCRIPTION
## Summary

Companion to the taffy float-placement stack (DioxusLabs/taffy#1066 → #1067; #1064/#1065 already merged). This PR now pins taffy at the head of **#1067** (per request), so it no longer uses #1068's `float_snapshot`/`restore_float_snapshot` API.

Inline float placement changes in `blitz-dom/src/layout/inline.rs`:

- **Line retries around floats**: each line is laid out into a float-shortened `ContentSlot`; if the committed line overflows the slot (or exceeds its valid height via `MaxHeightExceeded`), the line is reverted and re-laid in the next slot down. Fixes the `floats-wrap-top-below-inline-*` family.
- **Deferred floats**: a float encountered mid-line is placed alongside the line only if `advance + float_width <= slot_width`; otherwise its placement is deferred and it is placed below the committed line (per CSS2 §9.5.1 rule 5: a float may not be higher than the line's preceding content).

**Note:** the "revocable floats" logic (undoing a speculatively placed float when the line's content turns out unbreakable, e.g. `white-space: nowrap`) was removed since it requires taffy #1068's snapshot API. `float-nowrap-3/9.html` therefore fail again on this PR; re-adding that logic once #1068 lands would fix them.

## WPT results

`css/CSS2/floats` + `css/CSS2/floats-clear` (337 tests run):

- Current `main`: 227 PASS / 110 FAIL / 0 CRASH
- This PR (+ taffy #1067 head): **246 PASS / 91 FAIL / 0 CRASH** — 19 newly passing, 0 regressions

Newly passing: `floats-wrap-top-below-bfc-001l/001r/002l/002r/003l/003r`, `floats-wrap-top-below-inline-001l/001r/002l/002r/003l/003r`, `floats-zero-height-wrap-001/002`, `floats-placement-004`, `float-no-content-beside-001`, `zero-width-floats-positioning.tentative`, `floats-clear/floats-132`, `floats-clear/floats-bfc-003`.


Link to Devin session: https://app.devin.ai/sessions/2aa49a15ca484966b5b71922bfd2bb58
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**29** newly passing, **19** newly failing (net +10).

<details>
<summary>Full diff (48 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/css1/c414-flt-fit-001.xht
- Pass => Fail css/CSS2/css1/c5525-fltinln-000.xht
+ Fail => Pass css/CSS2/css1/c5525-fltwidth-001.xht
+ Fail => Pass css/CSS2/floats-clear/floats-132.xht
+ Fail => Pass css/CSS2/floats-clear/floats-bfc-003.html
+ Fail => Pass css/CSS2/floats/float-no-content-beside-001.html
+ Fail => Pass css/CSS2/floats/floats-placement-004.html
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-001l.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-001r.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-002l.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-002r.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-003l.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-bfc-003r.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-inline-001l.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-inline-001r.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-inline-002l.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-inline-002r.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-inline-003l.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-top-below-inline-003r.xht
+ Fail => Pass css/CSS2/floats/floats-zero-height-wrap-001.xht
+ Fail => Pass css/CSS2/floats/floats-zero-height-wrap-002.xht
+ Fail => Pass css/CSS2/floats/zero-width-floats-positioning.tentative.html
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-width-012.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-width-013.xht
- Pass => Fail css/CSS2/text/white-space-processing-048.xht
- Pass => Fail css/css-flexbox/flexbox-baseline-multi-line-vert-002.html
+ Fail => Pass css/css-shapes/shape-outside/shape-image/gradients/shape-outside-linear-gradient-001.html
- Pass => Fail css/css-shapes/shape-outside/shape-image/shape-image-001.html
- Pass => Fail css/css-shapes/shape-outside/shape-image/shape-image-012.html
- Pass => Fail css/css-shapes/shape-outside/shape-image/shape-image-013.html
- Pass => Fail css/css-shapes/shape-outside/shape-image/shape-image-014.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-028.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-029.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/inset/shape-outside-inset-030.html
+ Fail => Pass css/css-shapes/shape-outside/supported-shapes/path/shape-outside-path-000.html
+ Fail => Pass css/css-shapes/shape-outside/supported-shapes/path/shape-outside-path-001.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/polygon/shape-outside-polygon-012.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/polygon/shape-outside-polygon-013.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/polygon/shape-outside-polygon-014.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/polygon/shape-outside-polygon-015.html
- Pass => Fail css/css-shapes/shape-outside/supported-shapes/polygon/shape-outside-polygon-032.html
+ Fail => Pass css/css-shapes/shape-outside/supported-shapes/shape/shape-outside-shape-000.html
+ Fail => Pass css/css-shapes/shape-outside/supported-shapes/shape/shape-outside-shape-001.html
- Pass => Fail css/css-text/hyphens/hyphens-none-014.html
- Pass => Fail css/css-text/hyphens/hyphens-none-015.html
- Pass => Fail css/css-text/white-space/pre-float-001.html
- Pass => Fail css/css-transforms/transform-generated-001.html
+ Fail => Pass css/css-writing-modes/float-vlr-014.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32482002466).</sub>
<!-- wpt-results-end -->
