### PR TITLE
Implement background-attachment: fixed

### DIFF
--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -272,15 +272,18 @@ impl ElementCx<'_, '_> {
         }
     }
 
-    /// The background positioning area and the transform from its coordinate
-    /// space to the scene for a `background-attachment: fixed` layer: the
-    /// viewport, unaffected by any scrolling. Returns `None` if the element is
-    /// affected by a CSS transform, in which case `fixed` behaves as `scroll`
+    /// Whether the layer is positioned against the viewport
+    /// (`background-attachment: fixed`) rather than the element's origin box.
+    /// `fixed` behaves as `scroll` on elements affected by a CSS transform
     /// (the transformed element acts as the layer's containing block).
-    fn fixed_positioning_area(&self, layer: &ImageLayerStyles) -> Option<(Rect, Affine)> {
-        if layer.attachment != StyloBackgroundAttachment::Fixed || self.is_transformed() {
-            return None;
-        }
+    fn layer_is_fixed(&self, layer: &ImageLayerStyles) -> bool {
+        layer.attachment == StyloBackgroundAttachment::Fixed && !self.is_transformed()
+    }
+
+    /// The background positioning area and the transform from its coordinate
+    /// space to the scene for a fixed layer: the viewport, unaffected by any
+    /// scrolling.
+    fn fixed_positioning_area(&self) -> (Rect, Affine) {
         let viewport_rect = Rect::new(
             0.0,
             0.0,
@@ -288,7 +291,7 @@ impl ElementCx<'_, '_> {
             self.context.height as f64,
         );
         let transform = Affine::translate((self.context.initial_x, self.context.initial_y));
-        Some((viewport_rect, transform))
+        (viewport_rect, transform)
     }
 
     /// Whether this element or any of its ancestors has a CSS transform
@@ -319,9 +322,11 @@ impl ElementCx<'_, '_> {
             return;
         };
 
-        let (area_rect, base_transform) = self
-            .fixed_positioning_area(layer)
-            .unwrap_or((self.frame.padding_box, self.transform));
+        let (area_rect, base_transform) = if self.layer_is_fixed(layer) {
+            self.fixed_positioning_area()
+        } else {
+            (self.frame.padding_box, self.transform)
+        };
 
         let frame_w = (area_rect.width() / self.scale) as f32;
         let frame_h = (area_rect.height() / self.scale) as f32;
@@ -382,9 +387,11 @@ impl ElementCx<'_, '_> {
         let image_rendering = self.style.clone_image_rendering();
         let quality = to_image_quality(image_rendering);
 
-        let (origin_rect, base_transform) = self
-            .fixed_positioning_area(layer)
-            .unwrap_or((self.box_rect(layer.origin), self.transform));
+        let (origin_rect, base_transform) = if self.layer_is_fixed(layer) {
+            self.fixed_positioning_area()
+        } else {
+            (self.box_rect(layer.origin), self.transform)
+        };
 
         let image_width = image_data.width as f64;
         let image_height = image_data.height as f64;
@@ -455,12 +462,15 @@ impl ElementCx<'_, '_> {
         gradient: &StyloGradient,
         layer: &ImageLayerStyles,
     ) {
-        let fixed_area = self.fixed_positioning_area(layer);
-        let (origin_rect, base_transform) =
-            fixed_area.unwrap_or((self.box_rect(layer.origin), self.transform));
+        let is_fixed = self.layer_is_fixed(layer);
+        let (origin_rect, base_transform) = if is_fixed {
+            self.fixed_positioning_area()
+        } else {
+            (self.box_rect(layer.origin), self.transform)
+        };
         // For a fixed layer the positioning area (the viewport) already covers
         // everything visible, so no extension towards the clip box is needed.
-        let clip_rect = if fixed_area.is_some() {
+        let clip_rect = if is_fixed {
             origin_rect
         } else {
             self.box_rect(layer.clip)

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -3,11 +3,12 @@ use crate::color::{Color, ToColorColor};
 use crate::gradient::to_peniko_gradient;
 use anyrender::PaintScene;
 use blitz_dom::node::{ImageData, ImageResourceData, SpecialElementData};
-use kurbo::{self, BezPath, Point, Rect, Shape, Size, Vec2};
+use kurbo::{self, Affine, BezPath, Point, Rect, Shape, Size, Vec2};
 use peniko::{self, Fill};
 use style::{
     properties::{
         generated::longhands::{
+            background_attachment::single_value::computed_value::T as StyloBackgroundAttachment,
             background_clip::single_value::computed_value::T as StyloBackgroundClip,
             background_origin::single_value::computed_value::T as StyloBackgroundOrigin,
             mask_origin::single_value::computed_value::T as StyloMaskOrigin,
@@ -87,6 +88,7 @@ pub(super) struct ImageLayerStyles<'a> {
     pub size: &'a BackgroundSize,
     pub clip: BoxModelBox,
     pub origin: BoxModelBox,
+    pub attachment: StyloBackgroundAttachment,
 }
 
 impl<'a> ImageLayerStyles<'a> {
@@ -104,6 +106,7 @@ impl<'a> ImageLayerStyles<'a> {
             size: get_cyclic(&bg_styles.background_size.0, idx),
             clip: (*get_cyclic(&bg_styles.background_clip.0, idx)).into(),
             origin: (*get_cyclic(&bg_styles.background_origin.0, idx)).into(),
+            attachment: *get_cyclic(&bg_styles.background_attachment.0, idx),
         }
     }
 
@@ -121,6 +124,8 @@ impl<'a> ImageLayerStyles<'a> {
             size: get_cyclic(&svg_styles.mask_size.0, idx),
             clip: (*get_cyclic(&svg_styles.mask_clip.0, idx)).into(),
             origin: (*get_cyclic(&svg_styles.mask_origin.0, idx)).into(),
+            // There is no `mask-attachment` property
+            attachment: StyloBackgroundAttachment::Scroll,
         }
     }
 }
@@ -267,6 +272,37 @@ impl ElementCx<'_, '_> {
         }
     }
 
+    /// The background positioning area and the transform from its coordinate
+    /// space to the scene for a `background-attachment: fixed` layer: the
+    /// viewport, unaffected by any scrolling. Returns `None` if the element is
+    /// affected by a CSS transform, in which case `fixed` behaves as `scroll`
+    /// (the transformed element acts as the layer's containing block).
+    fn fixed_positioning_area(&self, layer: &ImageLayerStyles) -> Option<(Rect, Affine)> {
+        if layer.attachment != StyloBackgroundAttachment::Fixed || self.is_transformed() {
+            return None;
+        }
+        let viewport_rect = Rect::new(
+            0.0,
+            0.0,
+            self.context.width as f64,
+            self.context.height as f64,
+        );
+        let transform = Affine::translate((self.context.initial_x, self.context.initial_y));
+        Some((viewport_rect, transform))
+    }
+
+    /// Whether this element or any of its ancestors has a CSS transform
+    fn is_transformed(&self) -> bool {
+        let mut current = Some(self.node.id);
+        while let Some(node) = current.and_then(|id| self.context.dom.get_node(id)) {
+            if node.transform().is_some() {
+                return true;
+            }
+            current = node.parent;
+        }
+        false
+    }
+
     #[cfg(feature = "svg")]
     fn draw_svg_image_layer(&self, scene: &mut impl PaintScene, layer: &ImageLayerStyles) {
         use kurbo::Affine;
@@ -278,8 +314,12 @@ impl ElementCx<'_, '_> {
             return;
         };
 
-        let frame_w = (self.frame.padding_box.width() / self.scale) as f32;
-        let frame_h = (self.frame.padding_box.height() / self.scale) as f32;
+        let (area_rect, base_transform) = self
+            .fixed_positioning_area(layer)
+            .unwrap_or((self.frame.padding_box, self.transform));
+
+        let frame_w = (area_rect.width() / self.scale) as f32;
+        let frame_h = (area_rect.height() / self.scale) as f32;
 
         let svg_size = svg.tree.size();
 
@@ -319,7 +359,7 @@ impl ElementCx<'_, '_> {
             frame_h - bg_size.height as f32,
         );
 
-        let transform = self.transform
+        let transform = base_transform
             * kurbo::Affine::translate((bg_pos.x * self.scale, bg_pos.y * self.scale))
             * Affine::scale_non_uniform(x_ratio, y_ratio);
 
@@ -337,7 +377,9 @@ impl ElementCx<'_, '_> {
         let image_rendering = self.style.clone_image_rendering();
         let quality = to_image_quality(image_rendering);
 
-        let origin_rect = self.box_rect(layer.origin);
+        let (origin_rect, base_transform) = self
+            .fixed_positioning_area(layer)
+            .unwrap_or((self.box_rect(layer.origin), self.transform));
 
         let image_width = image_data.width as f64;
         let image_height = image_data.height as f64;
@@ -376,8 +418,7 @@ impl ElementCx<'_, '_> {
             y_ratio,
         );
 
-        let transform = self
-            .transform
+        let transform = base_transform
             .pre_scale_non_uniform(x_ratio, y_ratio)
             .then_translate(Vec2 {
                 x: x.translate,
@@ -409,8 +450,16 @@ impl ElementCx<'_, '_> {
         gradient: &StyloGradient,
         layer: &ImageLayerStyles,
     ) {
-        let origin_rect = self.box_rect(layer.origin);
-        let clip_rect = self.box_rect(layer.clip);
+        let fixed_area = self.fixed_positioning_area(layer);
+        let (origin_rect, base_transform) =
+            fixed_area.unwrap_or((self.box_rect(layer.origin), self.transform));
+        // For a fixed layer the positioning area (the viewport) already covers
+        // everything visible, so no extension towards the clip box is needed.
+        let clip_rect = if fixed_area.is_some() {
+            origin_rect
+        } else {
+            self.box_rect(layer.clip)
+        };
 
         let (bg_pos, bg_size) = compute_layer_position_and_size(
             layer,
@@ -461,7 +510,7 @@ impl ElementCx<'_, '_> {
         );
         let brush = anyrender::Paint::Gradient(&gradient);
 
-        let transform = self.transform.then_translate(Vec2 {
+        let transform = base_transform.then_translate(Vec2 {
             x: x.translate,
             y: y.translate,
         });

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -292,6 +292,11 @@ impl ElementCx<'_, '_> {
     }
 
     /// Whether this element or any of its ancestors has a CSS transform
+    ///
+    /// TODO: this misses transformed elements whose resolved transform is the
+    /// identity (e.g. `transform: translate(0)`), and elements with
+    /// `will-change: transform`, both of which should also degrade `fixed`
+    /// to `scroll` (see WPT css/css-transforms/transform-fixed-bg-005/008)
     fn is_transformed(&self) -> bool {
         let mut current = Some(self.node.id);
         while let Some(node) = current.and_then(|id| self.context.dom.get_node(id)) {

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -462,18 +462,18 @@ impl ElementCx<'_, '_> {
         gradient: &StyloGradient,
         layer: &ImageLayerStyles,
     ) {
-        let is_fixed = self.layer_is_fixed(layer);
-        let (origin_rect, base_transform) = if is_fixed {
-            self.fixed_positioning_area()
-        } else {
-            (self.box_rect(layer.origin), self.transform)
-        };
         // For a fixed layer the positioning area (the viewport) already covers
-        // everything visible, so no extension towards the clip box is needed.
-        let clip_rect = if is_fixed {
-            origin_rect
+        // everything visible, so it also serves as the clip rect (no extension
+        // towards the clip box is needed).
+        let (origin_rect, base_transform, clip_rect) = if self.layer_is_fixed(layer) {
+            let (viewport_rect, transform) = self.fixed_positioning_area();
+            (viewport_rect, transform, viewport_rect)
         } else {
-            self.box_rect(layer.clip)
+            (
+                self.box_rect(layer.origin),
+                self.transform,
+                self.box_rect(layer.clip),
+            )
         };
 
         let (bg_pos, bg_size) = compute_layer_position_and_size(


### PR DESCRIPTION
## Summary

Implements `background-attachment: fixed` (stacked on #645). For a fixed layer, the background positioning area becomes the viewport instead of the element's origin box, and the layer is drawn in viewport space (unaffected by any scrolling) while still being clipped by the element's `background-clip` box:

```rust
// ElementCx
fn fixed_positioning_area(&self, layer) -> Option<(Rect, Affine)> {
    // None unless layer.attachment == Fixed, or if the element is affected
    // by a CSS transform (fixed then degrades to scroll per css-transforms)
    Some((Rect(0, 0, viewport_w, viewport_h), Affine::translate(initial_offset)))
}

// in each of draw_raster_image_layer / draw_gradient_layer / draw_svg_image_layer:
let (origin_rect, base_transform) = self
    .fixed_positioning_area(layer)
    .unwrap_or((self.box_rect(layer.origin), self.transform));
```

`ImageLayerStyles` gains an `attachment` field (cyclic per layer, like the other `background-*` lists); mask layers hardcode `Scroll` as there is no `mask-attachment` property. Percentage `background-position`/`background-size` on fixed layers resolve against the viewport, which falls out of reusing the positioning-area rect.

`local` is not included: the servo-engine stylo build doesn't parse the `local` keyword yet (it's gecko-only in `longhands.toml`), so that needs an upstream stylo change first.

Verified with the `screenshot` example that a fixed gradient layer renders the viewport-anchored slice through the element's box (distinct from an identical `scroll` layer), and `just wpt css/css-backgrounds` shows zero status changes vs the base branch (the attachment reftests there require script-driven scrolling, which the WPT runner skips).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/adffb5f273074c819eda1794acd87032
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**5** newly passing, **4** newly failing (net +1).

<details>
<summary>Full diff (9 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/backgrounds/background-attachment-applies-to-007.xht
+ Fail => Pass css/CSS2/backgrounds/background-attachment-applies-to-009.xht
+ Fail => Pass css/CSS2/backgrounds/background-attachment-applies-to-012.xht
+ Fail => Pass css/CSS2/backgrounds/background-attachment-applies-to-013.xht
+ Fail => Pass css/CSS2/backgrounds/background-attachment-applies-to-014.xht
- Pass => Fail css/CSS2/backgrounds/background-bg-pos-206.xht
- Pass => Fail css/css-transforms/transform-fixed-bg-005.html
- Pass => Fail css/css-transforms/transform-fixed-bg-008.tentative.html
- Pass => Fail css/cssom-view/add-background-attachment-fixed-during-smooth-scroll.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31736037150).</sub>
<!-- wpt-results-end -->
