### PR TITLE
Bump anyrender patch rev: fix double-applied SVG text transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "anyrender"
 version = "0.12.0"
-source = "git+https://github.com/DioxusLabs/anyrender?branch=devin%2F1785858394-usvg-048#baed6ca2253c9b3005c295948ceba8690235cf86"
+source = "git+https://github.com/DioxusLabs/anyrender?branch=devin%2F1785858394-usvg-048#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "kurbo",
  "peniko",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "anyrender_svg"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/anyrender?branch=devin%2F1785858394-usvg-048#baed6ca2253c9b3005c295948ceba8690235cf86"
+source = "git+https://github.com/DioxusLabs/anyrender?branch=devin%2F1785858394-usvg-048#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "anyrender",
  "image",


### PR DESCRIPTION
## Summary
Bumps the `anyrender`/`anyrender_svg` `[patch.crates-io]` rev to [dcd2197](https://github.com/DioxusLabs/anyrender/commit/dcd219746ff13a5832beab552f3f7f494d1bd84d), which fixes SVG `<text>` being rendered with its transform applied twice under usvg 0.48 (whose `Text::flattened()` children now carry the text node's absolute transform — an intentional upstream change in resvg #1040).

This fixes text on shields.io badges (e.g. `https://img.shields.io/crates/v/blitz.svg`, which wraps text in `<g transform="scale(.1)">` with `font-size="110"`) rendering 100× too small and effectively invisible.

Before / after (Blitz screenshot example):

![before](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvNTgyNDkxMzYtYWMwMy00YTYzLWI1YWMtOWFhOTFkOTg0OWEwIiwiaWF0IjoxNzg2MTU4Mjg2LCJleHAiOjE3ODY3NjMwODYsImZpbGVuYW1lIjoiYmVmb3JlLnBuZyJ9.Hd77P9YJ8GOy_A6oFTn3yUxLcvxRsW4xCHaCHm8aiJo)
![after](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvMmNmYWY3MmQtZjVjOC00YzM2LThjNTMtMmJlMWExY2E3NTU2IiwiaWF0IjoxNzg2MTU4Mjg2LCJleHAiOjE3ODY3NjMwODYsImZpbGVuYW1lIjoiYWZ0ZXIucG5nIn0.z3GelUyJxLHljHoK2giJUOphmyvj2a4MY49y57XcrOs)

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e3ee5d93814646ef9f657861d05792d9
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31236411623).</sub>
<!-- wpt-results-end -->
