### PR TITLE
Table: pass calc() cell widths through to Taffy for column sizing

### DIFF
--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -298,7 +298,10 @@ pub(crate) fn collect_table_cells(
                         }
                     }
                     taffy::CompactLength::AUTO_TAG => style_helpers::auto(),
-                    _ => unreachable!(),
+                    // Dimension values are always length, percentage, auto or calc(),
+                    // so any other tag is a calc() value. Pass it through so that
+                    // Taffy resolves it against the table's inner width.
+                    _ => style.size.width.into(),
                 };
                 columns.push(column);
             }


### PR DESCRIPTION
## Summary

Fixes CRASHes in `css/css-values/calc-width-table-auto-1.html` and `css/css-values/calc-width-table-fixed-1.html` (css/css-values: 6 → 4 crashes; the remaining 4 are unrelated).

The `match` over `taffy::CompactLength` tags in `collect_table_cells` column sizing (`table.rs:301`) hit `unreachable!()` for `calc()` cell widths. Since `taffy::Dimension` can only be length, percent, auto or calc, the remaining case is calc; the fix passes the `Dimension` through as the column track sizing function (`_ => style.size.width.into()`), so Taffy resolves the calc expression against the table's inner width during track sizing — the appropriate basis, which isn't known at column-collection time.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a8bd4846bf354f33a6037fffaca1f583
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**1** newly passing, **0** newly failing (net +1), **1** other status change.

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
+ Crash => Pass css/css-values/calc-width-table-auto-1.html
! Crash => Fail css/css-values/calc-width-table-fixed-1.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31265761450).</sub>
<!-- wpt-results-end -->
