### PR TITLE
clip-path: implement closest-corner and farthest-corner shape radii

### DIFF
--- a/packages/blitz-paint/src/render/clip_path.rs
+++ b/packages/blitz-paint/src/render/clip_path.rs
@@ -234,8 +234,20 @@ fn resolve_shape_radius(
             .max(center_offset_secondary)
             .max(secondary_size - center_offset_secondary),
 
-        GenericShapeRadius::FarthestCorner => todo!(),
-        GenericShapeRadius::ClosestCorner => todo!(),
+        GenericShapeRadius::FarthestCorner => {
+            let dp = center_offset_primary.max(primary_size - center_offset_primary);
+            let ds = center_offset_secondary.max(secondary_size - center_offset_secondary);
+            dp.hypot(ds)
+        }
+        GenericShapeRadius::ClosestCorner => {
+            let dp = center_offset_primary
+                .min(primary_size - center_offset_primary)
+                .max(0.0);
+            let ds = center_offset_secondary
+                .min(secondary_size - center_offset_secondary)
+                .max(0.0);
+            dp.hypot(ds)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes CRASHes (`todo!()`) in `css/css-masking/clip-path/clip-path-circle-closest-corner.html` and `clip-path-circle-farthest-corner.html` (2 → 0 crashes; both now PASS).

Implements `GenericShapeRadius::ClosestCorner`/`FarthestCorner` in `resolve_shape_radius` per css-shapes-1: the radius is the distance from the shape's centre to the closest/farthest corner of the reference box, i.e. `hypot` of the per-axis closest/farthest side distances (`min`/`max` of `offset` and `size - offset` on each axis, clamped to ≥ 0 for closest-corner when the centre lies outside the box).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a8bd4846bf354f33a6037fffaca1f583
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**2** newly passing, **0** newly failing (net +2).

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
+ Crash => Pass css/css-masking/clip-path/clip-path-circle-closest-corner.html
+ Crash => Pass css/css-masking/clip-path/clip-path-circle-farthest-corner.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31265768642).</sub>
<!-- wpt-results-end -->
