### PR TITLE
Carry needs_wrap into a display:contents child's layout children

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -338,11 +338,18 @@ fn classify_flow_children(
     }
 }
 
-pub(crate) fn collect_layout_children(
+/// Per-container preparation that must run whenever layout children are
+/// (re)collected, whichever collection strategy is used: resets construction
+/// flags, drops any stale inline layout, generates/updates pseudo-elements,
+/// sets up special elements (text inputs, checkboxes, svg) and numbers list
+/// items.
+///
+/// Returns `false` if the container was fully handled as a special element or
+/// has nothing to collect, in which case child collection must not proceed.
+fn prepare_layout_children_collection(
     doc: &mut BaseDocument,
     container_node_id: NodeId,
-    out: &mut LayoutChildren,
-) {
+) -> bool {
     // Reset construction flags
     // TODO: make incremental and only remove this if the element is no longer an inline root
     doc.nodes[container_node_id]
@@ -364,16 +371,16 @@ pub(crate) fn collect_layout_children(
                 .and_then(|el| el.attr(local_name!("type")));
             if tag_name == "textarea" {
                 create_text_editor(doc, container_node_id, true);
-                return;
+                return false;
             } else if matches!(
                 type_attr,
                 None | Some("text" | "password" | "email" | "number" | "search" | "tel" | "url")
             ) {
                 create_text_editor(doc, container_node_id, false);
-                return;
+                return false;
             } else if matches!(type_attr, Some("checkbox" | "radio")) {
                 create_checkbox_input(doc, container_node_id);
-                return;
+                return false;
             }
         }
 
@@ -414,7 +421,7 @@ pub(crate) fn collect_layout_children(
                     let _ = err;
                 }
             };
-            return;
+            return false;
         }
 
         //Only ol tags have start and reversed attributes
@@ -435,8 +442,20 @@ pub(crate) fn collect_layout_children(
     {
         let node = &doc.nodes[container_node_id];
         if node.children.is_empty() && node.before().is_none() && node.after().is_none() {
-            return;
+            return false;
         }
+    }
+
+    true
+}
+
+pub(crate) fn collect_layout_children(
+    doc: &mut BaseDocument,
+    container_node_id: NodeId,
+    out: &mut LayoutChildren,
+) {
+    if !prepare_layout_children_collection(doc, container_node_id) {
+        return;
     }
 
     let container_display = doc.nodes[container_node_id].display_style().unwrap_or(
@@ -755,16 +774,18 @@ fn collect_complex_layout_children(
         if child_node_kind == NodeKind::Comment || (hide_whitespace && is_whitespace_node) {
             // return;
         }
-        // Recurse into `Display::Contents` nodes.
-        //
-        // The children of a `display: contents` element take part in the
-        // *enclosing* container's formatting context, so they need that
-        // container's wrapping policy. Restarting via collect_layout_children
-        // dropped it, which let a text child land in a block container with no
-        // anonymous block around it -- and taffy then asks that Text node for
-        // its `style`, which panics.
+        // Recurse into `Display::Contents` nodes: their children take part in
+        // the *enclosing* container's formatting context, so they are
+        // collected with the enclosing container's wrapping policy (sharing
+        // its open anonymous block). The contents element itself still gets
+        // the usual per-container preparation (construction flags,
+        // pseudo-elements, special elements, list numbering).
         else if display_inside == DisplayInside::Contents {
-            collect_complex_layout_children(doc, child_id, out, hide_whitespace, needs_wrap)
+            if prepare_layout_children_collection(doc, child_id) {
+                doc.nodes[child_id]
+                    .remove_damage(CONSTRUCT_BOX | CONSTRUCT_DESCENDENT | CONSTRUCT_FC);
+                collect_complex_layout_children(doc, child_id, out, hide_whitespace, needs_wrap)
+            }
         }
         // Push nodes that need wrapping into the current "anonymous block container".
         // If there is not an open one then we create one.

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -728,7 +728,7 @@ fn collect_complex_layout_children(
     container_node_id: NodeId,
     out: &mut LayoutChildren,
     hide_whitespace: bool,
-    needs_wrap: impl Fn(NodeKind, DisplayOutside) -> bool,
+    needs_wrap: impl Fn(NodeKind, DisplayOutside) -> bool + Copy,
 ) {
     doc.iter_children_and_pseudos_mut(container_node_id, |child_id, doc| {
         // Get node kind (text, element, comment, etc)
@@ -755,9 +755,16 @@ fn collect_complex_layout_children(
         if child_node_kind == NodeKind::Comment || (hide_whitespace && is_whitespace_node) {
             // return;
         }
-        // Recurse into `Display::Contents` nodes
+        // Recurse into `Display::Contents` nodes.
+        //
+        // The children of a `display: contents` element take part in the
+        // *enclosing* container's formatting context, so they need that
+        // container's wrapping policy. Restarting via collect_layout_children
+        // dropped it, which let a text child land in a block container with no
+        // anonymous block around it -- and taffy then asks that Text node for
+        // its `style`, which panics.
         else if display_inside == DisplayInside::Contents {
-            collect_layout_children(doc, child_id, out)
+            collect_complex_layout_children(doc, child_id, out, hide_whitespace, needs_wrap)
         }
         // Push nodes that need wrapping into the current "anonymous block container".
         // If there is not an open one then we create one.


### PR DESCRIPTION
`collect_complex_layout_children` recurses into a `display: contents` child through `collect_layout_children`, which does not carry the enclosing container's `needs_wrap` policy. The text child is then pushed into a block container unwrapped, and taffy asks that Text node for its `style`, panicking with ```style` is not available on this node kind`.

Minimal reproduction, no script and no shadow DOM:

```html
<div><span style="display:contents">x</span><div>y</div></div>
```

`<slot>` is `display: contents` in the UA stylesheet, so this tends to surface as a shadow-DOM failure although it has nothing to do with shadow trees.

One behavioural note, measured rather than assumed: against the Web Platform Tests this clears a large share of the panics of this class but not all of them, and it changes `display-contents-suppression-dynamic-001` from PASS to FAIL. That test appears to have been passing because the subtree was suppressed by the bug rather than by the cascade, but I have not confirmed that reading and would welcome a second look.

Found while running WPT against blitz-dom in [OpenKitesurf](https://github.com/latentharbor/OpenKitesurf).

<!-- wpt-results-start -->
## WPT results

**8** newly passing, **1** newly failing (net +7), **24** other status changes.

<details>
<summary>Full diff (33 changed tests)</summary>

```diff
! Crash => Fail css/css-display/display-contents-before-after-001.html
+ Crash => Pass css/css-display/display-contents-button.html
! Crash => Fail css/css-display/display-contents-details.html
! Crash => Fail css/css-display/display-contents-dynamic-before-after-001.html
+ Crash => Pass css/css-display/display-contents-dynamic-flex-001-inline.html
+ Crash => Pass css/css-display/display-contents-dynamic-flex-001-none.html
! Crash => Fail css/css-display/display-contents-dynamic-flex-002-inline.html
! Crash => Fail css/css-display/display-contents-dynamic-flex-002-none.html
! Crash => Fail css/css-display/display-contents-dynamic-flex-003-inline.html
! Crash => Fail css/css-display/display-contents-dynamic-flex-003-none.html
! Crash => Fail css/css-display/display-contents-dynamic-inline-flex-001-inline.html
! Crash => Fail css/css-display/display-contents-dynamic-inline-flex-001-none.html
! Crash => Fail css/css-display/display-contents-dynamic-list-001-inline.html
! Crash => Fail css/css-display/display-contents-dynamic-list-001-none.html
! Crash => Fail css/css-display/display-contents-fieldset.html
+ Crash => Pass css/css-display/display-contents-flex-001.html
! Crash => Fail css/css-display/display-contents-flex-002.html
! Crash => Fail css/css-display/display-contents-flex-003.html
+ Crash => Pass css/css-display/display-contents-float-001.html
! Crash => Fail css/css-display/display-contents-inline-flex-001.html
! Crash => Fail css/css-display/display-contents-line-height.html
! Crash => Fail css/css-display/display-contents-list-001.html
+ Crash => Pass css/css-display/display-contents-oof-001.html
+ Crash => Pass css/css-display/display-contents-oof-002.html
! Crash => Fail css/css-display/display-contents-shadow-dom-1.html
- Pass => Fail css/css-display/display-contents-suppression-dynamic-001.html
! Crash => Fail css/css-display/display-contents-text-inherit.html
+ Crash => Pass css/css-display/display-contents-text-only-001.html
! Crash => Fail css/css-text/text-autospace/text-autospace-elements-002.html
! Crash => Fail css/css-text/text-autospace/text-autospace-elements-003.html
! Crash => Fail css/css-text/text-autospace/text-autospace-elements-004.html
! Crash => Fail css/css-text/text-autospace/text-autospace-elements-006.html
! Crash => Fail css/css-text/text-autospace/text-autospace-elements-007.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31244968318).</sub>
<!-- wpt-results-end -->
