### PR TITLE
Apply relative inset offsets to atomic inline boxes

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -674,6 +674,8 @@ impl BaseDocument {
         }
         .maybe_max(container_pb.sum_axes().map(Some));
 
+        let container_direction = self.nodes[node_id].style().direction;
+
         // Store sizes and positions of inline boxes
         for line in inline_layout.layout.lines() {
             for item in line.items() {
@@ -741,14 +743,47 @@ impl BaseDocument {
                             .compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs)
                             .size;
                         let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
+
+                        // Resolve relative inset offsets against the containing block
+                        // (the content box of the inline container).
+                        let style = node.style();
+                        let container_content_size = final_size - content_box_inset.sum_axes();
+                        let inset_left = style
+                            .inset
+                            .left
+                            .maybe_resolve(container_content_size.width, resolve_calc_value);
+                        let inset_right = style
+                            .inset
+                            .right
+                            .maybe_resolve(container_content_size.width, resolve_calc_value);
+                        let inset_top = style
+                            .inset
+                            .top
+                            .maybe_resolve(container_content_size.height, resolve_calc_value);
+                        let inset_bottom = style
+                            .inset
+                            .bottom
+                            .maybe_resolve(container_content_size.height, resolve_calc_value);
+                        let inset_offset = taffy::Point {
+                            x: if container_direction == Direction::Rtl {
+                                inset_right.map(|x| -x).or(inset_left).unwrap_or(0.0)
+                            } else {
+                                inset_left.or(inset_right.map(|x| -x)).unwrap_or(0.0)
+                            },
+                            y: inset_top.or(inset_bottom.map(|x| -x)).unwrap_or(0.0),
+                        };
+
                         let layout = node.unrounded_layout_mut();
                         layout.size = size;
-                        layout.location.x = (ibox.x / scale) + margin.left + container_pb.left;
+                        layout.location.x =
+                            (ibox.x / scale) + margin.left + container_pb.left + inset_offset.x;
                         // A negative `margin-top` shrinks the space the box reserves in the
                         // line but does not move the box itself, which stays anchored to the
                         // bottom of the reserved space.
-                        layout.location.y =
-                            (ibox.y / scale) + margin.top.max(0.0) + container_pb.top;
+                        layout.location.y = (ibox.y / scale)
+                            + margin.top.max(0.0)
+                            + container_pb.top
+                            + inset_offset.y;
                         layout.padding = padding; //.map(|p| p / scale);
                         layout.border = border; //.map(|p| p / scale);
                     }

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -748,29 +748,31 @@ impl BaseDocument {
                         // (the content box of the inline container).
                         let style = node.style();
                         let container_content_size = final_size - content_box_inset.sum_axes();
-                        let inset_left = style
-                            .inset
-                            .left
-                            .maybe_resolve(container_content_size.width, resolve_calc_value);
-                        let inset_right = style
-                            .inset
-                            .right
-                            .maybe_resolve(container_content_size.width, resolve_calc_value);
-                        let inset_top = style
-                            .inset
-                            .top
-                            .maybe_resolve(container_content_size.height, resolve_calc_value);
-                        let inset_bottom = style
-                            .inset
-                            .bottom
-                            .maybe_resolve(container_content_size.height, resolve_calc_value);
+                        let inset = taffy::Rect {
+                            left: style
+                                .inset
+                                .left
+                                .maybe_resolve(container_content_size.width, resolve_calc_value),
+                            right: style
+                                .inset
+                                .right
+                                .maybe_resolve(container_content_size.width, resolve_calc_value),
+                            top: style
+                                .inset
+                                .top
+                                .maybe_resolve(container_content_size.height, resolve_calc_value),
+                            bottom: style
+                                .inset
+                                .bottom
+                                .maybe_resolve(container_content_size.height, resolve_calc_value),
+                        };
                         let inset_offset = taffy::Point {
                             x: if container_direction == Direction::Rtl {
-                                inset_right.map(|x| -x).or(inset_left).unwrap_or(0.0)
+                                inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)
                             } else {
-                                inset_left.or(inset_right.map(|x| -x)).unwrap_or(0.0)
+                                inset.left.or(inset.right.map(|x| -x)).unwrap_or(0.0)
                             },
-                            y: inset_top.or(inset_bottom.map(|x| -x)).unwrap_or(0.0),
+                            y: inset.top.or(inset.bottom.map(|x| -x)).unwrap_or(0.0),
                         };
 
                         let layout = node.unrounded_layout_mut();


### PR DESCRIPTION
## Summary

`position: relative` inset offsets were never applied to atomic inline-level boxes (e.g. `inline-block`) participating in an inline formatting context: the in-flow placement branch of `compute_inline_layout_inner` positioned boxes purely from `ibox.x/y + margin + container_pb`.

This PR resolves the box's inset styles and adds the resulting offset when storing the box's location:

```
inset_offset.x = ltr ? left.or(-right) : (-right).or(left)   // resolved against containing block width
inset_offset.y = top.or(-bottom)                             // resolved against containing block height
layout.location += inset_offset
```

Percentages resolve against the inline container's content box (`final_size - content_box_inset`), and the left/right precedence follows the containing block's `direction`, matching Taffy's block-layout behavior for relatively positioned children.

Non-atomic inlines (`<span>`s with text) are not layout nodes, so relative offsetting for them is out of scope here.

## Testing

- WPT `css/CSS2/positioning/position-relative-*`: no changes (the remaining failures involve span offsetting).
- WPT `css/css-position/position-relative-0*`: `position-relative-014.html` flips PASS→FAIL, but this is expected: it relies on script resetting `left` to `0px`, and Blitz doesn't run script — previously it "passed" only because the inset was ignored entirely.
- Manual render check: three inline-blocks with `left/top` and `right/bottom` offsets render at the expected offset positions.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/28431661884b4489a5f5eec28b2cab81
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**90** newly passing, **3** newly failing (net +87).

<details>
<summary>Full diff (93 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/floats-clear/clear-002.xht
+ Fail => Pass css/CSS2/floats-clear/clear-float-005.xht
+ Fail => Pass css/CSS2/linebox/line-height-002.xht
+ Fail => Pass css/CSS2/linebox/line-height-004.xht
+ Fail => Pass css/CSS2/linebox/line-height-005.xht
+ Fail => Pass css/CSS2/linebox/line-height-006.xht
+ Fail => Pass css/CSS2/linebox/line-height-007.xht
+ Fail => Pass css/CSS2/linebox/line-height-013.xht
+ Fail => Pass css/CSS2/linebox/line-height-015.xht
+ Fail => Pass css/CSS2/linebox/line-height-016.xht
+ Fail => Pass css/CSS2/linebox/line-height-017.xht
+ Fail => Pass css/CSS2/linebox/line-height-018.xht
+ Fail => Pass css/CSS2/linebox/line-height-024.xht
+ Fail => Pass css/CSS2/linebox/line-height-025.xht
+ Fail => Pass css/CSS2/linebox/line-height-026.xht
+ Fail => Pass css/CSS2/linebox/line-height-027.xht
+ Fail => Pass css/CSS2/linebox/line-height-028.xht
+ Fail => Pass css/CSS2/linebox/line-height-029.xht
+ Fail => Pass css/CSS2/linebox/line-height-035.xht
+ Fail => Pass css/CSS2/linebox/line-height-037.xht
+ Fail => Pass css/CSS2/linebox/line-height-038.xht
+ Fail => Pass css/CSS2/linebox/line-height-039.xht
+ Fail => Pass css/CSS2/linebox/line-height-040.xht
+ Fail => Pass css/CSS2/linebox/line-height-046.xht
+ Fail => Pass css/CSS2/linebox/line-height-048.xht
+ Fail => Pass css/CSS2/linebox/line-height-049.xht
+ Fail => Pass css/CSS2/linebox/line-height-050.xht
+ Fail => Pass css/CSS2/linebox/line-height-051.xht
+ Fail => Pass css/CSS2/linebox/line-height-057.xht
+ Fail => Pass css/CSS2/linebox/line-height-058.xht
+ Fail => Pass css/CSS2/linebox/line-height-059.xht
+ Fail => Pass css/CSS2/linebox/line-height-060.xht
+ Fail => Pass css/CSS2/linebox/line-height-061.xht
+ Fail => Pass css/CSS2/linebox/line-height-062.xht
+ Fail => Pass css/CSS2/linebox/line-height-068.xht
+ Fail => Pass css/CSS2/linebox/line-height-069.xht
+ Fail => Pass css/CSS2/linebox/line-height-070.xht
+ Fail => Pass css/CSS2/linebox/line-height-071.xht
+ Fail => Pass css/CSS2/linebox/line-height-072.xht
+ Fail => Pass css/CSS2/linebox/line-height-073.xht
+ Fail => Pass css/CSS2/linebox/line-height-079.xht
+ Fail => Pass css/CSS2/linebox/line-height-080.xht
+ Fail => Pass css/CSS2/linebox/line-height-081.xht
+ Fail => Pass css/CSS2/linebox/line-height-082.xht
+ Fail => Pass css/CSS2/linebox/line-height-083.xht
+ Fail => Pass css/CSS2/linebox/line-height-084.xht
+ Fail => Pass css/CSS2/linebox/line-height-090.xht
+ Fail => Pass css/CSS2/linebox/line-height-092.xht
+ Fail => Pass css/CSS2/linebox/line-height-093.xht
+ Fail => Pass css/CSS2/linebox/line-height-094.xht
+ Fail => Pass css/CSS2/linebox/line-height-095.xht
+ Fail => Pass css/CSS2/linebox/line-height-101.xht
+ Fail => Pass css/CSS2/linebox/line-height-102.xht
+ Fail => Pass css/CSS2/linebox/line-height-103.xht
+ Fail => Pass css/CSS2/linebox/line-height-104.xht
+ Fail => Pass css/CSS2/linebox/line-height-105.xht
+ Fail => Pass css/CSS2/linebox/line-height-106.xht
+ Fail => Pass css/CSS2/linebox/line-height-112.xht
- Pass => Fail css/CSS2/linebox/vertical-align-applies-to-007.xht
+ Fail => Pass css/CSS2/positioning/right-offset-004.xht
+ Fail => Pass css/CSS2/visuren/box-offsets-rel-pos-002.xht
+ Fail => Pass css/css-backgrounds/background-image-001.html
+ Fail => Pass css/css-backgrounds/background-image-002.html
+ Fail => Pass css/css-backgrounds/background-image-003.html
+ Fail => Pass css/css-backgrounds/background-image-004.html
+ Fail => Pass css/css-backgrounds/background-image-005.html
+ Fail => Pass css/css-backgrounds/background-image-006.html
+ Fail => Pass css/css-backgrounds/background-origin/origin-border-box_with_position.html
+ Fail => Pass css/css-backgrounds/background-origin/origin-content-box_with_position.html
+ Fail => Pass css/css-backgrounds/background-origin/origin-padding-box_with_position.html
- Pass => Fail css/css-contain/contain-layout-baseline-004.html
- Pass => Fail css/css-position/position-relative-014.html
+ Fail => Pass css/css-pseudo/active-selection-043.html
+ Fail => Pass css/css-pseudo/active-selection-045.html
+ Fail => Pass css/css-shapes/shape-outside/shape-image/shape-image-013.html
+ Fail => Pass css/css-transforms/transform-input-001.html
+ Fail => Pass css/css-transforms/transform-input-003.html
+ Fail => Pass css/css-transforms/transform-input-004.html
+ Fail => Pass css/css-transforms/transform-input-005.html
+ Fail => Pass css/css-transforms/transform-input-006.html
+ Fail => Pass css/css-transforms/transform-input-007.html
+ Fail => Pass css/css-transforms/transform-input-008.html
+ Fail => Pass css/css-transforms/transform-input-009.html
+ Fail => Pass css/css-transforms/transform-input-010.html
+ Fail => Pass css/css-transforms/transform-input-011.html
+ Fail => Pass css/css-transforms/transform-input-012.html
+ Fail => Pass css/css-transforms/transform-input-013.html
+ Fail => Pass css/css-transforms/transform-input-014.html
+ Fail => Pass css/css-transforms/transform-input-015.html
+ Fail => Pass css/css-transforms/transform-input-016.html
+ Fail => Pass css/css-transforms/transform-input-017.html
+ Fail => Pass css/css-transforms/transform-input-018.html
+ Fail => Pass css/css-transforms/transform-input-019.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31233485140).</sub>
<!-- wpt-results-end -->
