### PR TITLE
layout: skip display:none children when classifying flow children

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -299,6 +299,9 @@ fn classify_flow_children(
             // no vote itself — its children decide.
             classification.has_contents = true;
             classify_flow_children(doc, &child.children, classification);
+        } else if matches!(display.inside(), DisplayInside::None) {
+            // display:none children generate no boxes and cast no vote.
+            continue;
         } else {
             let position = style
                 .map(|s| s.clone_position())


### PR DESCRIPTION
## Summary

`classify_flow_children` let `display:none` children vote in the inline-vs-block classification: they cleared `all_out_of_flow` while leaving `all_inline` true. For `css/css-overflow/overflow-body-propagation-013.html` (`:root { display: none }`), the Document node's only child (the display:none `<html>`) produced an "all inline" classification, so the Document node itself was queued as an inline layout root, panicking at `resolve.rs:375` on `element_data_mut().unwrap()` (Document nodes have no element data).

`display:none` children generate no boxes, so they now cast no vote at all (skipped like whitespace/comments):

```rust
} else if matches!(display.inside(), DisplayInside::None) {
    continue;
}
```

With this (plus the harness fix in #660) the test goes CRASH → PASS. Full css WPT run shows no regressions from this change (a few FAIL → PASS improvements).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f1a0d6696eaa4076a48f366a24bfd26f
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**9** newly passing, **0** newly failing (net +9), **2** other status changes.

<details>
<summary>Full diff (11 changed tests)</summary>

```diff
+ Crash => Pass css/CSS2/box-display/root-box-003.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-016.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-applies-to-016.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-applies-to-016.xht
+ Fail => Pass css/CSS2/normal-flow/min-width-applies-to-016.xht
+ Fail => Pass css/css-animations/animation-name-in-shadow-part-inner-match.html
+ Crash => Pass css/css-backgrounds/background-color-body-propagation-005.html
! Crash => Fail css/css-backgrounds/background-color-root-propagation-001.html
+ Crash => Pass css/css-page/root-element-display-none-print.html
! Crash => Fail css/css-view-transitions/new-content-from-root-display-none.html
+ Crash => Pass css/selectors/not-default-ns-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31266239360).</sub>
<!-- wpt-results-end -->
