### PR TITLE
WPT runner: add crashtest support

### DIFF
--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -84,6 +84,7 @@ bitflags! {
 enum TestKind {
     Ref,
     Attr,
+    Crash,
     Unknown,
 }
 
@@ -92,6 +93,7 @@ impl Display for TestKind {
         match self {
             TestKind::Ref => f.write_str("REF"),
             TestKind::Attr => f.write_str("ATT"),
+            TestKind::Crash => f.write_str("CRA"),
             TestKind::Unknown => f.write_str("UNK"),
         }
     }

--- a/wpt/runner/src/test_runners/crash_test.rs
+++ b/wpt/runner/src/test_runners/crash_test.rs
@@ -1,0 +1,35 @@
+use anyrender::{ImageRenderer as _, PaintScene as _};
+use blitz_dom::util::Color;
+use blitz_paint::paint_scene;
+use peniko::Fill;
+use peniko::kurbo::Rect;
+
+use super::parse_and_resolve_document;
+use crate::{BufferKind, HEIGHT, SCALE, SubtestCounts, ThreadCtx, WIDTH};
+
+/// Runs a crashtest: the test passes if the document parses, resolves style/layout,
+/// and renders without panicking. No image comparison is performed.
+pub fn process_crash_test(ctx: &mut ThreadCtx, relative_path: &str, html: &str) -> SubtestCounts {
+    let mut document = parse_and_resolve_document(ctx, html, relative_path);
+
+    let buf = ctx.buffers.get_mut(BufferKind::Test);
+    ctx.renderer.render_to_vec(
+        |scene| {
+            scene.reset();
+
+            // Render white background
+            scene.fill(
+                Fill::NonZero,
+                Default::default(),
+                Color::WHITE,
+                Default::default(),
+                &Rect::new(0.0, 0.0, WIDTH as f64, HEIGHT as f64),
+            );
+
+            paint_scene(scene, &mut document, SCALE, WIDTH, HEIGHT, 0, 0);
+        },
+        buf,
+    );
+
+    SubtestCounts::ONE_OF_ONE
+}

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -7,9 +7,11 @@ use log::debug;
 use crate::{SubtestCounts, TestFlags, TestKind, TestStatus, ThreadCtx};
 
 mod attr_test;
+mod crash_test;
 mod ref_test;
 
 pub use attr_test::process_attr_test;
+pub use crash_test::process_crash_test;
 pub use ref_test::process_ref_test;
 
 pub struct SubtestResult {
@@ -59,6 +61,24 @@ pub fn process_test_file(
         flags |= TestFlags::USES_SCRIPT;
     }
 
+    // Crash Test
+    if is_crash_test(relative_path) {
+        // Blitz doesn't run JavaScript, so skip crashtests which rely on it
+        if flags.contains(TestFlags::USES_SCRIPT) {
+            return (
+                TestKind::Crash,
+                flags,
+                TestStatus::Skip,
+                SubtestCounts::ZERO_OF_ZERO,
+                Vec::new(),
+            );
+        }
+
+        let counts = process_crash_test(ctx, relative_path, &file_contents);
+        let status = counts.as_status();
+        return (TestKind::Crash, flags, status, counts, Vec::new());
+    }
+
     // Ref Test
     let reference = ctx
         .reftest_re
@@ -104,6 +124,13 @@ pub fn process_test_file(
         SubtestCounts::ZERO_OF_ZERO,
         Vec::new(),
     )
+}
+
+fn is_crash_test(relative_path: &str) -> bool {
+    relative_path.split('/').any(|seg| seg == "crashtests")
+        || [".html", ".htm", ".xht", ".xhtml"]
+            .iter()
+            .any(|ext| relative_path.ends_with(&format!("-crash{ext}")))
 }
 
 fn parse_and_resolve_document(


### PR DESCRIPTION
## Summary

Adds a crashtest kind to the WPT runner, matching upstream WPT classification:

- Files under a `crashtests/` directory or named `*-crash.html`/`.htm`/`.xht`/`.xhtml` are classified as `TestKind::Crash` (printed as `CRA`).
- A crashtest passes if the document parses, resolves style/layout, and paints without panicking — no image comparison (`process_crash_test` in the new `crash_test.rs`).
- Crashtests that rely on JavaScript (match `<script` or `onload=` via the existing `script_re`) are still SKIPped, since Blitz doesn't run JS.

A panic during the test is caught by the existing `catch_unwind` in `main.rs` and reported as CRASH, as before.

## Testing

- Ran against `css/css-flexbox`: 30 crashtests classified as `CRA`; the non-JS ones (e.g. `negative-flex-margins-crash.html`, `crashtests/` files with script) run and PASS, JS-based ones are SKIPped. No behavior change for other test kinds.
- `cargo fmt` / `cargo clippy -p wpt` clean (the one clippy warning is pre-existing in `blitz-dom`).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0683f2df1e2348d2a0683437adeb5cf8
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**564** newly passing, **0** newly failing (net +564), **3** other status changes.

<details>
<summary>Full diff (567 changed tests)</summary>

```diff
+ Skip => Pass css/CSS2/floats/crashtests/firefox-bug-1904409.html
+ Skip => Pass css/CSS2/floats/crashtests/firefox-bug-1904419.html
+ Skip => Pass css/CSS2/floats/crashtests/firefox-bug-1904421.html
+ Skip => Pass css/CSS2/floats/crashtests/firefox-bug-1904428.html
+ Skip => Pass css/CSS2/floats/crashtests/firefox-bug-1906768.html
+ Skip => Pass css/CSS2/floats/crashtests/float-rewind-parallel-flow-1-crash.html
+ Skip => Pass css/CSS2/floats/crashtests/float-rewind-parallel-flow-2-crash.html
+ Skip => Pass css/CSS2/floats/crashtests/float-rewind-parallel-flow-3-crash.html
+ Skip => Pass css/CSS2/floats/crashtests/huge-width-after-float.html
+ Skip => Pass css/CSS2/floats/line-pushed-by-floats-crash.html
+ Skip => Pass css/CSS2/linebox/crashtests/inline-block-baseline-crash.html
+ Skip => Pass css/CSS2/linebox/soft-wrap-opportunity-after-replaced-content-crash.html
+ Skip => Pass css/CSS2/text/crashtests/bidi-inline-fragment-oof-crash.html
+ Skip => Pass css/CSS2/visudet/crashtests/canvas-huge-min-max-sizes.html
+ Skip => Pass css/CSS2/visufx/crashtests/firefox-bug-1996058.html
+ Skip => Pass css/compositing/mix-blend-mode/mix-blend-mode-root-element-transform-crash.html
+ Skip => Pass css/compositing/root-element-background-contain-hidden-crash.html
+ Skip => Pass css/compositing/root-element-background-image-opaque-crash.html
+ Skip => Pass css/css-anchor-position/anchor-as-multicol-crash.html
+ Skip => Pass css/css-anchor-position/anchor-fallback-to-self-crash.html
+ Skip => Pass css/css-anchor-position/anchor-function-in-calc-number-crash.html
+ Skip => Pass css/css-anchor-position/anchor-in-multicol-crash.html
+ Skip => Pass css/css-anchor-position/anchor-in-multicol-inherit-crash.html
+ Skip => Pass css/css-anchor-position/anchor-loop-crash.html
+ Skip => Pass css/css-anchor-position/anchor-scroll-composited-scrolling-001-crash.html
+ Skip => Pass css/css-anchor-position/anchor-size-in-flex-basis-crash.html
+ Skip => Pass css/css-anchor-position/chrome-336164421-crash.html
+ Skip => Pass css/css-anchor-position/chrome-380321441-crash.html
+ Skip => Pass css/css-anchor-position/chrome-419501749-crash.html
+ Skip => Pass css/css-anchor-position/chrome-420329041-crash.html
+ Skip => Pass css/css-anchor-position/grid-anchor-center-crash.html
+ Skip => Pass css/css-anchor-position/position-try-fallbacks-crash.html
+ Skip => Pass css/css-anchor-position/position-try-invalid-anchor-crash.html
+ Skip => Pass css/css-anchor-position/viewport-overflow-hidden-invisible-anchor-crash.html
+ Skip => Pass css/css-animations/crashtests/chrome-bug-405795970.html
+ Skip => Pass css/css-animations/crashtests/chrome-bug-415627003.html
+ Skip => Pass css/css-animations/crashtests/inherit.html
+ Skip => Pass css/css-animations/crashtests/keyframe-timing-function-unset.html
+ Skip => Pass css/css-animations/crashtests/pseudo-element-animation-with-color.html
+ Skip => Pass css/css-animations/crashtests/servo-bug-45008.html
+ Skip => Pass css/css-animations/crashtests/svg-element-css-animation.html
+ Skip => Pass css/css-animations/crashtests/transform-css-animation-squash.html
+ Skip => Pass css/css-animations/crashtests/universal-selector-opacity-inherit.html
+ Skip => Pass css/css-animations/crashtests/update-delay-of-paused-animation.html
+ Skip => Pass css/css-animations/neutral-var-keyframe-cycle-crash.html
+ Skip => Pass css/css-animations/neutral-var-keyframe-cycle-registered-additive-crash.html
+ Skip => Pass css/css-animations/neutral-var-keyframe-cycle-registered-crash.html
+ Skip => Pass css/css-backgrounds/animations/background-color-animation-field-crash.html
+ Skip => Pass css/css-backgrounds/animations/background-color-animation-non-empty-no-draw-crash.html
+ Skip => Pass css/css-backgrounds/background-repeat-round-empty-crash.html
+ Skip => Pass css/css-backgrounds/background-repeat/background-repeat-image-larger-than-positioning-area-crash.html
+ Skip => Pass css/css-backgrounds/crashtests/border-image-fill.html
+ Skip => Pass css/css-backgrounds/crashtests/border-radius-constraint.html
+ Skip => Pass css/css-backgrounds/gradient-wrong-interpolation-crash.html
+ Skip => Pass css/css-backgrounds/linear-gradient-calc-crash.html
+ Skip => Pass css/css-backgrounds/tiny-foreignObject-double-border-radius-crash.html
+ Skip => Pass css/css-borders/border-shape/crashtests/border-shape-shape-arc-animation-crash.html
+ Skip => Pass css/css-borders/corner-shape/corner-shape-zoom-overlap-extreme-values-crash.html
+ Skip => Pass css/css-break/area-crash.html
+ Skip => Pass css/css-break/area-in-inline-crash.html
+ Skip => Pass css/css-break/auto-overflow-inside-second-abspos-fragment-crash.html
+ Skip => Pass css/css-break/box-decoration-break-clone-032-crash.html
+ Skip => Pass css/css-break/box-decoration-break-clone-035-crash.html
+ Skip => Pass css/css-break/box-decoration-break-clone-036-crash.html
+ Skip => Pass css/css-break/break-after-in-parallel-flow-crash.html
+ Skip => Pass css/css-break/break-after-oof-before-preceding-pushed-float-crash.html
+ Skip => Pass css/css-break/break-before-broken-leading-float-001-crash.html
+ Skip => Pass css/css-break/break-before-broken-leading-float-002-crash.html
+ Skip => Pass css/css-break/break-before-float-after-line-after-floats-crash.html
+ Skip => Pass css/css-break/chrome-bug-1283776-000-crash.html
+ Skip => Pass css/css-break/clear-br-in-size-containment-crash.html
+ Skip => Pass css/css-break/clear-float-in-size-containment-crash.html
+ Skip => Pass css/css-break/clear-past-float-with-oof-twice-crash.html
+ Skip => Pass css/css-break/column-balancing-with-oofs-crash.html
+ Skip => Pass css/css-break/empty-fieldset-tall-bottom-padding-crash.html
+ Skip => Pass css/css-break/firefox-bug-1693616-001-crash.html
+ Skip => Pass css/css-break/firefox-bug-1693616-002-crash.html
+ Skip => Pass css/css-break/firefox-bug-2021187-crash.html
+ Skip => Pass css/css-break/flex-item-padding-block-in-inline-crash.html
+ Skip => Pass css/css-break/flexbox/auto-height-flex-item-in-multicol-crash.html
+ Skip => Pass css/css-break/flexbox/button-in-multicol-crash.html
+ Skip => Pass css/css-break/flexbox/float-in-webkit-box-in-multicol-crash.html
+ Skip => Pass css/css-break/flexbox/image-in-fragmented-flexbox-001-crash.html
+ Skip => Pass css/css-break/flexbox/image-in-fragmented-flexbox-002-crash.html
+ Skip => Pass css/css-break/flexbox/monolithic-item-in-fragmented-flexbox-crash.html
+ Skip => Pass css/css-break/flexbox/quirks-flex-in-multicol-crash.html
+ Skip => Pass css/css-break/flexbox/slider-in-multicol-crash.html
+ Skip => Pass css/css-break/flexbox/small-definite-flex-line-crash.html
+ Skip => Pass css/css-break/flexbox/textarea-input-flex-items-in-multicol-crash.html
+ Skip => Pass css/css-break/float-011-crash.html
+ Skip => Pass css/css-break/float-after-self-collapsing-block-in-inline-crash.html
+ Skip => Pass css/css-break/float-in-inline-widows-orphans-crash.html
+ Skip => Pass css/css-break/floated-multicol-in-multicol-crash.html
+ Skip => Pass css/css-break/fragmentainer-1px-clamping-000-crash.html
+ Skip => Pass css/css-break/fragmentainer-1px-clamping-001-crash.html
+ Skip => Pass css/css-break/fragmented-empty-contenteditable-crash.html
+ Skip => Pass css/css-break/fragmented-float-in-inline-crash.html
+ Skip => Pass css/css-break/grid/grid-item-oof-crash.html
+ Skip => Pass css/css-break/grid/grid-item-placement-crash.html
+ Skip => Pass css/css-break/grid/grid-item-placement-multiple-crash.html
+ Skip => Pass css/css-break/grid/grid-large-end-border-crash.html
+ Skip => Pass css/css-break/grid/grid-nested-columns-crash.html
+ Skip => Pass css/css-break/iframe-in-repeated-table-header-crash.html
+ Skip => Pass css/css-break/inline-skipping-fragmentainer-003-crash.html
+ Skip => Pass css/css-break/inline-skipping-fragmentainer-004-crash.html
+ Skip => Pass css/css-break/large-text-node-oof-crash.html
+ Skip => Pass css/css-break/line-and-fragmentainer-break-before-float-crash.html
+ Skip => Pass css/css-break/max-height-with-margin-pushed-below-fragmentation-line-crash.html
+ Skip => Pass css/css-break/nested-fixedpos-in-inline-000-crash.html
+ Skip => Pass css/css-break/nested-fixedpos-in-inline-001-crash.html
+ Skip => Pass css/css-break/nested-fixedpos-in-inline-002-crash.html
+ Skip => Pass css/css-break/nested-fixedpos-in-inline-003-crash.html
+ Skip => Pass css/css-break/nested-float-in-multicol-crash.html
+ Skip => Pass css/css-break/nested-multicol-with-spanner-and-oof-001-crash.html
+ Skip => Pass css/css-break/nested-multicol-with-spanner-and-oof-002-crash.html
+ Skip => Pass css/css-break/nested-multicol-with-spanner-and-oof-003-crash.html
+ Skip => Pass css/css-break/nested-multicol-with-spanner-and-oof-004-crash.html
+ Skip => Pass css/css-break/nested-multicol-with-spanner-and-oof-005-crash.html
+ Skip => Pass css/css-break/nested-multicol-with-spanner-and-oof-006-crash.html
+ Skip => Pass css/css-break/nested-multicol-with-spanner-and-oof-007-crash.html
+ Skip => Pass css/css-break/nested-multicol-with-spanner-and-oof-008-crash.html
+ Skip => Pass css/css-break/nested-oof-in-multicol-crash.html
+ Skip => Pass css/css-break/no-room-for-line-in-first-fragmentainer-crash.html
+ Skip => Pass css/css-break/out-of-flow-in-inline-with-negative-offset-crash.html
+ Skip => Pass css/css-break/out-of-flow-in-multicolumn-crash.html
+ Skip => Pass css/css-break/out-of-flow-in-nested-spanner-multicol-crash.html
+ Skip => Pass css/css-break/out-of-flow-in-new-column-crash.html
+ Skip => Pass css/css-break/out-of-flow-with-negative-offset-crash.html
+ Skip => Pass css/css-break/out-of-order-float-in-inline-crash.html
+ Skip => Pass css/css-break/overflow-auto-height-with-bottom-padding-crash.html
+ Skip => Pass css/css-break/parallel-flow-trailing-margin-003-crash.html
+ Skip => Pass css/css-break/resumed-float-and-inline-block-crash.html
+ Skip => Pass css/css-break/table-cell-padding-block-in-inline-crash.html
+ Skip => Pass css/css-break/table/bottom-padding-repeated-header-crash.html
+ Skip => Pass css/css-break/table/break-before-repeated-footer-instead-of-border-crash.html
+ Skip => Pass css/css-break/table/caption-bottom-margin-at-boundary-crash.html
+ Skip => Pass css/css-break/table/cell-large-bottom-padding-crash.html
+ Skip => Pass css/css-break/table/repeated-section/border-spacing-taller-than-fragmentainer-001-crash.html
+ Skip => Pass css/css-break/table/repeated-section/border-spacing-taller-than-fragmentainer-002-crash.html
+ Skip => Pass css/css-break/table/repeated-section/border-spacing-taller-than-fragmentainer-003-crash.html
+ Skip => Pass css/css-break/table/repeated-section/nested-repeated-header-crash.html
+ Skip => Pass css/css-break/table/repeated-section/repeated-footer-insufficient-space-crash.html
+ Skip => Pass css/css-break/table/repeated-section/variable-fragmentainer-size-003-crash.html
+ Skip => Pass css/css-break/table/repeated-section/variable-fragmentainer-size-004-crash.html
+ Skip => Pass css/css-break/table/repeated-section/variable-fragmentainer-size-005-crash.html
+ Skip => Pass css/css-break/table/repeated-section/variable-fragmentainer-size-006-crash.html
+ Skip => Pass css/css-break/table/table-in-abspos-multicol-with-nested-meter-crash.html
+ Skip => Pass css/css-break/table/table-row-end-border-1-crash.html
+ Skip => Pass css/css-break/table/table-row-end-border-2-crash.html
+ Skip => Pass css/css-break/table/table-row-end-padding-crash.html
+ Skip => Pass css/css-break/table/tall-padding-crash.html
+ Skip => Pass css/css-break/table/zero-height-repeated-footer-crash.html
+ Skip => Pass css/css-break/uncontained-oof-in-inline-after-break-001-crash.html
+ Skip => Pass css/css-break/wide-line-after-floats-crash.html
+ Skip => Pass css/css-cascade/layer-namespace-sandwich-crash.html
+ Skip => Pass css/css-cascade/layer-statement-copy-crash.html
+ Skip => Pass css/css-cascade/scope-declaration-list-crash.html
+ Skip => Pass css/css-cascade/scope-inner-pseudo-scope-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/br-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/chrome-bug-1289718-000-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/chrome-bug-1289718-001-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/chrome-bug-1362391-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/chrome-bug-1429955-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/chrome-custom-highlight-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/chrome-quotes-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/columns-in-table-001-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/container-in-canvas-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/iframe-init-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/inline-multicol-inside-container-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/orthogonal-replaced-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/pseudo-container-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/reversed-ol-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/svg-text-crash.html
+ Skip => Pass css/css-conditional/container-queries/crashtests/table-in-columns-005-crash.html
+ Skip => Pass css/css-conditional/container-queries/no-layout-containment-subgrid-crash.html
+ Skip => Pass css/css-conditional/container-queries/position-sticky-crash.html
+ Skip => Pass css/css-conditional/crashtests/supports-malformed.html
+ Skip => Pass css/css-contain/content-visibility/content-visibility-auto-applied-to-th-crash.html
+ Skip => Pass css/css-contain/content-visibility/content-visibility-continuations-crash.html
+ Skip => Pass css/css-contain/content-visibility/content-visibility-form-controls-crash.html
+ Skip => Pass css/css-contain/content-visibility/content-visibility-output-crash.html
+ Skip => Pass css/css-contain/content-visibility/content-visibility-with-float-crash.html
+ Skip => Pass css/css-contain/content-visibility/crashtests/container-query-force-visible-for-accessibility.html
+ Skip => Pass css/css-contain/content-visibility/crashtests/div-in-hidden.html
+ Skip => Pass css/css-contain/content-visibility/crashtests/fieldset.html
+ Skip => Pass css/css-contain/content-visibility/crashtests/first-line-and-inline-block.html
+ Skip => Pass css/css-contain/content-visibility/display-ruby-text-crash.html
+ Skip => Pass css/css-contain/content-visibility/locked-frame-crash.html
+ Skip => Pass css/css-contain/content-visibility/slot-content-visibility-2-crash.html
+ Skip => Pass css/css-contain/content-visibility/slot-content-visibility-22-crash.html
+ Skip => Pass css/css-contain/content-visibility/slot-content-visibility-3-crash.html
+ Skip => Pass css/css-contain/content-visibility/slot-content-visibility-6-crash.html
+ Skip => Pass css/css-content/element-replacement-gradient-details-crash.html
+ Skip => Pass css/css-easing/linear-timing-functions-chrome-406926307-crash.html
+ Skip => Pass css/css-flexbox/anonymous-flex-item-document-white-space-crash.html
+ Skip => Pass css/css-flexbox/balance/balance-line-break-crash.html
+ Skip => Pass css/css-flexbox/button-column-wrap-crash.html
+ Skip => Pass css/css-flexbox/column-intrinsic-size-aspect-ratio-crash.html
+ Skip => Pass css/css-flexbox/fixedpos-video-in-abspos-quirk-crash.html
+ Skip => Pass css/css-flexbox/flex-shrink-large-value-crash.html
+ Skip => Pass css/css-flexbox/inline-flex-frameset-main-axis-crash.html
+ Skip => Pass css/css-flexbox/inline-flexbox-absurd-block-size-crash.html
+ Skip => Pass css/css-flexbox/intrinsic-size/col-wrap-crash.html
+ Skip => Pass css/css-flexbox/min-height-min-content-crash.html
+ Skip => Pass css/css-flexbox/mixed-containing-blocks-crash.html
+ Skip => Pass css/css-flexbox/negative-available-size-crash.html
+ Skip => Pass css/css-flexbox/negative-flex-margins-crash.html
+ Skip => Pass css/css-flexbox/negative-flex-rounding-crash.html
+ Skip => Pass css/css-flexbox/negative-item-margins-002-crash.html
+ Skip => Pass css/css-flexbox/negative-item-margins-crash.html
+ Skip => Pass css/css-flexbox/position-relative-with-scrollable-with-abspos-crash.html
+ Skip => Pass css/css-flexbox/zero-content-size-with-scrollbar-crash.html
+ Skip => Pass css/css-fonts/font-face-local-css-wide-keyword-crash.html
+ Skip => Pass css/css-fonts/font-features-two-stylesheets-crash.html
+ Skip => Pass css/css-fonts/font-palette-relative-color-crash.html
+ Skip => Pass css/css-fonts/font-size-adjust-generic-font-fallback-crash.html
+ Skip => Pass css/css-fonts/font-size-adjust-nan-crash.html
+ Skip => Pass css/css-fonts/infinite-size-crash.html
+ Skip => Pass css/css-fonts/math-script-level-and-math-style/math-depth-001-crash.html
+ Skip => Pass css/css-fonts/oblique-request-italic-only-family-no-crash.html
+ Skip => Pass css/css-fonts/variable-in-feature-crash.html
+ Skip => Pass css/css-gaps/agnostic/gap-decorations-007-crash.html
+ Skip => Pass css/css-gaps/agnostic/gap-decorations-008-crash.html
+ Skip => Pass css/css-gaps/agnostic/gap-decorations-011-crash.html
+ Skip => Pass css/css-gaps/flex/flex-gap-decorations-026-crash.html
+ Skip => Pass css/css-gaps/flex/fragmentation/flex-gap-decorations-fragmentation-022-crash.html
+ Skip => Pass css/css-gaps/flex/fragmentation/flex-gap-decorations-fragmentation-023-crash.html
+ Skip => Pass css/css-gaps/grid/fragmentation/grid-gap-decorations-fragmentation-018-crash.html
+ Skip => Pass css/css-gaps/grid/fragmentation/grid-gap-decorations-fragmentation-019-crash.html
+ Skip => Pass css/css-gaps/grid/grid-gap-decorations-041-crash.html
+ Skip => Pass css/css-gaps/grid/grid-gap-decorations-043-crash.html
+ Skip => Pass css/css-gaps/grid/grid-gap-decorations-044-crash.html
+ Skip => Pass css/css-gaps/grid/grid-gap-decorations-058-crash.html
+ Skip => Pass css/css-gaps/grid/grid-gap-decorations-059-crash.html
+ Skip => Pass css/css-gaps/grid/grid-gap-decorations-060-crash.html
+ Skip => Pass css/css-grid/abspos/abspos-in-flexbox-in-grid-crash.html
+ Skip => Pass css/css-grid/abspos/positioned-grid-items-crash.html
+ Skip => Pass css/css-grid/chrome-521184744-crash.html
+ Skip => Pass css/css-grid/fieldset-first-line-crash.html
+ Skip => Pass css/css-grid/firefox-bug-1958131-crash.html
+ Skip => Pass css/css-grid/grid-definition/grid-repeat-out-of-bounds-crash.html
+ Skip => Pass css/css-grid/grid-lanes/grid-lanes-fieldset-crash.html
+ Skip => Pass css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/grid-lanes-subgrid-baseline-crash.html
+ Skip => Pass css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/subgrid-in-wrong-axis-with-atuo-repeat-crash.html
+ Skip => Pass css/css-grid/grid-lanes/tentative/parsing/grid-lanes-shorthand-crash.html
+ Skip => Pass css/css-grid/grid-lanes/track-sizing/auto-repeat/auto-repeat-no-children-crash.html
+ Skip => Pass css/css-grid/grid-lanes/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-no-items-crash.html
+ Skip => Pass css/css-grid/grid-lanes/track-sizing/auto-repeat/intrinsic-auto-repeat/repeat-auto-fit-auto-crash.html
+ Skip => Pass css/css-grid/grid-lanes/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-no-items-crash.html
+ Skip => Pass css/css-grid/subgrid/crashtests/contain-strict-subgrid.html
+ Skip => Pass css/css-grid/subgrid/crashtests/subgrid-auto-placed-overflowing-span-crash.html
+ Skip => Pass css/css-grid/subgrid/crashtests/subgrid-locked-major-axis-overflowing-span-crash.html
+ Skip => Pass css/css-grid/subgrid/crashtests/subgrid-rows-auto-placed-overflowing-span-crash.html
+ Skip => Pass css/css-grid/subgrid/crashtests/subgrid-rows-locked-major-axis-overflowing-span-crash.html
+ Skip => Pass css/css-grid/subgrid/crashtests/subgrid-with-atuo-repeat-crash.html
+ Skip => Pass css/css-grid/subgrid/crashtests/subgridded-axis-auto-repeater-001.html
+ Skip => Pass css/css-grid/subgrid/crashtests/subgridded-axis-auto-repeater-002.html
+ Skip => Pass css/css-grid/subgrid/crashtests/subgridded-axis-auto-repeater-003.html
+ Skip => Pass css/css-images/cross-fade-legacy-2-crash.html
+ Skip => Pass css/css-images/empty-radial-gradient-crash.html
+ Skip => Pass css/css-images/gradient-nan-crash.html
+ Skip => Pass css/css-images/image-multipart-crash.html
+ Skip => Pass css/css-images/radial-gradient-transition-hint-crash.html
+ Skip => Pass css/css-inline/firefox-bug-1901624-crash.html
+ Skip => Pass css/css-inline/inline-002-crash.html
+ Skip => Pass css/css-inline/inline-crash.html
+ Skip => Pass css/css-lists/before-after-selectors-on-code-element-crash.html
+ Skip => Pass css/css-lists/counters-container-crash.html
+ Skip => Pass css/css-lists/crashtests/chrome-bug-1377573.html
+ Skip => Pass css/css-lists/crashtests/chrome-legacy-propagation-crash.html
+ Skip => Pass css/css-lists/li-without-ul-counter-crash.html
+ Skip => Pass css/css-lists/list-marker-position-crash.html
+ Skip => Pass css/css-lists/style-containment-counter-crash.html
+ Skip => Pass css/css-masking/clip-path/crashtests/clip-path-shape-arc-animation-crash.html
+ Skip => Pass css/css-masking/crashtests/mask-repeat-round-one-tile.html
+ Skip => Pass css/css-masking/mask-image/firefox-bug-1928736-crash.html
+ Skip => Pass css/css-motion-path/crashtests/rotation-overflow.html
+ Skip => Pass css/css-multicol/balance-extremely-tall-monolithic-content-crash.html
+ Skip => Pass css/css-multicol/column-balancing-with-overflow-auto-crash.html
+ Skip => Pass css/css-multicol/crashtests/as-baseline-aligned-grid-item.html
+ Skip => Pass css/css-multicol/crashtests/balance-break-inside-avoid-on-root.html
+ Skip => Pass css/css-multicol/crashtests/balance-with-forced-break.html
+ Skip => Pass css/css-multicol/crashtests/balancing-flex-item-trailing-margin-freeze.html
+ Skip => Pass css/css-multicol/crashtests/balancing-tall-borders-freeze.html
+ Skip => Pass css/css-multicol/crashtests/block-in-inline-with-spanner-in-overflowed-parent-nested-multicol.html
+ Skip => Pass css/css-multicol/crashtests/block-in-inline-with-spanner-in-overflowed-parent.html
+ Skip => Pass css/css-multicol/crashtests/break-before-multicol-caption.html
+ Skip => Pass css/css-multicol/crashtests/chrome-bug-1297118.html
+ Skip => Pass css/css-multicol/crashtests/chrome-bug-1303256.html
+ Skip => Pass css/css-multicol/crashtests/chrome-bug-1314866.html
+ Skip => Pass css/css-multicol/crashtests/first-letter-column-span-fieldset.html
+ Skip => Pass css/css-multicol/crashtests/fit-content-with-spanner-and-auto-scrollbar-sibling.html
+ Skip => Pass css/css-multicol/crashtests/float-beside-whitespace-ruby.html
+ Skip => Pass css/css-multicol/crashtests/float-multicol-crash.html
+ Skip => Pass css/css-multicol/crashtests/forced-break-in-oof-in-column-balancing-nested.html
+ Skip => Pass css/css-multicol/crashtests/forced-break-in-oof-in-column-balancing.html
+ Skip => Pass css/css-multicol/crashtests/inline-with-spanner-in-overflowed-container-before-multicol-float.html
+ Skip => Pass css/css-multicol/crashtests/interleaved-bfc-crash.html
+ Skip => Pass css/css-multicol/crashtests/margin-and-break-before-child-spanner.html
+ Skip => Pass css/css-multicol/crashtests/monolithic-oof-in-clipped-container.html
+ Skip => Pass css/css-multicol/crashtests/multicol-at-page-boundary-print.html
+ Skip => Pass css/css-multicol/crashtests/multicol-block-in-inline-crash.html
+ Skip => Pass css/css-multicol/crashtests/multicol-cached-consumed-bsize-crash.html
+ Skip => Pass css/css-multicol/crashtests/multicol-floats-in-ifc.html
+ Skip => Pass css/css-multicol/crashtests/multicol-parallel-flow-after-spanner-in-inline.html
+ Skip => Pass css/css-multicol/crashtests/multicol-table-caption-parallel-flow-after-spanner-in-inline.html
+ Skip => Pass css/css-multicol/crashtests/multicol-with-monolithic-oof-with-multicol-with-oof.html
+ Skip => Pass css/css-multicol/crashtests/multicol-with-oof-in-multicol-with-oof-in-multicol.html
+ Skip => Pass css/css-multicol/crashtests/negative-margin-on-column-spanner.html
+ Skip => Pass css/css-multicol/crashtests/nested-floated-multicol-with-tall-margin.html
+ Skip => Pass css/css-multicol/crashtests/nested-multicol-and-float-with-tall-padding-before-float.html
+ Skip => Pass css/css-multicol/crashtests/nested-multicol-and-float-with-tall-padding.html
+ Skip => Pass css/css-multicol/crashtests/nested-multicol-fieldset-tall-trailing-border-freeze.html
+ Skip => Pass css/css-multicol/crashtests/nested-multicol-fieldset-tall-trailing-padding.html
+ Skip => Pass css/css-multicol/crashtests/nested-multicol-in-svg-foreignobject.html
+ Skip => Pass css/css-multicol/crashtests/nested-multicol-nested-flex.html
+ Skip => Pass css/css-multicol/crashtests/nested-multicol-with-float-between.html
+ Skip => Pass css/css-multicol/crashtests/nested-oof-multicol-with-monolithic-child.html
+ Skip => Pass css/css-multicol/crashtests/nested-oof-multicol-with-oof-needing-additional-columns.html
+ Skip => Pass css/css-multicol/crashtests/nested-oof-multicol-with-padding.html
+ Skip => Pass css/css-multicol/crashtests/nested-spanner-with-negative-margin.html
+ Skip => Pass css/css-multicol/crashtests/nested-with-fragmented-oof-negative-top-offset.html
+ Skip => Pass css/css-multicol/crashtests/nested-with-multicol-table-caption.html
+ Skip => Pass css/css-multicol/crashtests/nested-with-multicol-table-cell.html
+ Skip => Pass css/css-multicol/crashtests/nested-with-percentage-size-and-oof.html
+ Skip => Pass css/css-multicol/crashtests/nested-with-tall-padding-and-oof.html
+ Skip => Pass css/css-multicol/crashtests/nested-with-tall-padding-and-spanner-and-content.html
+ Skip => Pass css/css-multicol/crashtests/nested-with-tall-padding.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-nested-line-float.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-oof-multicol-in-multicol-spanner-in-multicol.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-oof-multicol-in-relpos-in-oof-in-multicol-in-multicol.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-oof-multicol-in-relpos-spanner-in-multicol-in-relpos-multicol-in-multicol.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-oof-multicol-in-relpos-spanner-in-spanner-multicol-in-multicol-in-multicol.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-oof-multicol-in-spanner-in-multicol-in-spanner-in-nested-multicol.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-oof-multicol-in-spanner-in-nested-multicol.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-relpos-in-oof-multicol-in-oof-in-relpos-in-oof-multicol-in-multicol.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-relpos-in-oof-multicol-in-relpos-in-oof-multicol-in-relpos-multicol.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-spanner-in-relpos-in-multicol-in-relpos-multicol-001.html
+ Skip => Pass css/css-multicol/crashtests/oof-in-spanner-in-relpos-in-multicol-in-relpos-multicol-002.html
+ Skip => Pass css/css-multicol/crashtests/oof-nested-multicol-inside-oof.html
+ Skip => Pass css/css-multicol/crashtests/repeated-section-in-nested-table-nested-multicol.html
+ Skip => Pass css/css-multicol/crashtests/repeated-table-footer-in-caption-nested-multicol.html
+ Skip => Pass css/css-multicol/crashtests/restricted-height-bottom-border-overflow-and-spanner.html
+ Skip => Pass css/css-multicol/crashtests/scrollable-spanner-in-nested.html
+ Skip => Pass css/css-multicol/crashtests/spanner-after-parallel-flow.html
+ Skip => Pass css/css-multicol/crashtests/spanner-in-inline-after-very-tall-content-001.html
+ Skip => Pass css/css-multicol/crashtests/spanner-in-inline-after-very-tall-content-002.html
+ Skip => Pass css/css-multicol/crashtests/spanner-in-overflowed-clipped-container.html
+ Skip => Pass css/css-multicol/crashtests/spanner-in-overflowed-container-before-float.html
+ Skip => Pass css/css-multicol/crashtests/spanner-in-overflowed-container-before-inline-content.html
+ Skip => Pass css/css-multicol/crashtests/spanner-inside-inline-in-overflowed-container.html
+ Skip => Pass css/css-multicol/crashtests/specified-height-with-just-spanner-and-oof.html
+ Skip => Pass css/css-multicol/crashtests/sticky-in-abs-in-sticky.html
+ Skip => Pass css/css-multicol/crashtests/table-caption-in-clipped-overflow.html
+ Skip => Pass css/css-multicol/crashtests/text-box-trim-end-and-widows.html
+ Skip => Pass css/css-multicol/crashtests/text-in-inline-interrupted-by-float.html
+ Skip => Pass css/css-multicol/crashtests/trailing-parent-padding-between-spanners.html
+ Skip => Pass css/css-multicol/crashtests/vertical-rl-column-rules-wide-columns.html
+ Skip => Pass css/css-multicol/crashtests/zero-column-height.html
+ Skip => Pass css/css-multicol/img-alt-as-multicol-crash.html
+ Skip => Pass css/css-multicol/multicol-loads-indefinitely-001-crash.html
+ Skip => Pass css/css-multicol/nested-balanced-monolithic-multicol-crash.html
+ Skip => Pass css/css-multicol/nested-balanced-very-tall-content-crash.html
+ Skip => Pass css/css-multicol/nested-floated-shape-outside-multicol-with-monolithic-child-crash.html
+ Skip => Pass css/css-multicol/nested-with-overflowing-padding-crash.html
+ Skip => Pass css/css-multicol/overflow-scroll-in-multicol-crash.html
+ Skip => Pass css/css-multicol/spanning-legend-000-crash.html
+ Skip => Pass css/css-multicol/table/balance-breakafter-before-table-section-crash.html
+ Skip => Pass css/css-multicol/textarea-text-overflow-ellipsis-crash.html
+ Skip => Pass css/css-multicol/triply-nested-with-fixedpos-in-abspos-crash.html
! Skip => Crash css/css-nesting/double-parent-pseudo-in-placeholder-crash.html
! Skip => Crash css/css-nesting/parent-pseudo-in-placeholder-crash.html
+ Skip => Pass css/css-nesting/pseudo-part-crash.html
+ Skip => Pass css/css-nesting/pseudo-where-crash.html
+ Skip => Pass css/css-overflow/ellipsis-with-image-crash.html
+ Skip => Pass css/css-overflow/line-clamp/line-clamp-040-crash.html
+ Skip => Pass css/css-overflow/line-clamp/line-clamp-auto-001-crash.html
+ Skip => Pass css/css-overflow/line-clamp/line-clamp-auto-002-crash.html
+ Skip => Pass css/css-overflow/line-clamp/webkit-line-clamp-041-crash.html
+ Skip => Pass css/css-overflow/line-clamp/webkit-line-clamp-042-crash.html
+ Skip => Pass css/css-overflow/line-clamp/webkit-line-clamp-bug-1926732-crash.html
+ Skip => Pass css/css-overflow/multicol-in-orthogonal-writing-mode-crash.html
+ Skip => Pass css/css-overflow/overflow-clip-002-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/chrome-421199213-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/column-scroll-marker-no-content-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/inline-with-scroll-marker-group-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/root-element-layout-parent-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/scroll-buttons-container-query-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/scroll-marker-014-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/scroll-markers-container-query-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/scroll-markers-inside-canvas-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/scroll-markers-inside-select-crash.html
+ Skip => Pass css/css-overflow/scroll-markers/scroll-target-group-inline-crash.html
+ Skip => Pass css/css-overflow/table-header-group-overflow-crash.html
+ Skip => Pass css/css-page/crashtests/negative-margin-print.html
+ Skip => Pass css/css-page/crashtests/percentage-padding-print.html
+ Skip => Pass css/css-page/crashtests/tall-inline-block-in-float-in-table-cell-print.html
+ Skip => Pass css/css-page/trailing-declaration-crash.html
+ Skip => Pass css/css-position/crashtests/position-absolute-crash-014.html
+ Skip => Pass css/css-properties-values-api/crashtests/computed-property-universal-syntax.html
# ... and 167 more (see the workflow logs)
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31330189572).</sub>
<!-- wpt-results-end -->
