### PR TITLE
Don't let display:none children force an inline formatting context

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -313,6 +313,11 @@ fn classify_flow_children(
                 continue;
             }
 
+            // display:none children generate no boxes and cast no vote
+            if matches!(display.outside(), DisplayOutside::None) {
+                continue;
+            }
+
             let is_in_flow = matches!(
                 position,
                 PositionProperty::Static | PositionProperty::Relative | PositionProperty::Sticky


### PR DESCRIPTION
## Summary
Fixes a panic (`Option::unwrap()` on `None` at `resolve.rs:375`) hit by 6 WPT tests where the root element is `display: none` (e.g. `css/CSS2/box-display/root-box-003.xht`).

`classify_flow_children` counted `display: none` children as in-flow inline content (they cleared `all_out_of_flow` while leaving `all_inline` set). A container whose only non-whitespace children are `display: none` — such as the Document node when `<html>` is `display: none` — was therefore classified as all-inline and queued as an inline-layout construction task. The deferred-task loop then called `element_data_mut().unwrap()` on the Document node, which has no `ElementData`, and panicked.

Fix: skip `display: none` children in the classification (they generate no boxes, so they cast no vote). Such containers now take the `all_out_of_flow` path and their children are pushed as normal layout children, where Taffy already handles `Display::None`.

WPT: the 6 crashing tests now run (4 PASS, 2 FAIL for unrelated reasons); full `css` run shows no previously-passing test regressed and no new crashes.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/dde09f37a79d43a2ac7993911b21d308
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31715744508).</sub>
<!-- wpt-results-end -->
