### PR TITLE
Support justify-self on block-level boxes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7188,8 +7188,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c034e05f6ee85a12daa63863c2245797715075c70649947aa0da54f3f2ab1d0f"
+source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1786316501-block-justify-self#62ad258f0531f2135f8afb8cae9a5b4bcd790fdb"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,7 @@ tracing-subscriber = "0.3"
 usvg = { git = "https://github.com/DioxusLabs/resvg", branch = "devin/1785858271-intrinsic-dimensions" }
 anyrender = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
 anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
+taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "devin/1786316501-block-justify-self" }
 
 # [patch.crates-io]
 # anyrender = { path = "../anyrender/crates/anyrender" }
@@ -299,10 +300,6 @@ anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", branch = "dev
 # style_config = { path = "../stylo/stylo_config", package = "stylo_config" }
 # style_dom = { path = "../stylo/stylo_dom", package = "stylo_dom" }
 # selectors = { path = "../stylo/selectors", package = "selectors" }
-
-# [patch.crates-io]
-# [patch."https://github.com/dioxuslabs/taffy"]
-# taffy = { path = "../taffy" }
 
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -173,6 +173,11 @@ impl<T: Deref<Target = ComputedValues>> taffy::BlockItemStyle for TaffyStyloStyl
     fn is_table(&self) -> bool {
         convert::is_table(self.0.clone_display())
     }
+
+    #[inline]
+    fn justify_self(&self) -> Option<taffy::AlignSelf> {
+        convert::item_alignment(self.0.get_position().justify_self.0)
+    }
 }
 
 // FlexboxContainerStyle impl


### PR DESCRIPTION
## Summary

Block-level boxes now honour `justify-self` (`/css/css-align/self-alignment/block-justify-self.html`). Taffy gained the block-layout implementation in DioxusLabs/taffy#1086; this side just feeds Stylo's computed value into the new style accessor:

```rust
impl BlockItemStyle for TaffyStyloStyle<T> {
    fn justify_self(&self) -> Option<taffy::AlignSelf> {
        convert::item_alignment(self.0.get_position().justify_self.0)
    }
}
```

`taffy` is patched to that PR's branch until it is released, matching the existing `usvg`/`anyrender` patches.

Verified against Chrome: every alignment row of the WPT fixture (all keywords, LTR/RTL containers, `direction`-differing children, auto/explicit widths, margins, floats, absolute children) now lands at the same x as Chrome, and matches the grid reference in Blitz's own rendering. The reftest still fails on vertical offsets only: Blitz's text metrics wrap `self-start (rtl)` onto two lines where Chrome fits one, so the rows below the float row are shifted 19px in the test but not in the reference — a font/inline-layout difference unrelated to alignment.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/49e63862a7874317af1f714bb5da599a
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**13** newly passing, **1** newly failing (net +12).

<details>
<summary>Full diff (14 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-028.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-min-height-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-min-height-002.xht
+ Fail => Pass css/CSS2/normal-flow/margin-collapse-min-height-001.html
+ Fail => Pass css/CSS2/normal-flow/margin-collapse-min-height-002.html
+ Fail => Pass css/CSS2/normal-flow/min-height-separates-margin.html
- Pass => Fail css/css-align/abspos/align-items-static-position-001.tentative.html
+ Fail => Pass css/css-align/blocks/justify-self-auto-margins-2.html
+ Fail => Pass css/css-align/blocks/justify-self-block-in-inline.html
+ Fail => Pass css/css-align/blocks/justify-self-htb-ltr-htb.html
+ Fail => Pass css/css-align/blocks/justify-self-text-align.html
+ Fail => Pass css/css-align/blocks/safe-justify-self-htb.html
+ Fail => Pass css/css-flexbox/flexbox-mbp-horiz-004.xhtml
+ Fail => Pass css/css-flexbox/percentage-padding-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31340916113).</sub>
<!-- wpt-results-end -->
