### PR TITLE
WPT runner: parse meta name=fuzzy and use tolerances in reftest comparison

### DIFF
--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -245,7 +245,9 @@ struct ThreadCtx {
     buffers: Buffers,
 
     // Things that aren't really thread-specifc, but are convenient to store here
-    reftest_re: Regex,
+    link_re: Regex,
+    rel_re: Regex,
+    href_re: Regex,
     attrtest_re: Regex,
     float_re: Regex,
     intrinsic_re: Regex,
@@ -448,9 +450,10 @@ fn main() {
                         ColorScheme::Light,
                     );
                     let net_provider = Arc::new(WptNetProvider::new(&wpt_dir));
-                    let reftest_re =
-                        Regex::new(r#"<link\s+rel=['"]?match['"]?\s+href=['"]([^'"]+)['"]"#)
-                            .unwrap();
+                    let link_re = Regex::new(r#"<link\s[^>]*>"#).unwrap();
+                    let rel_re = Regex::new(r#"rel\s*=\s*['"]?(match|mismatch)['"]?"#).unwrap();
+                    let href_re =
+                        Regex::new(r#"href\s*=\s*(?:['"]([^'"]+)['"]|([^\s'">]+))"#).unwrap();
 
                     let float_re = Regex::new(r#"float:"#).unwrap();
                     let intrinsic_re =
@@ -479,7 +482,9 @@ fn main() {
                             test_buffer,
                             ref_buffer,
                         },
-                        reftest_re,
+                        link_re,
+                        rel_re,
+                        href_re,
                         attrtest_re,
                         float_re,
                         intrinsic_re,

--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -259,7 +259,9 @@ struct ThreadCtx {
     buffers: Buffers,
 
     // Things that aren't really thread-specifc, but are convenient to store here
-    reftest_re: Regex,
+    link_re: Regex,
+    rel_re: Regex,
+    href_re: Regex,
     attrtest_re: Regex,
     float_re: Regex,
     intrinsic_re: Regex,
@@ -463,9 +465,10 @@ fn main() {
                         ColorScheme::Light,
                     );
                     let net_provider = Arc::new(WptNetProvider::new(&wpt_dir));
-                    let reftest_re =
-                        Regex::new(r#"<link\s+rel=['"]?match['"]?\s+href=['"]([^'"]+)['"]"#)
-                            .unwrap();
+                    let link_re = Regex::new(r#"<link\s[^>]*>"#).unwrap();
+                    let rel_re = Regex::new(r#"rel\s*=\s*['"]?(match|mismatch)['"]?"#).unwrap();
+                    let href_re =
+                        Regex::new(r#"href\s*=\s*(?:['"]([^'"]+)['"]|([^\s'">]+))"#).unwrap();
 
                     let float_re = Regex::new(r#"float:"#).unwrap();
                     let intrinsic_re =
@@ -495,7 +498,9 @@ fn main() {
                             test_buffer,
                             ref_buffer,
                         },
-                        reftest_re,
+                        link_re,
+                        rel_re,
+                        href_re,
                         attrtest_re,
                         float_re,
                         intrinsic_re,

--- a/wpt/runner/src/test_runners/fuzzy.rs
+++ b/wpt/runner/src/test_runners/fuzzy.rs
@@ -1,0 +1,231 @@
+//! Parsing of `<meta name=fuzzy>` tags, which specify tolerances for reftest image
+//! comparison. See <https://web-platform-tests.org/writing-tests/reftests.html#fuzzy-matching>
+//!
+//! The `content` attribute has the form `[ <ref-name> ":" ] <fuzzy-value>` where
+//! `<fuzzy-value>` is `maxDifference=<range>;totalPixels=<range>` (the key names are
+//! optional, in which case the ranges are positional) and `<range>` is either a single
+//! number or `<min>-<max>`.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+static META_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"<meta\s[^>]*>"#).unwrap());
+static NAME_FUZZY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"name\s*=\s*['"]?fuzzy['"]?"#).unwrap());
+static CONTENT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"content\s*=\s*(?:['"]([^'"]*)['"]|([^\s'">]+))"#).unwrap());
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct FuzzyRange {
+    pub min: u64,
+    pub max: u64,
+}
+
+impl FuzzyRange {
+    fn parse(s: &str) -> Option<Self> {
+        let s = s.trim();
+        let (min, max) = match s.split_once('-') {
+            Some((min, max)) => (min.trim().parse().ok()?, max.trim().parse().ok()?),
+            None => {
+                let value = s.parse().ok()?;
+                (value, value)
+            }
+        };
+        (min <= max).then_some(Self { min, max })
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct FuzzyTolerance {
+    pub max_difference: FuzzyRange,
+    pub total_pixels: FuzzyRange,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FuzzySpec {
+    /// Reference file this tolerance applies to (`None` = all references)
+    pub reference: Option<String>,
+    pub tolerance: FuzzyTolerance,
+}
+
+/// Parses all `<meta name=fuzzy>` tags in the document
+pub fn parse_fuzzy_metas(html: &str) -> Vec<FuzzySpec> {
+    META_RE
+        .find_iter(html)
+        .filter_map(|tag| {
+            let tag = tag.as_str();
+            if !NAME_FUZZY_RE.is_match(tag) {
+                return None;
+            }
+            let content = CONTENT_RE
+                .captures(tag)
+                .and_then(|c| c.get(1).or(c.get(2)))?;
+            parse_fuzzy_content(content.as_str())
+        })
+        .collect()
+}
+
+fn parse_fuzzy_content(content: &str) -> Option<FuzzySpec> {
+    let content = content.trim();
+    let (reference, value) = match content.split_once(':') {
+        Some((prefix, rest)) if !prefix.contains('=') => (Some(prefix.trim().to_string()), rest),
+        _ => (None, content),
+    };
+
+    let mut max_difference = None;
+    let mut total_pixels = None;
+    for (index, part) in value.split(';').enumerate() {
+        let part = part.trim();
+        if let Some(range) = part.strip_prefix("maxDifference=") {
+            max_difference = FuzzyRange::parse(range);
+        } else if let Some(range) = part.strip_prefix("totalPixels=") {
+            total_pixels = FuzzyRange::parse(range);
+        } else if index == 0 {
+            max_difference = FuzzyRange::parse(part);
+        } else {
+            total_pixels = FuzzyRange::parse(part);
+        }
+    }
+
+    Some(FuzzySpec {
+        reference,
+        tolerance: FuzzyTolerance {
+            max_difference: max_difference?,
+            total_pixels: total_pixels?,
+        },
+    })
+}
+
+/// Finds the tolerance applicable to `ref_file`: a spec naming that reference takes
+/// precedence over an unnamed one.
+pub fn tolerance_for_reference<'a>(
+    specs: &'a [FuzzySpec],
+    ref_file: &str,
+) -> Option<&'a FuzzyTolerance> {
+    specs
+        .iter()
+        .find(|spec| spec.reference.as_deref() == Some(ref_file))
+        .or_else(|| specs.iter().find(|spec| spec.reference.is_none()))
+        .map(|spec| &spec.tolerance)
+}
+
+/// Compares two RGBA buffers, returning the maximum per-channel difference and the
+/// number of pixels which differ in any channel.
+pub fn fuzzy_buffer_diff(test_buffer: &[u8], ref_buffer: &[u8]) -> (u64, u64) {
+    let mut max_difference: u64 = 0;
+    let mut differing_pixels: u64 = 0;
+
+    for (test_px, ref_px) in test_buffer.chunks_exact(4).zip(ref_buffer.chunks_exact(4)) {
+        let mut pixel_differs = false;
+        for (t, r) in test_px.iter().zip(ref_px.iter()) {
+            let diff = t.abs_diff(*r) as u64;
+            if diff > 0 {
+                pixel_differs = true;
+                max_difference = max_difference.max(diff);
+            }
+        }
+        differing_pixels += pixel_differs as u64;
+    }
+
+    (max_difference, differing_pixels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range(min: u64, max: u64) -> FuzzyRange {
+        FuzzyRange { min, max }
+    }
+
+    #[test]
+    fn parse_named_ranges() {
+        let spec = parse_fuzzy_content("maxDifference=0-2;totalPixels=0-40").unwrap();
+        assert_eq!(spec.reference, None);
+        assert_eq!(spec.tolerance.max_difference, range(0, 2));
+        assert_eq!(spec.tolerance.total_pixels, range(0, 40));
+    }
+
+    #[test]
+    fn parse_named_ranges_with_space() {
+        let spec = parse_fuzzy_content("maxDifference=0-99; totalPixels=0-410").unwrap();
+        assert_eq!(spec.tolerance.max_difference, range(0, 99));
+        assert_eq!(spec.tolerance.total_pixels, range(0, 410));
+    }
+
+    #[test]
+    fn parse_positional_ranges() {
+        let spec = parse_fuzzy_content("2;40").unwrap();
+        assert_eq!(spec.tolerance.max_difference, range(2, 2));
+        assert_eq!(spec.tolerance.total_pixels, range(40, 40));
+    }
+
+    #[test]
+    fn parse_per_reference() {
+        let spec = parse_fuzzy_content("ref.html:maxDifference=0-2;totalPixels=0-40").unwrap();
+        assert_eq!(spec.reference.as_deref(), Some("ref.html"));
+        assert_eq!(spec.tolerance.max_difference, range(0, 2));
+        assert_eq!(spec.tolerance.total_pixels, range(0, 40));
+    }
+
+    #[test]
+    fn parse_invalid() {
+        assert_eq!(parse_fuzzy_content("garbage"), None);
+        assert_eq!(parse_fuzzy_content("maxDifference=0-2"), None);
+    }
+
+    #[test]
+    fn parse_metas_from_html() {
+        let html = r#"
+            <meta charset="utf-8">
+            <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-100">
+            <meta content="ref.html:maxDifference=1;totalPixels=2" name=fuzzy>
+        "#;
+        let specs = parse_fuzzy_metas(html);
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0].reference, None);
+        assert_eq!(specs[1].reference.as_deref(), Some("ref.html"));
+        assert_eq!(specs[1].tolerance.max_difference, range(1, 1));
+    }
+
+    #[test]
+    fn tolerance_selection() {
+        let specs = vec![
+            FuzzySpec {
+                reference: None,
+                tolerance: FuzzyTolerance {
+                    max_difference: range(0, 1),
+                    total_pixels: range(0, 1),
+                },
+            },
+            FuzzySpec {
+                reference: Some("ref.html".to_string()),
+                tolerance: FuzzyTolerance {
+                    max_difference: range(0, 2),
+                    total_pixels: range(0, 2),
+                },
+            },
+        ];
+        assert_eq!(
+            tolerance_for_reference(&specs, "ref.html")
+                .unwrap()
+                .max_difference,
+            range(0, 2)
+        );
+        assert_eq!(
+            tolerance_for_reference(&specs, "other.html")
+                .unwrap()
+                .max_difference,
+            range(0, 1)
+        );
+        assert_eq!(tolerance_for_reference(&[], "ref.html"), None);
+    }
+
+    #[test]
+    fn buffer_diff() {
+        let a = [0u8, 0, 0, 255, 10, 10, 10, 255];
+        let b = [0u8, 0, 0, 255, 10, 13, 10, 255];
+        assert_eq!(fuzzy_buffer_diff(&a, &b), (3, 1));
+        assert_eq!(fuzzy_buffer_diff(&a, &a), (0, 0));
+    }
+}

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -7,6 +7,7 @@ use log::debug;
 use crate::{SubtestCounts, TestFlags, TestKind, TestStatus, ThreadCtx};
 
 mod attr_test;
+mod fuzzy;
 mod ref_test;
 
 pub use attr_test::process_attr_test;

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -80,16 +80,33 @@ pub fn process_test_file(
     }
 
     // Ref Test
-    let reference = ctx
-        .reftest_re
-        .captures(&file_contents)
-        .and_then(|captures| captures.get(1).map(|href| href.as_str().to_string()));
-    if let Some(reference) = reference {
+    let mut match_references: Vec<String> = Vec::new();
+    let mut mismatch_references: Vec<String> = Vec::new();
+    for link in ctx.link_re.find_iter(&file_contents) {
+        let tag = link.as_str();
+        let Some(rel) = ctx.rel_re.captures(tag).and_then(|c| c.get(1)) else {
+            continue;
+        };
+        let Some(href) = ctx
+            .href_re
+            .captures(tag)
+            .and_then(|c| c.get(1).or(c.get(2)))
+        else {
+            continue;
+        };
+        match rel.as_str() {
+            "match" => match_references.push(href.as_str().to_string()),
+            "mismatch" => mismatch_references.push(href.as_str().to_string()),
+            _ => {}
+        }
+    }
+    if !match_references.is_empty() || !mismatch_references.is_empty() {
         let counts = process_ref_test(
             ctx,
             relative_path,
             file_contents.as_str(),
-            reference.as_str(),
+            &match_references,
+            &mismatch_references,
             &mut flags,
         );
 

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -60,16 +60,33 @@ pub fn process_test_file(
     }
 
     // Ref Test
-    let reference = ctx
-        .reftest_re
-        .captures(&file_contents)
-        .and_then(|captures| captures.get(1).map(|href| href.as_str().to_string()));
-    if let Some(reference) = reference {
+    let mut match_references: Vec<String> = Vec::new();
+    let mut mismatch_references: Vec<String> = Vec::new();
+    for link in ctx.link_re.find_iter(&file_contents) {
+        let tag = link.as_str();
+        let Some(rel) = ctx.rel_re.captures(tag).and_then(|c| c.get(1)) else {
+            continue;
+        };
+        let Some(href) = ctx
+            .href_re
+            .captures(tag)
+            .and_then(|c| c.get(1).or(c.get(2)))
+        else {
+            continue;
+        };
+        match rel.as_str() {
+            "match" => match_references.push(href.as_str().to_string()),
+            "mismatch" => mismatch_references.push(href.as_str().to_string()),
+            _ => {}
+        }
+    }
+    if !match_references.is_empty() || !mismatch_references.is_empty() {
         let counts = process_ref_test(
             ctx,
             relative_path,
             file_contents.as_str(),
-            reference.as_str(),
+            &match_references,
+            &mismatch_references,
             &mut flags,
         );
 

--- a/wpt/runner/src/test_runners/ref_test.rs
+++ b/wpt/runner/src/test_runners/ref_test.rs
@@ -152,7 +152,7 @@ fn render_reference_and_compare(
     );
 
     if ctx.buffers.test_buffer == ctx.buffers.ref_buffer {
-        return true;
+        return Some(true);
     }
 
     let test_image = ImageBuffer::from_raw(WIDTH, HEIGHT, ctx.buffers.test_buffer.clone()).unwrap();
@@ -167,9 +167,9 @@ fn render_reference_and_compare(
         let parent = path.parent().unwrap();
         fs::create_dir_all(parent).unwrap();
         diff.1.save_with_format(path, ImageFormat::Png).unwrap();
-        false
+        Some(false)
     } else {
-        true
+        Some(true)
     }
 }
 

--- a/wpt/runner/src/test_runners/ref_test.rs
+++ b/wpt/runner/src/test_runners/ref_test.rs
@@ -13,14 +13,68 @@ use url::Url;
 use super::parse_and_resolve_document;
 use crate::{BufferKind, HEIGHT, SCALE, SubtestCounts, TestFlags, ThreadCtx, WIDTH};
 
-#[allow(clippy::too_many_arguments)]
 pub fn process_ref_test(
     ctx: &mut ThreadCtx,
     test_relative_path: &str,
     test_html: &str,
-    ref_file: &str,
+    match_references: &[String],
+    mismatch_references: &[String],
     flags: &mut TestFlags,
 ) -> SubtestCounts {
+    let test_out_path = ctx
+        .out_dir
+        .join(format!("{}{}", test_relative_path, "-test.png"));
+    render_html_to_buffer(
+        ctx,
+        BufferKind::Test,
+        test_relative_path,
+        &test_out_path,
+        test_html,
+    );
+
+    let image_is_blank = ctx.buffers.test_buffer.iter().all(|x| *x == 0);
+    if image_is_blank {
+        return SubtestCounts::ZERO_OF_ONE;
+    }
+
+    // A test passes if its rendering matches ANY of its `rel=match` references
+    // and differs from ALL of its `rel=mismatch` references.
+    let mut ref_index = 0;
+
+    let mut matches_pass = match_references.is_empty();
+    for ref_file in match_references {
+        ref_index += 1;
+        if render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags) {
+            matches_pass = true;
+            break;
+        }
+    }
+
+    let mut mismatches_pass = true;
+    for ref_file in mismatch_references {
+        ref_index += 1;
+        if render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags) {
+            mismatches_pass = false;
+            break;
+        }
+    }
+
+    if matches_pass && mismatches_pass {
+        SubtestCounts::ONE_OF_ONE
+    } else {
+        SubtestCounts::ZERO_OF_ONE
+    }
+}
+
+/// Renders `ref_file` to the reference buffer and compares it against the already-rendered
+/// test buffer. Returns `true` if the two renderings are considered equal.
+fn render_reference_and_compare(
+    ctx: &mut ThreadCtx,
+    test_relative_path: &str,
+    ref_file: &str,
+    ref_index: usize,
+    flags: &mut TestFlags,
+) -> bool {
     let ref_url: Url = ctx
         .dummy_base_url
         .join(test_relative_path)
@@ -53,20 +107,14 @@ pub fn process_ref_test(
         *flags |= TestFlags::USES_GRID_LANES;
     }
 
-    let test_out_path = ctx
-        .out_dir
-        .join(format!("{}{}", test_relative_path, "-test.png"));
-    render_html_to_buffer(
-        ctx,
-        BufferKind::Test,
-        test_relative_path,
-        &test_out_path,
-        test_html,
-    );
-
+    let suffix = if ref_index == 1 {
+        String::new()
+    } else {
+        format!("-{ref_index}")
+    };
     let ref_out_path = ctx
         .out_dir
-        .join(format!("{}{}", test_relative_path, "-ref.png"));
+        .join(format!("{test_relative_path}-ref{suffix}.png"));
     render_html_to_buffer(
         ctx,
         BufferKind::Ref,
@@ -75,13 +123,8 @@ pub fn process_ref_test(
         &ref_html,
     );
 
-    let image_is_blank = ctx.buffers.test_buffer.iter().all(|x| *x == 0);
-    if image_is_blank {
-        return SubtestCounts::ZERO_OF_ONE;
-    }
-
     if ctx.buffers.test_buffer == ctx.buffers.ref_buffer {
-        return SubtestCounts::ONE_OF_ONE;
+        return true;
     }
 
     let test_image = ImageBuffer::from_raw(WIDTH, HEIGHT, ctx.buffers.test_buffer.clone()).unwrap();
@@ -92,13 +135,13 @@ pub fn process_ref_test(
     if let Some(diff) = diff {
         let path = ctx
             .out_dir
-            .join(format!("{}{}", test_relative_path, "-diff.png"));
+            .join(format!("{test_relative_path}-diff{suffix}.png"));
         let parent = path.parent().unwrap();
         fs::create_dir_all(parent).unwrap();
         diff.1.save_with_format(path, ImageFormat::Png).unwrap();
-        SubtestCounts::ZERO_OF_ONE
+        false
     } else {
-        SubtestCounts::ONE_OF_ONE
+        true
     }
 }
 

--- a/wpt/runner/src/test_runners/ref_test.rs
+++ b/wpt/runner/src/test_runners/ref_test.rs
@@ -37,15 +37,17 @@ pub fn process_ref_test(
         return SubtestCounts::ZERO_OF_ONE;
     }
 
-    // A test passes if its rendering matches its `rel=match` reference
+    // A test passes if its rendering matches ANY of its `rel=match` references
     // and differs from ALL of its `rel=mismatch` references.
     let mut ref_index = 0;
 
     let mut matches_pass = match_references.is_empty();
-    if let Some(ref_file) = match_references.first() {
+    for ref_file in match_references {
         ref_index += 1;
-        matches_pass =
-            render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags);
+        if render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags) {
+            matches_pass = true;
+            break;
+        }
     }
 
     let mut mismatches_pass = true;

--- a/wpt/runner/src/test_runners/ref_test.rs
+++ b/wpt/runner/src/test_runners/ref_test.rs
@@ -10,6 +10,7 @@ use std::io::Write;
 use std::path::Path;
 use url::Url;
 
+use super::fuzzy::{FuzzySpec, fuzzy_buffer_diff, parse_fuzzy_metas, tolerance_for_reference};
 use super::parse_and_resolve_document;
 use crate::{BufferKind, HEIGHT, SCALE, SubtestCounts, TestFlags, ThreadCtx, WIDTH};
 
@@ -37,6 +38,8 @@ pub fn process_ref_test(
         return SubtestCounts::ZERO_OF_ONE;
     }
 
+    let fuzzy_specs = parse_fuzzy_metas(test_html);
+
     // A test passes if its rendering matches ANY of its `rel=match` references
     // and differs from ALL of its `rel=mismatch` references.
     let mut ref_index = 0;
@@ -44,7 +47,14 @@ pub fn process_ref_test(
     let mut matches_pass = match_references.is_empty();
     for ref_file in match_references {
         ref_index += 1;
-        if render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags) {
+        if render_reference_and_compare(
+            ctx,
+            test_relative_path,
+            ref_file,
+            ref_index,
+            &fuzzy_specs,
+            flags,
+        ) {
             matches_pass = true;
             break;
         }
@@ -53,7 +63,14 @@ pub fn process_ref_test(
     let mut mismatches_pass = true;
     for ref_file in mismatch_references {
         ref_index += 1;
-        if render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags) {
+        if render_reference_and_compare(
+            ctx,
+            test_relative_path,
+            ref_file,
+            ref_index,
+            &fuzzy_specs,
+            flags,
+        ) {
             mismatches_pass = false;
             break;
         }
@@ -73,6 +90,7 @@ fn render_reference_and_compare(
     test_relative_path: &str,
     ref_file: &str,
     ref_index: usize,
+    fuzzy_specs: &[FuzzySpec],
     flags: &mut TestFlags,
 ) -> bool {
     let ref_url: Url = ctx
@@ -127,6 +145,19 @@ fn render_reference_and_compare(
         return true;
     }
 
+    // If the test declares a `<meta name=fuzzy>` tolerance applicable to this reference,
+    // use it to decide whether the renderings match. Otherwise fall back to the fixed
+    // dify threshold.
+    let fuzzy_tolerance = tolerance_for_reference(fuzzy_specs, ref_file);
+    let is_match = if let Some(tolerance) = fuzzy_tolerance {
+        let (max_difference, differing_pixels) =
+            fuzzy_buffer_diff(&ctx.buffers.test_buffer, &ctx.buffers.ref_buffer);
+        max_difference <= tolerance.max_difference.max
+            && differing_pixels <= tolerance.total_pixels.max
+    } else {
+        true
+    };
+
     let test_image = ImageBuffer::from_raw(WIDTH, HEIGHT, ctx.buffers.test_buffer.clone()).unwrap();
     let ref_image = ImageBuffer::from_raw(WIDTH, HEIGHT, ctx.buffers.ref_buffer.clone()).unwrap();
 
@@ -139,9 +170,9 @@ fn render_reference_and_compare(
         let parent = path.parent().unwrap();
         fs::create_dir_all(parent).unwrap();
         diff.1.save_with_format(path, ImageFormat::Png).unwrap();
-        false
+        fuzzy_tolerance.is_some() && is_match
     } else {
-        true
+        is_match
     }
 }
 

--- a/wpt/runner/src/test_runners/ref_test.rs
+++ b/wpt/runner/src/test_runners/ref_test.rs
@@ -13,14 +13,66 @@ use url::Url;
 use super::parse_and_resolve_document;
 use crate::{BufferKind, HEIGHT, SCALE, SubtestCounts, TestFlags, ThreadCtx, WIDTH};
 
-#[allow(clippy::too_many_arguments)]
 pub fn process_ref_test(
     ctx: &mut ThreadCtx,
     test_relative_path: &str,
     test_html: &str,
-    ref_file: &str,
+    match_references: &[String],
+    mismatch_references: &[String],
     flags: &mut TestFlags,
 ) -> SubtestCounts {
+    let test_out_path = ctx
+        .out_dir
+        .join(format!("{}{}", test_relative_path, "-test.png"));
+    render_html_to_buffer(
+        ctx,
+        BufferKind::Test,
+        test_relative_path,
+        &test_out_path,
+        test_html,
+    );
+
+    let image_is_blank = ctx.buffers.test_buffer.iter().all(|x| *x == 0);
+    if image_is_blank {
+        return SubtestCounts::ZERO_OF_ONE;
+    }
+
+    // A test passes if its rendering matches its `rel=match` reference
+    // and differs from ALL of its `rel=mismatch` references.
+    let mut ref_index = 0;
+
+    let mut matches_pass = match_references.is_empty();
+    if let Some(ref_file) = match_references.first() {
+        ref_index += 1;
+        matches_pass =
+            render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags);
+    }
+
+    let mut mismatches_pass = true;
+    for ref_file in mismatch_references {
+        ref_index += 1;
+        if render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags) {
+            mismatches_pass = false;
+            break;
+        }
+    }
+
+    if matches_pass && mismatches_pass {
+        SubtestCounts::ONE_OF_ONE
+    } else {
+        SubtestCounts::ZERO_OF_ONE
+    }
+}
+
+/// Renders `ref_file` to the reference buffer and compares it against the already-rendered
+/// test buffer. Returns `true` if the two renderings are considered equal.
+fn render_reference_and_compare(
+    ctx: &mut ThreadCtx,
+    test_relative_path: &str,
+    ref_file: &str,
+    ref_index: usize,
+    flags: &mut TestFlags,
+) -> bool {
     let ref_url: Url = ctx
         .dummy_base_url
         .join(test_relative_path)
@@ -53,20 +105,14 @@ pub fn process_ref_test(
         *flags |= TestFlags::USES_GRID_LANES;
     }
 
-    let test_out_path = ctx
-        .out_dir
-        .join(format!("{}{}", test_relative_path, "-test.png"));
-    render_html_to_buffer(
-        ctx,
-        BufferKind::Test,
-        test_relative_path,
-        &test_out_path,
-        test_html,
-    );
-
+    let suffix = if ref_index == 1 {
+        String::new()
+    } else {
+        format!("-{ref_index}")
+    };
     let ref_out_path = ctx
         .out_dir
-        .join(format!("{}{}", test_relative_path, "-ref.png"));
+        .join(format!("{test_relative_path}-ref{suffix}.png"));
     render_html_to_buffer(
         ctx,
         BufferKind::Ref,
@@ -75,13 +121,8 @@ pub fn process_ref_test(
         &ref_html,
     );
 
-    let image_is_blank = ctx.buffers.test_buffer.iter().all(|x| *x == 0);
-    if image_is_blank {
-        return SubtestCounts::ZERO_OF_ONE;
-    }
-
     if ctx.buffers.test_buffer == ctx.buffers.ref_buffer {
-        return SubtestCounts::ONE_OF_ONE;
+        return true;
     }
 
     let test_image = ImageBuffer::from_raw(WIDTH, HEIGHT, ctx.buffers.test_buffer.clone()).unwrap();
@@ -92,13 +133,13 @@ pub fn process_ref_test(
     if let Some(diff) = diff {
         let path = ctx
             .out_dir
-            .join(format!("{}{}", test_relative_path, "-diff.png"));
+            .join(format!("{test_relative_path}-diff{suffix}.png"));
         let parent = path.parent().unwrap();
         fs::create_dir_all(parent).unwrap();
         diff.1.save_with_format(path, ImageFormat::Png).unwrap();
-        SubtestCounts::ZERO_OF_ONE
+        false
     } else {
-        SubtestCounts::ONE_OF_ONE
+        true
     }
 }
 

--- a/wpt/runner/src/test_runners/ref_test.rs
+++ b/wpt/runner/src/test_runners/ref_test.rs
@@ -141,7 +141,6 @@ fn render_reference_and_compare(
         &ref_html,
     );
 
-<<<<<<< HEAD
     if ctx.buffers.test_buffer == ctx.buffers.ref_buffer {
         return true;
     }
@@ -158,20 +157,6 @@ fn render_reference_and_compare(
     } else {
         true
     };
-||||||| 5081c658
-    let image_is_blank = ctx.buffers.test_buffer.iter().all(|x| *x == 0);
-    if image_is_blank {
-        return SubtestCounts::ZERO_OF_ONE;
-    }
-
-    if ctx.buffers.test_buffer == ctx.buffers.ref_buffer {
-        return SubtestCounts::ONE_OF_ONE;
-    }
-=======
-    if ctx.buffers.test_buffer == ctx.buffers.ref_buffer {
-        return true;
-    }
->>>>>>> devin/1786299933-mismatch-reftests
 
     let test_image = ImageBuffer::from_raw(WIDTH, HEIGHT, ctx.buffers.test_buffer.clone()).unwrap();
     let ref_image = ImageBuffer::from_raw(WIDTH, HEIGHT, ctx.buffers.ref_buffer.clone()).unwrap();
@@ -185,21 +170,9 @@ fn render_reference_and_compare(
         let parent = path.parent().unwrap();
         fs::create_dir_all(parent).unwrap();
         diff.1.save_with_format(path, ImageFormat::Png).unwrap();
-<<<<<<< HEAD
         fuzzy_tolerance.is_some() && is_match
-||||||| 5081c658
-        SubtestCounts::ZERO_OF_ONE
-=======
-        false
->>>>>>> devin/1786299933-mismatch-reftests
     } else {
-<<<<<<< HEAD
         is_match
-||||||| 5081c658
-        SubtestCounts::ONE_OF_ONE
-=======
-        true
->>>>>>> devin/1786299933-mismatch-reftests
     }
 }
 


### PR DESCRIPTION
## Summary

Parses `<meta name=fuzzy content=...>` per the [WPT fuzzy-matching spec](https://web-platform-tests.org/writing-tests/reftests.html#fuzzy-matching) and uses the declared tolerances in the reftest image comparison.

New `fuzzy.rs` module (with unit tests):
- `parse_fuzzy_metas(html) -> Vec<FuzzySpec>` — parses all fuzzy meta tags, robust to attribute order/quoting. Supports named (`maxDifference=0-2;totalPixels=0-40`), positional (`2;40`), single-value ranges (`2` → `2-2`), and per-reference prefixes (`ref.html:maxDifference=...`).
- `tolerance_for_reference` — a spec naming the reference takes precedence over an unnamed one.
- `fuzzy_buffer_diff` — returns (max per-channel difference, count of differing pixels) for the two RGBA buffers.

In `render_reference_and_compare`, when a fuzzy tolerance applies to the reference being compared, the match decision becomes:

```
max_difference <= tolerance.max_difference.max && differing_pixels <= tolerance.total_pixels.max
```

instead of the fixed dify 0.1 threshold (dify is still run to produce the `-diff.png` debug image, and remains the comparison for tests without fuzzy metadata). Range minimums are parsed but deliberately not enforced: upstream calibrates them against real browsers, and Blitz renderings that happen to match a reference exactly shouldn't fail.

Depends on #670 and #665 (this branch includes their commits, since all three restructure `ref_test.rs`); those should merge first, after which this PR's diff reduces to the fuzzy changes.

## Testing

- `cargo test -p wpt`: 8 new unit tests for parsing/selection/diffing pass.
- Ran against `css/css-backgrounds` and diffed `wpt_expectations.txt`: `background-size-025.html` (fuzzy `0-70;0-7294`) flips FAIL→PASS, `border-radius-clip-002.htm` (fuzzy `0-70;0-50`, stricter than dify) flips PASS→FAIL; no other result changes.
- `cargo fmt` / `cargo clippy -p wpt` clean.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0683f2df1e2348d2a0683437adeb5cf8
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**16** newly passing, **4** newly failing (net +12).

<details>
<summary>Full diff (20 changed tests)</summary>

```diff
+ Fail => Pass css/css-backgrounds/background-size-025.html
- Pass => Fail css/css-backgrounds/border-radius-clip-002.htm
- Pass => Fail css/css-borders/corner-shape/corner-shape-img-border.html
+ Fail => Pass css/css-images/gradient/legacy-color-gradient.html
+ Fail => Pass css/css-images/gradient/srgb-gradient.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-from-image-composited-dynamic2.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-from-image-dynamic2.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-none-content-images.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-none.html
- Pass => Fail css/css-masking/clip-path/animations/clip-path-animation-custom-timing-function.html
- Pass => Fail css/css-masking/clip-path/clip-path-inset-round-rendering.html
+ Fail => Pass css/css-transforms/2d-rotate-001.html
+ Fail => Pass css/css-transforms/group/svg-transform-group-009.html
+ Fail => Pass css/css-transforms/group/svg-transform-nested-014.html
+ Fail => Pass css/css-transforms/skewY/svg-skewy-001.html
+ Fail => Pass css/css-transforms/skewY/svg-skewy-006.html
+ Fail => Pass css/css-transforms/skewY/svg-skewy-011.html
+ Fail => Pass css/css-transforms/skewY/svg-skewy-016.html
+ Fail => Pass css/css-transforms/skewY/svg-skewy-021.html
+ Fail => Pass css/css-view-transitions/nested/nested-group-in-pseudo-basic.tentative.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31720207607).</sub>
<!-- wpt-results-end -->
