### PR TITLE
fix: skip critical-resource gating when NetProvider is a no-op

### DIFF
--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -900,7 +900,7 @@ impl<'doc> DocumentMutator<'doc> {
             },
         );
 
-        if is_in_head {
+        if is_in_head && !self.doc.net_provider.is_noop() {
             self.doc
                 .pending_critical_resources
                 .insert(handler.request_id());

--- a/packages/blitz-traits/src/net.rs
+++ b/packages/blitz-traits/src/net.rs
@@ -18,6 +18,15 @@ pub use url::Url;
 /// This may be over the network via http(s), via the filesystem, or some other method.
 pub trait NetProvider: Send + Sync + 'static {
     fn fetch(&self, doc_id: usize, request: Request, handler: Box<dyn NetHandler>);
+
+    /// Whether this provider is a no-op (e.g. `DummyNetProvider`) that will never
+    /// deliver resources. When true, callers must NOT register resources as
+    /// "pending critical" — doing so blocks painting forever, since the
+    /// completion callback never fires. Used by integrations that feed a
+    /// pre-rendered DOM and perform no sub-fetches (e.g. aginxbrowser).
+    fn is_noop(&self) -> bool {
+        false
+    }
 }
 
 /// A type that parses raw bytes from a network request into a Data and then calls
@@ -158,6 +167,9 @@ impl From<PathBuf> for EntryValue {
 pub struct DummyNetProvider;
 impl NetProvider for DummyNetProvider {
     fn fetch(&self, _doc_id: usize, _request: Request, _handler: Box<dyn NetHandler>) {}
+    fn is_noop(&self) -> bool {
+        true
+    }
 }
 
 /// The AbortController interface represents a controller object that


### PR DESCRIPTION
## Problem

When a `Document` is created without a `net_provider`, blitz-dom falls back to `DummyNetProvider`, whose `fetch()` is a no-op that drops the handler. However, `load_linked_stylesheet` still registered `<head>` stylesheets as **pending critical resources** — and since the completion callback never fires, `pending_critical_resources` never drained.

`paint_scene` begins with:

```rust
if self.dom.has_pending_critical_resources() {
    return;
}
```

So the **entire page is never painted** — blank output.

## Who hits this

Integrations that feed a **pre-rendered DOM** and perform no sub-fetches — e.g. a server-side browser engine that has already run JS (V8) and hands the serialized DOM to blitz purely for layout/paint.

Real sites (Baidu search, GitHub trending, People's Daily) render as blank; trivial SSR pages render fine because they have no `<head>` stylesheets. So this looks like "blitz can't render complex sites" when it's actually a resource-gating bug.

## Fix

- Add `NetProvider::is_noop()` (default `false`), override to `true` on `DummyNetProvider`.
- In `load_linked_stylesheet`, skip the `pending_critical_resources` insert when the provider is a no-op: `if is_in_head && !self.doc.net_provider.is_noop()`.

The `fetch()` call is still a no-op, so no spurious work is done; head stylesheets simply don't block painting. Real net providers are unaffected (default `is_noop() == false`).

## Verification

Feeding V8-rendered DOM (no net provider) to blitz:

| Page | Before | After |
|---|---|---|
| Baidu search | 1 color (blank) | 1653 colors (layout + text + links) |
| GitHub trending | 1 color (blank) | 516 colors (repo list + links) |
| People's Daily | 1 color (blank) | 615 colors (text + links) |

ASCII render of the post-fix output shows correct layout structure (search box, result blocks, repo rows).

## Notes

- The default `is_noop() == false` means existing `NetProvider` implementations (including `blitz-net::Provider`) behave exactly as before.
- `DummyNetProvider` is only used as the fallback when `DocumentConfig.net_provider` is `None`, so this only changes the "no networking" code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wpt-results-start -->
## WPT results

**51** newly passing, **107** newly failing (net -56), **69** other status changes.

<details>
<summary>Full diff (227 changed tests)</summary>

```diff
- Pass => Fail css/CSS2/css1/c43-rpl-bbx-002.xht
- Pass => Fail css/CSS2/floats-clear/clear-002.xht
- Pass => Fail css/CSS2/floats-clear/clear-float-005.xht
- Pass => Fail css/CSS2/floats-clear/floats-141.xht
+ Fail => Pass css/CSS2/inline-svg-100-percent-in-body.html
+ Crash => Pass css/CSS2/linebox/iframe-in-block-in-inline.html
+ Crash => Pass css/CSS2/linebox/iframe-in-wrapped-span.html
- Pass => Fail css/CSS2/linebox/line-height-002.xht
- Pass => Fail css/CSS2/linebox/line-height-004.xht
- Pass => Fail css/CSS2/linebox/line-height-005.xht
- Pass => Fail css/CSS2/linebox/line-height-006.xht
- Pass => Fail css/CSS2/linebox/line-height-007.xht
- Pass => Fail css/CSS2/linebox/line-height-013.xht
- Pass => Fail css/CSS2/linebox/line-height-015.xht
- Pass => Fail css/CSS2/linebox/line-height-016.xht
- Pass => Fail css/CSS2/linebox/line-height-017.xht
- Pass => Fail css/CSS2/linebox/line-height-018.xht
- Pass => Fail css/CSS2/linebox/line-height-024.xht
- Pass => Fail css/CSS2/linebox/line-height-025.xht
- Pass => Fail css/CSS2/linebox/line-height-026.xht
- Pass => Fail css/CSS2/linebox/line-height-027.xht
- Pass => Fail css/CSS2/linebox/line-height-028.xht
- Pass => Fail css/CSS2/linebox/line-height-029.xht
- Pass => Fail css/CSS2/linebox/line-height-035.xht
- Pass => Fail css/CSS2/linebox/line-height-037.xht
- Pass => Fail css/CSS2/linebox/line-height-038.xht
- Pass => Fail css/CSS2/linebox/line-height-039.xht
- Pass => Fail css/CSS2/linebox/line-height-040.xht
- Pass => Fail css/CSS2/linebox/line-height-046.xht
- Pass => Fail css/CSS2/linebox/line-height-048.xht
- Pass => Fail css/CSS2/linebox/line-height-049.xht
- Pass => Fail css/CSS2/linebox/line-height-050.xht
- Pass => Fail css/CSS2/linebox/line-height-051.xht
- Pass => Fail css/CSS2/linebox/line-height-057.xht
- Pass => Fail css/CSS2/linebox/line-height-058.xht
- Pass => Fail css/CSS2/linebox/line-height-059.xht
- Pass => Fail css/CSS2/linebox/line-height-060.xht
- Pass => Fail css/CSS2/linebox/line-height-061.xht
- Pass => Fail css/CSS2/linebox/line-height-062.xht
- Pass => Fail css/CSS2/linebox/line-height-068.xht
- Pass => Fail css/CSS2/linebox/line-height-069.xht
- Pass => Fail css/CSS2/linebox/line-height-070.xht
- Pass => Fail css/CSS2/linebox/line-height-071.xht
- Pass => Fail css/CSS2/linebox/line-height-072.xht
- Pass => Fail css/CSS2/linebox/line-height-073.xht
- Pass => Fail css/CSS2/linebox/line-height-079.xht
- Pass => Fail css/CSS2/linebox/line-height-080.xht
- Pass => Fail css/CSS2/linebox/line-height-081.xht
- Pass => Fail css/CSS2/linebox/line-height-082.xht
- Pass => Fail css/CSS2/linebox/line-height-083.xht
- Pass => Fail css/CSS2/linebox/line-height-084.xht
- Pass => Fail css/CSS2/linebox/line-height-090.xht
- Pass => Fail css/CSS2/linebox/line-height-092.xht
- Pass => Fail css/CSS2/linebox/line-height-093.xht
- Pass => Fail css/CSS2/linebox/line-height-094.xht
- Pass => Fail css/CSS2/linebox/line-height-095.xht
- Pass => Fail css/CSS2/linebox/line-height-101.xht
- Pass => Fail css/CSS2/linebox/line-height-102.xht
- Pass => Fail css/CSS2/linebox/line-height-103.xht
- Pass => Fail css/CSS2/linebox/line-height-104.xht
- Pass => Fail css/CSS2/linebox/line-height-105.xht
- Pass => Fail css/CSS2/linebox/line-height-106.xht
- Pass => Fail css/CSS2/linebox/line-height-112.xht
+ Fail => Pass css/CSS2/linebox/vertical-align-applies-to-007.xht
- Pass => Fail css/CSS2/margin-padding-clear/margin-collapse-015a.xht
- Pass => Fail css/CSS2/normal-flow/block-replaced-height-001.xht
- Pass => Fail css/CSS2/normal-flow/block-replaced-height-002.xht
- Pass => Fail css/CSS2/normal-flow/block-replaced-height-004.xht
- Pass => Fail css/CSS2/normal-flow/block-replaced-height-005.xht
- Pass => Fail css/CSS2/normal-flow/block-replaced-height-007.xht
! Crash => Fail css/CSS2/normal-flow/resizable-iframe-paint-order.html
- Pass => Fail css/CSS2/positioning/absolute-replaced-width-001.xht
- Pass => Fail css/CSS2/positioning/absolute-replaced-width-008.xht
- Pass => Fail css/CSS2/positioning/absolute-replaced-width-015.xht
- Pass => Fail css/CSS2/positioning/right-offset-004.xht
- Pass => Fail css/CSS2/visuren/box-offsets-rel-pos-002.xht
! Crash => Fail css/compositing/mix-blend-mode/mix-blend-mode-iframe-parent.html
! Crash => Fail css/compositing/mix-blend-mode/mix-blend-mode-iframe-sibling.html
- Pass => Fail css/css-align/baseline-of-scrollable-1b.html
- Pass => Fail css/css-backgrounds/background-image-001.html
- Pass => Fail css/css-backgrounds/background-image-002.html
- Pass => Fail css/css-backgrounds/background-image-003.html
- Pass => Fail css/css-backgrounds/background-image-004.html
- Pass => Fail css/css-backgrounds/background-image-005.html
- Pass => Fail css/css-backgrounds/background-image-006.html
+ Crash => Pass css/css-backgrounds/background-margin-iframe-root.html
- Pass => Fail css/css-backgrounds/background-origin/origin-border-box_with_position.html
- Pass => Fail css/css-backgrounds/background-origin/origin-content-box_with_position.html
- Pass => Fail css/css-backgrounds/background-origin/origin-padding-box_with_position.html
! Crash => Fail css/css-borders/border-shape/border-shape-overflow-replaced-iframe.html
! Crash => Fail css/css-borders/corner-shape/corner-shape-iframe-border.html
! Crash => Fail css/css-cascade/presentational-hints-rollback.html
+ Crash => Pass css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-about-blank.tentative.html
! Crash => Fail css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-alpha.html
! Crash => Fail css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic.html
! Crash => Fail css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque.html
! Crash => Fail css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-used-preferred.html
+ Crash => Pass css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background.html
+ Crash => Pass css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin.sub.html
! Crash => Fail css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark.html
! Crash => Fail css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light.html
! Crash => Fail css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred.html
! Crash => Fail css/css-conditional/at-media-dynamic-001.html
! Crash => Fail css/css-contain/contain-inline-size-replaced.html
+ Fail => Pass css/css-contain/contain-layout-baseline-004.html
- Pass => Fail css/css-contain/contain-layout-independent-formatting-context-002.html
- Pass => Fail css/css-contain/contain-paint-independent-formatting-context-002.html
! Crash => Fail css/css-contain/contain-size-replaced-003a.html
! Crash => Fail css/css-contain/contain-size-replaced-003b.html
! Crash => Fail css/css-contain/contain-size-replaced-003c.html
+ Crash => Pass css/css-contain/content-visibility/content-visibility-004.html
+ Crash => Pass css/css-contain/content-visibility/content-visibility-019.sub.https.html
+ Crash => Pass css/css-contain/content-visibility/content-visibility-020.html
+ Crash => Pass css/css-contain/content-visibility/content-visibility-023.html
! Crash => Fail css/css-contain/content-visibility/content-visibility-032.html
+ Crash => Pass css/css-contain/content-visibility/content-visibility-auto-in-iframe.html
! Crash => Fail css/css-display/display-change-iframe.html
+ Crash => Pass css/css-fonts/downloadable-font-in-iframe-print.html
+ Crash => Pass css/css-fonts/downloadable-font-scoped-to-document.html
- Pass => Fail css/css-grid/grid-items/percentage-size-indefinite-replaced.html
! Crash => Fail css/css-highlight-api/painting/custom-highlight-dynamic-container-metrics-001.html
! Crash => Fail css/css-highlight-api/painting/custom-highlight-dynamic-viewport-metrics-001.html
! Crash => Fail css/css-highlight-api/painting/custom-highlight-dynamic-viewport-metrics-first-line-001.html
+ Crash => Pass css/css-highlight-api/painting/custom-highlight-painting-iframe-001.html
+ Crash => Pass css/css-highlight-api/painting/custom-highlight-painting-iframe-002.html
! Crash => Fail css/css-highlight-api/painting/custom-highlight-painting-iframe-003.html
! Crash => Fail css/css-highlight-api/painting/custom-highlight-painting-iframe-004.html
+ Crash => Pass css/css-highlight-api/painting/custom-highlight-painting-iframe-005.html
+ Crash => Pass css/css-highlight-api/painting/custom-highlight-painting-iframe-006.html
+ Crash => Pass css/css-images/image-orientation/image-orientation-from-image-embedded-content.html
+ Crash => Pass css/css-images/image-orientation/image-orientation-iframe.html
+ Crash => Pass css/css-images/image-orientation/image-orientation-none-image-document.html
+ Crash => Pass css/css-images/object-view-box-iframe.html
+ Fail => Pass css/css-lists/list-item-definition.html
+ Crash => Pass css/css-overflow/overflow-replaced-element-002.html
+ Crash => Pass css/css-overflow/scrollbar-large-scale-in-iframe.html
! Crash => Fail css/css-page/fixedpos-with-iframe-print.html
! Crash => Fail css/css-page/media-queries-002-print.html
+ Fail => Pass css/css-position/position-relative-014.html
+ Crash => Pass css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html
- Pass => Fail css/css-pseudo/active-selection-043.html
- Pass => Fail css/css-pseudo/active-selection-045.html
+ Fail => Pass css/css-rhythm/replaced-elements/block-level-canvas-margins-affected-by-block-step-size.html
+ Fail => Pass css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size.html
! Crash => Fail css/css-scroll-anchoring/vertical-rl-viewport-size-change-000.html
! Crash => Fail css/css-scroll-anchoring/vertical-rl-viewport-size-change-001.html
! Crash => Fail css/css-scroll-snap/scroll-target-align-001.html
! Crash => Fail css/css-scroll-snap/scroll-target-align-004.html
! Crash => Fail css/css-scroll-snap/scroll-target-margin-001.html
! Crash => Fail css/css-scroll-snap/scroll-target-padding-001.html
! Crash => Fail css/css-scroll-snap/scroll-target-snap-001.html
+ Crash => Pass css/css-scrollbars/viewport-scrollbar-body.html
+ Crash => Pass css/css-scrollbars/viewport-scrollbar.html
- Pass => Fail css/css-shapes/shape-outside/shape-image/shape-image-013.html
- Pass => Fail css/css-sizing/block-image-percentage-max-height-inside-inline.html
! Crash => Fail css/css-sizing/dynamic-available-size-iframe.html
- Pass => Fail css/css-sizing/intrinsic-percent-replaced-033.html
! Crash => Fail css/css-sizing/responsive-iframe/responsive-iframe-meta-after-head.html
+ Crash => Pass css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-append-after-body.html
! Crash => Fail css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-append-to-doc.html
! Crash => Fail css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-append.html
+ Crash => Pass css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-name-change-after-body.html
! Crash => Fail css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-name-change.html
! Crash => Fail css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-remove.html
! Crash => Fail css/css-sizing/responsive-iframe/responsive-iframe-meta-dynamic-write.html
+ Crash => Pass css/css-sizing/responsive-iframe/responsive-iframe-meta-in-body.html
+ Crash => Pass css/css-sizing/responsive-iframe/responsive-iframe-no-match-element.html
+ Crash => Pass css/css-sizing/responsive-iframe/responsive-iframe-not-embedded-sized.html
! Crash => Fail css/css-sizing/responsive-iframe/responsive-iframe-request-resize.html
! Crash => Fail css/css-sizing/responsive-iframe/responsive-iframe.html
+ Crash => Pass css/css-transforms/transform-iframe-001.html
! Crash => Fail css/css-transforms/transform-iframe-002.html
! Crash => Fail css/css-transforms/transform-iframe-scroll-position.html
- Pass => Fail css/css-transforms/transform-input-001.html
- Pass => Fail css/css-transforms/transform-input-003.html
- Pass => Fail css/css-transforms/transform-input-004.html
- Pass => Fail css/css-transforms/transform-input-005.html
- Pass => Fail css/css-transforms/transform-input-006.html
- Pass => Fail css/css-transforms/transform-input-007.html
- Pass => Fail css/css-transforms/transform-input-008.html
- Pass => Fail css/css-transforms/transform-input-009.html
- Pass => Fail css/css-transforms/transform-input-010.html
- Pass => Fail css/css-transforms/transform-input-011.html
- Pass => Fail css/css-transforms/transform-input-012.html
- Pass => Fail css/css-transforms/transform-input-013.html
- Pass => Fail css/css-transforms/transform-input-014.html
- Pass => Fail css/css-transforms/transform-input-015.html
- Pass => Fail css/css-transforms/transform-input-016.html
- Pass => Fail css/css-transforms/transform-input-017.html
- Pass => Fail css/css-transforms/transform-input-018.html
- Pass => Fail css/css-transforms/transform-input-019.html
! Crash => Fail css/css-values/inline-cache-base-uri.html
+ Crash => Pass css/css-values/vh-support-transform-origin.html
+ Crash => Pass css/css-values/vh-support-transform-translate.html
+ Crash => Pass css/css-values/vh-update-and-transition-in-subframe.html
+ Crash => Pass css/css-view-transitions/backdrop-filter-while-promise-pending.html
+ Crash => Pass css/css-view-transitions/dialog-in-rtl-iframe.html
! Crash => Fail css/css-view-transitions/iframe-and-main-frame-transition-new-main-new-iframe.html
! Crash => Fail css/css-view-transitions/iframe-and-main-frame-transition-new-main-old-iframe.html
! Crash => Fail css/css-view-transitions/iframe-and-main-frame-transition-old-main-new-iframe.html
! Crash => Fail css/css-view-transitions/iframe-and-main-frame-transition-old-main-old-iframe.html
! Crash => Fail css/css-view-transitions/iframe-and-main-frame-transition-old-main.html
! Crash => Fail css/css-view-transitions/iframe-and-main-frame-transition-with-name-on-iframe.html
+ Crash => Pass css/css-view-transitions/iframe-new-has-scrollbar.html
+ Crash => Pass css/css-view-transitions/iframe-old-has-scrollbar.html
+ Crash => Pass css/css-view-transitions/iframe-transition.sub.html
+ Crash => Pass css/css-view-transitions/navigation/root-element-transition-iframe-cross-origin.sub.html
! Crash => Fail css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html
+ Crash => Pass css/css-view-transitions/navigation/root-element-transition-iframe.html
! Crash => Fail css/css-view-transitions/paint-holding-in-iframe.html
! Crash => Fail css/css-view-transitions/sibling-frames-transition.html
+ Crash => Pass css/css-view-transitions/snapshot-containing-block-static-iframe.html
+ Crash => Pass css/css-view-transitions/transition-in-empty-iframe.html
! Crash => Fail css/css-writing-modes/background-size-document-root-vrl-002.html
! Crash => Fail css/css-writing-modes/background-size-document-root-vrl-004.html
! Crash => Fail css/css-writing-modes/background-size-document-root-vrl-006.html
! Crash => Fail css/css-writing-modes/background-size-document-root-vrl-008.html
! Crash => Fail css/css-writing-modes/bidi-dynamic-iframe-001.html
! Crash => Fail css/css-writing-modes/orthogonal-root-resize-icb-001.html
! Crash => Fail css/css-writing-modes/orthogonal-root-resize-icb-002.html
! Crash => Fail css/css-writing-modes/orthogonal-root-resize-icb-003.html
! Crash => Fail css/css-writing-modes/orthogonal-root-resize-icb-004.html
! Crash => Fail css/css-writing-modes/orthogonal-root-resize-icb-005.html
! Crash => Fail css/css-writing-modes/orthogonal-root-resize-icb-006.html
! Crash => Fail css/css-writing-modes/orthogonal-root-resize-icb-007.html
! Crash => Fail css/filter-effects/svg-relative-urls-001.html
! Crash => Fail css/mediaqueries/min-width-tables-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31232438016).</sub>
<!-- wpt-results-end -->
