### PR TITLE
Apply root element margins and propagate body background to the canvas

### DIFF
--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -398,6 +398,22 @@ impl BaseDocument {
         // println!("\n\nRESOLVE LAYOUT\n===========\n");
 
         taffy::compute_root_layout(self, root_element_id, available_space);
+
+        // `compute_root_layout` resolves the root element's margins but always positions
+        // its border box at the origin. The root element's margins offset it within the
+        // viewport (and never collapse with descendants per CSS2 §8.3.1).
+        {
+            let root_node_id = crate::dom_node_id(root_element_id);
+            let is_rtl = self.nodes[root_node_id].style().direction == taffy::Direction::Rtl;
+            let layout = self.nodes[root_node_id].unrounded_layout_mut();
+            if is_rtl {
+                layout.location.x -= layout.margin.right;
+            } else {
+                layout.location.x += layout.margin.left;
+            }
+            layout.location.y += layout.margin.top;
+        }
+
         taffy::round_layout(self, root_element_id);
 
         // println!("\n\n");

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -40,7 +40,20 @@ use style::{
 use kurbo::{self, Affine, Insets, Point, Rect, Shape, Size, Stroke, Vec2};
 use peniko::{self, Fill, ImageData, ImageSampler};
 use style::values::generics::color::GenericColor;
+use style::values::generics::image::GenericImage;
 use taffy::Layout;
+
+/// Whether the element's background is entirely transparent/none such that a root
+/// element's background is taken from the `body` element (CSS Backgrounds §2.11.2)
+fn background_is_none(style: &ComputedValues) -> bool {
+    let bg = style.get_background();
+    bg.background_color == GenericColor::TRANSPARENT_BLACK
+        && bg
+            .background_image
+            .0
+            .iter()
+            .all(|image| matches!(image, GenericImage::None))
+}
 
 /// A short-lived struct which holds a bunch of parameters for rendering a scene so
 /// that we don't have to pass them down as parameters
@@ -54,6 +67,11 @@ pub struct BlitzDomPainter<'dom, 'a> {
     pub(crate) initial_y: f64,
     /// The id of the document's root element (cached to avoid re-resolving it for every element)
     pub(crate) root_element_id: Option<NodeId>,
+    /// The id of the `body` element whose background propagates to the canvas because the
+    /// root element's background is entirely transparent/none (CSS Backgrounds §2.11.2).
+    /// Such an element does not paint its own background: it is painted as the canvas
+    /// background, positioned as if it were painted for the root element.
+    pub(crate) canvas_bg_body_id: Option<NodeId>,
     /// Scrollbar hover/drag state, resolved once per scene like the root element
     #[cfg(feature = "scrollbars")]
     pub(crate) hovered_scrollbar: Option<blitz_dom::node::ScrollbarRef>,
@@ -87,6 +105,23 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         let layer_manager = LayerManager::default();
         let root_element_id = dom.try_root_element().map(|el| el.id);
 
+        let canvas_bg_body_id = dom.try_root_element().and_then(|root| {
+            let root_bg_is_none = root
+                .primary_styles()
+                .is_none_or(|styles| background_is_none(&styles));
+            if !root_bg_is_none {
+                return None;
+            }
+            root.children
+                .iter()
+                .find(|id| {
+                    dom.get_node(**id).is_some_and(|node| {
+                        node.data.is_element_with_tag_name(&local_name!("body"))
+                    })
+                })
+                .copied()
+        });
+
         Self {
             dom,
             scale,
@@ -95,6 +130,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             initial_x,
             initial_y,
             root_element_id,
+            canvas_bg_body_id,
             #[cfg(feature = "scrollbars")]
             hovered_scrollbar: dom.hovered_scrollbar(),
             #[cfg(feature = "scrollbars")]
@@ -125,20 +161,10 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         let bg_height = (self.height as f32).max(root_element.final_layout().size.height);
 
         let background_color = {
-            let html_color = root_element
-                .primary_styles()
-                .map(|s| s.clone_background_color())
-                .unwrap_or(GenericColor::TRANSPARENT_BLACK);
-            if html_color == GenericColor::TRANSPARENT_BLACK {
-                root_element
-                    .children
-                    .iter()
-                    .find_map(|id| {
-                        self.dom
-                            .as_ref()
-                            .get_node(*id)
-                            .filter(|node| node.data.is_element_with_tag_name(&local_name!("body")))
-                    })
+            if let Some(body_id) = self.canvas_bg_body_id {
+                self.dom
+                    .as_ref()
+                    .get_node(body_id)
                     .and_then(|body| body.primary_styles())
                     .map(|style| {
                         let current_color = style.clone_color();
@@ -147,8 +173,12 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                             .resolve_to_absolute(&current_color)
                     })
             } else {
-                let current_color = root_element.primary_styles().unwrap().clone_color();
-                Some(html_color.resolve_to_absolute(&current_color))
+                root_element.primary_styles().map(|style| {
+                    let current_color = style.clone_color();
+                    style
+                        .clone_background_color()
+                        .resolve_to_absolute(&current_color)
+                })
             }
         };
 
@@ -159,6 +189,24 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                 (bg_width as f64, bg_height as f64),
             );
             scene.fill(Fill::NonZero, Affine::IDENTITY, bg_color, None, &rect);
+        }
+
+        // Paint the body element's background propagated to the canvas. Its background
+        // positioning area is determined as if it were painted for the root element.
+        if let Some(body_id) = self.canvas_bg_body_id {
+            let body_node = &self.dom.as_ref().tree()[body_id];
+            if body_node.primary_styles().is_some() && body_node.element_data().is_some() {
+                let root_layout = *root_element.final_layout();
+                let box_position =
+                    Vec2::new(root_layout.location.x as f64, root_layout.location.y as f64)
+                        * self.scale;
+                let transform = Affine::translate(Vec2 {
+                    x: self.initial_x - (viewport_scroll.x * self.scale),
+                    y: self.initial_y - (viewport_scroll.y * self.scale),
+                }) * Affine::translate(box_position);
+                let cx = self.element_cx(body_node, root_layout, transform, None);
+                cx.draw_background(scene);
+            }
         }
 
         // The root clip rectangle is the viewport (in screen coordinates, with the
@@ -416,7 +464,11 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                     filter,
                     backdrop_filter,
                     |scene| {
-                        cx.draw_background(scene);
+                        // A body element whose background propagates to the canvas does
+                        // not paint its own background (it is painted in `paint_scene`).
+                        if self.canvas_bg_body_id != Some(node_id) {
+                            cx.draw_background(scene);
+                        }
                         cx.draw_inset_box_shadow(scene);
                         cx.draw_table_row_backgrounds(scene);
                         cx.draw_table_borders(scene);


### PR DESCRIPTION
## Summary

Fixes WPT `css/CSS2/margin-padding-clear/margin-collapse-020.xht` and `margin-collapse-021.xht`.

Two related root/body issues:

1. **Root element margins** — `taffy::compute_root_layout` resolves the root element's margins but always positions its border box at the origin. `resolve_layout` now offsets the root's `location` by its resolved margins after root layout (RTL-aware for the horizontal axis); per CSS2 §8.3.1 the root's margins never collapse with descendants.

2. **Body background propagation** (CSS Backgrounds §2.11.2) — when the root element's background is entirely transparent/none, the `body`'s background propagates to the canvas. Previously only the body's background *color* was used as the canvas color while the body still painted its background at its own position; with root margins applied this left the canvas mispositioned relative to the test's expectation. `BlitzDomPainter` now resolves a `canvas_bg_body_id` up front; that body's background (color *and* images) is painted for the canvas with its positioning area determined as if it were painted for the root element, and is skipped during the body's own painting:

```text
paint_scene:
  fill viewport with body's background-color
  draw body's background with root element's layout/transform
render_element:
  if canvas_bg_body_id != Some(node_id) { cx.draw_background(scene) }
```

`background_is_none` checks both `background-color: transparent` and all `background-image: none`, so a root with only a background *image* (as in margin-collapse-020) correctly prevents propagation.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/19d83a7d94fb4e43a489abaa566115ba
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**16** newly passing, **7** newly failing (net +9).

<details>
<summary>Full diff (23 changed tests)</summary>

```diff
- Pass => Fail css/CSS2/backgrounds/background-position-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-004.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-005.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-006.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-011.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-012a.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-012b.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-013a.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-013b.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-014a.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-014b.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-017.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-020.xht
- Pass => Fail css/CSS2/floats-clear/margin-collapse-clear-017.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-020.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-021.xht
+ Fail => Pass css/CSS2/normal-flow/root-box-001.xht
- Pass => Fail css/css-backgrounds/box-shadow-body.html
- Pass => Fail css/css-image-animation/image-animation-body-background-no-propagation-paused.html
- Pass => Fail css/css-images/linear-gradient-body-sibling-index.html
- Pass => Fail css/css-transforms/perspective-split-by-zero-w.html
- Pass => Fail css/css-transforms/transform-background-007.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31234432957).</sub>
<!-- wpt-results-end -->
