### PR TITLE
WPT runner: support mismatch reftests

### DIFF
--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -259,7 +259,9 @@ struct ThreadCtx {
     buffers: Buffers,
 
     // Things that aren't really thread-specifc, but are convenient to store here
-    reftest_re: Regex,
+    link_re: Regex,
+    rel_re: Regex,
+    href_re: Regex,
     attrtest_re: Regex,
     float_re: Regex,
     intrinsic_re: Regex,
@@ -463,9 +465,10 @@ fn main() {
                         ColorScheme::Light,
                     );
                     let net_provider = Arc::new(WptNetProvider::new(&wpt_dir));
-                    let reftest_re =
-                        Regex::new(r#"<link\s+rel=['"]?match['"]?\s+href=['"]([^'"]+)['"]"#)
-                            .unwrap();
+                    let link_re = Regex::new(r#"<link\s[^>]*>"#).unwrap();
+                    let rel_re = Regex::new(r#"rel\s*=\s*['"]?(match|mismatch)['"]?"#).unwrap();
+                    let href_re =
+                        Regex::new(r#"href\s*=\s*(?:['"]([^'"]+)['"]|([^\s'">]+))"#).unwrap();
 
                     let float_re = Regex::new(r#"float:"#).unwrap();
                     let intrinsic_re =
@@ -495,7 +498,9 @@ fn main() {
                             test_buffer,
                             ref_buffer,
                         },
-                        reftest_re,
+                        link_re,
+                        rel_re,
+                        href_re,
                         attrtest_re,
                         float_re,
                         intrinsic_re,

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -80,16 +80,33 @@ pub fn process_test_file(
     }
 
     // Ref Test
-    let reference = ctx
-        .reftest_re
-        .captures(&file_contents)
-        .and_then(|captures| captures.get(1).map(|href| href.as_str().to_string()));
-    if let Some(reference) = reference {
+    let mut match_references: Vec<String> = Vec::new();
+    let mut mismatch_references: Vec<String> = Vec::new();
+    for link in ctx.link_re.find_iter(&file_contents) {
+        let tag = link.as_str();
+        let Some(rel) = ctx.rel_re.captures(tag).and_then(|c| c.get(1)) else {
+            continue;
+        };
+        let Some(href) = ctx
+            .href_re
+            .captures(tag)
+            .and_then(|c| c.get(1).or(c.get(2)))
+        else {
+            continue;
+        };
+        match rel.as_str() {
+            "match" => match_references.push(href.as_str().to_string()),
+            "mismatch" => mismatch_references.push(href.as_str().to_string()),
+            _ => {}
+        }
+    }
+    if !match_references.is_empty() || !mismatch_references.is_empty() {
         let counts = process_ref_test(
             ctx,
             relative_path,
             file_contents.as_str(),
-            reference.as_str(),
+            &match_references,
+            &mismatch_references,
             &mut flags,
         );
 

--- a/wpt/runner/src/test_runners/ref_test.rs
+++ b/wpt/runner/src/test_runners/ref_test.rs
@@ -13,14 +13,66 @@ use url::Url;
 use super::parse_and_resolve_document;
 use crate::{BufferKind, HEIGHT, SCALE, SubtestCounts, TestFlags, ThreadCtx, WIDTH};
 
-#[allow(clippy::too_many_arguments)]
 pub fn process_ref_test(
     ctx: &mut ThreadCtx,
     test_relative_path: &str,
     test_html: &str,
-    ref_file: &str,
+    match_references: &[String],
+    mismatch_references: &[String],
     flags: &mut TestFlags,
 ) -> SubtestCounts {
+    let test_out_path = ctx
+        .out_dir
+        .join(format!("{}{}", test_relative_path, "-test.png"));
+    render_html_to_buffer(
+        ctx,
+        BufferKind::Test,
+        test_relative_path,
+        &test_out_path,
+        test_html,
+    );
+
+    let image_is_blank = ctx.buffers.test_buffer.iter().all(|x| *x == 0);
+    if image_is_blank {
+        return SubtestCounts::ZERO_OF_ONE;
+    }
+
+    // A test passes if its rendering matches its `rel=match` reference
+    // and differs from ALL of its `rel=mismatch` references.
+    let mut ref_index = 0;
+
+    let mut matches_pass = match_references.is_empty();
+    if let Some(ref_file) = match_references.first() {
+        ref_index += 1;
+        matches_pass =
+            render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags);
+    }
+
+    let mut mismatches_pass = true;
+    for ref_file in mismatch_references {
+        ref_index += 1;
+        if render_reference_and_compare(ctx, test_relative_path, ref_file, ref_index, flags) {
+            mismatches_pass = false;
+            break;
+        }
+    }
+
+    if matches_pass && mismatches_pass {
+        SubtestCounts::ONE_OF_ONE
+    } else {
+        SubtestCounts::ZERO_OF_ONE
+    }
+}
+
+/// Renders `ref_file` to the reference buffer and compares it against the already-rendered
+/// test buffer. Returns `true` if the two renderings are considered equal.
+fn render_reference_and_compare(
+    ctx: &mut ThreadCtx,
+    test_relative_path: &str,
+    ref_file: &str,
+    ref_index: usize,
+    flags: &mut TestFlags,
+) -> bool {
     let ref_url: Url = ctx
         .dummy_base_url
         .join(test_relative_path)
@@ -53,20 +105,14 @@ pub fn process_ref_test(
         *flags |= TestFlags::USES_GRID_LANES;
     }
 
-    let test_out_path = ctx
-        .out_dir
-        .join(format!("{}{}", test_relative_path, "-test.png"));
-    render_html_to_buffer(
-        ctx,
-        BufferKind::Test,
-        test_relative_path,
-        &test_out_path,
-        test_html,
-    );
-
+    let suffix = if ref_index == 1 {
+        String::new()
+    } else {
+        format!("-{ref_index}")
+    };
     let ref_out_path = ctx
         .out_dir
-        .join(format!("{}{}", test_relative_path, "-ref.png"));
+        .join(format!("{test_relative_path}-ref{suffix}.png"));
     render_html_to_buffer(
         ctx,
         BufferKind::Ref,
@@ -75,13 +121,8 @@ pub fn process_ref_test(
         &ref_html,
     );
 
-    let image_is_blank = ctx.buffers.test_buffer.iter().all(|x| *x == 0);
-    if image_is_blank {
-        return SubtestCounts::ZERO_OF_ONE;
-    }
-
     if ctx.buffers.test_buffer == ctx.buffers.ref_buffer {
-        return SubtestCounts::ONE_OF_ONE;
+        return true;
     }
 
     let test_image = ImageBuffer::from_raw(WIDTH, HEIGHT, ctx.buffers.test_buffer.clone()).unwrap();
@@ -92,13 +133,13 @@ pub fn process_ref_test(
     if let Some(diff) = diff {
         let path = ctx
             .out_dir
-            .join(format!("{}{}", test_relative_path, "-diff.png"));
+            .join(format!("{test_relative_path}-diff{suffix}.png"));
         let parent = path.parent().unwrap();
         fs::create_dir_all(parent).unwrap();
         diff.1.save_with_format(path, ImageFormat::Png).unwrap();
-        SubtestCounts::ZERO_OF_ONE
+        false
     } else {
-        SubtestCounts::ONE_OF_ONE
+        true
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `<link rel=mismatch>` reftest support: a test passes if its rendering DIFFERS from every mismatch reference, combined with the existing match semantics:

```
pass = (match_refs.is_empty() || first match_ref renders equal)
    && all(mismatch_ref renders different)
```

Link parsing is now robust to attribute order: `<link ...>` tags are located first, then `rel`/`href` are extracted independently (also accepts unquoted attribute values). Per-reference rendering/comparison is extracted into `render_reference_and_compare`; additional references write `-ref-N.png`/`-diff-N.png` output images.

This PR should land first; #665 (multiple rel=match OR semantics) and #669 (fuzzy tolerances) build on it.

## Testing

- Ran against `css/css-text/line-breaking` (contains `rel=mismatch` tests `line-breaking-024..027`): now classified and run as reftests (previously skipped as UNK) with mismatch semantics applied.
- `cargo fmt` / `cargo clippy -p wpt` clean.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0683f2df1e2348d2a0683437adeb5cf8
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**147** newly passing, **49** newly failing (net +98), **197** other status changes.

<details>
<summary>Full diff (393 changed tests)</summary>

```diff
+ Skip => Pass css/CSS2/borders/groove-default.html
+ Skip => Pass css/CSS2/borders/ridge-default.html
- Pass => Fail css/CSS2/box/rtl-linebreak.xht
+ Skip => Pass css/CSS2/floats/float-in-nested-multicol-001.html
! Skip => Fail css/CSS2/floats/float-nowrap-1.html
+ Skip => Pass css/CSS2/text/text-indent-113-ref-margin.xht
+ Skip => Pass css/CSS2/text/text-indent-wrap-001-notref-block-margin.xht
+ Skip => Pass css/CSS2/text/text-indent-wrap-001-ref-float.xht
! Skip => Fail css/CSS2/visudet/content-height-005.html
+ Skip => Pass css/CSS2/visudet/line-height-203.html
+ Skip => Pass css/CSS2/visudet/line-height-206.html
! Skip => Fail css/compositing/mix-blend-mode/mix-blend-mode-image.html
! Skip => Fail css/compositing/mix-blend-mode/mix-blend-mode-video-sibling.html
! Skip => Fail css/compositing/mix-blend-mode/mix-blend-mode-video.html
! Skip => Fail css/css-backgrounds/background-gradient-interpolation-001.html
! Skip => Fail css/css-backgrounds/background-gradient-interpolation-002.html
+ Skip => Pass css/css-backgrounds/border-width-pixel-snapping-001-a.html
+ Skip => Pass css/css-backgrounds/border-width-small-values-001-a.html
+ Skip => Pass css/css-backgrounds/border-width-small-values-001-b.html
+ Skip => Pass css/css-backgrounds/border-width-small-values-001-c.html
+ Skip => Pass css/css-backgrounds/border-width-small-values-001-d.html
+ Skip => Pass css/css-backgrounds/border-width-small-values-001-e.html
+ Skip => Pass css/css-break/break-inside-avoid-multicol-iframe-crash-print.html
+ Skip => Pass css/css-break/firefox-bug-2026295-print.html
! Skip => Fail css/css-color-adjust/rendering/dark-color-scheme/color-scheme-change-checkbox.html
+ Skip => Pass css/css-color/t31-color-text-a.xht
- Pass => Crash css/css-contain/contain-inline-size-grid-indefinite-height-min-height-flex-row.html
! Skip => Fail css/css-contain/contain-layout-breaks-002.html
! Skip => Fail css/css-counter-styles/counter-style-at-rule/disclosure-closed-extends-direction-001.html
! Skip => Fail css/css-counter-styles/counter-style-at-rule/disclosure-closed-extends-direction-002.html
! Skip => Fail css/css-counter-styles/counter-style-at-rule/disclosure-closed-extends-direction-003.html
! Skip => Fail css/css-counter-styles/counter-style-at-rule/disclosure-open-vs-closed-001.html
! Skip => Fail css/css-counter-styles/counter-style-at-rule/disclosure-open-vs-closed-002.html
+ Skip => Pass css/css-counter-styles/counter-style-at-rule/empty-string-symbol.html
! Skip => Fail css/css-flexbox/inline-flexbox-vertical-rl-image-flexitem-crash-print.html
+ Skip => Pass css/css-font-loading/fontface-from-arraybuffer.html
! Skip => Fail css/css-fonts/font-palette-13.html
! Skip => Fail css/css-fonts/font-palette-16.html
! Skip => Fail css/css-fonts/font-palette-17.html
! Skip => Fail css/css-fonts/font-palette-18.html
! Skip => Fail css/css-fonts/font-palette-19.html
! Skip => Fail css/css-fonts/font-palette-22.html
! Skip => Fail css/css-fonts/font-palette-3.html
! Skip => Fail css/css-fonts/font-palette-4.html
! Skip => Fail css/css-fonts/font-palette-5.html
! Skip => Fail css/css-fonts/font-palette-6.html
! Skip => Fail css/css-fonts/font-palette-7.html
! Skip => Fail css/css-fonts/font-palette-8.html
! Skip => Fail css/css-fonts/font-palette-9.html
! Skip => Fail css/css-fonts/font-palette-add.html
! Skip => Fail css/css-fonts/font-palette-modify.html
! Skip => Fail css/css-fonts/font-palette-remove.html
! Skip => Fail css/css-fonts/font-variant-emoji-1.html
! Skip => Fail css/css-fonts/font-variant-position-04.html
+ Skip => Pass css/css-fonts/font-variant-position-05.html
! Skip => Fail css/css-fonts/hiragana-katakana-kerning.html
! Skip => Fail css/css-fonts/lang-attribute-affects-rendering-of-second-text-run.html
! Skip => Fail css/css-fonts/lang-attribute-affects-rendering.html
! Skip => Fail css/css-fonts/matching/font-unicode-PUA-primary-font.html
! Skip => Fail css/css-fonts/palette-values-rule-add.html
! Skip => Fail css/css-fonts/palette-values-rule-delete.html
+ Skip => Pass css/css-fonts/standard-font-family-10.html
+ Skip => Pass css/css-fonts/standard-font-family-11.html
+ Skip => Pass css/css-fonts/standard-font-family-12.html
+ Skip => Pass css/css-fonts/standard-font-family-13.html
+ Skip => Pass css/css-fonts/standard-font-family-14.html
+ Skip => Pass css/css-fonts/standard-font-family-15.html
+ Skip => Pass css/css-fonts/standard-font-family-16.html
+ Skip => Pass css/css-fonts/standard-font-family-17.html
+ Skip => Pass css/css-fonts/standard-font-family-18.html
+ Skip => Pass css/css-fonts/standard-font-family-19.html
+ Skip => Pass css/css-fonts/standard-font-family-20.html
+ Skip => Pass css/css-fonts/standard-font-family-3.html
+ Skip => Pass css/css-fonts/standard-font-family-4.html
+ Skip => Pass css/css-fonts/standard-font-family-5.html
+ Skip => Pass css/css-fonts/standard-font-family-8.html
+ Skip => Pass css/css-fonts/standard-font-family-9.html
+ Skip => Pass css/css-fonts/system-ui-ar.html
! Skip => Fail css/css-fonts/system-ui-ja-vs-zh.html
! Skip => Fail css/css-fonts/system-ui-ja.html
! Skip => Fail css/css-fonts/system-ui-ur-vs-ar.html
+ Skip => Pass css/css-fonts/system-ui-ur.html
! Skip => Fail css/css-fonts/system-ui-zh.html
+ Skip => Pass css/css-fonts/system-ui.html
+ Skip => Pass css/css-fonts/test-synthetic-bold.html
+ Skip => Pass css/css-fonts/test-synthetic-italic.html
- Pass => Fail css/css-fonts/variations/variable-avar2-rvrn.html
- Pass => Fail css/css-fonts/variations/variable-avar2-warp.html
! Skip => Fail css/css-forms/select-combobox-print.html
! Skip => Fail css/css-highlight-api/highlight-image.html
! Skip => Fail css/css-highlight-api/highlight-text-dynamic.html
! Skip => Fail css/css-images/image-rendering-border-image.html
+ Skip => Pass css/css-images/image-rendering-mixed-scaled.html
+ Skip => Pass css/css-images/multiple-position-color-stop-linear-2.html
+ Skip => Pass css/css-images/multiple-position-color-stop-radial-2.html
! Skip => Fail css/css-multicol/column-count-used-001.html
! Skip => Fail css/css-overflow/overflow-video-hidden.html
! Skip => Fail css/css-page/basic-pagination-004-print.html
+ Skip => Pass css/css-page/basic-pagination-005-print.html
+ Skip => Pass css/css-page/page-orientation-on-portrait-002-print.html
+ Skip => Pass css/css-page/page-orientation-on-portrait-003-print.html
+ Skip => Pass css/css-page/tentative/safe-printable-inset-large-crash-print.html
! Skip => Fail css/css-position/hypothetical-box-scroll-parent.html
! Skip => Fail css/css-position/hypothetical-box-scroll-viewport.html
+ Skip => Pass css/css-position/position-fixed-video-controls-print.html
! Skip => Fail css/css-pseudo/active-selection-041.html
! Skip => Fail css/css-pseudo/file-selector-button-001.html
! Skip => Fail css/css-pseudo/file-selector-button-after-part.html
! Skip => Fail css/css-pseudo/file-selector-button-float.html
! Skip => Fail css/css-pseudo/highlight-cascade/highlight-paired-cascade-004.html
+ Skip => Pass css/css-pseudo/marker-inherit-line-height.html
! Skip => Fail css/css-pseudo/placeholder-input-number.html
! Skip => Fail css/css-pseudo/selection-background-color-transparent.html
+ Skip => Pass css/css-pseudo/selection-paint-image.html
! Skip => Fail css/css-pseudo/slider/slider-fill-001.html
! Skip => Fail css/css-pseudo/slider/slider-fill-002.html
! Skip => Fail css/css-pseudo/slider/slider-fill-003.html
! Skip => Fail css/css-pseudo/slider/slider-thumb-001.html
! Skip => Fail css/css-pseudo/slider/slider-track-001.html
! Skip => Fail css/css-pseudo/slider/slider-track-002.html
! Skip => Fail css/css-pseudo/slider/slider-track-003.html
+ Skip => Pass css/css-pseudo/spelling-error-006.html
! Skip => Fail css/css-ruby/interlinear-block-margin-box.html
+ Skip => Pass css/css-ruby/ruby-reflow-001-opaqueruby.html
- Pass => Fail css/css-scrollbars/scrollbar-color-006.html
- Pass => Fail css/css-scrollbars/scrollbar-color-007.html
- Pass => Fail css/css-scrollbars/scrollbar-color-008.html
- Pass => Fail css/css-scrollbars/scrollbar-color-009.html
- Pass => Fail css/css-scrollbars/scrollbar-color-010.html
- Pass => Fail css/css-scrollbars/scrollbar-color-011.html
- Pass => Fail css/css-scrollbars/scrollbar-color-dynamic-1.html
- Pass => Fail css/css-scrollbars/scrollbar-color-dynamic-2.html
- Pass => Fail css/css-scrollbars/scrollbar-color-dynamic-3.html
- Pass => Fail css/css-scrollbars/scrollbar-color-dynamic-4.html
- Pass => Fail css/css-scrollbars/scrollbar-color-dynamic-5.html
- Pass => Fail css/css-scrollbars/scrollbar-color-dynamic-6.html
- Pass => Fail css/css-scrollbars/scrollbar-color-dynamic-7.html
- Pass => Fail css/css-scrollbars/scrollbar-width-paint-001.html
- Pass => Fail css/css-scrollbars/scrollbar-width-paint-002.html
- Pass => Fail css/css-scrollbars/scrollbar-width-paint-004.html
- Pass => Fail css/css-scrollbars/scrollbar-width-paint-006.html
- Pass => Fail css/css-scrollbars/viewport-scrollbar-body.html
- Pass => Fail css/css-scrollbars/viewport-scrollbar.html
! Skip => Fail css/css-shadow/part/interaction-with-placeholder.html
+ Skip => Pass css/css-tables/border-collapse-double-border.html
! Skip => Fail css/css-tables/tfoot-crash-print.html
! Skip => Fail css/css-text-decor/text-combine-emphasis.html
+ Skip => Pass css/css-text-decor/text-decoration-inset-010.html
+ Skip => Pass css/css-text-decor/text-decoration-line-through-wavy-covers-whole-line-length-001.html
+ Skip => Pass css/css-text-decor/text-decoration-overline-wavy-covers-whole-line-length-001.html
! Skip => Fail css/css-text-decor/text-decoration-skip-ink-001.html
! Skip => Fail css/css-text-decor/text-decoration-skip-ink-004.html
! Skip => Fail css/css-text-decor/text-decoration-skip-ink-005.html
! Skip => Fail css/css-text-decor/text-decoration-skip-ink-sidewayslr-001.html
! Skip => Fail css/css-text-decor/text-decoration-skip-ink-sidewaysrl-001.html
! Skip => Fail css/css-text-decor/text-decoration-skip-ink-upright-001.html
! Skip => Fail css/css-text-decor/text-decoration-skip-ink-vertical-001.html
+ Skip => Pass css/css-text-decor/text-decoration-subelements-001.html
! Skip => Fail css/css-text-decor/text-decoration-thickness-001.html
! Skip => Fail css/css-text-decor/text-decoration-thickness-single.html
+ Skip => Pass css/css-text-decor/text-decoration-thickness-single2.html
+ Skip => Pass css/css-text-decor/text-decoration-underline-wavy-covers-whole-line-length-001.html
! Skip => Fail css/css-text-decor/text-shadow/blur.html
! Skip => Fail css/css-text-decor/text-underline-offset-001.html
! Skip => Fail css/css-text-decor/text-underline-offset-negative.html
! Skip => Fail css/css-text/hyphens/hyphens-shaping-002.html
+ Skip => Pass css/css-text/line-breaking/line-breaking-023.html
! Skip => Fail css/css-text/line-breaking/line-breaking-024.html
! Skip => Fail css/css-text/line-breaking/line-breaking-025.html
! Skip => Fail css/css-text/line-breaking/line-breaking-026.html
! Skip => Fail css/css-text/line-breaking/line-breaking-027.html
! Skip => Fail css/css-text/text-align/text-align-center-last-center.html
! Skip => Fail css/css-text/text-align/text-align-center-last-end.html
! Skip => Fail css/css-text/text-align/text-align-center-last-justify.html
! Skip => Fail css/css-text/text-align/text-align-center-last-start.html
! Skip => Fail css/css-text/text-align/text-align-end-last-center.html
! Skip => Fail css/css-text/text-align/text-align-end-last-end.html
! Skip => Fail css/css-text/text-align/text-align-end-last-justify.html
! Skip => Fail css/css-text/text-align/text-align-end-last-start.html
! Skip => Fail css/css-text/text-align/text-align-justify-last-center.html
! Skip => Fail css/css-text/text-align/text-align-justify-last-end.html
! Skip => Fail css/css-text/text-align/text-align-justify-last-justify.html
! Skip => Fail css/css-text/text-align/text-align-justify-last-start.html
! Skip => Fail css/css-text/text-align/text-align-start-last-center.html
! Skip => Fail css/css-text/text-align/text-align-start-last-end.html
! Skip => Fail css/css-text/text-align/text-align-start-last-justify.html
! Skip => Fail css/css-text/text-align/text-align-start-last-start.html
- Pass => Fail css/css-text/text-autospace/text-autospace-dynamic-001.html
- Pass => Fail css/css-text/text-autospace/text-autospace-no-001.html
! Skip => Fail css/css-text/text-stroke-width-subpixel.html
+ Skip => Pass css/css-text/white-space/control-chars-000.html
+ Skip => Pass css/css-text/white-space/control-chars-001.html
+ Skip => Pass css/css-text/white-space/control-chars-002.html
+ Skip => Pass css/css-text/white-space/control-chars-003.html
+ Skip => Pass css/css-text/white-space/control-chars-004.html
+ Skip => Pass css/css-text/white-space/control-chars-005.html
+ Skip => Pass css/css-text/white-space/control-chars-006.html
+ Skip => Pass css/css-text/white-space/control-chars-007.html
+ Skip => Pass css/css-text/white-space/control-chars-008.html
! Skip => Fail css/css-text/white-space/control-chars-00B.html
! Skip => Fail css/css-text/white-space/control-chars-00C.html
+ Skip => Pass css/css-text/white-space/control-chars-00E.html
+ Skip => Pass css/css-text/white-space/control-chars-00F.html
+ Skip => Pass css/css-text/white-space/control-chars-010.html
+ Skip => Pass css/css-text/white-space/control-chars-011.html
+ Skip => Pass css/css-text/white-space/control-chars-012.html
+ Skip => Pass css/css-text/white-space/control-chars-013.html
+ Skip => Pass css/css-text/white-space/control-chars-014.html
+ Skip => Pass css/css-text/white-space/control-chars-015.html
+ Skip => Pass css/css-text/white-space/control-chars-016.html
+ Skip => Pass css/css-text/white-space/control-chars-017.html
+ Skip => Pass css/css-text/white-space/control-chars-018.html
+ Skip => Pass css/css-text/white-space/control-chars-019.html
+ Skip => Pass css/css-text/white-space/control-chars-01A.html
+ Skip => Pass css/css-text/white-space/control-chars-01B.html
+ Skip => Pass css/css-text/white-space/control-chars-01C.html
+ Skip => Pass css/css-text/white-space/control-chars-01D.html
+ Skip => Pass css/css-text/white-space/control-chars-01E.html
+ Skip => Pass css/css-text/white-space/control-chars-01F.html
+ Skip => Pass css/css-text/white-space/control-chars-07F.html
+ Skip => Pass css/css-text/white-space/control-chars-080.html
+ Skip => Pass css/css-text/white-space/control-chars-081.html
+ Skip => Pass css/css-text/white-space/control-chars-082.html
+ Skip => Pass css/css-text/white-space/control-chars-083.html
+ Skip => Pass css/css-text/white-space/control-chars-084.html
! Skip => Fail css/css-text/white-space/control-chars-085.html
+ Skip => Pass css/css-text/white-space/control-chars-086.html
+ Skip => Pass css/css-text/white-space/control-chars-087.html
+ Skip => Pass css/css-text/white-space/control-chars-088.html
+ Skip => Pass css/css-text/white-space/control-chars-089.html
+ Skip => Pass css/css-text/white-space/control-chars-08A.html
+ Skip => Pass css/css-text/white-space/control-chars-08B.html
+ Skip => Pass css/css-text/white-space/control-chars-08C.html
+ Skip => Pass css/css-text/white-space/control-chars-08D.html
+ Skip => Pass css/css-text/white-space/control-chars-08E.html
+ Skip => Pass css/css-text/white-space/control-chars-08F.html
+ Skip => Pass css/css-text/white-space/control-chars-090.html
+ Skip => Pass css/css-text/white-space/control-chars-091.html
+ Skip => Pass css/css-text/white-space/control-chars-092.html
+ Skip => Pass css/css-text/white-space/control-chars-093.html
+ Skip => Pass css/css-text/white-space/control-chars-094.html
+ Skip => Pass css/css-text/white-space/control-chars-095.html
+ Skip => Pass css/css-text/white-space/control-chars-096.html
+ Skip => Pass css/css-text/white-space/control-chars-097.html
+ Skip => Pass css/css-text/white-space/control-chars-098.html
+ Skip => Pass css/css-text/white-space/control-chars-099.html
+ Skip => Pass css/css-text/white-space/control-chars-09A.html
+ Skip => Pass css/css-text/white-space/control-chars-09B.html
+ Skip => Pass css/css-text/white-space/control-chars-09C.html
+ Skip => Pass css/css-text/white-space/control-chars-09D.html
+ Skip => Pass css/css-text/white-space/control-chars-09E.html
+ Skip => Pass css/css-text/white-space/control-chars-09F.html
! Skip => Fail css/css-text/white-space/object-replacement-1.html
! Skip => Fail css/css-text/white-space/object-replacement-2.html
! Skip => Fail css/css-text/white-space/text-wrap-balance-002.html
- Pass => Fail css/css-text/white-space/text-wrap-balance-004.html
! Skip => Fail css/css-text/word-break/word-break-normal-002.html
! Skip => Fail css/css-text/word-break/word-break-normal-003.html
! Skip => Fail css/css-text/word-break/word-break-normal-th-001.html
! Skip => Fail css/css-transforms/css-transform-animate-translate-implied-y.html
! Skip => Fail css/css-transforms/preserve3d-overflow-percent.html
! Skip => Crash css/css-transforms/text-perspective-001.html
+ Skip => Pass css/css-transforms/transform-abspos-005.html
! Skip => Crash css/css-transforms/transform-flattening-001.html
+ Skip => Pass css/css-transforms/transform-origin-001.html
+ Skip => Pass css/css-transforms/transform-origin-002.html
- Pass => Fail css/css-transforms/transform-table-009.html
- Pass => Fail css/css-transforms/transform-table-010.html
- Pass => Fail css/css-transforms/transform-table-011.html
- Pass => Fail css/css-transforms/transform3d-matrix3d-002.html
- Pass => Fail css/css-transforms/transform3d-matrix3d-003.html
- Pass => Fail css/css-transforms/transform3d-matrix3d-004.html
- Pass => Fail css/css-transforms/transform3d-perspective-001.html
- Pass => Fail css/css-transforms/transform3d-perspective-002.html
- Pass => Fail css/css-transforms/transform3d-perspective-007.html
- Pass => Fail css/css-transforms/transform3d-perspective-009.html
- Pass => Fail css/css-transforms/transform3d-rotate3d-002.html
! Skip => Fail css/css-transforms/transform3d-rotatex-perspective-001.html
! Skip => Fail css/css-transforms/transform3d-rotatex-perspective-002.html
- Pass => Fail css/css-transforms/transform3d-rotatex-perspective-003.html
- Pass => Fail css/css-transforms/transform3d-rotatex-transformorigin-001.html
- Pass => Fail css/css-transforms/transform3d-rotatey-001.html
- Pass => Fail css/css-transforms/transform3d-translate3d-001.html
- Pass => Fail css/css-transforms/transform3d-translatez-001.html
+ Skip => Pass css/css-transforms/ttwf-css-3d-polygon-cycle-mismatch.html
! Skip => Fail css/css-ui/accent-color-checkbox-checked-001.html
! Skip => Fail css/css-ui/accent-color-radio-checked-001.html
! Skip => Fail css/css-ui/appearance-menulist-button-002.tentative.html
! Skip => Fail css/css-ui/caret-eol-001.html
! Skip => Fail css/css-ui/caret-eol-002.html
+ Skip => Pass css/css-ui/caret-eol-003.html
! Skip => Fail css/css-ui/caret-eol-004.tentative.html
! Skip => Fail css/css-ui/caret-shape-underscore-001.html
! Skip => Fail css/css-ui/outline-007.html
+ Skip => Pass css/css-ui/outline-021.html
! Skip => Fail css/css-ui/outline-offset-inset-006.html
! Skip => Fail css/css-ui/outline-offset-table-001.html
! Skip => Fail css/css-ui/webkit-appearance-menulist-button-002.tentative.html
- Pass => Fail css/css-values/viewport-page-print.html
! Skip => Fail css/css-variables/variable-reference-without-whitespace.html
! Skip => Fail css/css-viewport/zoom/explicit-inherit/border-radius.html
+ Skip => Pass css/css-viewport/zoom/explicit-inherit/column.html
! Skip => Fail css/css-viewport/zoom/explicit-inherit/flex-basis.html
+ Skip => Pass css/css-viewport/zoom/explicit-inherit/margin.html
+ Skip => Pass css/css-viewport/zoom/explicit-inherit/outline.html
! Skip => Fail css/css-viewport/zoom/explicit-inherit/webkit-border-radius.html
! Skip => Fail css/css-viewport/zoom/explicit-inherit/webkit-flex-basis.html
+ Skip => Pass css/css-viewport/zoom/iframe-zoom-nested.html
+ Skip => Pass css/css-viewport/zoom/iframe-zoom.sub.html
+ Skip => Pass css/css-writing-modes/astral-bidi/adlam.html
+ Skip => Pass css/css-writing-modes/astral-bidi/cypriot.html
! Skip => Fail css/css-writing-modes/forms/button-appearance-native-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/button-appearance-native-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/button-appearance-none-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/button-appearance-none-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/color-input-appearance-native-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/color-input-appearance-native-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/color-input-appearance-none-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/color-input-appearance-none-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/date-input-appearance-native-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/date-input-appearance-native-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/date-input-appearance-none-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/date-input-appearance-none-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/file-input-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/file-input-vertical-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/file-input-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/meter-appearance-native-horizontal-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/meter-appearance-native-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/meter-appearance-native-vertical-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/meter-appearance-native-vertical.optional.html
+ Skip => Pass css/css-writing-modes/forms/progress-appearance-native-horizontal-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/progress-appearance-native-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/progress-appearance-native-vertical-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/progress-appearance-native-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/progress-appearance-none-horizontal-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/progress-appearance-none-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/progress-appearance-none-vertical-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/progress-appearance-none-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/range-input-appearance-native-horizontal-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/range-input-appearance-native-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/range-input-appearance-native-vertical-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/range-input-appearance-native-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/range-input-appearance-none-horizontal-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/range-input-appearance-none-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/range-input-appearance-none-vertical-rtl.optional.html
! Skip => Fail css/css-writing-modes/forms/range-input-appearance-none-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/select-appearance-native-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/select-appearance-native-vertical.optional.html
! Skip => Fail css/css-writing-modes/forms/select-appearance-none-horizontal.optional.html
- Pass => Fail css/css-writing-modes/forms/select-appearance-none-vertical-lr.optional.html
- Pass => Fail css/css-writing-modes/forms/select-appearance-none-vertical-rl.optional.html
! Skip => Fail css/css-writing-modes/forms/select-multiple-appearance-native-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/select-multiple-appearance-native-vlr.optional.html
! Skip => Fail css/css-writing-modes/forms/select-multiple-appearance-native-vrl.optional.html
! Skip => Fail css/css-writing-modes/forms/select-multiple-appearance-none-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/select-multiple-appearance-none-vlr.optional.html
! Skip => Fail css/css-writing-modes/forms/select-multiple-appearance-none-vrl.optional.html
! Skip => Fail css/css-writing-modes/forms/textarea-appearance-native-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/textarea-appearance-native-vlr.optional.html
! Skip => Fail css/css-writing-modes/forms/textarea-appearance-native-vrl.optional.html
! Skip => Fail css/css-writing-modes/forms/textarea-appearance-none-horizontal.optional.html
! Skip => Fail css/css-writing-modes/forms/textarea-appearance-none-vlr.optional.html
! Skip => Fail css/css-writing-modes/forms/textarea-appearance-none-vrl.optional.html
! Skip => Fail css/css-writing-modes/full-width-001.html
! Skip => Fail css/css-writing-modes/full-width-002.html
! Skip => Fail css/css-writing-modes/full-width-003.html
- Pass => Fail css/css-writing-modes/text-combine-upright-value-digits2-003.html
- Pass => Fail css/css-writing-modes/text-combine-upright-value-digits3-003.html
- Pass => Fail css/css-writing-modes/text-combine-upright-value-digits4-003.html
- Pass => Fail css/css-writing-modes/text-combine-upright-value-none-001.html
+ Skip => Pass css/filter-effects/backdrop-filter-svg-background-image-blur.html
! Skip => Fail css/filter-effects/blur-clip-stacking-context-002.html
+ Skip => Pass css/filter-effects/filter-svg-background-image-blur.html
+ Skip => Pass css/printing/animated-image-print-image-orientation-none.html
+ Skip => Pass css/printing/animated-image-print.html
+ Skip => Pass css/printing/conic-gradient-skia-crash-print.html
+ Skip => Pass css/printing/destination-backslash-crash-print.html
+ Skip => Pass css/printing/emoji-print.html
+ Skip => Pass css/printing/fixed-pos-object-pdf-crash-print.html
+ Skip => Pass css/printing/fragmented-inline-block-001-print.html
+ Skip => Pass css/printing/huge-font-crash-print.html
! Skip => Fail css/printing/input-password-print.html
+ Skip => Pass css/printing/number-input-link-crash-print.html
! Skip => Fail css/printing/page-overflow-crash-print.html
! Skip => Fail css/printing/table-container-query-crash-print.html
! Skip => Fail css/printing/table-overflow-quirks-frameset-crash-print.html
! Skip => Fail css/selectors/first-letter-flag-001.html
! Skip => Fail css/selectors/first-line-bidi-001.html
! Skip => Fail css/selectors/first-line-bidi-002.html
+ Skip => Pass css/selectors/floating-first-letter-05d0.html
+ Skip => Pass css/selectors/floating-first-letter-feff.html
! Skip => Fail css/selectors/selection-image-001.html
! Skip => Fail css/selectors/selection-image-002.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31330510331).</sub>
<!-- wpt-results-end -->
