### PR TITLE
Map img/object width/height attributes to dimension properties

### DIFF
--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -940,6 +940,8 @@ impl<'a> TElement for BlitzNode<'a> {
             let is_height = *name == local_name!("height");
             let is_embedded = *tag == local_name!("iframe")
                 || *tag == local_name!("embed")
+                || *tag == local_name!("img")
+                || *tag == local_name!("object")
                 || *tag == local_name!("video");
             let maps_to_dimension = if is_width {
                 is_embedded


### PR DESCRIPTION
## Summary

`img` and `object` were missing from the [embedded-content dimension attribute mapping](https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images) in `stylo.rs`, so e.g. `width="100%"` on an `<img>` was ignored (only plain numeric attribute values were picked up as intrinsic-size overrides by the replaced measure function). Adding them makes percentage/length dimension attributes resolve as CSS `width`/`height`, fixing e.g. `css/CSS2/inline-svg-100-percent-in-body.html` (~10 WPT tests when combined with #634's intrinsic sizing).

Split out of #634.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/51256d0b440341bd874c6dc59e138478
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**49** newly passing, **5** newly failing (net +44).

<details>
<summary>Full diff (54 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/backgrounds/background-001.xht
+ Fail => Pass css/CSS2/backgrounds/background-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-003.xht
+ Fail => Pass css/CSS2/backgrounds/background-006.xht
+ Fail => Pass css/CSS2/backgrounds/background-007.xht
+ Fail => Pass css/CSS2/backgrounds/background-008.xht
+ Fail => Pass css/CSS2/backgrounds/background-009.xht
+ Fail => Pass css/CSS2/backgrounds/background-010.xht
+ Fail => Pass css/CSS2/backgrounds/background-014.xht
+ Fail => Pass css/CSS2/backgrounds/background-018.xht
+ Fail => Pass css/CSS2/backgrounds/background-022.xht
+ Fail => Pass css/CSS2/backgrounds/background-087.xht
+ Fail => Pass css/CSS2/backgrounds/background-182.xht
+ Fail => Pass css/CSS2/backgrounds/background-328.xht
+ Fail => Pass css/CSS2/backgrounds/background-329.xht
- Pass => Fail css/CSS2/backgrounds/background-attachment-applies-to-007.xht
- Pass => Fail css/CSS2/backgrounds/background-attachment-applies-to-009.xht
- Pass => Fail css/CSS2/backgrounds/background-attachment-applies-to-012.xht
- Pass => Fail css/CSS2/backgrounds/background-attachment-applies-to-013.xht
- Pass => Fail css/CSS2/backgrounds/background-attachment-applies-to-014.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-cover-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-cover-004.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-cover-attachment-001.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-transparency-001.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-001.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-003.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-005.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-003.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-025.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-058.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-069.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-080.xht
+ Fail => Pass css/CSS2/borders/border-top-width-003.xht
+ Fail => Pass css/CSS2/borders/border-top-width-025.xht
+ Fail => Pass css/CSS2/borders/border-top-width-058.xht
+ Fail => Pass css/CSS2/borders/border-top-width-069.xht
+ Fail => Pass css/CSS2/borders/border-top-width-080.xht
+ Fail => Pass css/CSS2/borders/border-width-shorthand-001.xht
+ Fail => Pass css/CSS2/borders/border-width-shorthand-002.xht
+ Fail => Pass css/CSS2/borders/border-width-shorthand-003.xht
+ Fail => Pass css/CSS2/borders/border-width-shorthand-004.xht
+ Fail => Pass css/CSS2/floats-clear/float-replaced-width-011.xht
+ Fail => Pass css/CSS2/inline-svg-100-percent-in-body.html
+ Fail => Pass css/CSS2/normal-flow/block-replaced-width-006.xht
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-width-006.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-width-006.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-006.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-013.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-020.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-027.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-034.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-069.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-076.xht
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31235257409).</sub>
<!-- wpt-results-end -->
