### PR TITLE
WPT runner: classify testharness.js tests as TestKind::Testharness

### DIFF
--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -84,6 +84,7 @@ bitflags! {
 enum TestKind {
     Ref,
     Attr,
+    Testharness,
     Unknown,
 }
 
@@ -92,6 +93,7 @@ impl Display for TestKind {
         match self {
             TestKind::Ref => f.write_str("REF"),
             TestKind::Attr => f.write_str("ATT"),
+            TestKind::Testharness => f.write_str("TSH"),
             TestKind::Unknown => f.write_str("UNK"),
         }
     }
@@ -255,6 +257,7 @@ struct ThreadCtx {
     subgrid_re: Regex,
     grid_lanes_re: Regex,
     script_re: Regex,
+    testharness_re: Regex,
     out_dir: PathBuf,
     wpt_dir: PathBuf,
     dummy_base_url: Url,
@@ -461,6 +464,7 @@ fn main() {
                     let subgrid_re = Regex::new(r#"subgrid"#).unwrap();
                     let grid_lanes_re = Regex::new(r#"grid-lanes"#).unwrap();
                     let script_re = Regex::new(r#"<script|onload="#).unwrap();
+                    let testharness_re = Regex::new(r#"/resources/testharness\.js"#).unwrap();
 
                     let attrtest_re =
                         Regex::new(r#"checkLayout\(\s*['"]([^'"]*)['"]\s*(,\s*(true|false))?\)"#)
@@ -489,6 +493,7 @@ fn main() {
                         subgrid_re,
                         grid_lanes_re,
                         script_re,
+                        testharness_re,
                         out_dir: out_dir.clone(),
                         wpt_dir: wpt_dir.clone(),
                         dummy_base_url,

--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -84,7 +84,7 @@ bitflags! {
 enum TestKind {
     Ref,
     Attr,
-    Testharness,
+    TestHarness,
     Unknown,
 }
 
@@ -93,7 +93,7 @@ impl Display for TestKind {
         match self {
             TestKind::Ref => f.write_str("REF"),
             TestKind::Attr => f.write_str("ATT"),
-            TestKind::Testharness => f.write_str("TSH"),
+            TestKind::TestHarness => f.write_str("HAR"),
             TestKind::Unknown => f.write_str("UNK"),
         }
     }

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -100,7 +100,7 @@ pub fn process_test_file(
     // classified but not run.
     if ctx.testharness_re.is_match(&file_contents) {
         return (
-            TestKind::Testharness,
+            TestKind::TestHarness,
             flags,
             TestStatus::Skip,
             SubtestCounts::ZERO_OF_ZERO,

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -96,6 +96,18 @@ pub fn process_test_file(
         return (TestKind::Attr, flags, status, counts, results);
     }
 
+    // Testharness (testharness.js) tests. Blitz doesn't run JavaScript, so these are
+    // classified but not run.
+    if ctx.testharness_re.is_match(&file_contents) {
+        return (
+            TestKind::Testharness,
+            flags,
+            TestStatus::Skip,
+            SubtestCounts::ZERO_OF_ZERO,
+            Vec::new(),
+        );
+    }
+
     // TODO: Handle other test formats.
     (
         TestKind::Unknown,


### PR DESCRIPTION
## Summary

Files referencing `/resources/testharness.js` are now classified as a new `TestKind::Testharness` (printed as `TSH`) instead of falling through to `Unknown`. They are still SKIPped (Blitz doesn't run JavaScript) — this just makes skip stats meaningful by distinguishing "testharness test we can't run" from "unrecognized file".

The check runs after attr-test detection, since `checkLayout()` tests also include testharness.js and should keep being classified (and run) as `Attr`.

## Testing

- Ran against `css/css-flexbox`: testharness files (e.g. `align-content-rounding.html`, `animation/*.html`) now report `SKIP ... TSH` instead of `UNK`; `checkLayout` tests still run as `ATT`.
- `cargo fmt` / `cargo clippy -p wpt` clean.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0683f2df1e2348d2a0683437adeb5cf8
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31329864975).</sub>
<!-- wpt-results-end -->
