### PR TITLE
Map the HTML presentational attributes per spec

### DIFF
--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -861,25 +861,79 @@ impl<'a> TElement for BlitzNode<'a> {
             None
         }
 
+        /// The HTML "rules for parsing dimension values".
+        ///
+        /// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-dimension-values
+        ///
+        /// This is emphatically not `str::parse::<f32>()` with the unit peeled
+        /// off. The differences all show up in real attribute values:
+        ///
+        ///   * leading whitespace is skipped, so `"   00523   "` is 523px,
+        ///     but a sign is not a digit, so `"+200"` and `"-200"` are errors
+        ///     where `f32::from_str` happily accepts both;
+        ///   * anything after the number is ignored rather than fatal, so
+        ///     `"200in"`, `"200 %"` and `"200 abc"` are all 200px;
+        ///   * only a `%` *immediately* after the digits makes a percentage,
+        ///     which is why `"200%abc"` is 200% but `"200 %"` is 200px;
+        ///   * there is no exponent, so `"20.25e2"` is 20.25px and not 2025px
+        ///     -- `f32::from_str` gets this one wrong silently, which is worse
+        ///     than rejecting it;
+        ///   * a trailing `.` is allowed and consumes no digits, so `"200."`
+        ///     is 200px and `"200.%"` is 200%.
+        fn parse_dimension_attr(value: &str) -> Option<(f32, bool)> {
+            let bytes = value.as_bytes();
+            let mut i = 0;
+
+            // Skip ASCII whitespace.
+            while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\x0C' | b'\r') {
+                i += 1;
+            }
+
+            // Must begin with a digit. A sign or a bare `.` is an error.
+            if i >= bytes.len() || !bytes[i].is_ascii_digit() {
+                return None;
+            }
+
+            let int_start = i;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            let mut number: f64 = value[int_start..i].parse().ok()?;
+
+            // A fractional part, but only for as many digits as actually
+            // follow the `.`; the `.` itself is consumed either way.
+            if i < bytes.len() && bytes[i] == b'.' {
+                i += 1;
+                let mut divisor = 1.0f64;
+                while i < bytes.len() && bytes[i].is_ascii_digit() {
+                    divisor *= 10.0;
+                    number += f64::from(bytes[i] - b'0') / divisor;
+                    i += 1;
+                }
+            }
+
+            let is_percentage = i < bytes.len() && bytes[i] == b'%';
+            Some((number as f32, is_percentage))
+        }
+
+        /// `parse_dimension_attr`, packaged as a specified `<length-percentage>`.
+        /// `ignoring_zero` implements the spec's separate "maps to the
+        /// dimension property (ignoring zero)" mapping, where a zero value is
+        /// dropped rather than honoured.
         fn parse_size_attr(
             value: &str,
-            filter_fn: impl FnOnce(&f32) -> bool,
+            ignoring_zero: bool,
         ) -> Option<style::values::specified::LengthPercentage> {
             use style::values::specified::{LengthPercentage, NoCalcLength};
-            if let Some(value) = value.strip_suffix("px") {
-                let val: f32 = value.parse().ok()?;
-                return Some(LengthPercentage::Length(NoCalcLength::from_px(val)));
+            let (number, is_percentage) = parse_dimension_attr(value)?;
+            if ignoring_zero && number == 0.0 {
+                return None;
             }
-
-            if let Some(value) = value.strip_suffix("%") {
-                let val: f32 = value.parse().ok()?;
-                return Some(LengthPercentage::Percentage(NoCalcPercentage::new(
-                    val / 100.0,
-                )));
-            }
-
-            let val: f32 = value.parse().ok().filter(filter_fn)?;
-            Some(LengthPercentage::Length(NoCalcLength::from_px(val)))
+            Some(if is_percentage {
+                LengthPercentage::Percentage(NoCalcPercentage::new(number / 100.0))
+            } else {
+                LengthPercentage::Length(NoCalcLength::from_px(number))
+            })
         }
 
         /// Parse the value of an SVG `width`/`height` presentation attribute.
@@ -914,6 +968,15 @@ impl<'a> TElement for BlitzNode<'a> {
             Some(LengthPercentage::Length(length))
         }
 
+        // `<input type=image>` is the only input type that is replaced
+        // content, and it is the only one that takes the embedded-content
+        // presentational attributes. The type attribute is matched ASCII
+        // case-insensitively, as attribute keywords always are.
+        let is_image_input = *tag == local_name!("input")
+            && elem.attrs().iter().any(|attr| {
+                attr.name.local == local_name!("type") && attr.value.eq_ignore_ascii_case("image")
+            });
+
         for attr in elem.attrs() {
             let name = &attr.name.local;
             let value = attr.value.as_str();
@@ -938,15 +1001,21 @@ impl<'a> TElement for BlitzNode<'a> {
             // https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images
             let is_width = *name == local_name!("width");
             let is_height = *name == local_name!("height");
+            // The elements whose width/height attributes map to the dimension
+            // properties. `input` only joins them as type=image, which is the
+            // one replaced input type.
             let is_embedded = *tag == local_name!("iframe")
                 || *tag == local_name!("embed")
-                || *tag == local_name!("img")
+                || *tag == local_name!("video")
                 || *tag == local_name!("object")
-                || *tag == local_name!("video");
+                || *tag == local_name!("img")
+                || *tag == local_name!("marquee")
+                || is_image_input;
             let maps_to_dimension = if is_width {
                 is_embedded
                     || *tag == local_name!("table")
                     || *tag == local_name!("col")
+                    || *tag == local_name!("colgroup")
                     || *tag == local_name!("tr")
                     || *tag == local_name!("td")
                     || *tag == local_name!("th")
@@ -957,13 +1026,19 @@ impl<'a> TElement for BlitzNode<'a> {
                     || *tag == local_name!("thead")
                     || *tag == local_name!("tbody")
                     || *tag == local_name!("tfoot")
+                    || *tag == local_name!("tr")
+                    || *tag == local_name!("td")
+                    || *tag == local_name!("th")
             } else {
                 false
             };
             if maps_to_dimension {
-                let is_table = *tag == local_name!("table");
-                if let Some(size) = parse_size_attr(value, |v| !(is_table && is_width) || *v != 0.0)
-                {
+                // Three of these use the "(ignoring zero)" variant of the
+                // mapping, where a zero is dropped instead of honoured:
+                // `table width`, and `td`/`th` in both axes.
+                let is_cell = *tag == local_name!("td") || *tag == local_name!("th");
+                let ignoring_zero = is_cell || (is_width && *tag == local_name!("table"));
+                if let Some(size) = parse_size_attr(value, ignoring_zero) {
                     use style::values::generics::{NonNegative, length::Size};
                     let size = Size::LengthPercentage(NonNegative(size));
                     push_style(if is_width {
@@ -971,6 +1046,34 @@ impl<'a> TElement for BlitzNode<'a> {
                     } else {
                         PropertyDeclaration::Height(size)
                     });
+                }
+            }
+
+            // hspace/vspace map to the horizontal and vertical margins as
+            // dimension properties. This is a *smaller* set than the one that
+            // takes width/height: `iframe` and `video` take width and height
+            // but not hspace/vspace, and html/rendering/unmapped-attributes
+            // checks exactly that -- browsers have got it wrong before.
+            let takes_spacing = *tag == local_name!("embed")
+                || *tag == local_name!("img")
+                || *tag == local_name!("object")
+                || *tag == local_name!("marquee")
+                || is_image_input;
+            if takes_spacing {
+                let is_hspace = *name == local_name!("hspace");
+                let is_vspace = *name == local_name!("vspace");
+                if is_hspace || is_vspace {
+                    if let Some(size) = parse_size_attr(value, false) {
+                        use style::values::generics::length::GenericMargin;
+                        let margin = GenericMargin::LengthPercentage(size);
+                        if is_hspace {
+                            push_style(PropertyDeclaration::MarginLeft(margin.clone()));
+                            push_style(PropertyDeclaration::MarginRight(margin));
+                        } else {
+                            push_style(PropertyDeclaration::MarginTop(margin.clone()));
+                            push_style(PropertyDeclaration::MarginBottom(margin));
+                        }
+                    }
                 }
             }
 

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -861,118 +861,35 @@ impl<'a> TElement for BlitzNode<'a> {
             None
         }
 
-        /// The HTML "rules for parsing dimension values".
+        /// The HTML "rules for parsing dimension values" -- Stylo's
+        /// implementation of them -- packaged as a specified
+        /// `<length-percentage>`. `ignoring_zero` selects the spec's separate
+        /// "maps to the dimension property (ignoring zero)" mapping, where a
+        /// zero value is dropped rather than honoured.
         ///
         /// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-dimension-values
-        ///
-        /// This is emphatically not `str::parse::<f32>()` with the unit peeled
-        /// off. The differences all show up in real attribute values:
-        ///
-        ///   * leading whitespace is skipped, so `"   00523   "` is 523px,
-        ///     but a sign is not a digit, so `"+200"` and `"-200"` are errors
-        ///     where `f32::from_str` happily accepts both;
-        ///   * anything after the number is ignored rather than fatal, so
-        ///     `"200in"`, `"200 %"` and `"200 abc"` are all 200px;
-        ///   * only a `%` *immediately* after the digits makes a percentage,
-        ///     which is why `"200%abc"` is 200% but `"200 %"` is 200px;
-        ///   * there is no exponent, so `"20.25e2"` is 20.25px and not 2025px
-        ///     -- `f32::from_str` gets this one wrong silently, which is worse
-        ///     than rejecting it;
-        ///   * a trailing `.` is allowed and consumes no digits, so `"200."`
-        ///     is 200px and `"200.%"` is 200%.
-        fn parse_dimension_attr(value: &str) -> Option<(f32, bool)> {
-            let bytes = value.as_bytes();
-            let mut i = 0;
-
-            // Skip ASCII whitespace.
-            while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\x0C' | b'\r') {
-                i += 1;
-            }
-
-            // Must begin with a digit. A sign or a bare `.` is an error.
-            if i >= bytes.len() || !bytes[i].is_ascii_digit() {
-                return None;
-            }
-
-            let int_start = i;
-            while i < bytes.len() && bytes[i].is_ascii_digit() {
-                i += 1;
-            }
-            let mut number: f64 = value[int_start..i].parse().ok()?;
-
-            // A fractional part, but only for as many digits as actually
-            // follow the `.`; the `.` itself is consumed either way.
-            if i < bytes.len() && bytes[i] == b'.' {
-                i += 1;
-                let mut divisor = 1.0f64;
-                while i < bytes.len() && bytes[i].is_ascii_digit() {
-                    divisor *= 10.0;
-                    number += f64::from(bytes[i] - b'0') / divisor;
-                    i += 1;
-                }
-            }
-
-            let is_percentage = i < bytes.len() && bytes[i] == b'%';
-            Some((number as f32, is_percentage))
-        }
-
-        /// The HTML "rules for parsing non-negative integers", which is what
-        /// the "maps to the pixel length property" attributes use.
-        ///
-        /// Unlike the dimension rules above this one *does* accept a sign, so
-        /// `"+200"` is 200 and `"-0"` is 0, while `"-200"` is an error. Like
-        /// them it stops at the first non-digit, so `"200.25"`, `"200%"` and
-        /// `"200in"` are all plainly 200 -- there is no fraction and no unit.
-        ///
-        /// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-non-negative-integers
-        fn parse_pixel_length_attr(value: &str) -> Option<f32> {
-            let bytes = value.as_bytes();
-            let mut i = 0;
-            while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\x0C' | b'\r') {
-                i += 1;
-            }
-
-            let mut negative = false;
-            if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
-                negative = bytes[i] == b'-';
-                i += 1;
-            }
-
-            let start = i;
-            while i < bytes.len() && bytes[i].is_ascii_digit() {
-                i += 1;
-            }
-            if i == start {
-                return None;
-            }
-            let number: f64 = value[start..i].parse().ok()?;
-
-            // Negative is an error, but "-0" is zero and is accepted: the sign
-            // is rejected on the value, not on its presence.
-            if negative && number != 0.0 {
-                return None;
-            }
-            Some(number as f32)
-        }
-
-        /// `parse_dimension_attr`, packaged as a specified `<length-percentage>`.
-        /// `ignoring_zero` implements the spec's separate "maps to the
-        /// dimension property (ignoring zero)" mapping, where a zero value is
-        /// dropped rather than honoured.
         fn parse_size_attr(
             value: &str,
             ignoring_zero: bool,
         ) -> Option<style::values::specified::LengthPercentage> {
+            use style::servo::attr::{
+                LengthOrPercentageOrAuto, parse_length, parse_nonzero_length,
+            };
             use style::values::specified::{LengthPercentage, NoCalcLength};
-            let (number, is_percentage) = parse_dimension_attr(value)?;
-            if ignoring_zero && number == 0.0 {
-                return None;
-            }
-            Some(if is_percentage {
-                LengthPercentage::Percentage(NoCalcPercentage::new(number / 100.0))
+            let parsed = if ignoring_zero {
+                parse_nonzero_length(value)
             } else {
-                LengthPercentage::Length(NoCalcLength::from_px(number))
-            })
+                parse_length(value)
+            };
+            match parsed {
+                LengthOrPercentageOrAuto::Length(length) => Some(LengthPercentage::Length(
+                    NoCalcLength::from_px(length.to_f32_px()),
+                )),
+                LengthOrPercentageOrAuto::Percentage(fraction) => Some(
+                    LengthPercentage::Percentage(NoCalcPercentage::new(fraction)),
+                ),
+                LengthOrPercentageOrAuto::Auto => None,
+            }
         }
 
         /// Parse the value of an SVG `width`/`height` presentation attribute.
@@ -1144,9 +1061,9 @@ impl<'a> TElement for BlitzNode<'a> {
             if *name == local_name!("border")
                 && (*tag == local_name!("img") || *tag == local_name!("object") || is_image_input)
             {
-                if let Some(px) = parse_pixel_length_attr(value) {
+                if let Ok(px) = style::servo::attr::parse_unsigned_integer(value.chars()) {
                     use style::values::specified::{BorderSideWidth, BorderStyle};
-                    let width = BorderSideWidth::from_px(px);
+                    let width = BorderSideWidth::from_px(px as f32);
                     push_style(PropertyDeclaration::BorderTopWidth(width.clone()));
                     push_style(PropertyDeclaration::BorderRightWidth(width.clone()));
                     push_style(PropertyDeclaration::BorderBottomWidth(width.clone()));
@@ -1178,11 +1095,11 @@ impl<'a> TElement for BlitzNode<'a> {
                     _ => b"",
                 };
                 if !sides.is_empty() {
-                    if let Some(px) = parse_pixel_length_attr(value) {
+                    if let Ok(px) = style::servo::attr::parse_unsigned_integer(value.chars()) {
                         use style::values::generics::length::GenericMargin;
                         use style::values::specified::{LengthPercentage, NoCalcLength};
                         let margin = GenericMargin::LengthPercentage(LengthPercentage::Length(
-                            NoCalcLength::from_px(px),
+                            NoCalcLength::from_px(px as f32),
                         ));
                         for side in sides {
                             push_style(match side {

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -916,6 +916,45 @@ impl<'a> TElement for BlitzNode<'a> {
             Some((number as f32, is_percentage))
         }
 
+        /// The HTML "rules for parsing non-negative integers", which is what
+        /// the "maps to the pixel length property" attributes use.
+        ///
+        /// Unlike the dimension rules above this one *does* accept a sign, so
+        /// `"+200"` is 200 and `"-0"` is 0, while `"-200"` is an error. Like
+        /// them it stops at the first non-digit, so `"200.25"`, `"200%"` and
+        /// `"200in"` are all plainly 200 -- there is no fraction and no unit.
+        ///
+        /// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-non-negative-integers
+        fn parse_pixel_length_attr(value: &str) -> Option<f32> {
+            let bytes = value.as_bytes();
+            let mut i = 0;
+            while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\x0C' | b'\r') {
+                i += 1;
+            }
+
+            let mut negative = false;
+            if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
+                negative = bytes[i] == b'-';
+                i += 1;
+            }
+
+            let start = i;
+            while i < bytes.len() && bytes[i].is_ascii_digit() {
+                i += 1;
+            }
+            if i == start {
+                return None;
+            }
+            let number: f64 = value[start..i].parse().ok()?;
+
+            // Negative is an error, but "-0" is zero and is accepted: the sign
+            // is rejected on the value, not on its presence.
+            if negative && number != 0.0 {
+                return None;
+            }
+            Some(number as f32)
+        }
+
         /// `parse_dimension_attr`, packaged as a specified `<length-percentage>`.
         /// `ignoring_zero` implements the spec's separate "maps to the
         /// dimension property (ignoring zero)" mapping, where a zero value is
@@ -1093,6 +1132,68 @@ impl<'a> TElement for BlitzNode<'a> {
                     } else {
                         PropertyDeclaration::Height(size)
                     });
+                }
+            }
+
+            // The `border` attribute maps to the four border widths as a
+            // pixel length, plus the four border styles as `solid` -- width
+            // alone would compute back to zero against the default
+            // border-style of `none`. It is only these three elements:
+            // `embed`, `iframe`, `marquee` and non-image `input` all have a
+            // `border` attribute that must stay unmapped.
+            if *name == local_name!("border")
+                && (*tag == local_name!("img") || *tag == local_name!("object") || is_image_input)
+            {
+                if let Some(px) = parse_pixel_length_attr(value) {
+                    use style::values::specified::{BorderSideWidth, BorderStyle};
+                    let width = BorderSideWidth::from_px(px);
+                    push_style(PropertyDeclaration::BorderTopWidth(width.clone()));
+                    push_style(PropertyDeclaration::BorderRightWidth(width.clone()));
+                    push_style(PropertyDeclaration::BorderBottomWidth(width.clone()));
+                    push_style(PropertyDeclaration::BorderLeftWidth(width));
+                    push_style(PropertyDeclaration::BorderTopStyle(BorderStyle::Solid));
+                    push_style(PropertyDeclaration::BorderRightStyle(BorderStyle::Solid));
+                    push_style(PropertyDeclaration::BorderBottomStyle(BorderStyle::Solid));
+                    push_style(PropertyDeclaration::BorderLeftStyle(BorderStyle::Solid));
+                }
+            }
+
+            // `body` carries four legacy margin attributes, as pixel lengths:
+            // marginwidth and marginheight set both sides of an axis, and
+            // leftmargin and topmargin set one side each.
+            //
+            // There is deliberately no `rightmargin` or `bottommargin`. They
+            // look like the obvious counterparts to the two that exist, but
+            // the spec does not define them and browsers ignore them in both
+            // standards and quirks mode -- body-margin-3a/3b assert exactly
+            // that.
+            if *tag == local_name!("body") {
+                // Matched as strings: these are not in the static atom set,
+                // so `local_name!` will not compile for them.
+                let sides: &[u8] = match &**name {
+                    "marginwidth" => b"lr",
+                    "marginheight" => b"tb",
+                    "leftmargin" => b"l",
+                    "topmargin" => b"t",
+                    _ => b"",
+                };
+                if !sides.is_empty() {
+                    if let Some(px) = parse_pixel_length_attr(value) {
+                        use style::values::generics::length::GenericMargin;
+                        use style::values::specified::{LengthPercentage, NoCalcLength};
+                        let margin = GenericMargin::LengthPercentage(LengthPercentage::Length(
+                            NoCalcLength::from_px(px),
+                        ));
+                        for side in sides {
+                            push_style(match side {
+                                b'l' => PropertyDeclaration::MarginLeft(margin.clone()),
+                                b'r' => PropertyDeclaration::MarginRight(margin.clone()),
+                                b't' => PropertyDeclaration::MarginTop(margin.clone()),
+                                b'b' => PropertyDeclaration::MarginBottom(margin.clone()),
+                                _ => unreachable!("side table above only yields lrtb"),
+                            });
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Two commits reworking the legacy presentational-attribute mapping in `blitz-dom`.

**Map the HTML dimension attributes per spec**

The old parser was `parse::<f32>()` with any trailing unit peeled off, which

- rejected valid values like `200in` and `200 %` (trailing garbage is ignored per spec),
- accepted `-200` and `+200` (dimension values have no sign),
- read `20.25e2` as 2025px — the [rules for parsing dimension values](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-dimension-values) have no exponent, so that is 20.25px followed by junk.

It also fills in the missing parts of the element table: `width`/`height` on the embedded elements (`iframe`, `embed`, `video`, `object`, `img`, `marquee`, `input[type=image]`) and the table elements (`table`, `colgroup`, `col`, `tr`, `td`, `th`, with the ignore-zero rules for cells and table width), and `hspace`/`vspace` mapping to the margin pairs.

**Map border and the body margin attributes**

- `border` on `img`/`object`/`input[type=image]` follows the rules for parsing non-negative integers and maps to the four border widths plus `border-style: solid` on all four sides — width alone computes back to zero against the default `border-style: none`.
- `marginwidth`/`marginheight`/`topmargin`/`leftmargin` on `body` map to the margins the HTML standard lists for them. Deliberately no `rightmargin`/`bottommargin`: the spec does not define them, and WPT `body-margin-3a`/`3b` assert they are ignored.

## Validation

WPT via the in-tree runner:

- `html/rendering`: three tests go FAIL→PASS — `non-replaced-elements/tables/table-row-height.html`, `non-replaced-elements/the-hr-element-0/width.html`, `replaced-elements/attributes-for-embedded-content-and-images/img_border_percent.xhtml` — with no other status changes.
- `css/css-display` and `css/css-tables`: per-test statuses identical to main.

The body-margin and hspace/vspace mappings have no reftest signal in the runner (the WPT tests covering them are testharness.js-based, which the runner skips, and `body-margin-1`/`2` crash on an unrelated pre-existing iframe issue). I verified those with throwaway local reftests (e.g. `<body marginwidth=100 marginheight=30>` against `body { margin: 30px 100px }`, and `<img hspace=40 vspace=10>` against `margin: 10px 40px`): all fail on main and pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31347480300).</sub>
<!-- wpt-results-end -->
