### PR TITLE
Fix panic when a selector deposits parent flags on the Document

### DIFF
--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -122,9 +122,12 @@ pub struct ElementData {
 /// The document node participates in layout and styling like an element, so it
 /// carries the same style/layout fields that were previously stored directly on
 /// [`Node`](super::Node).
-#[derive(Debug)]
 pub struct DocumentData {
     pub stylo_element_data: StyloData,
+    /// Selector flags deposited here by `apply_selector_flags` when a
+    /// `for_parent()` flag is applied while matching the root `<html>` element,
+    /// whose parent node is the document.
+    pub selector_flags: Cell<ElementSelectorFlags>,
     /// A clone of the document's shared style lock. Set when the owning
     /// [`Node`](super::Node) is constructed.
     pub guard: Option<SharedRwLock>,
@@ -142,10 +145,34 @@ pub struct DocumentData {
     pub transform: Option<Affine>,
 }
 
+// Hand-written like `ElementData`'s, because `ElementSelectorFlags` does not
+// implement `Debug`. Every other field is still reported.
+impl std::fmt::Debug for DocumentData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DocumentData")
+            .field("stylo_element_data", &self.stylo_element_data)
+            .field("guard", &self.guard)
+            .field("dirty_descendants", &self.dirty_descendants)
+            .field("element_state", &self.element_state)
+            .field("has_snapshot", &self.has_snapshot)
+            .field("snapshot_handled", &self.snapshot_handled)
+            .field("style", &self.style)
+            .field("display_constructed_as", &self.display_constructed_as)
+            .field("cache", &self.cache)
+            .field("unrounded_layout", &self.unrounded_layout)
+            .field("final_layout", &self.final_layout)
+            .field("scroll_offset", &self.scroll_offset)
+            .field("scrollable_overflow", &self.scrollable_overflow)
+            .field("transform", &self.transform)
+            .finish_non_exhaustive()
+    }
+}
+
 impl DocumentData {
     pub fn new() -> Self {
         Self {
             stylo_element_data: Default::default(),
+            selector_flags: Cell::new(ElementSelectorFlags::empty()),
             guard: None,
             dirty_descendants: AtomicBool::new(true),
             element_state: ElementState::empty(),

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -157,34 +157,6 @@ macro_rules! universal_accessors {
     };
 }
 
-/// Generates forwarding accessors for fields that only live on [`ElementData`]
-/// (element / anonymous block nodes).
-macro_rules! element_accessors {
-    ($($(#[$meta:meta])* $field:ident / $field_mut:ident : $ty:ty),* $(,)?) => {
-        impl Node {
-            $(
-                $(#[$meta])*
-                #[inline]
-                pub fn $field(&self) -> &$ty {
-                    match &self.data {
-                        NodeData::Element(data) | NodeData::AnonymousBlock(data) => &data.$field,
-                        _ => panic!(concat!("`", stringify!($field), "` is not available on this node kind")),
-                    }
-                }
-
-                $(#[$meta])*
-                #[inline]
-                pub fn $field_mut(&mut self) -> &mut $ty {
-                    match &mut self.data {
-                        NodeData::Element(data) | NodeData::AnonymousBlock(data) => &mut data.$field,
-                        _ => panic!(concat!("`", stringify!($field), "` is not available on this node kind")),
-                    }
-                }
-            )*
-        }
-    };
-}
-
 universal_accessors! {
     stylo_element_data / stylo_element_data_mut: StyloData,
     style / style_mut: Style<Atom>,
@@ -199,9 +171,9 @@ universal_accessors! {
     // carries these:
     element_state / element_state_mut: ElementState,
     snapshot_handled / snapshot_handled_mut: AtomicBool,
-}
-
-element_accessors! {
+    // `apply_selector_flags` deposits `for_parent()` flags on the parent node,
+    // and the parent of the root <html> element is the document -- so the
+    // document has to be able to hold selector flags too.
     selector_flags / selector_flags_mut: Cell<ElementSelectorFlags>,
 }
 


### PR DESCRIPTION
`Node::selector_flags()` is generated by `element_accessors!`, so it exists only on Element and AnonymousBlock nodes. Stylo's `apply_selector_flags` deposits the `for_parent()` half of a match on the raw parent node:

```rust
if let Some(parent) = self.parent_node() {
    parent.selector_flags().set(parent.selector_flags().get() | parent_flags);
}
```

For the root `<html>` that parent is the Document node, where the field does not exist, and the accessor panics with ```selector_flags` is not available on this node kind`.

`for_parent()` covers `:first-child`, `:last-child`, `:only-child`, `:nth-child()`, `:nth-last-child()`, `~` and `+`, so the minimal reproduction needs no script, no network and no shadow DOM:

```html
<style>*:first-child { color: red }</style><p>hello</p>
```

`universal_accessors!` already carries a Document arm for `element_state` and `snapshot_handled` for exactly this reason; `selector_flags` was missed. This moves it to the same macro.

Found while running the Web Platform Tests against blitz-dom in [OpenKitesurf](https://github.com/latentharbor/OpenKitesurf), where it was breaking real pages — react.dev among them.

<!-- wpt-results-start -->
## WPT results

**8** newly passing, **3** newly failing (net +5), **2** other status changes.

<details>
<summary>Full diff (13 changed tests)</summary>

```diff
+ Crash => Pass css/CSS2/sec5/adjacent-002.xht
+ Crash => Pass css/CSS2/selectors/first-child-selector-003.xht
+ Crash => Pass css/CSS2/selectors/universal-selector-002.xht
- Pass => Fail css/css-align/self-alignment/self-align-safe-unsafe-flex-003.html
- Pass => Fail css/css-align/self-alignment/self-align-safe-unsafe-grid-003.html
- Pass => Fail css/css-text/text-align/text-align-match-parent-01.html
+ Fail => Pass css/css-text/text-align/text-align-match-parent-05.html
+ Fail => Pass css/css-writing-modes/direction-upright-002.html
+ Crash => Pass css/selectors/child-indexed-no-parent.html
! Crash => Fail css/selectors/invalidation/nth-child-in-shadow-root.html
! Crash => Fail css/selectors/invalidation/nth-last-child-in-shadow-root.html
+ Crash => Pass css/selectors/root-siblings.html
+ Crash => Pass css/selectors/selector-structural-pseudo-root.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31244960624).</sub>
<!-- wpt-results-end -->
