### PR TITLE
Do not let a degenerate aspect ratio become an infinite length

### DIFF
--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -74,13 +74,16 @@ pub fn replaced_measure_function(
     // A degenerate ratio -- zero, infinite, or NaN -- is discarded. Transferring
     // such a ratio between axes computes `width / ratio` or `height * ratio`,
     // which yields an infinite (ratio == 0) or NaN (ratio is NaN) size in the
-    // other axis. CSS Sizing 4 4.1 says a degenerate ratio behaves as `auto`:
-    // the element simply has no preferred aspect ratio and each axis is sized
-    // independently.
+    // other axis. CSS Sizing 4 4.1 says a degenerate ratio behaves as `auto`,
+    // so each source is filtered *before* the fallback: a degenerate style
+    // ratio falls back to the inherent one (that is what `auto` means for a
+    // replaced element), and only if both are degenerate or absent does the
+    // element get no preferred aspect ratio at all.
+    let is_usable_ratio = |ratio: &f32| ratio.is_finite() && *ratio > 0.0;
     let aspect_ratio: Option<f32> = style
         .aspect_ratio
-        .or(image_context.inherent_ratio)
-        .filter(|ratio| ratio.is_finite() && *ratio > 0.0);
+        .filter(is_usable_ratio)
+        .or(image_context.inherent_ratio.filter(is_usable_ratio));
 
     // See https://www.w3.org/TR/css-sizing-3/#replaced-percentage-min-contribution
     let basis_for_max_and_preferred = Size {

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -69,8 +69,18 @@ pub fn replaced_measure_function(
         Size::ZERO
     };
 
-    // Use aspect_ratio from style, fall back to inherent aspect ratio (if any)
-    let aspect_ratio: Option<f32> = style.aspect_ratio.or(image_context.inherent_ratio);
+    // Use aspect_ratio from style, fall back to inherent aspect ratio (if any).
+    //
+    // A degenerate ratio -- zero, infinite, or NaN -- is discarded. Transferring
+    // such a ratio between axes computes `width / ratio` or `height * ratio`,
+    // which yields an infinite (ratio == 0) or NaN (ratio is NaN) size in the
+    // other axis. CSS Sizing 4 4.1 says a degenerate ratio behaves as `auto`:
+    // the element simply has no preferred aspect ratio and each axis is sized
+    // independently.
+    let aspect_ratio: Option<f32> = style
+        .aspect_ratio
+        .or(image_context.inherent_ratio)
+        .filter(|ratio| ratio.is_finite() && *ratio > 0.0);
 
     // See https://www.w3.org/TR/css-sizing-3/#replaced-percentage-min-contribution
     let basis_for_max_and_preferred = Size {


### PR DESCRIPTION
A replaced element with a zero-width attribute — `<canvas width="0" height="1">` is the shortest reproduction — gives an inherent aspect ratio of 0.0. `replaced_measure_function` transfers a known size across axes by multiplying by the ratio or its reciprocal, so the cross size becomes `max_width * (1.0 / 0.0)` = +INFINITY.

Infinity survives the `.max(0.0)` floors on that path, where a NaN would not: Rust's `f32::max` discards NaN and returns the other operand. That is why `width="0" height="0"` lays out fine and `width="0" height="1"` does not — the first produces a NaN ratio, the second an infinite length.

The infinity then reaches parley as `InlineBox::height`. parley's "no maximum height" sentinel is `f32::MAX`, so `INFINITY > f32::MAX` holds, `break_next` returns `MaxHeightExceeded` **without mutating any breaker state**, and both the caller here and parley's own `break_remaining` spin on that forever. The page never finishes layout.

Filtering degenerate ratios where they are read keeps the fix in one place.

One latent variant this does **not** cover, flagged rather than silently left: `stylo_taffy::convert` passes CSS `aspect-ratio: 0 / 1` through as `Some(0.0)` unfiltered for non-replaced elements, which is the same hang waiting for a different input.

Found by running the Web Platform Tests against blitz-dom in [OpenKitesurf](https://github.com/latentharbor/OpenKitesurf), where it hung `html/rendering` for hours before it was isolated, and where it also stopped react.dev and vuejs.org from loading at all.

<!-- wpt-results-start -->
## WPT results

**2** newly passing, **0** newly failing (net +2).

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
+ Fail => Pass css/css-sizing/aspect-ratio/zero-or-infinity-007.html
+ Fail => Pass css/css-sizing/aspect-ratio/zero-or-infinity-008.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31264408056).</sub>
<!-- wpt-results-end -->
