### PR TITLE
Propagate root/body backgrounds to the canvas

### DIFF
--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -413,6 +413,17 @@ impl BaseDocument {
         taffy::compute_root_layout(self, root_element_id, available_space);
         taffy::round_layout(self, root_element_id);
 
+        // The root element's containing block is the initial containing block (which is
+        // anchored at the canvas origin), so its margin offsets its border box.
+        let root_id = self.root_element().id;
+        let root = &mut self.nodes[root_id];
+        let margin = root.final_layout().margin;
+        root.final_layout_mut().location.x += margin.left;
+        root.final_layout_mut().location.y += margin.top;
+        let unrounded_margin = root.unrounded_layout().margin;
+        root.unrounded_layout_mut().location.x += unrounded_margin.left;
+        root.unrounded_layout_mut().location.y += unrounded_margin.top;
+
         // println!("\n\n");
         // taffy::print_tree(self, root_node_id)
     }

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -40,6 +40,7 @@ use style::{
 use kurbo::{self, Affine, Insets, Point, Rect, Shape, Size, Stroke, Vec2};
 use peniko::{self, Fill, ImageData, ImageSampler};
 use style::values::generics::color::GenericColor;
+use style::values::generics::image::GenericImage;
 use taffy::Layout;
 
 /// A short-lived struct which holds a bunch of parameters for rendering a scene so
@@ -54,6 +55,10 @@ pub struct BlitzDomPainter<'dom, 'a> {
     pub(crate) initial_y: f64,
     /// The id of the document's root element (cached to avoid re-resolving it for every element)
     pub(crate) root_element_id: Option<NodeId>,
+    /// The id of the element whose background propagates to the canvas (the root element, or
+    /// the `<body>` element if the root element's background is entirely transparent). That
+    /// element's background is painted as the canvas background instead of on the element itself.
+    pub(crate) canvas_bg_source_id: Option<NodeId>,
     /// Scrollbar hover/drag state, resolved once per scene like the root element
     #[cfg(feature = "scrollbars")]
     pub(crate) hovered_scrollbar: Option<blitz_dom::node::ScrollbarRef>,
@@ -86,6 +91,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
 
         let layer_manager = LayerManager::default();
         let root_element_id = dom.try_root_element().map(|el| el.id);
+        let canvas_bg_source_id = resolve_canvas_background_source(dom);
 
         Self {
             dom,
@@ -95,6 +101,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             initial_x,
             initial_y,
             root_element_id,
+            canvas_bg_source_id,
             #[cfg(feature = "scrollbars")]
             hovered_scrollbar: dom.hovered_scrollbar(),
             #[cfg(feature = "scrollbars")]
@@ -128,41 +135,57 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         let bg_width = (self.width as f32).max(root_element.final_layout().size.width);
         let bg_height = (self.height as f32).max(root_element.final_layout().size.height);
 
-        let background_color = {
-            let html_color = root_element
-                .primary_styles()
-                .map(|s| s.clone_background_color())
-                .unwrap_or(GenericColor::TRANSPARENT_BLACK);
-            if html_color == GenericColor::TRANSPARENT_BLACK {
-                root_element
-                    .children
-                    .iter()
-                    .find_map(|id| {
-                        self.dom
-                            .as_ref()
-                            .get_node(*id)
-                            .filter(|node| node.data.is_element_with_tag_name(&local_name!("body")))
-                    })
-                    .and_then(|body| body.primary_styles())
-                    .map(|style| {
-                        let current_color = style.clone_color();
-                        style
-                            .clone_background_color()
-                            .resolve_to_absolute(&current_color)
-                    })
-            } else {
-                let current_color = root_element.primary_styles().unwrap().clone_color();
-                Some(html_color.resolve_to_absolute(&current_color))
+        // Paint the canvas background. The background of the root element (or of the <body>
+        // element if the root element's background is entirely transparent) propagates to the
+        // canvas: its painting area extends to cover the entire canvas, but its background
+        // images are positioned as if they were painted on the root element alone.
+        let canvas_bg_source = self
+            .canvas_bg_source_id
+            .and_then(|id| self.dom.as_ref().get_node(id));
+        if let Some(source) = canvas_bg_source {
+            if let Some(styles) = source.primary_styles() {
+                let current_color = styles.clone_color();
+                let bg_color = styles
+                    .clone_background_color()
+                    .resolve_to_absolute(&current_color)
+                    .as_srgb_color();
+                if bg_color != crate::color::Color::TRANSPARENT {
+                    let rect = Rect::from_origin_size(
+                        (self.initial_x * self.scale, self.initial_y * self.scale),
+                        (bg_width as f64, bg_height as f64),
+                    );
+                    scene.fill(Fill::NonZero, Affine::IDENTITY, bg_color, None, &rect);
+                }
             }
-        };
 
-        if let Some(bg_color) = background_color {
-            let bg_color = bg_color.as_srgb_color();
-            let rect = Rect::from_origin_size(
-                (self.initial_x * self.scale, self.initial_y * self.scale),
-                (bg_width as f64, bg_height as f64),
-            );
-            scene.fill(Fill::NonZero, Affine::IDENTITY, bg_color, None, &rect);
+            if let Some(source_element) = source.element_data() {
+                let root_node = &self.dom.as_ref().tree()[root_id];
+                let root_layout = *root_node.final_layout();
+                let box_position =
+                    Vec2::new(root_layout.location.x as f64, root_layout.location.y as f64)
+                        * self.scale;
+                let transform = Affine::translate(Vec2 {
+                    x: self.initial_x - (viewport_scroll.x * self.scale),
+                    y: self.initial_y - (viewport_scroll.y * self.scale),
+                }) * Affine::translate(box_position);
+
+                let mut cx = self.element_cx(root_node, root_layout, transform, None);
+                if source.id != root_id {
+                    if let Some(styles) = source.primary_styles() {
+                        cx.style = (*styles).clone();
+                    }
+                }
+
+                // The canvas rect in the root element's local coordinate space. The canvas
+                // covers at least the viewport (extended by the scroll offset so that it
+                // remains covered when the document is scrolled).
+                let canvas_width = bg_width as f64 + viewport_scroll.x * self.scale;
+                let canvas_height = bg_height as f64 + viewport_scroll.y * self.scale;
+                let canvas_rect = Rect::new(0.0, 0.0, canvas_width, canvas_height) - box_position;
+                cx.painting_rect_override = Some(canvas_rect);
+
+                cx.draw_canvas_background_layers(scene, canvas_rect, source_element);
+            }
         }
 
         // The root clip rectangle is the viewport (in screen coordinates, with the
@@ -548,8 +571,41 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             list_item: element.list_item_data.as_deref(),
             devtools: self.dom.devtools(),
             custom_widget_scene,
+            painting_rect_override: None,
         }
     }
+}
+
+/// Resolve the element whose background propagates to the canvas.
+///
+/// The root element's background always propagates to the canvas. If it is entirely
+/// transparent (its background-color is transparent and it has no background images)
+/// then the background of the root element's first `<body>` child element is
+/// propagated instead.
+fn resolve_canvas_background_source(dom: &BaseDocument) -> Option<NodeId> {
+    fn has_background(styles: &ComputedValues) -> bool {
+        styles.clone_background_color() != GenericColor::TRANSPARENT_BLACK
+            || styles
+                .get_background()
+                .background_image
+                .0
+                .iter()
+                .any(|image| !matches!(image, GenericImage::None))
+    }
+
+    let root_element = dom.try_root_element()?;
+    let root_styles = root_element.primary_styles()?;
+    if has_background(&root_styles) {
+        return Some(root_element.id);
+    }
+    root_element
+        .children
+        .iter()
+        .find_map(|id| {
+            dom.get_node(*id)
+                .filter(|node| node.data.is_element_with_tag_name(&local_name!("body")))
+        })
+        .map(|body| body.id)
 }
 
 fn to_image_quality(image_rendering: ImageRendering) -> peniko::ImageQuality {
@@ -595,6 +651,10 @@ struct ElementCx<'dom, 'a> {
     devtools: &'dom DevtoolSettings,
     #[cfg_attr(not(feature = "custom-widget"), expect(unused))]
     custom_widget_scene: Option<&'a Scene>,
+    /// When painting the canvas background, the background painting area extends to cover the
+    /// entire canvas rather than just the element's box. This is that area, in the element's
+    /// local coordinate space. `None` for regular (non-canvas) background painting.
+    painting_rect_override: Option<Rect>,
 }
 
 /// Converts parley BoundingBox into peniko Rect

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -790,10 +790,23 @@ fn raster_axis_tiling(
         }
         Space => {
             let (count, stride) = compute_space_count_and_stride(origin_len, tile_len);
+            // Tiling continues over the painting area at the same interval
+            let (pre, post) = if count > 1 {
+                space_extension_counts(
+                    origin_start,
+                    origin_len,
+                    painting_start,
+                    painting_len,
+                    stride,
+                )
+            } else {
+                (0, 0)
+            };
             AxisTiling {
-                translate: origin_start + if count == 1 { bg_pos } else { 0.0 },
+                translate: origin_start - pre as f64 * stride
+                    + if count == 1 { bg_pos } else { 0.0 },
                 rect_len: image_len,
-                count,
+                count: count + pre + post,
                 stride,
             }
         }
@@ -843,10 +856,23 @@ fn gradient_axis_tiling(
         }
         Space => {
             let (count, stride) = compute_space_count_and_stride(origin_len, tile_len);
+            // Tiling continues over the painting area at the same interval
+            let (pre, post) = if count > 1 {
+                space_extension_counts(
+                    origin_start,
+                    origin_len,
+                    painting_start,
+                    painting_len,
+                    stride,
+                )
+            } else {
+                (0, 0)
+            };
             AxisTiling {
-                translate: origin_start + if count == 1 { bg_pos } else { 0.0 },
+                translate: origin_start - pre as f64 * stride
+                    + if count == 1 { bg_pos } else { 0.0 },
                 rect_len: tile_len,
-                count,
+                count: count + pre + post,
                 stride,
             }
         }
@@ -857,6 +883,22 @@ fn gradient_axis_tiling(
             stride: 0.0,
         },
     }
+}
+
+/// The number of extra `Space` tiles needed before and after the positioning
+/// area so that tiling continues over the painting area at the same interval
+fn space_extension_counts(
+    origin_start: f64,
+    origin_len: f64,
+    painting_start: f64,
+    painting_len: f64,
+    stride: f64,
+) -> (u32, u32) {
+    let pre = ((origin_start - painting_start) / stride).ceil().max(0.0) as u32;
+    let post = ((painting_start + painting_len - (origin_start + origin_len)) / stride)
+        .ceil()
+        .max(0.0) as u32;
+    (pre, post)
 }
 
 fn compute_space_count_and_stride(bg_size: f64, size: f64) -> (u32, f64) {

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -132,6 +132,12 @@ impl<'a> ImageLayerStyles<'a> {
 
 impl ElementCx<'_, '_> {
     pub(super) fn draw_background(&self, scene: &mut impl PaintScene) {
+        // The background of the element that propagates to the canvas is painted as the
+        // canvas background, and must not be painted again on the element itself.
+        if self.context.canvas_bg_source_id == Some(self.node.id) {
+            return;
+        }
+
         let bg_styles = &self.style.get_background();
         let image_data = &self.element.background_images;
         let layer_count = bg_styles.background_image.0.len();
@@ -154,6 +160,42 @@ impl ElementCx<'_, '_> {
                 1.0,
                 self.transform,
                 &background_clip_path,
+                None,
+                None,
+                |scene| {
+                    self.draw_image_layer(scene, &layer);
+                },
+            );
+        }
+    }
+
+    /// Draw the canvas background image layers.
+    ///
+    /// The background is propagated from the root or `<body>` element (`source_element`),
+    /// whose styles are stored in `self.style`. `self` must be an `ElementCx` for the root
+    /// element: background images are positioned relative to the root element's boxes, but
+    /// painted across the entire canvas (`canvas_rect`, in the root element's local
+    /// coordinate space).
+    pub(super) fn draw_canvas_background_layers(
+        &self,
+        scene: &mut impl PaintScene,
+        canvas_rect: Rect,
+        source_element: &blitz_dom::ElementData,
+    ) {
+        let bg_styles = &self.style.get_background();
+        let image_data = &source_element.background_images;
+        let layer_count = bg_styles.background_image.0.len();
+
+        let canvas_path = canvas_rect.to_path(0.1);
+        for idx in (0..layer_count).rev() {
+            let layer = ImageLayerStyles::from_background(bg_styles, image_data, idx);
+
+            self.context.layer_manager.maybe_with_layer(
+                scene,
+                true,
+                1.0,
+                self.transform,
+                &canvas_path,
                 None,
                 None,
                 |scene| {
@@ -392,6 +434,16 @@ impl ElementCx<'_, '_> {
         } else {
             (self.box_rect(layer.origin), self.transform)
         };
+        // The area which repeated layers must cover: the clip box (or the whole canvas for
+        // the canvas background). Layers are positioned relative to `origin_rect` but tiled
+        // to cover `painting_rect`. For a fixed layer the positioning area (the viewport)
+        // already covers everything visible.
+        let painting_rect = if self.layer_is_fixed(layer) {
+            origin_rect
+        } else {
+            self.painting_rect_override
+                .unwrap_or_else(|| self.box_rect(layer.clip))
+        };
 
         let image_width = image_data.width as f64;
         let image_height = image_data.height as f64;
@@ -415,6 +467,8 @@ impl ElementCx<'_, '_> {
             *repeat_x,
             origin_rect.x0,
             origin_rect.width(),
+            painting_rect.x0,
+            painting_rect.width(),
             bg_pos.x,
             bg_size.width,
             image_width,
@@ -424,6 +478,8 @@ impl ElementCx<'_, '_> {
             *repeat_y,
             origin_rect.y0,
             origin_rect.height(),
+            painting_rect.y0,
+            painting_rect.height(),
             bg_pos.y,
             bg_size.height,
             image_height,
@@ -463,16 +519,17 @@ impl ElementCx<'_, '_> {
         layer: &ImageLayerStyles,
     ) {
         // For a fixed layer the positioning area (the viewport) already covers
-        // everything visible, so it also serves as the clip rect (no extension
-        // towards the clip box is needed).
-        let (origin_rect, base_transform, clip_rect) = if self.layer_is_fixed(layer) {
+        // everything visible, so it also serves as the painting rect (no
+        // extension towards the clip box is needed).
+        let (origin_rect, base_transform, painting_rect) = if self.layer_is_fixed(layer) {
             let (viewport_rect, transform) = self.fixed_positioning_area();
             (viewport_rect, transform, viewport_rect)
         } else {
             (
                 self.box_rect(layer.origin),
                 self.transform,
-                self.box_rect(layer.clip),
+                self.painting_rect_override
+                    .unwrap_or_else(|| self.box_rect(layer.clip)),
             )
         };
 
@@ -492,8 +549,8 @@ impl ElementCx<'_, '_> {
             *repeat_x,
             origin_rect.x0,
             origin_rect.width(),
-            clip_rect.x0,
-            clip_rect.width(),
+            painting_rect.x0,
+            painting_rect.width(),
             bg_pos.x,
             bg_size.width,
         );
@@ -501,12 +558,11 @@ impl ElementCx<'_, '_> {
             *repeat_y,
             origin_rect.y0,
             origin_rect.height(),
-            clip_rect.y0,
-            clip_rect.height(),
+            painting_rect.y0,
+            painting_rect.height(),
             bg_pos.y,
             bg_size.height,
         );
-
         // FIXME: https://wpt.live/css/css-backgrounds/background-size/background-size-near-zero-gradient.html
         if x.count as u64 * y.count as u64 > 500 {
             return;
@@ -689,16 +745,23 @@ struct AxisTiling {
 }
 
 /// Per-axis placement and tiling for a raster image layer. `Repeat`/`Round`
-/// produce a single fill covering the whole positioning area (relying on the
+/// produce a single fill covering the whole painting area (relying on the
 /// image brush repeating), while `Space` produces `count` explicit tiles
 /// spaced `stride` apart.
 ///
+/// Tiles are positioned relative to the positioning (origin) area but must
+/// cover the painting area, which may extend beyond it (e.g. the whole canvas
+/// for the propagated canvas background).
+///
 /// The fill rect is in image pixel coordinates (the drawing transform is
 /// pre-scaled by `ratio`), while translations are in device pixels.
+#[allow(clippy::too_many_arguments)]
 fn raster_axis_tiling(
     repeat: BackgroundRepeatKeyword,
     origin_start: f64,
     origin_len: f64,
+    painting_start: f64,
+    painting_len: f64,
     bg_pos: f64,
     tile_len: f64,
     image_len: f64,
@@ -708,10 +771,19 @@ fn raster_axis_tiling(
 
     match repeat {
         Repeat | Round => {
-            let extend_len = extend(bg_pos, tile_len);
+            // The painting area extends beyond the origin area iff it does so
+            // at either end
+            let painting_is_outer = painting_start < origin_start
+                || painting_start + painting_len > origin_start + origin_len;
+            let (area_start, area_len) = if painting_is_outer {
+                (painting_start, painting_len)
+            } else {
+                (origin_start, origin_len)
+            };
+            let extend_len = extend((origin_start - area_start) + bg_pos, tile_len);
             AxisTiling {
-                translate: origin_start - extend_len,
-                rect_len: (origin_len + extend_len) / ratio,
+                translate: area_start - extend_len,
+                rect_len: (area_len + extend_len) / ratio,
                 count: 1,
                 stride: 0.0,
             }
@@ -736,14 +808,14 @@ fn raster_axis_tiling(
 
 /// Per-axis placement and tiling for a gradient layer. Unlike raster images,
 /// gradients cannot rely on brush repetition, so `Repeat`/`Round` also produce
-/// explicit tiles. When the clip box extends beyond the origin box, tiling
-/// starts from the clip box edge so the pattern covers the whole clipped area.
+/// explicit tiles. When the painting area extends beyond the origin box,
+/// tiling starts from the painting area edge so the pattern covers it all.
 fn gradient_axis_tiling(
     repeat: BackgroundRepeatKeyword,
     origin_start: f64,
     origin_len: f64,
-    clip_start: f64,
-    clip_len: f64,
+    painting_start: f64,
+    painting_len: f64,
     bg_pos: f64,
     tile_len: f64,
 ) -> AxisTiling {
@@ -751,12 +823,12 @@ fn gradient_axis_tiling(
 
     match repeat {
         Repeat | Round => {
-            // The clip and origin boxes are nested, so the clip box extends
-            // beyond the origin box iff it does so at either end
-            let clip_is_outer =
-                clip_start < origin_start || clip_start + clip_len > origin_start + origin_len;
-            let (area_start, area_len) = if clip_is_outer {
-                (clip_start, clip_len)
+            // The painting area extends beyond the origin area iff it does so
+            // at either end
+            let painting_is_outer = painting_start < origin_start
+                || painting_start + painting_len > origin_start + origin_len;
+            let (area_start, area_len) = if painting_is_outer {
+                (painting_start, painting_len)
             } else {
                 (origin_start, origin_len)
             };

--- a/packages/blitz-paint/src/render/box_shadow.rs
+++ b/packages/blitz-paint/src/render/box_shadow.rs
@@ -20,7 +20,9 @@ impl ElementCx<'_, '_> {
             .background_color
             .resolve_to_absolute(&current_color)
             .as_srgb_color();
-        let bg_is_opaque = bg_color.components[3] >= 1.0;
+        // The background is not painted on the element itself if it propagates to the canvas
+        let bg_is_painted = self.context.canvas_bg_source_id != Some(self.node.id);
+        let bg_is_opaque = bg_color.components[3] >= 1.0 && bg_is_painted;
         let needs_clip = opacity < 1.0 || !bg_is_opaque;
 
         let max_shadow_rect = box_shadow.iter().fold(Rect::ZERO, |prev, shadow| {


### PR DESCRIPTION
## Summary

Fixes the `css/CSS2/backgrounds/background-root-*` WPT tests (+30 net passes across `css/CSS2`, `css/css-backgrounds`, `css/css-flexbox`, `css/css-grid`, `css/css-position`).

**Canvas background propagation** (`blitz-paint`): the root element's background (or the `<body>`'s, when the root's is entirely transparent) now propagates to the canvas per [CSS2 §14.2](https://www.w3.org/TR/CSS22/colors.html#background):
- `BlitzDomPainter` resolves a `canvas_bg_source_id` and paints that element's background color and image layers over the whole canvas in `paint_scene`, before rendering the tree.
- Image layers are positioned relative to the source element's background positioning area but tiled over a canvas-sized painting area, via a new `painting_rect_override` on `ElementCx`.
- `draw_background` skips the source element so the propagated background isn't painted twice.

**Root element margin** (`blitz-dom`): `resolve_layout` now offsets the root element's box by its margin (taffy's `compute_root_layout` resolves the margin into the available size but leaves `location` at the origin). Required by most `background-root-*` tests, and also fixes `root-box-001` and two `margin-collapse` tests.

**Repeat over the painting area** (`blitz-paint`): `repeat`/`round`/`space` tiles now cover the background *painting* area (clip box, or whole canvas for the canvas background) rather than just the positioning area:

```rust
let origin_rect = self.box_rect(layer.origin);
let painting_rect = self
    .painting_rect_override
    .unwrap_or_else(|| self.box_rect(layer.clip));
let extend_width = extend(bg_pos_x + (origin_rect.x0 - painting_rect.x0), bg_size.width);
```

This replaces the previous per-`(clip, origin)`-combination special cases with a general formula, and makes e.g. tiles visible beneath translucent borders (as in the `background-repeat-space-8` reference).

**Outset box-shadow clipping**: an element whose background propagates to the canvas paints no background of its own, so its outset shadow is now always clipped out of its border box (previously an opaque background was assumed to cover it).

## Test results

Before/after comparison over `css/CSS2 css/css-backgrounds css/css-flexbox css/css-grid css/css-position`: 30 tests fixed, 1 newly failing:
- `css/CSS2/backgrounds/background-position-002.xht` — the test page now renders correctly (body background propagated to canvas), but its *reference* page renders wrong due to a pre-existing bug: an absolutely positioned `height: 100%` element resolves its height against the body instead of the initial containing block. Previously both pages were wrong in the same way, so the test "passed".

Still failing (pre-existing, separate issues): `background-root-023` (fixed-position offset affected by sibling margin), `background-root-101/102/103` (require script support).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/cd28e74e905344f3b4530021070cd6b1
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**37** newly passing, **4** newly failing (net +33).

<details>
<summary>Full diff (41 changed tests)</summary>

```diff
- Pass => Fail css/CSS2/backgrounds/background-position-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-004.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-005.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-006.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-007.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-008.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-009.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-010.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-011.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-012a.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-012b.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-013a.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-013b.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-014a.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-014b.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-016.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-017.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-018.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-019.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-020.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-024.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-020.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-021.xht
+ Fail => Pass css/CSS2/normal-flow/root-box-001.xht
+ Fail => Pass css/CSS2/tables/table-backgrounds-bs-cell-001.xht
+ Fail => Pass css/CSS2/tables/table-backgrounds-bs-table-001.xht
+ Fail => Pass css/compositing/root-element-background-transparency.html
+ Fail => Pass css/css-backgrounds/background-origin/origin-content-box.html
+ Fail => Pass css/css-backgrounds/background-origin/origin-content-box_with_radius.html
+ Fail => Pass css/css-backgrounds/background-position/background-position-right-in-body.html
+ Fail => Pass css/css-backgrounds/background-repeat/gradient-repeat-spaced-with-borders.html
+ Fail => Pass css/css-display/display-contents-root-background.html
- Pass => Fail css/css-image-animation/image-animation-body-background-no-propagation-paused.html
- Pass => Fail css/css-images/linear-gradient-body-sibling-index.html
- Pass => Fail css/css-transforms/perspective-split-by-zero-w.html
+ Fail => Pass css/css-transforms/transform-background-005.html
+ Fail => Pass css/css-transforms/transform-background-006.html
+ Fail => Pass css/css-transforms/transform-background-008.html
+ Fail => Pass css/css-transforms/transform-translate-background-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31737520989).</sub>
<!-- wpt-results-end -->
