### PR TITLE
Map self-start/self-end alignment to Taffy's new SELF_START/SELF_END

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,12 +3354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "grid"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
-
-[[package]]
 name = "guillotiere"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7194,13 +7188,12 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340a09581f29809fc0df82a3955501dc7f2a21f887e5d1c13dbe288fe1c0bef4"
+source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1786140954-self-start-end-alignment#bc10b722ec64bfde5c42d10e8cbc37ff75c8f37b"
 dependencies = [
  "arrayvec",
- "grid",
  "serde",
  "slotmap",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7188,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.12.2"
-source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1786140954-self-start-end-alignment#bc10b722ec64bfde5c42d10e8cbc37ff75c8f37b"
+source = "git+https://github.com/DioxusLabs/taffy?rev=79578085#79578085932c76998c87e3282c29223ff9721c61"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ tracing-subscriber = "0.3"
 # `anyrender_svg` (with the usvg 0.48 bump) are released.
 [patch.crates-io]
 # TODO: remove once a taffy version with `self-start`/`self-end` alignment support is released
-taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "devin/1786140954-self-start-end-alignment" }
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "79578085" }
 usvg = { git = "https://github.com/DioxusLabs/resvg", branch = "devin/1785858271-intrinsic-dimensions" }
 anyrender = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
 anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,6 +273,8 @@ tracing-subscriber = "0.3"
 # TODO: remove these patches once `usvg` (with `Tree::intrinsic_dimensions`) and
 # `anyrender_svg` (with the usvg 0.48 bump) are released.
 [patch.crates-io]
+# TODO: remove once a taffy version with `self-start`/`self-end` alignment support is released
+taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "devin/1786140954-self-start-end-alignment" }
 usvg = { git = "https://github.com/DioxusLabs/resvg", branch = "devin/1785858271-intrinsic-dimensions" }
 anyrender = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
 anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -560,6 +560,7 @@ impl BaseDocument {
                             min_y,
                             direction,
                             clear,
+                            false,
                         );
 
                         let min_y = state.line_y() / scale as f64; //.max(pos.y as f64);

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -312,6 +312,7 @@ impl BaseDocument {
                 // The default CSS file will set
                 match node.style().display {
                     Display::Block => compute_block_layout(self, node_id, inputs, block_ctx),
+                    Display::FlowRoot => compute_block_layout(self, node_id, inputs, None),
                     Display::Flex => compute_flexbox_layout(self, node_id, inputs),
                     Display::Grid => compute_grid_layout(self, node_id, inputs),
                     Display::None => taffy::LayoutOutput::HIDDEN,
@@ -527,6 +528,7 @@ impl PrintTree for BaseDocument {
                     },
                     Display::Grid => "GRID",
                     Display::Block => "BLOCK",
+                    Display::FlowRoot => "FLOW ROOT",
                     Display::None => "NONE",
                 };
                 format!("{} ({})", node.node_debug_str(), display).leak()

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -1060,7 +1060,9 @@ impl ElementCx<'_, '_> {
             let stroke = Stroke::new(self.scale);
 
             let stroke_color = match self.node.style().display {
-                taffy::Display::Block => Color::new([1.0, 0.0, 0.0, 1.0]),
+                taffy::Display::Block | taffy::Display::FlowRoot => {
+                    Color::new([1.0, 0.0, 0.0, 1.0])
+                }
                 taffy::Display::Flex => Color::new([0.0, 1.0, 0.0, 1.0]),
                 taffy::Display::Grid => Color::new([0.0, 0.0, 1.0, 1.0]),
                 taffy::Display::None => Color::new([0.0, 0.0, 1.0, 1.0]),

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -331,8 +331,8 @@ pub fn item_alignment(input: stylo::AlignFlags) -> Option<taffy::AlignItems> {
         stylo::AlignFlags::STRETCH => Some(taffy::AlignItems::STRETCH),
         stylo::AlignFlags::FLEX_START => Some(taffy::AlignItems::FLEX_START),
         stylo::AlignFlags::FLEX_END => Some(taffy::AlignItems::FLEX_END),
-        stylo::AlignFlags::SELF_START => Some(taffy::AlignItems::START),
-        stylo::AlignFlags::SELF_END => Some(taffy::AlignItems::END),
+        stylo::AlignFlags::SELF_START => Some(taffy::AlignItems::SELF_START),
+        stylo::AlignFlags::SELF_END => Some(taffy::AlignItems::SELF_END),
         stylo::AlignFlags::START => Some(taffy::AlignItems::START),
         stylo::AlignFlags::END => Some(taffy::AlignItems::END),
         stylo::AlignFlags::LEFT => Some(taffy::AlignItems::START),
@@ -540,13 +540,18 @@ pub fn grid_template_area(input: &stylo::NamedArea) -> taffy::GridTemplateArea<A
 
 #[inline]
 #[cfg(feature = "grid")]
-fn grid_template_areas(input: &stylo::GridTemplateAreas) -> Vec<taffy::GridTemplateArea<Atom>> {
+fn grid_template_areas(input: &stylo::GridTemplateAreas) -> Option<taffy::GridTemplateAreas<Atom>> {
     match input {
-        stylo::GridTemplateAreas::None => Vec::new(),
+        stylo::GridTemplateAreas::None => None,
         stylo::GridTemplateAreas::Areas(template_areas_arc) => {
-            crate::wrapper::GridAreaWrapper(&template_areas_arc.0.areas)
-                .into_iter()
-                .collect()
+            let areas = &template_areas_arc.0;
+            Some(taffy::GridTemplateAreas {
+                areas: crate::wrapper::GridAreaWrapper(&areas.areas)
+                    .into_iter()
+                    .collect(),
+                row_count: areas.strings.len() as u16,
+                column_count: areas.width as u16,
+            })
         }
     }
 }


### PR DESCRIPTION
## Summary

Depends on DioxusLabs/taffy#1077. Wires up the new item-relative alignment keywords and updates Blitz to compile against current Taffy `main`:

- `stylo_taffy::convert::item_alignment` now maps `AlignFlags::SELF_START`/`SELF_END` to `taffy::AlignItems::SELF_START`/`SELF_END` instead of collapsing them to container-relative `START`/`END`, so `align-self: self-start` etc. resolve against the item's own `direction`.
- Adapts to Taffy API changes on `main`:
  - `grid_template_areas` now returns `Option<taffy::GridTemplateAreas>` (with `row_count`/`column_count` taken from stylo's `TemplateAreas::strings.len()`/`width`).
  - `BlockContext::place_floated_box` gained an `adjoins_unresolved_strut: bool` parameter (passed `false` from the inline float path).
  - `taffy::Display::FlowRoot` handled in layout dispatch (treated as a new block formatting context via `compute_block_layout` with no float context) and devtools paint.
- Temporarily patches `taffy` to the git branch of taffy#1077; this should be switched to `main` (or a release) once that PR merges.

WPT (css-flexbox/css-grid abspos + alignment subsuites) with this change: `flex-abspos-staticpos-align-self-rtl-004` goes 20/24 → 24/24 subtests (full pass), `grid-self-alignment.html` 24/72 → 36/72, and `grid-row-axis-alignment-positioned-items-{010,011,015,016}` each 0/4 → 2/4, with no regressions in supported features (remaining failures use vertical writing modes, baseline in unsupported positions, or other unsupported features).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ca2ab1b8ecbe43409053475335d0b957
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**292** newly passing, **11** newly failing (net +281), **1** other status change.

<details>
<summary>Full diff (304 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/borders/border-right-width-095.xht
+ Fail => Pass css/CSS2/css1/c5501-mrgn-t-000.xht
+ Fail => Pass css/CSS2/css1/c5503-mrgn-b-000.xht
+ Fail => Pass css/CSS2/css1/c62-percent-000.xht
+ Fail => Pass css/CSS2/floats-clear/adjoining-float-before-clearance.html
+ Fail => Pass css/CSS2/floats-clear/adjoining-float-nested-forced-clearance.html
+ Fail => Pass css/CSS2/floats-clear/adjoining-float-new-fc.html
+ Fail => Pass css/CSS2/floats-clear/clear-after-top-margin.html
+ Fail => Pass css/CSS2/floats-clear/clear-applies-to-013.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-001.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-002.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-003.xht
+ Fail => Pass css/CSS2/floats-clear/clear-float-002.xht
+ Fail => Pass css/CSS2/floats-clear/clear-float-003.xht
+ Fail => Pass css/CSS2/floats-clear/clear-on-child-with-margins-2.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-child-with-margins.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-parent-with-margins-no-clearance.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-parent-with-margins.html
+ Fail => Pass css/CSS2/floats-clear/clear-on-replaced-element.html
+ Fail => Pass css/CSS2/floats-clear/float-005.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-008a.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-013.xht
+ Fail => Pass css/CSS2/floats-clear/float-applies-to-014.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-007.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-008.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-009.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-010.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-011.xht
+ Fail => Pass css/CSS2/floats-clear/float-non-replaced-width-012.xht
+ Fail => Pass css/CSS2/floats-clear/float-replaced-height-002.xht
+ Fail => Pass css/CSS2/floats-clear/float-replaced-height-003.xht
+ Fail => Pass css/CSS2/floats-clear/floats-005.xht
+ Fail => Pass css/CSS2/floats-clear/floats-015.xht
+ Fail => Pass css/CSS2/floats-clear/floats-118.xht
+ Fail => Pass css/CSS2/floats-clear/floats-119.xht
+ Fail => Pass css/CSS2/floats-clear/floats-120.xht
+ Fail => Pass css/CSS2/floats-clear/floats-138.xht
+ Fail => Pass css/CSS2/floats-clear/floats-145.xht
+ Crash => Pass css/CSS2/floats-clear/floats-146.xht
+ Fail => Pass css/CSS2/floats-clear/floats-154.xht
+ Fail => Pass css/CSS2/floats-clear/floats-bfc-001.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-018.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-023.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-027.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-033.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-034.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-035.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-122.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-123.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-125.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-135.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-142.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-165.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-012.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-013.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-015.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-016.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-017.xht
+ Fail => Pass css/CSS2/floats-clear/negative-clearance-after-adjoining-float.html
+ Fail => Pass css/CSS2/floats-clear/negative-clearance-after-bottom-margin.html
+ Fail => Pass css/CSS2/floats-clear/nested-clearance-new-formatting-context.html
+ Fail => Pass css/CSS2/floats-clear/no-clearance-due-to-large-margin.html
+ Fail => Pass css/CSS2/floats-clear/second-float-inside-empty-cleared-block-after-margin.html
+ Fail => Pass css/CSS2/floats-clear/second-float-inside-empty-cleared-block.html
+ Fail => Pass css/CSS2/floats/floats-placement-003.html
+ Fail => Pass css/CSS2/floats/floats-rule3-outside-left-001.xht
+ Fail => Pass css/CSS2/floats/floats-rule3-outside-left-002.xht
+ Fail => Pass css/CSS2/floats/floats-rule3-outside-right-001.xht
+ Fail => Pass css/CSS2/floats/floats-rule3-outside-right-002.xht
+ Fail => Pass css/CSS2/floats/floats-rule7-outside-left-001.xht
+ Fail => Pass css/CSS2/floats/floats-rule7-outside-right-001.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-005.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-007.xht
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-008.html
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-with-margin-008.tentative.html
+ Fail => Pass css/CSS2/floats/floats-wrap-bfc-with-margin-009.tentative.html
+ Fail => Pass css/CSS2/floats/new-fc-beside-adjoining-float-2.html
+ Fail => Pass css/CSS2/floats/new-fc-beside-adjoining-float.html
+ Fail => Pass css/CSS2/floats/new-fc-separates-from-float-2.html
+ Fail => Pass css/CSS2/floats/new-fc-separates-from-float-3.html
+ Fail => Pass css/CSS2/floats/zero-space-between-floats-004.html
+ Fail => Pass css/CSS2/linebox/line-height-128.xht
+ Fail => Pass css/CSS2/lists/list-style-image-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-bottom-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-bottom-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-039.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-040.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-041.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-113.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-114.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-clear-011.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-016.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-017.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-018.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-028.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-029.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-030.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-040.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-041.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-042.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-052.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-053.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-054.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-064.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-065.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-066.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-076.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-077.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-078.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-088.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-089.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-090.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-103.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-104.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-109.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-110.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-111.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-112.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-007.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-014.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-012.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-016.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-023.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-024.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-026.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-027.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-034.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-035.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-037.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-038.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-045.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-046.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-048.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-049.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-056.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-057.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-059.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-060.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-067.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-068.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-070.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-071.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-078.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-079.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-081.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-082.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-100.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-101.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-102.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-002.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-003.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-004.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-005.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-006.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-009.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-013.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-014.xht
+ Fail => Pass css/CSS2/normal-flow/block-formatting-contexts-011.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-applies-to-018.html
+ Fail => Pass css/CSS2/normal-flow/max-width-106.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-110.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-applies-to-018.html
+ Fail => Pass css/CSS2/normal-flow/min-height-106.xht
+ Fail => Pass css/CSS2/positioning/abspos-008.xht
+ Fail => Pass css/CSS2/positioning/position-relative-018.xht
+ Fail => Pass css/CSS2/text/white-space-mixed-003.xht
+ Fail => Pass css/CSS2/values/units-004.xht
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-002.html
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-003.html
+ Fail => Pass css/css-backgrounds/box-shadow-overlapping-004.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-002.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-004.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-006.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-008.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-004.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-justify-content-003.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-justify-content-004.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-justify-content-007.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-justify-content-008.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-justify-content-rtl-001.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-margin-001.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-margin-002.html
+ Fail => Pass css/css-flexbox/abspos/flex-abspos-staticpos-margin-003.html
+ Fail => Pass css/css-flexbox/align-items-baseline-overflow-non-visible.html
+ Fail => Pass css/css-flexbox/aspect-ratio-transferred-max-size.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-006.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-007.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-column-009.html
+ Fail => Pass css/css-flexbox/flex-aspect-ratio-img-row-004.html
+ Fail => Pass css/css-flexbox/flex-flow-001.html
+ Fail => Pass css/css-flexbox/flex-flow-004.html
+ Fail => Pass css/css-flexbox/flex-lines/multi-line-wrap-reverse-column-reverse.html
+ Fail => Pass css/css-flexbox/flex-lines/multi-line-wrap-with-column-reverse.html
+ Fail => Pass css/css-flexbox/flexbox-justify-content-vert-001a.xhtml
+ Fail => Pass css/css-flexbox/flexbox-justify-content-vert-001b.xhtml
+ Fail => Pass css/css-flexbox/flexbox-justify-content-vert-006.xhtml
- Pass => Fail css/css-flexbox/flexbox-min-height-auto-002b.html
+ Fail => Pass css/css-flexbox/flexbox-paint-ordering-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox_box-clear.html
+ Fail => Pass css/css-flexbox/flexbox_fbfc.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-002.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-003.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-004.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-background-001.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-background-rtl-001.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-content-alignment-001.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-content-alignment-rtl-001.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-gaps-001.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-gaps-002-rtl.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-gaps-002.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-gaps-rtl-001.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-implicit-grid-001.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-implicit-grid-line-001.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-padding-001.html
+ Fail => Pass css/css-grid/abspos/grid-positioned-items-unknown-named-grid-line-001.html
+ Fail => Pass css/css-grid/abspos/grid-sizing-positioned-items-001.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-items-should-not-create-implicit-tracks-001.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-items-sizing-001.html
+ Fail => Pass css/css-grid/alignment/grid-content-alignment-and-self-alignment-002.html
+ Fail => Pass css/css-grid/alignment/grid-gutters-016.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/column-subgrid-writing-direction-003.html
+ Fail => Pass css/css-grid/grid-model/grid-box-sizing-001.html
+ Fail => Pass css/css-grid/grid-model/grid-floats-no-intrude-001.html
+ Fail => Pass css/css-grid/grid-model/grid-inline-floats-no-intrude-001.html
+ Fail => Pass css/css-grid/grid-model/grid-margins-no-collapse-002.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-find-fr-size-restart-algorithm.html
- Pass => Fail css/css-grid/layout-algorithm/grid-percent-cols-filled-shrinkwrap-001.html
- Pass => Fail css/css-grid/layout-algorithm/grid-percent-cols-spanned-shrinkwrap-001.html
- Pass => Fail css/css-grid/subgrid/writing-directions-003.html
- Pass => Fail css/css-multicol/inline-block-and-column-span-all.html
+ Fail => Pass css/css-overflow/scrollable-overflow-padding-inline.html
! Crash => Fail css/css-page/page-size-007-print.html
- Pass => Fail css/css-position/position-absolute-in-inline-margin-top.html
+ Fail => Pass css/css-rhythm/block-step-size-none-does-not-establish-block-formatting-context.html
+ Fail => Pass css/css-rhythm/block-step-size-none-does-not-establish-indepdendent-formatting-context.html
+ Fail => Pass css/css-sizing/aspect-ratio/block-aspect-ratio-025.html
+ Fail => Pass css/css-sizing/fit-content-contribution-001.html
- Pass => Fail css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-001.html
- Pass => Fail css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-002.html
- Pass => Fail css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-003.html
- Pass => Fail css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-004.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-001.html
+ Fail => Pass css/css-sizing/replaced-aspect-ratio-intrinsic-size-002.html
+ Fail => Pass css/css-tables/min-height-table.html
+ Fail => Pass css/css-text/overflow-wrap/overflow-wrap-min-content-size-003.html
+ Fail => Pass css/css-text/white-space/break-spaces-051.html
+ Fail => Pass css/css-text/white-space/pre-line-051.html
+ Fail => Pass css/css-text/white-space/pre-wrap-051.html
+ Fail => Pass css/css-text/white-space/white-space-pre-051.html
+ Fail => Pass css/css-transforms/transform-origin-013.html
+ Fail => Pass css/css-values/ic-unit-001.html
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vlr-007.xht
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vlr-009.xht
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vrl-006.xht
+ Fail => Pass css/css-writing-modes/contiguous-floated-table-vrl-008.xht
+ Fail => Pass css/css-writing-modes/inline-box-orthogonal-child-with-margins.html
+ Fail => Pass css/css-writing-modes/percent-margin-vlr-003.xht
+ Fail => Pass css/css-writing-modes/percent-margin-vrl-002.xht
+ Fail => Pass css/filter-effects/filtered-inline-applies-to-float.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31226119877).</sub>
<!-- wpt-results-end -->
