### PR TITLE
Don't collapse margins across an atomic inline boundary

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -277,6 +277,9 @@ impl BaseDocument {
             available_space,
             sizing_mode: SizingMode::InherentSize,
             parent_size: available_space.into_options(),
+            // Atomic inlines (e.g. inline-block) establish independent formatting
+            // contexts: their margins never collapse with their children's margins.
+            vertical_margins_are_collapsible: taffy::Line::FALSE,
             ..inputs
         };
         #[cfg(feature = "floats")]


### PR DESCRIPTION
## Summary

Fixes WPT `css/CSS2/margin-padding-clear/margin-collapse-015a.xht`.

Atomic inlines (e.g. `inline-block`) establish independent formatting contexts, so a block child's margins must not collapse with the atomic inline's own margins. In `compute_inline_layout`, the `child_inputs` used to size/lay out inline boxes were built with `..inputs`, inheriting the inline root's `vertical_margins_are_collapsible` (TRUE when the inline root participates in an outer BFC) — so the block child's `margin-top` escaped into the inline-block's `top_margin` output and was dropped, positioning the child at the inline-block's top edge.

```text
let child_inputs = taffy::tree::LayoutInput {
    ...
+   vertical_margins_are_collapsible: taffy::Line::FALSE,
    ..inputs
};
```


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/19d83a7d94fb4e43a489abaa566115ba
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**5** newly passing, **0** newly failing (net +5).

<details>
<summary>Full diff (5 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/floats-clear/floats-141.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-015a.xht
+ Fail => Pass css/css-align/baseline-of-scrollable-1b.html
+ Fail => Pass css/css-contain/contain-layout-independent-formatting-context-002.html
+ Fail => Pass css/css-contain/contain-paint-independent-formatting-context-002.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31234438852).</sub>
<!-- wpt-results-end -->
