### PR TITLE
Map the dir attribute with selectors the engine can parse

### DIFF
--- a/packages/blitz-dom/assets/default.css
+++ b/packages/blitz-dom/assets/default.css
@@ -11,26 +11,28 @@
     src: url("data:font/woff2;base64,d09GMgABAAAAAARYAAwAAAAACqAAAAQFAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cBmAAgwIRCAqKDIcYATYCJAMsCxgABCAFg2AHIBtDCFGUrM0MyM/DGJyndUclpZwnU8QPQ6wsFOHO+/yHNvV9IEqSQgsVJW2p+uZkohKbVExPEz/JUW7zk6rzYH9723UJ/4DzBII8CSzwgFMOOE4KW2rjAmh4qQWSiid60f7Y9FsXScfUpeluagFqTTQYyoQaQSubXil0lHRsBehAI9KofG/6ogF9/Hl6lBd920LmeTxj8JXBfFWKwYAY3QsAAXD17ZAB4M6Ocv/nsZlkaTl0gLipewIQEMB2d9lKDAT1ZjP/F7jmWsQ3wn8AZvZFgIIC7ESh4AP1iFb4nPnfWyJgcQArpUWqW9W96j71kHr/L9a/dNRbj+8/ujXLWCMMFYVYiXoEaZQ4YOC/E7Dkz3JEjaokxAP6i3hIUjv9fwYyE6I3yIozKkaGN63fP36aeLJmxlRZwZiFziPrMVvOlnCF98SQJfGO/Xllv/FnWAcEjrMqaMCPwVmktCDO5zzxcXqeKS+QFxYnvJLFVzKZAFcKnlZRwHEPVM3mXxNt2gdZEpkKaIAG9gbgDTU5SOYDcmX7Rr61evEA1U+1/3SMb6FFtUqh55nYleE95j2zPNxzdlnGoR5xu/PxQKzb7bFaFLvl79Z54Lx9OH+g0/PPYlcsNo/nwP2V2vsHUHsV4KqEsd+e2r6Fu2v7abkfvsb65b41uwvRvqewH25kTntqolbYsEr5DAqrX97a0jrBLjFRExVHR2dH1Za6unyZfCVZHqQP0BtYjuUYlg9J6SurcrTEiOr26m5xcuTW4Sp3ljkUYWJ9+/iVmzbzPpcuXnGeqU3U7IKjz/qeKSSCltyhuSoxkqqTZX+DXt/OMmAikC8SzVD0jg3dbhIE0eUqc04UFFrxCSXzFxgHclzRMPe0ocOjiKRoSZISE0OtpkBjECdxkkRM1KiaJV0ed0V5umBP1wyUPL2ZBGLSDh5itIHahHRF0CY5nZMGib6T3cOmDvcTSZKuPiFJFpPRGNTIOq7jl5OjDiGIoo6qEE0QtfQJ3VYUD2RZvbm5uWWCWOgR4HXAk5GxLEO0izhLdvPTfpTV3xeOnOfT96uR53CdPrPq+P9HZvzO4QCMmDr7lTcNZorT6iMOYgI+IxClMzeCspeoLt5ABGSpta6gRZmQSnzk9e9jmOAYKC7RsyGMYaB6MpbNKMiRq2U6vI0yPZuTMiODFytMrGEBi7pjGgkAMoaNLGOFSoYceaZMx1+XTC/UNpmRzY1nmwT7AIcK+fK5lYNjz893lwMTuXlD2AKl8Md+24AxitRaLH/MUMqd9z862owy/bZTuZUqs1iRQop0KdLgZwPc9JS0lprnkef1gitBCRhjgV+vjGK8BfIV8CrlVghj1vIyZfyC/AJvqbsQYAEA/v+IAQA=");
 }
 
-/* bidi */
+/* bidi
+ *
+ * The dir attribute mapping uses the attribute-selector form from the HTML
+ * spec's bidi rendering section rather than Gecko's internal pseudo-classes
+ * (:-moz-dir-attr-rtl and friends), which this engine's selector parser
+ * does not know: it dropped these rules, and the dir attribute did nothing.
+ * dir=auto keeps its isolation but not the content-based direction, which
+ * needs bidi analysis no selector can express.
+ */
 
-:-moz-has-dir-attr {
+[dir="ltr" i] {
+    direction: ltr;
     unicode-bidi: isolate;
 }
 
-:-moz-dir-attr-rtl {
+[dir="rtl" i] {
     direction: rtl;
+    unicode-bidi: isolate;
 }
 
-:-moz-dir-attr-ltr {
-    direction: ltr;
-}
-
-:-moz-dir-attr-like-auto:dir(ltr) {
-    direction: ltr;
-}
-
-:-moz-dir-attr-like-auto:dir(rtl) {
-    direction: rtl;
+[dir="auto" i] {
+    unicode-bidi: isolate;
 }
 
 [popover]:not(:popover-open):not(dialog[open]) {

--- a/tests/blitz-tests/tests/dir_attribute.rs
+++ b/tests/blitz-tests/tests/dir_attribute.rs
@@ -1,0 +1,87 @@
+//! The dir attribute sets the CSS direction, as the user agent stylesheet
+//! required by the HTML spec's bidi rendering section maps it.
+//!
+//! The engine's stylesheet inherited Gecko's bidi rules, which match through
+//! Gecko-internal pseudo-classes (`:-moz-dir-attr-rtl` and friends) that the
+//! servo selector parser drops, so the attribute set no direction at all.
+
+use blitz_test_harness::{Harness, HarnessOptions};
+
+/// A flex row with two 100px children in a 600px viewport. Under `rtl` the
+/// row starts at the right edge, so the first child sits at x = 500.
+fn page(html_attrs: &str, inner: &str) -> Harness {
+    let html = format!(
+        "<html {html_attrs}><head><style>body {{ margin: 0 }}</style></head><body>\
+         {inner}\
+         <div id=row style='display: flex'>\
+         <div id=first style='width: 100px; height: 20px'></div>\
+         <div id=second style='width: 100px; height: 20px'></div>\
+         </div></body></html>"
+    );
+    Harness::from_html_with(
+        &html,
+        HarnessOptions {
+            width: 600,
+            height: 400,
+            ..Default::default()
+        },
+    )
+}
+
+#[test]
+fn without_the_attribute_the_row_starts_at_the_left() {
+    let harness = page("", "");
+    assert_eq!(harness.layout_rect("#first").x, 0.0);
+    assert_eq!(harness.layout_rect("#second").x, 100.0);
+}
+
+#[test]
+fn dir_rtl_starts_the_row_at_the_right() {
+    let harness = page("dir=rtl", "");
+    assert_eq!(harness.layout_rect("#first").x, 500.0);
+    assert_eq!(harness.layout_rect("#second").x, 400.0);
+}
+
+/// The attribute value is matched case-insensitively.
+#[test]
+fn the_attribute_value_is_case_insensitive() {
+    let harness = page("dir=RTL", "");
+    assert_eq!(harness.layout_rect("#first").x, 500.0);
+}
+
+/// An inner dir=ltr island keeps its own direction inside an rtl page.
+#[test]
+fn an_inner_island_keeps_its_own_direction() {
+    let harness = page(
+        "dir=rtl",
+        "<div dir=ltr style='display: flex'>\
+         <div id=island style='width: 100px; height: 20px'></div>\
+         </div>",
+    );
+    assert_eq!(harness.layout_rect("#island").x, 0.0);
+    assert_eq!(harness.layout_rect("#first").x, 500.0);
+}
+
+/// Toggling the attribute at runtime restyles and relayouts, which is what
+/// an application's RTL switcher does.
+#[test]
+fn toggling_the_attribute_at_runtime_flips_the_layout() {
+    let mut harness = page("", "");
+    assert_eq!(harness.layout_rect("#first").x, 0.0);
+
+    let root = harness.node("html");
+    harness.base_mut().mutate().set_attribute(
+        root,
+        blitz_dom::QualName::new(None, blitz_dom::ns!(), blitz_dom::local_name!("dir")),
+        "rtl",
+    );
+    harness.pump();
+    assert_eq!(harness.layout_rect("#first").x, 500.0);
+
+    harness.base_mut().mutate().clear_attribute(
+        root,
+        blitz_dom::QualName::new(None, blitz_dom::ns!(), blitz_dom::local_name!("dir")),
+    );
+    harness.pump();
+    assert_eq!(harness.layout_rect("#first").x, 0.0);
+}


### PR DESCRIPTION
The bidi rules in the default stylesheet came from Gecko and match through its internal pseudo-classes (:-moz-dir-attr-rtl and friends), which the servo selector parser does not know. It dropped every one of them, so dir="rtl" set no direction and a page could not switch to right-to-left layout at all, even though the layout side fully supports it.

Use the attribute-selector form from the HTML spec's bidi rendering section instead. dir=auto keeps its isolation but not the content-based direction, which needs bidi analysis no selector can express.

<!-- wpt-results-start -->
## WPT results

**3** newly passing, **2** newly failing (net +1).

<details>
<summary>Full diff (5 changed tests)</summary>

```diff
+ Fail => Pass css/css-align/self-alignment/self-align-safe-unsafe-flex-003.html
+ Fail => Pass css/css-align/self-alignment/self-align-safe-unsafe-grid-003.html
+ Fail => Pass css/css-text/text-align/text-align-match-parent-01.html
- Pass => Fail css/css-text/text-align/text-align-match-parent-05.html
- Pass => Fail css/css-writing-modes/direction-upright-002.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31249884360).</sub>
<!-- wpt-results-end -->
