### PR TITLE
Propagate item_is_replaced to Taffy styles

### DIFF
--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -549,7 +549,7 @@ impl BaseDocument {
             // Compute the owned taffy style and display in an inner scope so the
             // immutable borrow of `node` (held by the stylo element data guard)
             // is released before we mutably access `node` below.
-            let (taffy_style, display_constructed_as) = {
+            let (mut taffy_style, display_constructed_as) = {
                 let stylo_element_data = node.stylo_element_data_opt().and_then(|s| s.get());
                 let primary_styles = stylo_element_data
                     .as_ref()
@@ -561,6 +561,10 @@ impl BaseDocument {
 
                 (stylo_taffy::to_taffy_style(style), style.clone_display())
             };
+            taffy_style.item_is_replaced = node
+                .data
+                .downcast_element()
+                .is_some_and(|el| crate::layout::replaced::is_replaced_element(&el.name.local));
 
             // if damage.intersects(RestyleDamage::RELAYOUT | CONSTRUCT_BOX) {
             *node.style_mut() = taffy_style;


### PR DESCRIPTION
## Summary

`stylo_taffy::to_taffy_style` always initialises `item_is_replaced: false` (it has no access to DOM identity), so Taffy's block layout stretch-sized replaced elements like ordinary blocks instead of resolving their own intrinsic size per [CSS2 §10.3.4](https://www.w3.org/TR/CSS22/visudet.html#block-replaced-width).

This sets the flag at the DOM-specific layer in `damage.rs`, where the taffy style is written to the node:

```rust
taffy_style.item_is_replaced = node
    .data
    .downcast_element()
    .is_some_and(|el| is_replaced_element(&el.name.local));
```

With this, Taffy skips stretch-sizing for replaced items (`img`, `svg`, `canvas`, `video`, `embed`, `iframe`) and defers to their measure function, fixing the auto-width/auto-margin resolution for block-level replaced elements (`css/CSS2/normal-flow/block-replaced-height-*` and friends).

Split out of #634, which builds on this and addresses SVG intrinsic sizing/rendering.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/51256d0b440341bd874c6dc59e138478
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**12** newly passing, **4** newly failing (net +8).

<details>
<summary>Full diff (16 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/css1/c43-rpl-bbx-002.xht
- Pass => Fail css/CSS2/inline-svg-100-percent-in-body.html
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-001.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-002.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-004.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-005.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-007.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-001.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-008.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-015.xht
+ Fail => Pass css/css-grid/grid-items/percentage-size-indefinite-replaced.html
- Pass => Fail css/css-lists/list-item-definition.html
- Pass => Fail css/css-rhythm/replaced-elements/block-level-canvas-margins-affected-by-block-step-size.html
- Pass => Fail css/css-rhythm/replaced-elements/block-level-img-margins-affected-by-block-step-size.html
+ Fail => Pass css/css-sizing/block-image-percentage-max-height-inside-inline.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-033.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31233841934).</sub>
<!-- wpt-results-end -->
