### PR TITLE
stylo_taffy: Map `AlignItems::LastBaseline` to end. Resolve `JustifyContent` left/right.

### DIFF
--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -287,6 +287,42 @@ pub fn content_alignment(input: stylo::ContentDistribution) -> Option<taffy::Ali
     Some(align)
 }
 
+/// Convert `justify-content`, resolving the physical `left`/`right` keywords against the
+/// container's flex main axis and text direction. `left`/`right` behave as `start` when the
+/// main axis is not the inline axis (<https://www.w3.org/TR/css-align-3/#positional-values>).
+#[inline]
+pub fn justify_content(
+    input: stylo::ContentDistribution,
+    flex_direction: stylo::FlexDirection,
+    direction: stylo::Direction,
+) -> Option<taffy::AlignContent> {
+    let is_row = matches!(
+        flex_direction,
+        stylo::FlexDirection::Row | stylo::FlexDirection::RowReverse
+    );
+    let is_rtl = matches!(direction, stylo::Direction::Rtl);
+    let primary = input.primary();
+    let physical = match primary.value() {
+        stylo::AlignFlags::LEFT => Some(false),
+        stylo::AlignFlags::RIGHT => Some(true),
+        _ => return self::content_alignment(input),
+    };
+    let mut align = match physical {
+        Some(is_right) if is_row => {
+            if is_right != is_rtl {
+                taffy::AlignContent::END
+            } else {
+                taffy::AlignContent::START
+            }
+        }
+        _ => taffy::AlignContent::START,
+    };
+    if primary.flags().contains(stylo::AlignFlags::SAFE) {
+        align.safety = taffy::AlignmentSafety::Safe;
+    }
+    Some(align)
+}
+
 #[inline]
 pub fn item_alignment(input: stylo::AlignFlags) -> Option<taffy::AlignItems> {
     let mut align = match input.value() {
@@ -303,6 +339,9 @@ pub fn item_alignment(input: stylo::AlignFlags) -> Option<taffy::AlignItems> {
         stylo::AlignFlags::RIGHT => Some(taffy::AlignItems::END),
         stylo::AlignFlags::CENTER => Some(taffy::AlignItems::CENTER),
         stylo::AlignFlags::BASELINE => Some(taffy::AlignItems::BASELINE),
+        // Taffy does not support last-baseline alignment, so map it to its
+        // fallback alignment of `self-end` (https://www.w3.org/TR/css-align-3/#baseline-values)
+        stylo::AlignFlags::LAST_BASELINE => Some(taffy::AlignItems::END),
         // Should never be hit. But no real reason to panic here.
         _ => None,
     }?;
@@ -671,7 +710,11 @@ pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style<Atom> {
         #[cfg(any(feature = "flexbox", feature = "grid"))]
         align_content: self::content_alignment(pos.align_content),
         #[cfg(any(feature = "flexbox", feature = "grid"))]
-        justify_content: self::content_alignment(pos.justify_content),
+        justify_content: self::justify_content(
+            pos.justify_content,
+            pos.flex_direction,
+            style.clone_direction(),
+        ),
         #[cfg(any(feature = "flexbox", feature = "grid"))]
         align_items: self::item_alignment(pos.align_items.0),
         #[cfg(any(feature = "flexbox", feature = "grid"))]


### PR DESCRIPTION
## Summary

Two `stylo_taffy` conversion fixes found while debugging the WPT `css/css-flexbox/abspos/flex-abspos-staticpos-*` tests:

- `align-self`/`align-items: last baseline` (`stylo::AlignFlags::LAST_BASELINE`) previously fell through to `None` (i.e. behaved as `auto`). Taffy has no last-baseline support, so it now maps to `AlignItems::END`, its spec fallback alignment of `self-end` (css-align-3 §baseline-values).
- `justify-content: left`/`right` were mapped axis-agnostically to `START`/`END`. New `justify_content()` helper resolves them physically: against `direction` when the main axis is a row (`left` in RTL → `END`), and as `start` when the main axis is a column (the keywords don't apply to a block axis).

Together with DioxusLabs/taffy#1072 this takes `css/css-flexbox/abspos` from 30→52 passing tests (the taffy PR fixes `start`/`end` vs flex-relative resolution, `space-between`/`normal` fallback, `baseline` fallback, and auto margins for abspos static position). This PR stands alone against taffy 0.12.2 and also fixes `flex-order-last-baseline*`, `flexbox-justify-content-vert-00{2,3,4}`, `flexbox_justifycontent-right-002` and `flexbox_justifycontent-rtl-00{1,2}` on its own.

Known remaining failure (needs taffy self-start/self-end keywords): `flex-abspos-staticpos-align-self-rtl-004` where the item's own direction differs from the container's. Minor tradeoff: mapping last-baseline to `END` regresses 3 subtests in tests mixing vertical writing modes (`flex-align-baseline-004/005`, `flex-align-baseline-overflow-001`) while fixing 2 full tests and many subtests elsewhere.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d0e25433ddd94622ac777e7ddbefb779
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**26** newly passing, **0** newly failing (net +26).

<details>
<summary>Full diff (26 changed tests)</summary>

```diff
+ Fail => Pass css/css-contain/contain-inline-size-grid-indefinite-height-min-height-flex-row.html
+ Fail => Pass css/css-contain/contain-size-grid-indefinite-height-min-height-flex-row.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-001.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-003.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-005.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-007.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-001.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-002.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-003.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-justify-content-005.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-justify-content-006.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-justify-content-rtl-002.html
+ Fail => Pass css/css-flexbox/flex-order-last-baseline-multiple.html
+ Fail => Pass css/css-flexbox/flex-order-last-baseline.html
+ Fail => Pass css/css-flexbox/flexbox-justify-content-vert-002.xhtml
+ Fail => Pass css/css-flexbox/flexbox-justify-content-vert-003.xhtml
+ Fail => Pass css/css-flexbox/flexbox-justify-content-vert-004.xhtml
+ Fail => Pass css/css-flexbox/flexbox_justifycontent-right-002.html
+ Fail => Pass css/css-flexbox/flexbox_justifycontent-rtl-001.html
+ Fail => Pass css/css-flexbox/flexbox_justifycontent-rtl-002.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-last-baseline-001.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-last-baseline-001.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-last-baseline-002.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-justify-self-last-baseline-001.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-justify-self-rtl-last-baseline-001.html
+ Fail => Pass css/css-grid/abspos/grid-abspos-staticpos-justify-self-rtl-last-baseline-002.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31219854084).</sub>
<!-- wpt-results-end -->
