### PR TITLE
Map event coordinates through CSS transforms

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -2424,6 +2424,45 @@ impl BaseDocument {
         Some(rects)
     }
 
+    /// Maps a point in document (page) coordinates into `node_id`'s local
+    /// coordinate space, taking ancestor scroll offsets and transforms into
+    /// account. For non-atomic inline elements (which have no layout box of
+    /// their own), the point is relative to the origin of the union of their
+    /// per-line-box fragment rects.
+    pub fn page_point_to_element_space(
+        &self,
+        node_id: NodeId,
+        x: f32,
+        y: f32,
+    ) -> Option<crate::util::Point<f32>> {
+        let node = self.get_node(node_id)?;
+        let scale = self.viewport().scale_f64();
+
+        if let Some(rects) = self.inline_fragment_rects(node_id) {
+            if rects.is_empty() {
+                return None;
+            }
+            let x0 = rects.iter().map(|r| r.x).fold(f64::INFINITY, f64::min);
+            let y0 = rects.iter().map(|r| r.y).fold(f64::INFINITY, f64::min);
+
+            // Fragment rects are viewport-relative and untransformed: convert
+            // their origin into the inline root's local space and take the
+            // offset from it there.
+            let inline_root = node.inline_root_ancestor()?;
+            let root_pos = inline_root.absolute_position(0.0, 0.0);
+            let origin_x = (x0 + self.viewport_scroll.x) as f32 - root_pos.x;
+            let origin_y = (y0 + self.viewport_scroll.y) as f32 - root_pos.y;
+
+            let local = inline_root.page_point_to_local(x, y, scale);
+            return Some(crate::util::Point {
+                x: local.x - origin_x,
+                y: local.y - origin_y,
+            });
+        }
+
+        Some(node.page_point_to_local(x, y, scale))
+    }
+
     pub fn find_title_node(&self) -> Option<&Node> {
         TreeTraverser::new(self)
             .find(|node_id| {

--- a/packages/blitz-dom/src/events/driver.rs
+++ b/packages/blitz-dom/src/events/driver.rs
@@ -325,9 +325,13 @@ impl<'doc, Handler: EventHandler> EventDriver<'doc, Handler> {
         coords: &PointerCoords,
         element: &mut Point<f32>,
     ) {
-        if let Some(rect) = self.doc.inner().get_client_bounding_rect(target) {
-            element.x = coords.client_x - rect.x as f32;
-            element.y = coords.client_y - rect.y as f32;
+        if let Some(point) =
+            self.doc
+                .inner()
+                .page_point_to_element_space(target, coords.page_x, coords.page_y)
+        {
+            element.x = point.x;
+            element.y = point.y;
         }
     }
 

--- a/packages/blitz-dom/src/events/mod.rs
+++ b/packages/blitz-dom/src/events/mod.rs
@@ -17,36 +17,59 @@ use crate::{BaseDocument, events::pointer::handle_wheel};
 
 fn adjust_coords_for_subdocument(
     coords: &mut PointerCoords,
-    offset: Point<f32>,
+    element: &mut blitz_traits::events::Point<f32>,
+    local_point: Point<f32>,
     viewport_scroll: Point<f64>,
 ) {
-    coords.page_x -= offset.x - viewport_scroll.x as f32;
-    coords.page_y -= offset.y - viewport_scroll.y as f32;
-    coords.client_x -= offset.x;
-    coords.client_y -= offset.y;
+    coords.client_x = local_point.x;
+    coords.client_y = local_point.y;
+    coords.page_x = local_point.x + viewport_scroll.x as f32;
+    coords.page_y = local_point.y + viewport_scroll.y as f32;
+    element.x = local_point.x;
+    element.y = local_point.y;
 }
 
 fn map_dom_event_to_ui_event(
     event: &mut DomEvent,
-    node_offset: Point<f32>,
+    local_point: Point<f32>,
     viewport_scroll: Point<f64>,
 ) -> Option<UiEvent> {
     // TODO: eliminate clone
     match event.data.clone() {
         DomEventData::PointerMove(mut event) => {
-            adjust_coords_for_subdocument(&mut event.coords, node_offset, viewport_scroll);
+            adjust_coords_for_subdocument(
+                &mut event.coords,
+                &mut event.element,
+                local_point,
+                viewport_scroll,
+            );
             Some(UiEvent::PointerMove(event))
         }
         DomEventData::PointerDown(mut event) => {
-            adjust_coords_for_subdocument(&mut event.coords, node_offset, viewport_scroll);
+            adjust_coords_for_subdocument(
+                &mut event.coords,
+                &mut event.element,
+                local_point,
+                viewport_scroll,
+            );
             Some(UiEvent::PointerDown(event))
         }
         DomEventData::PointerUp(mut event) => {
-            adjust_coords_for_subdocument(&mut event.coords, node_offset, viewport_scroll);
+            adjust_coords_for_subdocument(
+                &mut event.coords,
+                &mut event.element,
+                local_point,
+                viewport_scroll,
+            );
             Some(UiEvent::PointerUp(event))
         }
         DomEventData::PointerCancel(mut event) => {
-            adjust_coords_for_subdocument(&mut event.coords, node_offset, viewport_scroll);
+            adjust_coords_for_subdocument(
+                &mut event.coords,
+                &mut event.element,
+                local_point,
+                viewport_scroll,
+            );
             Some(UiEvent::PointerCancel(event))
         }
 
@@ -84,7 +107,15 @@ fn map_dom_event_to_ui_event(
         DomEventData::ContextMenu(_) => None,
         DomEventData::DoubleClick(_) => None,
         DomEventData::Input(_) => None,
-        DomEventData::Wheel(data) => Some(UiEvent::Wheel(data)),
+        DomEventData::Wheel(mut data) => {
+            adjust_coords_for_subdocument(
+                &mut data.coords,
+                &mut data.element,
+                local_point,
+                viewport_scroll,
+            );
+            Some(UiEvent::Wheel(data))
+        }
         DomEventData::Scroll(_) => None,
         DomEventData::Focus(_) => None,
         DomEventData::Blur(_) => None,
@@ -99,8 +130,25 @@ pub(crate) fn handle_dom_event<F: FnMut(DomEvent)>(
     mut dispatch_event: F,
 ) {
     let target_node_id = event.target;
+
+    // The point of the event mapped into the target node's local border-box
+    // space (used when forwarding events to sub-documents and custom widgets)
+    let scale = doc.viewport().scale_f64();
+    let event_coords = match &event.data {
+        DomEventData::PointerMove(e)
+        | DomEventData::PointerDown(e)
+        | DomEventData::PointerUp(e)
+        | DomEventData::PointerCancel(e) => Some(e.coords),
+        DomEventData::Wheel(e) => Some(e.coords),
+        _ => None,
+    };
+    let local_point = event_coords
+        .map(|coords| {
+            doc.nodes[target_node_id].page_point_to_local(coords.page_x, coords.page_y, scale)
+        })
+        .unwrap_or(Point { x: 0.0, y: 0.0 });
+
     let node = &mut doc.nodes[target_node_id];
-    let pos = node.absolute_position(0.0, 0.0);
 
     // Whether this event can move the caret/selection (or change the text) of a text input,
     // in which case we need to update the input's scroll offset afterwards.
@@ -123,7 +171,7 @@ pub(crate) fn handle_dom_event<F: FnMut(DomEvent)>(
             &event.data,
             DomEventData::PointerDown(_) | DomEventData::PointerUp(_)
         );
-        let ui_event = map_dom_event_to_ui_event(event, pos, viewport_scroll);
+        let ui_event = map_dom_event_to_ui_event(event, local_point, viewport_scroll);
 
         if let Some(ui_event) = ui_event {
             sub_doc.handle_ui_event(ui_event);
@@ -153,7 +201,7 @@ pub(crate) fn handle_dom_event<F: FnMut(DomEvent)>(
             DomEventData::PointerDown(_) | DomEventData::PointerUp(_)
         );
         let viewport_scroll = Point { x: 0.0, y: 0.0 };
-        let ui_event = map_dom_event_to_ui_event(event, pos, viewport_scroll);
+        let ui_event = map_dom_event_to_ui_event(event, local_point, viewport_scroll);
 
         if let Some(ui_event) = ui_event {
             widget_data.widget.handle_event(&ui_event);

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1346,6 +1346,42 @@ impl Node {
         Some(offset)
     }
 
+    /// Maps a point in document (page) coordinates into this node's local
+    /// border-box space, applying the same ancestor scroll offsets and
+    /// (inverse) transforms as hit-testing does.
+    pub fn page_point_to_local(&self, x: f32, y: f32, scale: f64) -> crate::util::Point<f32> {
+        // Collect the layout chain from the root down to this node
+        let mut chain = vec![self.id];
+        let mut parent = self.layout_parent.get();
+        while let Some(id) = parent {
+            chain.push(id);
+            parent = self.with(id).layout_parent.get();
+        }
+
+        let mut x = x;
+        let mut y = y;
+        for id in chain.into_iter().rev() {
+            let node = self.with(id);
+            x = x - node.final_layout().location.x + node.scroll_offset().x as f32;
+            y = y - node.final_layout().location.y + node.scroll_offset().y as f32;
+
+            if let Some(t) = *node.transform() {
+                let p = t.inverse() * kurbo::Point::new(x as f64 * scale, y as f64 * scale);
+                x = (p.x / scale) as f32;
+                y = (p.y / scale) as f32;
+            }
+
+            // Children of an inline root are positioned relative to its content box
+            if node.flags.is_inline_root() && id != self.id {
+                let layout = node.final_layout();
+                x -= layout.padding.left + layout.border.left;
+                y -= layout.padding.top + layout.border.top;
+            }
+        }
+
+        crate::util::Point { x, y }
+    }
+
     /// Computes the Document-relative coordinates of the `Node`
     pub fn absolute_position(&self, x: f32, y: f32) -> crate::util::Point<f32> {
         let x = x + self.final_layout().location.x - self.scroll_offset().x as f32;

--- a/tests/blitz-tests/tests/transformed_event_coords.rs
+++ b/tests/blitz-tests/tests/transformed_event_coords.rs
@@ -1,0 +1,155 @@
+//! Element coordinates of pointer events must be relative to the target's
+//! border box in its own (transformed) coordinate space: a CSS transform on an
+//! element (or an ancestor) moves the element on screen, so the point must be
+//! mapped through the inverse transform, not just offset by the untransformed
+//! layout position.
+//!
+//! Regression test for https://github.com/DioxusLabs/blitz/issues/663
+
+use blitz_dom::{Document, EventDriver, EventHandler};
+use blitz_test_harness::{Harness, HarnessOptions, mouse_pointer_event};
+use blitz_traits::events::{DomEvent, DomEventData, EventState, UiEvent};
+use blitz_traits::node_id::NodeId;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Dispatch a pointerdown at page coordinates `(x, y)`, returning the
+/// (target, element coordinates) of the dispatched `pointerdown` event.
+fn pointer_down_element_coords(harness: &mut Harness, x: f32, y: f32) -> (NodeId, (f32, f32)) {
+    #[derive(Clone, Default)]
+    struct RecordingHandler {
+        result: Rc<RefCell<Option<(NodeId, (f32, f32))>>>,
+    }
+
+    impl EventHandler for RecordingHandler {
+        fn handle_event(
+            &mut self,
+            _chain: &[NodeId],
+            event: &mut DomEvent,
+            _doc: &mut dyn blitz_dom::Document,
+            _event_state: &mut EventState,
+        ) {
+            if let DomEventData::PointerDown(data) = &event.data {
+                *self.result.borrow_mut() =
+                    Some((event.target, (data.element_x(), data.element_y())));
+            }
+        }
+    }
+
+    let handler = RecordingHandler::default();
+    let result = handler.result.clone();
+    let mut doc = harness.doc.inner_mut();
+    let mut driver = EventDriver::new(&mut *doc, handler);
+    driver.handle_ui_event(UiEvent::PointerDown(mouse_pointer_event(x, y)));
+    drop(doc);
+    let result = result.borrow().expect("no pointerdown event dispatched");
+    result
+}
+
+const TRANSLATED_HTML: &str = r#"<!DOCTYPE html>
+<html><head><style>
+    * { box-sizing: border-box; }
+    body { margin: 0; }
+</style></head>
+<body>
+    <div id="parent" style="position: relative; transform: translate(50px, 20px); width: 300px; height: 300px; border: 1px solid blue">
+        <div id="child" style="position: absolute; top: 10px; left: 10px; width: 200px; height: 200px; border: 1px solid red"></div>
+    </div>
+</body></html>
+"#;
+
+#[test]
+fn element_coords_account_for_ancestor_translation() {
+    let mut harness = Harness::from_html(TRANSLATED_HTML);
+
+    // #child's border box is at (50+1+10, 20+1+10) = (61, 31) in page coordinates
+    let child = harness.node("#child");
+    let (target, (x, y)) = pointer_down_element_coords(&mut harness, 75.0, 45.0);
+    assert_eq!(target, child);
+    assert!(
+        (x - 14.0).abs() < 0.01 && (y - 14.0).abs() < 0.01,
+        "expected element coords (14, 14), got ({x}, {y})"
+    );
+}
+
+#[test]
+fn element_coords_account_for_own_translation() {
+    let mut harness = Harness::from_html(TRANSLATED_HTML);
+
+    // Hit #parent itself (its border box is at (50, 20) in page coordinates),
+    // in the strip between its border and #child
+    let parent = harness.node("#parent");
+    let (target, (x, y)) = pointer_down_element_coords(&mut harness, 55.0, 25.0);
+    assert_eq!(target, parent);
+    assert!(
+        (x - 5.0).abs() < 0.01 && (y - 5.0).abs() < 0.01,
+        "expected element coords (5, 5), got ({x}, {y})"
+    );
+}
+
+#[test]
+fn element_coords_account_for_translation_at_hidpi_scale() {
+    let mut harness = Harness::from_html_with(
+        TRANSLATED_HTML,
+        HarnessOptions {
+            scale: 2.0,
+            ..Default::default()
+        },
+    );
+
+    let child = harness.node("#child");
+    let (target, (x, y)) = pointer_down_element_coords(&mut harness, 75.0, 45.0);
+    assert_eq!(target, child);
+    assert!(
+        (x - 14.0).abs() < 0.01 && (y - 14.0).abs() < 0.01,
+        "expected element coords (14, 14), got ({x}, {y})"
+    );
+}
+
+#[test]
+fn element_coords_account_for_rotation() {
+    let mut harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+<html><head><style>body { margin: 0; }</style></head>
+<body>
+    <div id="rotated" style="width: 100px; height: 100px; transform: rotate(90deg)"></div>
+</body></html>
+"#,
+    );
+
+    // The point (50, 10) maps to (10, 50) in the element's local space after
+    // inverting the 90deg rotation about the element's center (50, 50)
+    let rotated = harness.node("#rotated");
+    let (target, (x, y)) = pointer_down_element_coords(&mut harness, 50.0, 10.0);
+    assert_eq!(target, rotated);
+    assert!(
+        (x - 10.0).abs() < 0.01 && (y - 50.0).abs() < 0.01,
+        "expected element coords (10, 50), got ({x}, {y})"
+    );
+}
+
+#[test]
+fn element_coords_unchanged_without_transform() {
+    let mut harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+<html><head><style>
+    * { box-sizing: border-box; }
+    body { margin: 0; }
+</style></head>
+<body>
+    <div id="parent" style="position: relative; width: 300px; height: 300px; border: 1px solid blue">
+        <div id="child" style="position: absolute; top: 10px; left: 10px; width: 200px; height: 200px; border: 1px solid red"></div>
+    </div>
+</body></html>
+"#,
+    );
+
+    // #child's border box is at (11, 11) in page coordinates
+    let child = harness.node("#child");
+    let (target, (x, y)) = pointer_down_element_coords(&mut harness, 25.0, 35.0);
+    assert_eq!(target, child);
+    assert!(
+        (x - 14.0).abs() < 0.01 && (y - 24.0).abs() < 0.01,
+        "expected element coords (14, 24), got ({x}, {y})"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #663: a CSS transform on an element (or an ancestor) shifted the element coordinates of pointer/wheel events, and shifted the page/client coordinates forwarded to sub-documents and custom widgets.

Both paths derived coordinates from `absolute_position()`, which is a plain offset sum and ignores transforms:

- `EventDriver::adjust_element_coords`: `element = client - get_client_bounding_rect(target)`
- sub-document/widget forwarding in `handle_dom_event`: `coords -= node.absolute_position(0,0)`

The fix maps the event's page point into the target's local border-box space using the same math hit-testing already uses (per node along the layout chain: `- location + scroll_offset`, then inverse `transform`, then the inline-root content-box offset):

- new `Node::page_point_to_local(x, y, scale)` — walks the layout-parent chain top-down mirroring `hit_inner`
- new `BaseDocument::page_point_to_element_space(node_id, x, y)` — wraps it, handling non-atomic inline elements (no layout box) by mapping into the inline root and offsetting by their fragment-rect origin
- `adjust_element_coords` and the sub-document/custom-widget forwarding now use these; forwarding also sets the forwarded event's `element` point and now adjusts `Wheel` coords (previously forwarded unadjusted)

Hoisted (z-index) children work because their accumulated `HoistedPaintChild::position` equals the sum of intermediate layout locations minus scrolls, and intermediates between a stacking-context root and a hoisted child can't carry transforms (a transform is itself an SC root).

Regression tests in `tests/blitz-tests/tests/transformed_event_coords.rs` cover ancestor translation, the transformed element itself, hidpi scale, rotation, and the untransformed baseline.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f1ed0334be0c4f08a5b6b2aaa7194463
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31323017310).</sub>
<!-- wpt-results-end -->
