### PR TITLE
Floats no longer split the inline flow

### DIFF
--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -379,6 +379,14 @@ impl Node {
         if !is_in_flow {
             return false;
         }
+        // Floated boxes do not break up the inline flow: they participate in the
+        // inline formatting context as out-of-flow inline boxes
+        let is_floating = style
+            .map(|s| s.clone_float().is_floating())
+            .unwrap_or(false);
+        if is_floating {
+            return false;
+        }
         let display = style
             .map(|s| s.clone_display())
             .unwrap_or(StyloDisplay::inline());


### PR DESCRIPTION
## Summary

Split out of #628 per request. Based directly on `main` with no taffy version change.

`Node::is_or_contains_block` now returns `false` for floated nodes: floats are blockified by stylo, but they participate in the inline formatting context as out-of-flow inline boxes, so a span containing a float must not force anonymous-block splitting of its inline context. Fixes WPT `css/CSS2/floats/float-in-inline-001/002.html` and `floats-placement-vertical-001b/001c.xht` (in combination with the float support in #625/#628).

Link to Devin session: https://app.devin.ai/sessions/2aa49a15ca484966b5b71922bfd2bb58
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**11** newly passing, **5** newly failing (net +6).

<details>
<summary>Full diff (16 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/abspos/static-inside-float-inside-inline.html
+ Fail => Pass css/CSS2/floats-clear/floats-149.xht
+ Fail => Pass css/CSS2/floats/float-in-inline-001.html
+ Fail => Pass css/CSS2/floats/float-in-inline-002.html
- Pass => Fail css/CSS2/floats/float-nowrap-3.html
+ Fail => Pass css/CSS2/floats/float-nowrap-4.html
- Pass => Fail css/CSS2/floats/float-nowrap-9.html
+ Fail => Pass css/CSS2/floats/float-nowrap-hyphen-rewind-1.html
+ Fail => Pass css/CSS2/floats/floats-placement-vertical-001b.xht
+ Fail => Pass css/CSS2/floats/floats-placement-vertical-001c.xht
- Pass => Fail css/CSS2/normal-flow/block-in-inline-float-between-001.xht
- Pass => Fail css/CSS2/visuren/float-inside-inline-between-blocks-1.html
- Pass => Fail css/css-color/inline-opacity-float-child.html
+ Fail => Pass css/css-ruby/empty-ruby-text-container-float.html
+ Fail => Pass css/css-ruby/ruby-base-container-float.html
+ Fail => Pass css/css-ruby/ruby-float-handling-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31217675998).</sub>
<!-- wpt-results-end -->

