### PR TITLE
Preserve known dimensions in empty inline layout short-circuit

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -209,7 +209,11 @@ impl BaseDocument {
                 .unwrap()
                 .inline_layout_data = Some(inline_layout);
             return LayoutOutput::from_outer_size(
-                Size::ZERO.maybe_max(container_pb.sum_axes().map(Some)),
+                Size {
+                    width: known_dimensions.width.unwrap_or(0.0),
+                    height: known_dimensions.height.unwrap_or(0.0),
+                }
+                .maybe_max(container_pb.sum_axes().map(Some)),
             );
         }
 

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -208,13 +208,11 @@ impl BaseDocument {
                 .downcast_element_mut()
                 .unwrap()
                 .inline_layout_data = Some(inline_layout);
-            return LayoutOutput::from_outer_size(
-                Size {
-                    width: known_dimensions.width.unwrap_or(0.0),
-                    height: known_dimensions.height.unwrap_or(0.0),
-                }
-                .maybe_max(container_pb.sum_axes().map(Some)),
-            );
+            let pb_sum = container_pb.sum_axes();
+            return LayoutOutput::from_outer_size(Size {
+                width: known_dimensions.width.unwrap_or(pb_sum.width),
+                height: known_dimensions.height.unwrap_or(pb_sum.height),
+            });
         }
 
         // Resolve node's preferred/min/max sizes (width/heights) against the available space (percentages resolve to pixel values)


### PR DESCRIPTION
## Summary

Fixes the `css/css-flexbox/flexible-box-float.html` regression on #625.

When an inline formatting context contains only out-of-flow content (all children absolutely positioned or floated — e.g. a `<p>&nbsp;</p>` flex item whose only text is whitespace and whose box is floated), `compute_inline_layout` short-circuits and returned `Size::ZERO`, discarding the definite `known_dimensions` taffy passed for the item (its flexed target size, e.g. `300x30`). The flex items therefore collapsed to `0x0` and the test's red fail-flag became visible.

```diff
 return LayoutOutput::from_outer_size(
-    Size::ZERO.maybe_max(container_pb.sum_axes().map(Some)),
+    Size {
+        width: known_dimensions.width.unwrap_or(0.0),
+        height: known_dimensions.height.unwrap_or(0.0),
+    }
+    .maybe_max(container_pb.sum_axes().map(Some)),
 );
```

Together with DioxusLabs/taffy#1081 (which fixes `flexbox-min-height-auto-002b.html`), both flexbox regressions on #625 pass. Verified with the WPT runner and `cargo fmt`/`clippy`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/40e9a29868044e77a6dbf77a7b4b11e3
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**8** newly passing, **2** newly failing (net +6).

<details>
<summary>Full diff (10 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-016.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-zorder-002.xht
- Pass => Fail css/CSS2/normal-flow/inline-table-zorder-001.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-applies-to-016.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-applies-to-016.xht
+ Fail => Pass css/CSS2/normal-flow/min-width-applies-to-016.xht
+ Fail => Pass css/CSS2/text/white-space-007.xht
+ Fail => Pass css/css-animations/animation-name-in-shadow-part-inner-match.html
+ Fail => Pass css/css-flexbox/flexible-box-float.html
+ Fail => Pass css/css-values/lh-unit-002.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31231707273).</sub>
<!-- wpt-results-end -->
