### PR TITLE
Don't panic when matching pseudo-element selectors against unstyled elements

### DIFF
--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -470,10 +470,14 @@ impl selectors::Element for BlitzNode<'_> {
         _context: &mut MatchingContext<Self::Impl>,
     ) -> bool {
         let pseudo = match self.stylo_element_data_opt().and_then(|s| s.get()) {
-            Some(el) => el.styles.primary().pseudo().or(match &self.data {
-                NodeData::AnonymousBlock(_) => Some(PseudoElement::ServoAnonymousBox),
-                _ => None,
-            }),
+            Some(el) => el
+                .styles
+                .get_primary()
+                .and_then(|s| s.pseudo())
+                .or(match &self.data {
+                    NodeData::AnonymousBlock(_) => Some(PseudoElement::ServoAnonymousBox),
+                    _ => None,
+                }),
             None => None,
         };
 


### PR DESCRIPTION
## Summary

Fixes CRASHes in `css/css-nesting/nesting-basic.html` and `css/css-nesting/contextually-invalid-selectors-003.html` (2 → 0 crashes; both now PASS).

Nested rules under a pseudo-element rule (e.g. `.test::before { & { ... } }`) cause stylo to match a `::before` selector component against regular elements during the initial style traversal. Blitz's `TElement::match_pseudo_element` called `el.styles.primary()` (which `unwrap()`s) on the candidate element, but during initial traversal an element's `ElementData` exists before its primary style has been computed, so this panicked with `called Option::unwrap() on a None value` at stylo `data.rs:187`.

Fix in `match_pseudo_element`:
```diff
- el.styles.primary().pseudo().or(...)
+ el.styles.get_primary().and_then(|s| s.pseudo()).or(...)
```
Treating "no primary style yet" as "no pseudo-element identity" is correct: only Blitz's synthesized pseudo-element/anonymous-box nodes carry a pseudo, and those always have styles by the time they are matched (the `AnonymousBlock` fallback is unaffected).

Not a stylo bug: the `unwrap` is in stylo convenience API; the root cause was Blitz assuming primary styles always exist during selector matching.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a8bd4846bf354f33a6037fffaca1f583
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**2** newly passing, **0** newly failing (net +2).

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
+ Crash => Pass css/css-nesting/contextually-invalid-selectors-003.html
+ Crash => Pass css/css-nesting/nesting-basic.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31265752776).</sub>
<!-- wpt-results-end -->
