### PR TITLE
Implement support for `<iframe>` elements

### DIFF
--- a/examples/assets/iframe_navigation.html
+++ b/examples/assets/iframe_navigation.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 16px;
+      }
+      section {
+        margin-bottom: 24px;
+      }
+      h2 {
+        font-size: 16px;
+        margin: 0 0 4px;
+      }
+      p.hint {
+        font-size: 13px;
+        color: #555;
+        margin: 0 0 8px;
+      }
+      iframe {
+        width: 420px;
+        height: 200px;
+        border: 2px solid #333;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Iframe navigation</h1>
+
+    <section>
+      <h2>1. src navigation</h2>
+      <p class="hint">
+        Click the links inside the frame. Each click should replace the
+        sub-document with the linked page, without navigating this page.
+      </p>
+      <iframe src="./iframe_page_a.html"></iframe>
+    </section>
+
+    <section>
+      <h2>2. srcdoc navigation</h2>
+      <p class="hint">
+        The frame starts from a <code>srcdoc</code> document. Relative links
+        resolve against this (parent) document's URL.
+      </p>
+      <iframe
+        srcdoc="
+          <body style='font-family: sans-serif; background: #eef6ff'>
+            <h3>srcdoc frame</h3>
+            <a href='./iframe_page_a.html'>Navigate to page A</a>
+          </body>
+        "
+      ></iframe>
+    </section>
+
+    <section>
+      <h2>3. nested frames</h2>
+      <p class="hint">
+        Page A embeds another frame. Navigating the inner frame should not
+        affect the outer one.
+      </p>
+      <iframe src="./iframe_page_a.html" style="height: 320px"></iframe>
+    </section>
+
+    <section>
+      <h2>4. targeting the top document</h2>
+      <p class="hint">
+        This link navigates the outer document, for comparison with the
+        in-frame navigations above.
+      </p>
+      <a href="./iframe_page_b.html">Navigate this page to page B</a>
+    </section>
+  </body>
+</html>

--- a/examples/assets/iframe_page_a.html
+++ b/examples/assets/iframe_page_a.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        font-family: sans-serif;
+        background: #e8f5e9;
+        margin: 8px;
+      }
+      h3 {
+        margin: 0 0 8px;
+      }
+      iframe {
+        width: 300px;
+        height: 120px;
+        border: 1px dashed #888;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Page A</h3>
+    <ul>
+      <li><a href="./iframe_page_b.html">Go to page B (relative)</a></li>
+      <li><a href="./iframe_page_a.html">Reload page A</a></li>
+      <li><a href="./does_not_exist.html">Broken link (should stay usable)</a></li>
+    </ul>
+    <p>A nested frame:</p>
+    <iframe src="./iframe_page_b.html"></iframe>
+  </body>
+</html>

--- a/examples/assets/iframe_page_b.html
+++ b/examples/assets/iframe_page_b.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        font-family: sans-serif;
+        background: #fff3e0;
+        margin: 8px;
+      }
+      h3 {
+        margin: 0 0 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <h3>Page B</h3>
+    <p>Loaded an image relative to page B's own URL:</p>
+    <img src="./square.png" style="width: 40px; height: 40px" />
+    <p><a href="./iframe_page_a.html">Back to page A</a></p>
+  </body>
+</html>

--- a/packages/blitz-dom/src/config.rs
+++ b/packages/blitz-dom/src/config.rs
@@ -59,4 +59,7 @@ pub struct DocumentConfig {
     /// document will carry this signal. Aborting it cancels every in-flight
     /// fetch tied to this document.
     pub abort_signal: Option<AbortSignal>,
+    /// How deeply this document is nested within other documents
+    /// (0 for a root document). Used to limit `<iframe>` nesting depth.
+    pub subdocument_depth: usize,
 }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1268,7 +1268,7 @@ impl BaseDocument {
 
                 self.apply_loaded_image(url, image);
             }
-            Resource::IframeHtml(html) => {
+            Resource::DocumentSrc(html) => {
                 let Some(node_id) = res.node_id else {
                     return;
                 };

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -179,6 +179,12 @@ impl Document for Rc<RefCell<BaseDocument>> {
 
 pub enum DocumentEvent {
     ResourceLoad(ResourceLoadResponse),
+    /// A navigation originating from within an iframe's sub-document
+    /// (e.g. a link click), to be applied to the iframe identified by `node_id`.
+    NavigateIframe {
+        node_id: NodeId,
+        url: Url,
+    },
 }
 
 pub struct BaseDocument {
@@ -200,6 +206,9 @@ pub struct BaseDocument {
     pub(crate) style_threading: StyleThreading,
     /// Whether incremental layout is enabled for this document.
     pub(crate) incremental_layout: bool,
+    /// How deeply this document is nested within other documents
+    /// (0 for a root document). Used to limit `<iframe>` nesting depth.
+    pub(crate) subdocument_depth: usize,
 
     // Events
     pub(crate) tx: Sender<DocumentEvent>,
@@ -289,6 +298,9 @@ pub struct BaseDocument {
     pub(crate) controls_to_form: HashMap<NodeId, NodeId>,
     /// Nodes that contain sub documents
     pub(crate) sub_document_nodes: HashSet<NodeId>,
+    /// Load state (abort controller and in-flight request id) for each
+    /// `<iframe>` element whose sub-document is loaded automatically
+    pub(crate) iframe_loads: HashMap<NodeId, crate::iframe::IframeLoad>,
     /// Set of changed nodes for updating the accessibility tree
     pub(crate) changed_nodes: HashSet<NodeId>,
     /// Set of changed nodes for updating the accessibility tree
@@ -443,6 +455,7 @@ impl BaseDocument {
             media_type,
             style_threading: config.style_threading,
             incremental_layout: config.incremental.unwrap_or(true),
+            subdocument_depth: config.subdocument_depth,
             devtool_settings: DevtoolSettings::default(),
             viewport_scroll: crate::Point::ZERO,
             url: base_url,
@@ -464,6 +477,7 @@ impl BaseDocument {
             subdoc_is_animating: false,
             has_canvas: false,
             sub_document_nodes: HashSet::new(),
+            iframe_loads: HashMap::new(),
 
             #[cfg(feature = "custom-widget")]
             custom_widget_nodes: HashSet::new(),
@@ -741,6 +755,9 @@ impl BaseDocument {
             .unwrap()
             .remove_sub_document();
         self.sub_document_nodes.remove(&node_id);
+        if let Some(load) = self.iframe_loads.remove(&node_id) {
+            load.abort_controller.abort();
+        }
     }
 
     #[cfg(feature = "custom-widget")]
@@ -1189,6 +1206,7 @@ impl BaseDocument {
     pub fn handle_message(&mut self, msg: DocumentEvent) {
         match msg {
             DocumentEvent::ResourceLoad(resource) => self.load_resource(resource),
+            DocumentEvent::NavigateIframe { node_id, url } => self.navigate_iframe(node_id, url),
         }
     }
 
@@ -1249,6 +1267,12 @@ impl BaseDocument {
                 };
 
                 self.apply_loaded_image(url, image);
+            }
+            Resource::IframeHtml(html) => {
+                let Some(node_id) = res.node_id else {
+                    return;
+                };
+                self.apply_iframe_html(node_id, res.request_id, res.resolved_url, &html);
             }
             Resource::Font(bytes, overrides) => {
                 let font = Blob::new(Arc::new(bytes));

--- a/packages/blitz-dom/src/html.rs
+++ b/packages/blitz-dom/src/html.rs
@@ -1,4 +1,4 @@
-use crate::DocumentMutator;
+use crate::{BaseDocument, Document, DocumentConfig, DocumentMutator, PlainDocument};
 use blitz_traits::node_id::NodeId;
 
 pub trait HtmlParserProvider {
@@ -8,6 +8,14 @@ pub trait HtmlParserProvider {
         element_id: NodeId,
         html: &str,
     );
+
+    /// Parse a full HTML document (e.g. the contents of an `<iframe>`).
+    ///
+    /// The default implementation ignores the HTML and returns an empty document.
+    fn parse_document(&self, html: &str, config: DocumentConfig) -> Box<dyn Document> {
+        let _ = html;
+        Box::new(PlainDocument(BaseDocument::new(config)))
+    }
 }
 
 pub struct DummyHtmlParserProvider;

--- a/packages/blitz-dom/src/iframe.rs
+++ b/packages/blitz-dom/src/iframe.rs
@@ -1,0 +1,184 @@
+//! Loading of `<iframe>` elements into sub-documents.
+
+use std::sync::Arc;
+use std::sync::mpsc::Sender;
+
+use blitz_traits::navigation::{NavigationOptions, NavigationProvider};
+use blitz_traits::net::{AbortController, AbortSignal, Url};
+use blitz_traits::node_id::NodeId;
+use blitz_traits::shell::ShellProvider;
+
+use crate::document::DocumentEvent;
+use crate::net::{IframeHtmlHandler, ResourceHandler, stamped_request};
+use crate::{BaseDocument, DocumentConfig, local_name};
+
+/// Maximum nesting depth of documents-within-documents. Iframes nested deeper
+/// than this are not loaded (this guards against infinitely recursive
+/// self-embedding pages).
+pub(crate) const MAX_SUBDOCUMENT_DEPTH: usize = 10;
+
+/// Per-iframe load state: the abort controller covering the current
+/// "generation" of the iframe's content (the HTML fetch and, once loaded, the
+/// sub-document's own sub-resource fetches), plus the id of the in-flight HTML
+/// request (if any) so stale responses can be discarded.
+pub(crate) struct IframeLoad {
+    pub(crate) request_id: Option<usize>,
+    pub(crate) abort_controller: AbortController,
+}
+
+/// A [`NavigationProvider`] given to iframe sub-documents. It routes
+/// navigations (e.g. link clicks within the iframe) back to the parent
+/// document, which reloads the iframe's sub-document with the new URL.
+struct IframeNavigationProvider {
+    node_id: NodeId,
+    tx: Sender<DocumentEvent>,
+    shell_provider: Arc<dyn ShellProvider>,
+}
+
+impl NavigationProvider for IframeNavigationProvider {
+    fn navigate_to(&self, options: NavigationOptions) {
+        let _ = self.tx.send(DocumentEvent::NavigateIframe {
+            node_id: self.node_id,
+            url: options.url,
+        });
+        self.shell_provider.request_redraw();
+    }
+}
+
+impl BaseDocument {
+    /// Build the [`DocumentConfig`] for an iframe sub-document, inheriting
+    /// providers and settings from this (parent) document.
+    fn iframe_document_config(
+        &self,
+        node_id: NodeId,
+        base_url: Option<String>,
+        abort_signal: AbortSignal,
+    ) -> DocumentConfig {
+        DocumentConfig {
+            viewport: None,
+            base_url,
+            ua_stylesheets: None,
+            net_provider: Some(self.net_provider.clone()),
+            navigation_provider: Some(Arc::new(IframeNavigationProvider {
+                node_id,
+                tx: self.tx.clone(),
+                shell_provider: self.shell_provider.clone(),
+            })),
+            shell_provider: Some(self.shell_provider.clone()),
+            html_parser_provider: Some(self.html_parser_provider.clone()),
+            font_ctx: Some(self.font_ctx.lock().unwrap().clone()),
+            media_type: Some(self.media_type.clone()),
+            style_threading: self.style_threading,
+            incremental: Some(self.incremental_layout),
+            abort_signal: Some(abort_signal),
+            subdocument_depth: self.subdocument_depth + 1,
+        }
+    }
+
+    /// Abort the current generation of the iframe's content (in-flight HTML
+    /// fetch and/or the loaded sub-document's sub-resource fetches) and start
+    /// a new generation.
+    fn new_iframe_generation(&mut self, node_id: NodeId, request_id: Option<usize>) -> AbortSignal {
+        if let Some(load) = self.iframe_loads.remove(&node_id) {
+            load.abort_controller.abort();
+        }
+        let abort_controller = AbortController::default();
+        let signal = abort_controller.signal.clone();
+        self.iframe_loads.insert(
+            node_id,
+            IframeLoad {
+                request_id,
+                abort_controller,
+            },
+        );
+        signal
+    }
+
+    /// Parse `html` and attach the resulting document as `node_id`'s
+    /// sub-document.
+    pub(crate) fn attach_iframe_document(
+        &mut self,
+        node_id: NodeId,
+        html: &str,
+        base_url: Option<String>,
+        abort_signal: AbortSignal,
+    ) {
+        let config = self.iframe_document_config(node_id, base_url, abort_signal);
+        let sub_doc = self
+            .html_parser_provider
+            .clone()
+            .parse_document(html, config);
+        self.set_sub_document(node_id, sub_doc);
+        self.shell_provider.request_redraw();
+    }
+
+    /// Attach a sub-document parsed from the iframe's `srcdoc` attribute.
+    /// Relative URLs within a `srcdoc` document resolve against the parent
+    /// document's base URL.
+    pub(crate) fn load_iframe_srcdoc(&mut self, node_id: NodeId, srcdoc: &str) {
+        let signal = self.new_iframe_generation(node_id, None);
+        let base_url = Some(self.url.to_string());
+        self.attach_iframe_document(node_id, srcdoc, base_url, signal);
+    }
+
+    /// Start fetching HTML for an iframe from `url`. The parsed document is
+    /// attached when the response arrives (via [`DocumentEvent::ResourceLoad`]).
+    pub(crate) fn start_iframe_load(&mut self, node_id: NodeId, url: Url) {
+        let handler = ResourceHandler::new(
+            self.tx.clone(),
+            self.id(),
+            Some(node_id),
+            self.shell_provider.clone(),
+            IframeHtmlHandler,
+        );
+        let signal = self.new_iframe_generation(node_id, Some(handler.request_id()));
+        self.net_provider.fetch(
+            self.id(),
+            stamped_request(url, Some(&signal)),
+            Box::new(handler),
+        );
+    }
+
+    /// Handle a navigation originating from within an iframe's sub-document
+    /// (e.g. a link click) by loading the new URL into the iframe.
+    pub(crate) fn navigate_iframe(&mut self, node_id: NodeId, url: Url) {
+        let Some(node) = self.get_node(node_id) else {
+            return;
+        };
+        if !node.flags.is_in_document() {
+            return;
+        }
+        self.start_iframe_load(node_id, url);
+    }
+
+    /// Apply fetched iframe HTML, discarding stale responses (the iframe may
+    /// have been removed or re-navigated since the request was issued).
+    pub(crate) fn apply_iframe_html(
+        &mut self,
+        node_id: NodeId,
+        request_id: usize,
+        resolved_url: Option<String>,
+        html: &str,
+    ) {
+        let is_current = self
+            .iframe_loads
+            .get(&node_id)
+            .is_some_and(|load| load.request_id == Some(request_id));
+        if !is_current {
+            return;
+        }
+        let load = self.iframe_loads.get_mut(&node_id).unwrap();
+        load.request_id = None;
+        let signal = load.abort_controller.signal.clone();
+
+        let node_is_iframe = self
+            .get_node(node_id)
+            .and_then(|node| node.element_data())
+            .is_some_and(|el| el.name.local == local_name!("iframe"));
+        if !node_is_iframe {
+            return;
+        }
+
+        self.attach_iframe_document(node_id, html, resolved_url, signal);
+    }
+}

--- a/packages/blitz-dom/src/iframe.rs
+++ b/packages/blitz-dom/src/iframe.rs
@@ -9,7 +9,7 @@ use blitz_traits::node_id::NodeId;
 use blitz_traits::shell::ShellProvider;
 
 use crate::document::DocumentEvent;
-use crate::net::{IframeHtmlHandler, ResourceHandler, stamped_request};
+use crate::net::{DocumentSrcHandler, ResourceHandler, stamped_request};
 use crate::{BaseDocument, DocumentConfig, local_name};
 
 /// Maximum nesting depth of documents-within-documents. Iframes nested deeper
@@ -129,7 +129,7 @@ impl BaseDocument {
             self.id(),
             Some(node_id),
             self.shell_provider.clone(),
-            IframeHtmlHandler,
+            DocumentSrcHandler,
         );
         let signal = self.new_iframe_generation(node_id, Some(handler.request_id()));
         self.net_provider.fetch(

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -238,7 +238,9 @@ impl BaseDocument {
                         // width/height attributes, defaulting to 300x150. Other replaced
                         // elements without intrinsic dimensions (video, iframe, embed) use
                         // the 300x150 default object size but have no intrinsic ratio.
-                        SpecialElementData::Canvas(_) | SpecialElementData::None => {
+                        SpecialElementData::Canvas(_)
+                        | SpecialElementData::SubDocument(_)
+                        | SpecialElementData::None => {
                             let tag_name = &element_data.name.local;
                             if *tag_name == local_name!("img") || *tag_name == local_name!("svg") {
                                 (taffy::Size::ZERO, None)

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -45,6 +45,8 @@ mod events;
 mod font_metrics;
 mod form;
 mod html;
+/// Loading of `<iframe>` elements into sub-documents.
+mod iframe;
 /// Integration of taffy and the DOM.
 mod layout;
 mod mutator;

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -33,6 +33,7 @@ pub enum AppendTextErr {
 /// function for borrow-checker reasons.
 enum SpecialOp {
     LoadImage(NodeId),
+    LoadIframe(NodeId),
     LoadStylesheet(NodeId),
     UnloadStylesheet(NodeId),
     LoadCustomPaintSource(NodeId),
@@ -334,6 +335,10 @@ impl DocumentMutator<'_> {
             self.load_custom_paint_src(node_id);
         } else if (tag, attr) == tag_and_attr!("link", "href") {
             self.load_linked_stylesheet(node_id);
+        } else if (tag, attr) == tag_and_attr!("iframe", "src")
+            || (tag, attr) == tag_and_attr!("iframe", "srcdoc")
+        {
+            self.load_iframe(node_id);
         }
     }
 
@@ -415,6 +420,9 @@ impl DocumentMutator<'_> {
             self.recompute_is_animating = true;
         } else if (tag, attr) == tag_and_attr!("link", "href") {
             self.unload_stylesheet(node_id);
+        } else if (tag, attr) == tag_and_attr!("iframe", "srcdoc") && node_is_in_document {
+            // Fall back to loading from the `src` attribute (if any)
+            self.load_iframe(node_id);
         }
     }
 
@@ -718,6 +726,7 @@ impl<'doc> DocumentMutator<'doc> {
         for op in ops.drain(0..) {
             match op {
                 SpecialOp::LoadImage(node_id) => self.load_image(node_id),
+                SpecialOp::LoadIframe(node_id) => self.load_iframe(node_id),
                 SpecialOp::LoadStylesheet(node_id) => self.load_linked_stylesheet(node_id),
                 SpecialOp::UnloadStylesheet(node_id) => self.unload_stylesheet(node_id),
                 SpecialOp::LoadCustomPaintSource(node_id) => self.load_custom_paint_src(node_id),
@@ -753,6 +762,7 @@ impl<'doc> DocumentMutator<'doc> {
                 "title" => self.title_node = Some(node_id),
                 "link" => self.eager_op_queue.push(SpecialOp::LoadStylesheet(node_id)),
                 "img" => self.eager_op_queue.push(SpecialOp::LoadImage(node_id)),
+                "iframe" => self.eager_op_queue.push(SpecialOp::LoadIframe(node_id)),
                 "canvas" => self
                     .eager_op_queue
                     .push(SpecialOp::LoadCustomPaintSource(node_id)),
@@ -978,6 +988,42 @@ impl<'doc> DocumentMutator<'doc> {
                 );
             }
         }
+    }
+
+    fn load_iframe(&mut self, target_id: NodeId) {
+        if self.doc.subdocument_depth >= crate::iframe::MAX_SUBDOCUMENT_DEPTH {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                "Not loading iframe: max sub-document nesting depth ({}) reached",
+                crate::iframe::MAX_SUBDOCUMENT_DEPTH
+            );
+            return;
+        }
+
+        let node = &self.doc.nodes[target_id];
+        let Some(element) = node.element_data() else {
+            return;
+        };
+
+        // `srcdoc` takes precedence over `src`
+        if let Some(srcdoc) = element.attr(local_name!("srcdoc")) {
+            let srcdoc = srcdoc.to_string();
+            self.doc.load_iframe_srcdoc(target_id, &srcdoc);
+            return;
+        }
+
+        let Some(raw_src) = element.attr(local_name!("src")) else {
+            return;
+        };
+        if raw_src.is_empty() {
+            return;
+        }
+        let Some(url) = self.doc.url.resolve_relative(raw_src) else {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("Not loading iframe: could not resolve url {raw_src}");
+            return;
+        };
+        self.doc.start_iframe_load(target_id, url);
     }
 
     fn load_custom_paint_src(&mut self, target_id: NodeId) {

--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -62,7 +62,7 @@ pub enum Resource {
     Css(DocumentStyleSheet),
     Font(Bytes, FontFaceOverrides),
     /// HTML fetched for an `<iframe>` element's `src`
-    IframeHtml(String),
+    DocumentSrc(String),
     None,
 }
 
@@ -505,12 +505,12 @@ fn stylo_to_fontique_style(style: &FontStyleRange) -> parley::fontique::FontStyl
 }
 
 /// Handles HTML fetched for an `<iframe>` element's `src`
-pub(crate) struct IframeHtmlHandler;
+pub(crate) struct DocumentSrcHandler;
 
-impl NetHandler for ResourceHandler<IframeHtmlHandler> {
+impl NetHandler for ResourceHandler<DocumentSrcHandler> {
     fn bytes(self: Box<Self>, resolved_url: String, bytes: Bytes) {
         let html = String::from_utf8_lossy(&bytes).into_owned();
-        self.respond(resolved_url, Ok(Resource::IframeHtml(html)));
+        self.respond(resolved_url, Ok(Resource::DocumentSrc(html)));
     }
 }
 

--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -61,6 +61,8 @@ pub enum Resource {
     Svg(ImageType, crate::node::SvgImageData),
     Css(DocumentStyleSheet),
     Font(Bytes, FontFaceOverrides),
+    /// HTML fetched for an `<iframe>` element's `src`
+    IframeHtml(String),
     None,
 }
 
@@ -499,6 +501,16 @@ fn stylo_to_fontique_style(style: &FontStyleRange) -> parley::fontique::FontStyl
                 Fq::Oblique(angle)
             }
         }
+    }
+}
+
+/// Handles HTML fetched for an `<iframe>` element's `src`
+pub(crate) struct IframeHtmlHandler;
+
+impl NetHandler for ResourceHandler<IframeHtmlHandler> {
+    fn bytes(self: Box<Self>, resolved_url: String, bytes: Bytes) {
+        let html = String::from_utf8_lossy(&bytes).into_owned();
+        self.respond(resolved_url, Ok(Resource::IframeHtml(html)));
     }
 }
 

--- a/packages/blitz-html/src/html_sink.rs
+++ b/packages/blitz-html/src/html_sink.rs
@@ -35,6 +35,14 @@ impl HtmlParserProvider for HtmlProvider {
     ) {
         DocumentHtmlParser::parse_inner_html_into_mutator(mutr, element_id, html);
     }
+
+    fn parse_document(
+        &self,
+        html: &str,
+        config: blitz_dom::DocumentConfig,
+    ) -> Box<dyn blitz_dom::Document> {
+        Box::new(crate::HtmlDocument::from_html(html, config))
+    }
 }
 
 pub struct DocumentHtmlParser<'m, 'doc> {


### PR DESCRIPTION
## Summary

Iframes now load automatically, building on the existing SubDocument infrastructure (which already handles layout, painting, event forwarding, focus, and teardown for sub-documents). Previously sub-documents could only be attached manually (e.g. by the browser shell).

**Parsing hook** — `blitz-dom` can't depend on `blitz-html`, so full-document parsing goes through the existing `HtmlParserProvider` boundary:

```rust
trait HtmlParserProvider {
    fn parse_inner_html(...);
    // NEW: default impl returns an empty document
    fn parse_document(&self, html: &str, config: DocumentConfig) -> Box<dyn Document>;
}
// blitz-html's HtmlProvider: Box::new(HtmlDocument::from_html(html, config))
```

**Load pipeline** (`DocumentMutator::load_iframe`, mirrors the `img`/`link` pattern): triggered on iframe insertion and on `src`/`srcdoc` attribute changes. `srcdoc` takes precedence over `src` and is parsed synchronously against the parent's base URL; `src` is resolved and fetched via the `NetProvider` with a new `Resource::IframeHtml` variant, then parsed and attached in `load_resource` when the response arrives.

**Config inheritance** — the child `DocumentConfig` inherits the parent's net/shell/parser providers, font context, media type, style threading, and incremental-layout settings. The child's viewport is synced from the iframe's layout each frame by the existing subdocument resolve loop (which also pumps the child's resource messages via its own `resolve`).

**Lifecycle** (`iframe.rs`) — each iframe "generation" gets an `AbortController` covering its HTML fetch and the loaded sub-document's own sub-resource fetches; re-navigating or removing the iframe aborts the previous generation. Stale fetch responses are discarded via request-id matching. Nesting is capped at `MAX_SUBDOCUMENT_DEPTH = 10` (via a new `DocumentConfig::subdocument_depth` field) to guard against recursive self-embedding.

**Navigation** — child documents get an `IframeNavigationProvider` that routes link clicks back to the parent as a `DocumentEvent::NavigateIframe`, which reloads the iframe's sub-document with the new URL (instead of navigating the top-level page).

Out of scope (follow-ups): `target="_top"`/`_parent`, history semantics, scripting/`postMessage`, `sandbox`/CSP, and arbitrary transforms of sub-documents in painting (existing limitation).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a2a6f41396a948609f58593900018c50
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**0** newly passing, **44** newly failing (net -44), **69** other status changes.

<details>
<summary>Full diff (113 changed tests)</summary>

```diff
- Pass => Crash css/CSS2/linebox/iframe-in-block-in-inline.html
- Pass => Crash css/CSS2/linebox/iframe-in-wrapped-span.html
! Fail => Crash css/CSS2/normal-flow/resizable-iframe-paint-order.html
! Fail => Crash css/compositing/mix-blend-mode/mix-blend-mode-iframe-parent.html
! Fail => Crash css/compositing/mix-blend-mode/mix-blend-mode-iframe-sibling.html
- Pass => Crash css/css-backgrounds/background-margin-iframe-root.html
! Fail => Crash css/css-borders/border-shape/border-shape-overflow-replaced-iframe.html
! Fail => Crash css/css-borders/corner-shape/corner-shape-iframe-border.html
! Fail => Crash css/css-cascade/presentational-hints-rollback.html
- Pass => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-about-blank.tentative.html
! Fail => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-alpha.html
! Fail => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic.html
! Fail => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque.html
! Fail => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-used-preferred.html
- Pass => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background.html
- Pass => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin.sub.html
! Fail => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark.html
! Fail => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light.html
! Fail => Crash css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred.html
! Fail => Crash css/css-conditional/at-media-dynamic-001.html
! Fail => Crash css/css-contain/contain-inline-size-replaced.html
! Fail => Crash css/css-contain/contain-size-replaced-003a.html
! Fail => Crash css/css-contain/contain-size-replaced-003b.html
! Fail => Crash css/css-contain/contain-size-replaced-003c.html
- Pass => Crash css/css-contain/content-visibility/content-visibility-004.html
- Pass => Crash css/css-contain/content-visibility/content-visibility-019.sub.https.html
- Pass => Crash css/css-contain/content-visibility/content-visibility-020.html
- Pass => Crash css/css-contain/content-visibility/content-visibility-023.html
! Fail => Crash css/css-contain/content-visibility/content-visibility-032.html
- Pass => Crash css/css-contain/content-visibility/content-visibility-auto-in-iframe.html
! Fail => Crash css/css-display/display-change-iframe.html
- Pass => Crash css/css-fonts/downloadable-font-in-iframe-print.html
- Pass => Crash css/css-fonts/downloadable-font-scoped-to-document.html
! Fail => Crash css/css-highlight-api/painting/custom-highlight-dynamic-container-metrics-001.html
! Fail => Crash css/css-highlight-api/painting/custom-highlight-dynamic-viewport-metrics-001.html
! Fail => Crash css/css-highlight-api/painting/custom-highlight-dynamic-viewport-metrics-first-line-001.html
- Pass => Crash css/css-highlight-api/painting/custom-highlight-painting-iframe-001.html
- Pass => Crash css/css-highlight-api/painting/custom-highlight-painting-iframe-002.html
! Fail => Crash css/css-highlight-api/painting/custom-highlight-painting-iframe-003.html
! Fail => Crash css/css-highlight-api/painting/custom-highlight-painting-iframe-004.html
- Pass => Crash css/css-highlight-api/painting/custom-highlight-painting-iframe-005.html
- Pass => Crash css/css-highlight-api/painting/custom-highlight-painting-iframe-006.html
- Pass => Crash css/css-images/image-orientation/image-orientation-from-image-embedded-content.html
- Pass => Crash css/css-images/image-orientation/image-orientation-iframe.html
- Pass => Crash css/css-images/image-orientation/image-orientation-none-image-document.html
- Pass => Crash css/css-images/object-view-box-iframe.html
- Pass => Crash css/css-overflow/overflow-replaced-element-002.html
- Pass => Crash css/css-overflow/scrollbar-large-scale-in-iframe.html
! Fail => Crash css/css-page/fixedpos-with-iframe-print.html
! Fail => Crash css/css-page/media-queries-002-print.html
- Pass => Crash css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html
! Fail => Crash css/css-scroll-anchoring/vertical-rl-viewport-size-change-000.html
! Fail => Crash css/css-scroll-anchoring/vertical-rl-viewport-size-change-001.html
! Fail => Crash css/css-scroll-snap/scroll-target-align-001.html
! Fail => Crash css/css-scroll-snap/scroll-target-align-004.html
! Fail => Crash css/css-scroll-snap/scroll-target-margin-001.html
! Fail => Crash css/css-scroll-snap/scroll-target-padding-001.html
! Fail => Crash css/css-scroll-snap/scroll-target-snap-001.html
- Pass => Crash css/css-scrollbars/viewport-scrollbar-body.html
- Pass => Crash css/css-scrollbars/viewport-scrollbar.html
! Fail => Crash css/css-sizing/dynamic-available-size-iframe.html
! Fail => Crash css/css-sizing/responsive-iframe/responsive-iframe-meta-after-head.html
- Pass => Crash css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-append-after-body.html
! Fail => Crash css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-append-to-doc.html
! Fail => Crash css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-append.html
- Pass => Crash css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-name-change-after-body.html
! Fail => Crash css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-name-change.html
! Fail => Crash css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-remove.html
! Fail => Crash css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-write.html
- Pass => Crash css/css-sizing/responsive-iframe/responsive-iframe-meta-in-body.html
- Pass => Crash css/css-sizing/responsive-iframe/responsive-iframe-no-match-element.html
- Pass => Crash css/css-sizing/responsive-iframe/responsive-iframe-not-embedded-sized.html
! Fail => Crash css/css-sizing/responsive-iframe/responsive-iframe-request-resize.html
! Fail => Crash css/css-sizing/responsive-iframe/responsive-iframe.html
- Pass => Crash css/css-transforms/transform-iframe-001.html
! Fail => Crash css/css-transforms/transform-iframe-002.html
! Fail => Crash css/css-transforms/transform-iframe-scroll-position.html
! Fail => Crash css/css-values/inline-cache-base-uri.html
- Pass => Crash css/css-values/vh-support-transform-origin.html
- Pass => Crash css/css-values/vh-support-transform-translate.html
- Pass => Crash css/css-values/vh-update-and-transition-in-subframe.html
- Pass => Crash css/css-view-transitions/backdrop-filter-while-promise-pending.html
- Pass => Crash css/css-view-transitions/dialog-in-rtl-iframe.html
! Fail => Crash css/css-view-transitions/iframe-and-main-frame-transition-new-main-new-iframe.html
! Fail => Crash css/css-view-transitions/iframe-and-main-frame-transition-new-main-old-iframe.html
! Fail => Crash css/css-view-transitions/iframe-and-main-frame-transition-old-main-new-iframe.html
! Fail => Crash css/css-view-transitions/iframe-and-main-frame-transition-old-main-old-iframe.html
! Fail => Crash css/css-view-transitions/iframe-and-main-frame-transition-old-main.html
! Fail => Crash css/css-view-transitions/iframe-and-main-frame-transition-with-name-on-iframe.html
- Pass => Crash css/css-view-transitions/iframe-new-has-scrollbar.html
- Pass => Crash css/css-view-transitions/iframe-old-has-scrollbar.html
- Pass => Crash css/css-view-transitions/iframe-transition.sub.html
- Pass => Crash css/css-view-transitions/navigation/root-element-transition-iframe-cross-origin.sub.html
! Fail => Crash css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html
- Pass => Crash css/css-view-transitions/navigation/root-element-transition-iframe.html
! Fail => Crash css/css-view-transitions/paint-holding-in-iframe.html
! Fail => Crash css/css-view-transitions/sibling-frames-transition.html
- Pass => Crash css/css-view-transitions/snapshot-containing-block-static-iframe.html
- Pass => Crash css/css-view-transitions/transition-in-empty-iframe.html
! Fail => Crash css/css-writing-modes/background-size-document-root-vrl-002.html
! Fail => Crash css/css-writing-modes/background-size-document-root-vrl-004.html
! Fail => Crash css/css-writing-modes/background-size-document-root-vrl-006.html
! Fail => Crash css/css-writing-modes/background-size-document-root-vrl-008.html
! Fail => Crash css/css-writing-modes/bidi-dynamic-iframe-001.html
! Fail => Crash css/css-writing-modes/orthogonal-root-resize-icb-001.html
! Fail => Crash css/css-writing-modes/orthogonal-root-resize-icb-002.html
! Fail => Crash css/css-writing-modes/orthogonal-root-resize-icb-003.html
! Fail => Crash css/css-writing-modes/orthogonal-root-resize-icb-004.html
! Fail => Crash css/css-writing-modes/orthogonal-root-resize-icb-005.html
! Fail => Crash css/css-writing-modes/orthogonal-root-resize-icb-006.html
! Fail => Crash css/css-writing-modes/orthogonal-root-resize-icb-007.html
! Fail => Crash css/filter-effects/svg-relative-urls-001.html
! Fail => Crash css/mediaqueries/min-width-tables-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31233330496).</sub>
<!-- wpt-results-end -->
