### PR TITLE
Offset table row backgrounds and collapsed borders by table border/padding

### DIFF
--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -43,8 +43,8 @@ pub struct TableContext {
 #[derive(Debug, Clone)]
 pub struct TableCell {
     // kind: TableItemKind,
-    node_id: NodeId,
-    style: taffy::Style<Atom>,
+    pub node_id: NodeId,
+    pub style: taffy::Style<Atom>,
 }
 
 #[derive(Debug, Clone)]

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -76,6 +76,7 @@ pub use crate::node::Widget;
 pub use blitz_traits::node_id::NodeId;
 pub use config::{DocumentConfig, StyleThreading};
 pub use document::{BaseDocument, DocGuard, DocGuardMut, Document, PlainDocument};
+pub use layout::table::{TableCell, TableContext, TableRow};
 pub use markup5ever::{
     LocalName, Namespace, NamespaceStaticSet, Prefix, PrefixStaticSet, QualName, local_name,
     namespace_prefix, namespace_url, ns,

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -23,7 +23,6 @@ use style::{
         specified::background::BackgroundRepeatKeyword,
     },
 };
-use taffy::ResolveOrZero;
 
 #[cfg(feature = "tracing")]
 use tracing::warn;
@@ -220,32 +219,22 @@ impl ElementCx<'_, '_> {
             return;
         };
 
-        let cols = &grid_info.columns;
-        let inner_width =
-            (cols.sizes.iter().sum::<f32>() + cols.gutters.iter().sum::<f32>()) as f64;
+        let Some(coords) = self.table_grid_coords(table, grid_info) else {
+            return;
+        };
+        let (x_min, x_max) = (coords.col_starts[0], *coords.col_ends.last().unwrap());
 
-        // Cells are positioned within the table's content box, so row background
-        // rects must be offset by the table's border and padding.
-        let border = table.style.border.resolve_or_zero(None, |_, _| 0.0);
-        let padding = table.style.padding.resolve_or_zero(None, |_, _| 0.0);
-        let x = (border.left + padding.left) as f64;
-
-        let rows = &grid_info.rows;
-        let mut y = (border.top + padding.top) as f64
-            + rows.gutters.first().copied().unwrap_or_default() as f64;
-        for ((row, &height), &gutter) in table
+        for (row, (&top, &bottom)) in table
             .rows
             .iter()
-            .zip(rows.sizes.iter())
-            .zip(rows.gutters.iter().skip(1))
+            .zip(coords.row_starts.iter().zip(coords.row_ends.iter()))
         {
             let row_node = &self.context.dom.get_node(row.node_id).unwrap();
             let Some(style) = row_node.primary_styles() else {
                 continue;
             };
 
-            let shape =
-                Rect::new(x, y, x + inner_width, y + height as f64).scale_from_origin(self.scale);
+            let shape = Rect::new(x_min, top, x_max, bottom).scale_from_origin(self.scale);
 
             let current_color = style.clone_color();
             let background_color = &style.get_background().background_color;
@@ -257,8 +246,6 @@ impl ElementCx<'_, '_> {
                 // Fill the color
                 scene.fill(Fill::NonZero, self.transform, bg_color, None, &shape);
             }
-
-            y += (height + gutter) as f64;
         }
     }
 

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -23,6 +23,7 @@ use style::{
         specified::background::BackgroundRepeatKeyword,
     },
 };
+use taffy::ResolveOrZero;
 
 #[cfg(feature = "tracing")]
 use tracing::warn;
@@ -223,8 +224,15 @@ impl ElementCx<'_, '_> {
         let inner_width =
             (cols.sizes.iter().sum::<f32>() + cols.gutters.iter().sum::<f32>()) as f64;
 
+        // Cells are positioned within the table's content box, so row background
+        // rects must be offset by the table's border and padding.
+        let border = table.style.border.resolve_or_zero(None, |_, _| 0.0);
+        let padding = table.style.padding.resolve_or_zero(None, |_, _| 0.0);
+        let x = (border.left + padding.left) as f64;
+
         let rows = &grid_info.rows;
-        let mut y = rows.gutters.first().copied().unwrap_or_default() as f64;
+        let mut y = (border.top + padding.top) as f64
+            + rows.gutters.first().copied().unwrap_or_default() as f64;
         for ((row, &height), &gutter) in table
             .rows
             .iter()
@@ -237,7 +245,7 @@ impl ElementCx<'_, '_> {
             };
 
             let shape =
-                Rect::new(0.0, y, inner_width, y + height as f64).scale_from_origin(self.scale);
+                Rect::new(x, y, x + inner_width, y + height as f64).scale_from_origin(self.scale);
 
             let current_color = style.clone_color();
             let background_color = &style.get_background().background_color;

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -7,6 +7,7 @@ use style::{
     computed_values::border_collapse::T as BorderCollapse,
     values::computed::{BorderStyle, OutlineStyle},
 };
+use taffy::ResolveOrZero;
 
 use crate::{
     color::{ToColorColor as _, contrast_ratio},
@@ -547,13 +548,20 @@ impl ElementCx<'_, '_> {
             return;
         }
 
-        let border_width = border_style.border_top_width.0.to_f64_px();
+        // Cells are positioned within the table's content box, so border rects
+        // must be offset by the table's border and padding.
+        let border = table.style.border.resolve_or_zero(None, |_, _| 0.0);
+        let padding = table.style.padding.resolve_or_zero(None, |_, _| 0.0);
+        let x0 = (border.left + padding.left) as f64;
+        let y0 = (border.top + padding.top) as f64;
+        let table_width = x0 + inner_width + (padding.right + border.right) as f64;
+        let table_height = y0 + inner_height + (padding.bottom + border.bottom) as f64;
 
         // Draw horizontal inner borders
-        let mut y = 0.0;
+        let mut y = y0;
         for (&height, &gutter) in rows.sizes.iter().zip(rows.gutters.iter()) {
             let shape =
-                Rect::new(0.0, y, inner_width, y + gutter as f64).scale_from_origin(self.scale);
+                Rect::new(x0, y, x0 + inner_width, y + gutter as f64).scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
 
             y += (height + gutter) as f64;
@@ -563,21 +571,26 @@ impl ElementCx<'_, '_> {
         // Top border
         if outer_border_style.border_top_style != BorderStyle::Hidden {
             let shape =
-                Rect::new(0.0, 0.0, inner_width, border_width).scale_from_origin(self.scale);
+                Rect::new(0.0, 0.0, table_width, border.top as f64).scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
         }
         // Bottom border
         if outer_border_style.border_bottom_style != BorderStyle::Hidden {
-            let shape = Rect::new(0.0, inner_height, inner_width, inner_height + border_width)
-                .scale_from_origin(self.scale);
+            let shape = Rect::new(
+                0.0,
+                table_height - border.bottom as f64,
+                table_width,
+                table_height,
+            )
+            .scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
         }
 
         // Draw vertical inner borders
-        let mut x = 0.0;
+        let mut x = x0;
         for (&width, &gutter) in cols.sizes.iter().zip(cols.gutters.iter()) {
-            let shape =
-                Rect::new(x, 0.0, x + gutter as f64, inner_height).scale_from_origin(self.scale);
+            let shape = Rect::new(x, y0, x + gutter as f64, y0 + inner_height)
+                .scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
 
             x += (width + gutter) as f64;
@@ -587,13 +600,18 @@ impl ElementCx<'_, '_> {
         // Left border
         if outer_border_style.border_left_style != BorderStyle::Hidden {
             let shape =
-                Rect::new(0.0, 0.0, border_width, inner_height).scale_from_origin(self.scale);
+                Rect::new(0.0, 0.0, border.left as f64, table_height).scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
         }
         // Right border
         if outer_border_style.border_right_style != BorderStyle::Hidden {
-            let shape = Rect::new(inner_width, 0.0, inner_width + border_width, inner_height)
-                .scale_from_origin(self.scale);
+            let shape = Rect::new(
+                table_width - border.right as f64,
+                0.0,
+                table_width,
+                table_height,
+            )
+            .scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
         }
     }

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -1,4 +1,5 @@
 use anyrender::PaintScene;
+use blitz_dom::TableContext;
 use blitz_dom::node::SpecialElementData;
 use kurbo::{BezPath, Cap, Circle, Insets, Join, PathEl, Point, Rect, Shape as _, Stroke, Vec2};
 use peniko::{Color, Fill};
@@ -7,13 +8,24 @@ use style::{
     computed_values::border_collapse::T as BorderCollapse,
     values::computed::{BorderStyle, OutlineStyle},
 };
-use taffy::ResolveOrZero;
+use taffy::{DetailedGridInfo, ResolveOrZero};
 
 use crate::{
     color::{ToColorColor as _, contrast_ratio},
     kurbo_css::Edge,
     render::ElementCx,
 };
+
+/// Positions of a table's grid lines (in CSS pixels, relative to the table's
+/// border box), used for painting row backgrounds and collapsed borders.
+pub(super) struct TableGridCoords {
+    pub row_starts: Vec<f64>,
+    pub row_ends: Vec<f64>,
+    pub col_starts: Vec<f64>,
+    pub col_ends: Vec<f64>,
+    pub table_width: f64,
+    pub table_height: f64,
+}
 
 /// A darker version of a colour (mirrors WebKit/Blink's `Color::Dark`): the
 /// brightest channel is reduced by a fixed amount and the others scaled to match,
@@ -510,6 +522,95 @@ impl ElementCx<'_, '_> {
         scene.pop_layer();
     }
 
+    /// Compute the positions of the table's grid lines (in CSS pixels, relative
+    /// to the table's border box) for painting row backgrounds and collapsed
+    /// borders.
+    ///
+    /// Track positions are accumulated from the sizes/gutters in `grid_info`
+    /// (offset by the table's border and padding, since cells are positioned
+    /// within the table's content box) and then snapped to the edges of the
+    /// cells' rounded layouts so that painted rects join the cell backgrounds
+    /// without gaps.
+    pub(super) fn table_grid_coords(
+        &self,
+        table: &TableContext,
+        grid_info: &DetailedGridInfo,
+    ) -> Option<TableGridCoords> {
+        let rows = &grid_info.rows;
+        let cols = &grid_info.columns;
+        if rows.sizes.is_empty() || cols.sizes.is_empty() {
+            return None;
+        }
+
+        let border = table.style.border.resolve_or_zero(None, |_, _| 0.0);
+        let padding = table.style.padding.resolve_or_zero(None, |_, _| 0.0);
+
+        fn track_positions(sizes: &[f32], gutters: &[f32], offset: f32) -> (Vec<f64>, Vec<f64>) {
+            let mut starts = Vec::with_capacity(sizes.len());
+            let mut ends = Vec::with_capacity(sizes.len());
+            let mut pos = (offset + gutters.first().copied().unwrap_or(0.0)) as f64;
+            for (i, &size) in sizes.iter().enumerate() {
+                starts.push(pos);
+                pos += size as f64;
+                ends.push(pos);
+                pos += gutters.get(i + 1).copied().unwrap_or(0.0) as f64;
+            }
+            (starts, ends)
+        }
+
+        let (col_starts_u, col_ends_u) =
+            track_positions(&cols.sizes, &cols.gutters, border.left + padding.left);
+        let (row_starts_u, row_ends_u) =
+            track_positions(&rows.sizes, &rows.gutters, border.top + padding.top);
+
+        let mut col_starts: Vec<f64> = col_starts_u.iter().map(|v| v.round()).collect();
+        let mut col_ends: Vec<f64> = col_ends_u.iter().map(|v| v.round()).collect();
+        let mut row_starts: Vec<f64> = row_starts_u.iter().map(|v| v.round()).collect();
+        let mut row_ends: Vec<f64> = row_ends_u.iter().map(|v| v.round()).collect();
+
+        /// Snap the grid line nearest to `value` to `value` itself. Cell edges
+        /// can deviate from the unrounded line position by up to 1px due to
+        /// layout rounding.
+        fn snap(unrounded: &[f64], rounded: &mut [f64], value: f64) {
+            let (idx, dist) = unrounded
+                .iter()
+                .enumerate()
+                .map(|(i, &u)| (i, (u - value).abs()))
+                .min_by(|a, b| a.1.total_cmp(&b.1))
+                .unwrap();
+            if dist <= 1.0 {
+                rounded[idx] = value;
+            }
+        }
+
+        for cell in &table.cells {
+            let Some(node) = self.context.dom.get_node(cell.node_id) else {
+                continue;
+            };
+            let layout = node.final_layout();
+            let x = layout.location.x as f64;
+            let y = layout.location.y as f64;
+            snap(&col_starts_u, &mut col_starts, x);
+            snap(&col_ends_u, &mut col_ends, x + layout.size.width as f64);
+            snap(&row_starts_u, &mut row_starts, y);
+            snap(&row_ends_u, &mut row_ends, y + layout.size.height as f64);
+        }
+
+        let table_width =
+            (col_ends_u.last().unwrap() + (padding.right + border.right) as f64).round();
+        let table_height =
+            (row_ends_u.last().unwrap() + (padding.bottom + border.bottom) as f64).round();
+
+        Some(TableGridCoords {
+            row_starts,
+            row_ends,
+            col_starts,
+            col_ends,
+            table_width,
+            table_height,
+        })
+    }
+
     pub(crate) fn draw_table_borders(&self, scene: &mut impl PaintScene) {
         let SpecialElementData::TableRoot(table) = &self.element.special_data else {
             return;
@@ -528,14 +629,6 @@ impl ElementCx<'_, '_> {
 
         let outer_border_style = self.style.get_border();
 
-        let cols = &grid_info.columns;
-        let rows = &grid_info.rows;
-
-        let inner_width =
-            (cols.sizes.iter().sum::<f32>() + cols.gutters.iter().sum::<f32>()) as f64;
-        let inner_height =
-            (rows.sizes.iter().sum::<f32>() + rows.gutters.iter().sum::<f32>()) as f64;
-
         // TODO: support different colors for different borders
         let current_color = self.style.clone_color();
         let border_color = border_style
@@ -548,71 +641,55 @@ impl ElementCx<'_, '_> {
             return;
         }
 
-        // Cells are positioned within the table's content box, so border rects
-        // must be offset by the table's border and padding.
-        let border = table.style.border.resolve_or_zero(None, |_, _| 0.0);
-        let padding = table.style.padding.resolve_or_zero(None, |_, _| 0.0);
-        let x0 = (border.left + padding.left) as f64;
-        let y0 = (border.top + padding.top) as f64;
-        let table_width = x0 + inner_width + (padding.right + border.right) as f64;
-        let table_height = y0 + inner_height + (padding.bottom + border.bottom) as f64;
+        let Some(coords) = self.table_grid_coords(table, grid_info) else {
+            return;
+        };
+        let (x_min, x_max) = (coords.col_starts[0], *coords.col_ends.last().unwrap());
+        let (y_min, y_max) = (coords.row_starts[0], *coords.row_ends.last().unwrap());
+
+        let mut fill = |rect: Rect| {
+            let shape = rect.scale_from_origin(self.scale);
+            scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
+        };
 
         // Draw horizontal inner borders
-        let mut y = y0;
-        for (&height, &gutter) in rows.sizes.iter().zip(rows.gutters.iter()) {
-            let shape =
-                Rect::new(x0, y, x0 + inner_width, y + gutter as f64).scale_from_origin(self.scale);
-            scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
-
-            y += (height + gutter) as f64;
+        for (&end, &next_start) in coords.row_ends.iter().zip(coords.row_starts.iter().skip(1)) {
+            fill(Rect::new(x_min, end, x_max, next_start));
         }
 
         // Draw horizontal outer borders
         // Top border
         if outer_border_style.border_top_style != BorderStyle::Hidden {
-            let shape =
-                Rect::new(0.0, 0.0, table_width, border.top as f64).scale_from_origin(self.scale);
-            scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
+            fill(Rect::new(0.0, 0.0, coords.table_width, y_min));
         }
         // Bottom border
         if outer_border_style.border_bottom_style != BorderStyle::Hidden {
-            let shape = Rect::new(
+            fill(Rect::new(
                 0.0,
-                table_height - border.bottom as f64,
-                table_width,
-                table_height,
-            )
-            .scale_from_origin(self.scale);
-            scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
+                y_max,
+                coords.table_width,
+                coords.table_height,
+            ));
         }
 
         // Draw vertical inner borders
-        let mut x = x0;
-        for (&width, &gutter) in cols.sizes.iter().zip(cols.gutters.iter()) {
-            let shape = Rect::new(x, y0, x + gutter as f64, y0 + inner_height)
-                .scale_from_origin(self.scale);
-            scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
-
-            x += (width + gutter) as f64;
+        for (&end, &next_start) in coords.col_ends.iter().zip(coords.col_starts.iter().skip(1)) {
+            fill(Rect::new(end, y_min, next_start, y_max));
         }
 
         // Draw vertical outer borders
         // Left border
         if outer_border_style.border_left_style != BorderStyle::Hidden {
-            let shape =
-                Rect::new(0.0, 0.0, border.left as f64, table_height).scale_from_origin(self.scale);
-            scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
+            fill(Rect::new(0.0, 0.0, x_min, coords.table_height));
         }
         // Right border
         if outer_border_style.border_right_style != BorderStyle::Hidden {
-            let shape = Rect::new(
-                table_width - border.right as f64,
+            fill(Rect::new(
+                x_max,
                 0.0,
-                table_width,
-                table_height,
-            )
-            .scale_from_origin(self.scale);
-            scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
+                coords.table_width,
+                coords.table_height,
+            ));
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes misaligned table painting visible on https://blitz.is/status/wpt/css/CSS2/floats: white first-column cell backgrounds didn't line up with rows and the coloured `<tr>` backgrounds bled through the collapsed-border gutters.

Table cells are laid out inside the table's content box (offset by the table-level border/padding that `build_table_context` synthesizes — in `border-collapse: collapse` mode the table border is set to the cell border width), but `draw_table_row_backgrounds` and `draw_table_borders` painted their rects starting at the border-box origin `(0, 0)`. Every row-background rect and inner gutter fill was therefore shifted up/left by one border width relative to the cells:

```text
before: row k bg at   y = Σ sizes/gutters            (misses border.top)
after:  row k bg at   y = border.top + padding.top + Σ sizes/gutters
```

Both functions now resolve `table.style.border`/`padding` (via `ResolveOrZero`) and offset all rects by them. The outer borders in `draw_table_borders` are also now drawn from the table's own resolved border widths spanning the full border-box (previously they used the first cell's border width and only spanned `inner_width`/`inner_height`, leaving the corners uncovered and sitting one border width too high/left on the bottom/right edges).

Verified against the live page and a minimal repro: row backgrounds, cell backgrounds, and collapsed borders now align.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/65672de3b7ef45f88c8a46c16e1ac8b2
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**3** newly passing, **0** newly failing (net +3).

<details>
<summary>Full diff (3 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/tables/border-collapse-dynamic-table-003.xht
+ Fail => Pass css/CSS2/visufx/overflow-applies-to-001.xht
+ Fail => Pass css/css-backgrounds/ttwf-reftest-borderRadius.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31233905578).</sub>
<!-- wpt-results-end -->
