### PR TITLE
wpt: add --diff flag that diffs a run against the latest main-branch results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /examples/output/**/*.jpeg
 /out
 /wpt/output
+/wpt/cache
 /wpt/*.json
 /apps/wpt/output
 /sites

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3902,6 +3902,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6056,6 +6058,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -6399,16 +6402,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-jsonlines"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bdd6db666f827c1843d4710520093675e6c0b6e39a02e1a8d9e9b2f71cbb58"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -9281,6 +9274,7 @@ dependencies = [
  "pollster",
  "rayon",
  "regex",
+ "reqwest",
  "serde_json",
  "stylo_traits",
  "supports-hyperlinks",
@@ -9289,17 +9283,18 @@ dependencies = [
  "thread_local",
  "url",
  "wptreport",
+ "zstd",
 ]
 
 [[package]]
 name = "wptreport"
-version = "0.0.5"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b22e83bcee4a21b467d421fb50924b19176898babbc1aa30af9668fa6068f0b"
+checksum = "953056bb09aa6fcbc8503d338d9440b8545fb459acb0d93373d94ca32d615987"
 dependencies = [
+ "indexmap",
  "rayon",
  "serde",
- "serde-jsonlines",
  "serde_json",
 ]
 
@@ -9682,6 +9677,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/wpt/runner/Cargo.toml
+++ b/wpt/runner/Cargo.toml
@@ -41,6 +41,8 @@ pollster = "0.4.0"
 atomic_float = "1"
 supports-hyperlinks = "3.1.0"
 terminal-link = "0.1.0"
-wptreport = { version = "0.0.5", default-features = false }
+wptreport = { version = "0.0.13", default-features = false }
+reqwest = { workspace = true, features = ["blocking", "native-tls"] }
+zstd = "0.13"
 os_info = "3.10.0"
 serde_json = "1.0.140"

--- a/wpt/runner/src/diff.rs
+++ b/wpt/runner/src/diff.rs
@@ -1,0 +1,205 @@
+//! Diffing a local test run against the latest results from the `main` branch.
+//!
+//! The `main` branch results are published to GitHub Pages by the WPT CI workflow. They are cached
+//! locally (in `wpt/cache`) and revalidated with a conditional (`If-Modified-Since`) request on
+//! each run.
+
+use std::fs;
+use std::io::Cursor;
+use std::path::Path;
+use std::time::Duration;
+
+use owo_colors::OwoColorize;
+use reqwest::StatusCode;
+use reqwest::blocking::Client;
+use wptreport::TestResultIter as _;
+use wptreport::aggregate::aggregate;
+use wptreport::wpt_report::{TestResult, TestStatus, WptReport};
+
+/// The `main` branch report, as published by the WPT CI workflow
+const MAIN_REPORT_URL: &str = "https://dioxuslabs.github.io/blitz/wptreport.json.zst";
+const REPORT_FILE_NAME: &str = "main-wptreport.json.zst";
+const LAST_MODIFIED_FILE_NAME: &str = "main-wptreport.last-modified";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Download the latest `main` branch report, using (and updating) a local cache in `cache_dir`.
+///
+/// The report is filtered down to the tests belonging to `suites` so that a partial run is only
+/// diffed against the corresponding part of the `main` branch results.
+///
+/// Returns `None` if the report could neither be downloaded nor read from the cache.
+pub fn fetch_main_report(cache_dir: &Path, suites: &[String]) -> Option<WptReport> {
+    let report_path = cache_dir.join(REPORT_FILE_NAME);
+    let last_modified_path = cache_dir.join(LAST_MODIFIED_FILE_NAME);
+
+    if let Err(err) = fs::create_dir_all(cache_dir) {
+        eprintln!("Failed to create cache directory {cache_dir:?}: {err}");
+        return None;
+    }
+
+    // Only send If-Modified-Since if we actually have the corresponding cached report
+    let cached_last_modified = report_path
+        .exists()
+        .then(|| fs::read_to_string(&last_modified_path).ok())
+        .flatten();
+
+    match download(cached_last_modified.as_deref()) {
+        Ok(Some(response)) => {
+            if let Err(err) = fs::write(&report_path, &response.body) {
+                eprintln!("Failed to write cached report to {report_path:?}: {err}");
+                return None;
+            }
+            match response.last_modified {
+                Some(last_modified) => {
+                    let _ = fs::write(&last_modified_path, last_modified);
+                }
+                // Without a Last-Modified value we cannot revalidate: drop any stale one
+                None => {
+                    let _ = fs::remove_file(&last_modified_path);
+                }
+            }
+            println!("Downloaded new main-branch results");
+        }
+        Ok(None) => println!("Cached main-branch results are up to date"),
+        Err(err) => {
+            eprintln!("Failed to download main-branch results: {err}");
+            if !report_path.exists() {
+                return None;
+            }
+            eprintln!("Falling back to cached results");
+        }
+    }
+
+    let mut report = parse_report(&report_path)?;
+    report
+        .results
+        .retain(|test| suites.iter().any(|suite| test.test.starts_with(suite)));
+
+    Some(report)
+}
+
+struct Response {
+    body: Vec<u8>,
+    last_modified: Option<String>,
+}
+
+/// Returns `Ok(None)` if the server responded that the cached copy is still up to date.
+fn download(cached_last_modified: Option<&str>) -> Result<Option<Response>, String> {
+    let client = Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|err| err.to_string())?;
+
+    let mut request = client.get(MAIN_REPORT_URL);
+    if let Some(last_modified) = cached_last_modified {
+        request = request.header("If-Modified-Since", last_modified);
+    }
+
+    let response = request.send().map_err(|err| err.to_string())?;
+
+    if response.status() == StatusCode::NOT_MODIFIED {
+        return Ok(None);
+    }
+    if !response.status().is_success() {
+        return Err(format!("{MAIN_REPORT_URL} returned {}", response.status()));
+    }
+
+    let last_modified = response
+        .headers()
+        .get("last-modified")
+        .and_then(|value| value.to_str().ok())
+        .map(String::from);
+    let body = response.bytes().map_err(|err| err.to_string())?.to_vec();
+
+    Ok(Some(Response {
+        body,
+        last_modified,
+    }))
+}
+
+fn parse_report(report_path: &Path) -> Option<WptReport> {
+    let compressed = fs::read(report_path)
+        .map_err(|err| format!("Failed to read {report_path:?}: {err}"))
+        .ok()?;
+    let json = zstd::decode_all(Cursor::new(&compressed))
+        .map_err(|err| format!("Failed to decompress {report_path:?}: {err}"))
+        .ok()?;
+    serde_json::from_slice(&json)
+        .map_err(|err| format!("Failed to parse {report_path:?}: {err}"))
+        .ok()
+}
+
+/// Print a diff of `current` against `main_report` (the baseline).
+pub fn print_diff(main_report: WptReport, current: WptReport) {
+    println!(
+        "\nDiff against main ({})\n=====================",
+        main_report
+            .run_info
+            .browser_version
+            .as_deref()
+            .unwrap_or("unknown revision")
+    );
+
+    let mut added = 0u32;
+    let mut removed = 0u32;
+    let mut improved = 0u32;
+    let mut regressed = 0u32;
+
+    let mut reports = [main_report, current];
+    aggregate(&mut reports, |results| match (results[0], results[1]) {
+        (None, None) => unreachable!(),
+        (Some(base), None) => {
+            removed += 1;
+            println!("{} {}", "REM ".bright_black(), base.test);
+        }
+        (None, Some(new)) => {
+            added += 1;
+            println!("{} {}", "ADD ".bright_black(), new.test);
+        }
+        (Some(base), Some(new)) => {
+            let base_counts = base.subtest_counts();
+            let new_counts = new.subtest_counts();
+            if base_counts == new_counts {
+                return;
+            }
+
+            let change = format!(
+                "{} => {} {}",
+                format_counts(base),
+                format_counts(new),
+                new.test
+            );
+            if new_counts.pass_fraction() >= base_counts.pass_fraction() {
+                improved += 1;
+                println!("{}", change.green());
+            } else {
+                regressed += 1;
+                println!("{}", change.red());
+            }
+        }
+    });
+
+    println!("---\n");
+    println!("{regressed:>4} tests REGRESSED");
+    println!("{improved:>4} tests IMPROVED");
+    println!("{added:>4} tests ADDED");
+    println!("{removed:>4} tests REMOVED");
+    if regressed == 0 && improved == 0 && added == 0 && removed == 0 {
+        println!("\nNo changes compared to main");
+    }
+}
+
+fn format_counts(test: &TestResult) -> String {
+    let counts = test.subtest_counts();
+    let status = match test.status {
+        TestStatus::Pass | TestStatus::Ok => "PASS",
+        TestStatus::Fail => "FAIL",
+        TestStatus::Skip => "SKIP",
+        TestStatus::Crash => "CRASH",
+        TestStatus::Error => "ERROR",
+        TestStatus::Timeout => "TIMEOUT",
+        TestStatus::Assert => "ASSERT",
+        TestStatus::PreconditionFailed => "PRECONDITION_FAILED",
+    };
+    format!("{status}({}/{})", counts.pass, counts.total)
+}

--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -37,6 +37,7 @@ use std::{env, fs};
 
 mod test_runners;
 
+mod diff;
 mod net_provider;
 mod panic_backtrace;
 mod report;
@@ -201,9 +202,8 @@ fn filter_path(p: &Path) -> bool {
     !(is_ref | is_notref | is_manual | is_support_file | is_blocked | is_dir)
 }
 
-fn collect_tests(wpt_dir: &Path) -> Vec<PathBuf> {
-    let mut test_paths = Vec::new();
-
+/// The test suites (path prefixes relative to `WPT_DIR`) to run
+fn collect_suites() -> Vec<String> {
     let mut suites: Vec<_> = std::env::args()
         .skip(1)
         .filter(|arg| !arg.starts_with('-'))
@@ -212,6 +212,11 @@ fn collect_tests(wpt_dir: &Path) -> Vec<PathBuf> {
         suites.push("css/css-flexbox".to_string());
         suites.push("css/css-grid".to_string());
     }
+    suites
+}
+
+fn collect_tests(wpt_dir: &Path, suites: &[String]) -> Vec<PathBuf> {
+    let mut test_paths = Vec::new();
 
     for suite in suites {
         for pat in ["", "/**/*.htm", "/**/*.html", "/**/*.xht", "/**/*.xhtml"] {
@@ -395,6 +400,7 @@ fn main() {
     std::panic::set_hook(Box::new(panic_backtrace::stash_panic_handler));
 
     let verbose = env::args().any(|arg| arg == "--verbose" || arg == "-v");
+    let diff = env::args().any(|arg| arg == "--diff");
     let wpt_dir = path::absolute(env::var("WPT_DIR").expect("WPT_DIR is not set")).unwrap();
     info!("WPT_DIR: {}", wpt_dir.display());
     if !wpt_dir.exists() {
@@ -402,15 +408,21 @@ fn main() {
             "WPT_DIR does not exist. This should be set to a local copy of https://github.com/web-platform-tests/wpt."
         );
     }
-    let test_paths = collect_tests(&wpt_dir);
+    let suites = collect_suites();
+    let test_paths = collect_tests(&wpt_dir, &suites);
     let count = test_paths.len();
 
     let cargo_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let out_dir = cargo_dir.parent().unwrap().join("output");
+    let wpt_crate_dir = cargo_dir.parent().unwrap();
+    let out_dir = wpt_crate_dir.join("output");
     if fs::exists(&out_dir).unwrap() {
         fs::remove_dir_all(&out_dir).unwrap();
     }
     fs::create_dir(&out_dir).unwrap();
+
+    // Fetch (and cache) the main-branch results up-front so that network failures are reported
+    // before spending time running the tests.
+    let main_report = diff.then(|| diff::fetch_main_report(&wpt_crate_dir.join("cache"), &suites));
 
     let pass_count = AtomicU32::new(0);
     let fail_count = AtomicU32::new(0);
@@ -755,4 +767,11 @@ fn main() {
         report_path,
         write_report_start.elapsed().as_millis()
     );
+
+    // Diff against the main-branch results
+    match main_report {
+        None => {}
+        Some(None) => eprintln!("\nSkipping diff: no main-branch results available"),
+        Some(Some(main_report)) => diff::print_diff(main_report, report),
+    }
 }

--- a/wpt/runner/src/report.rs
+++ b/wpt/runner/src/report.rs
@@ -39,6 +39,7 @@ pub fn generate_run_info(wpt_dir: &Path) -> WptRunInfo {
         wasm: false,
         os: String::new(),
         os_version: String::new(),
+        linux_distro: None,
         version: String::new(),
         processor: String::new(),
         bits: match os_info.bitness() {


### PR DESCRIPTION
## Summary

`cargo run -rp wpt <suite> --diff` now compares the local run against the latest `main` branch results, so regressions/improvements are visible locally without going through CI.

The baseline is `https://dioxuslabs.github.io/blitz/wptreport.json.zst` (same artifact the website consumes). It is cached in `wpt/cache/` (gitignored) as the raw `.zst` body plus the response's `Last-Modified` value, and every `--diff` run revalidates with `If-Modified-Since`, so a 304 skips the download. Download failures fall back to the cache; if there's no cache either, the run still completes and only the diff is skipped.

Diffing uses `wptreport::aggregate` (bumped `wptreport` 0.0.5 -> 0.0.13, which added `aggregate`/`merge` and `WptRunInfo::linux_distro`). The baseline is filtered to the suites being run, so a partial run (e.g. `css/css-flexbox/alignment`) doesn't report every other test as removed. Tests whose subtest counts changed are printed with their before/after status, classified as improved or regressed by pass fraction, followed by a summary:

```
Diff against main (708eb61323e9dda6d57d6f0a667512bb4dfd0068)
=====================
FAIL(3/5) => PASS(5/5) css/css-flexbox/foo.html
ADD  css/css-flexbox/bar.html
---

   0 tests REGRESSED
   1 tests IMPROVED
   1 tests ADDED
   0 tests REMOVED
```


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ea75dffa87234844b3902d8f14a202c7
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31338123501).</sub>
<!-- wpt-results-end -->
