### PR TITLE
Fix duplicate table cell padding with float layout

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -644,11 +644,8 @@ impl BaseDocument {
 
         #[cfg(feature = "floats")]
         {
-            let contains_floats = is_bfc_root;
-            if contains_floats {
-                height = height.max(
-                    (block_ctx.floated_content_height_contribution() + container_pb.top) * scale,
-                )
+            if is_bfc_root {
+                height = height.max(block_ctx.floated_content_height_contribution() * scale)
             };
         }
 

--- a/tests/blitz-tests/Cargo.toml
+++ b/tests/blitz-tests/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 [dev-dependencies]
 # Blitz dependencies
 blitz-test-harness = { workspace = true }
-blitz-dom = { workspace = true, features = ["accessibility", "system-fonts"] }
+blitz-dom = { workspace = true, features = ["accessibility", "floats", "system-fonts"] }
 blitz-html = { workspace = true }
 blitz-traits = { workspace = true }
 blitz-paint = { workspace = true, features = ["scrollbars", "svg"] }

--- a/tests/blitz-tests/tests/inline_bfc_padding.rs
+++ b/tests/blitz-tests/tests/inline_bfc_padding.rs
@@ -1,0 +1,10 @@
+use blitz_test_harness::Harness;
+
+#[test]
+fn float_layout_counts_table_cell_padding_once() {
+    let harness = Harness::from_html(
+        r#"<table style="border-spacing:0"><tr><td id="cell" style="font-size:10px;line-height:20px;padding:40px 0 10px">x</td></tr></table>"#,
+    );
+
+    assert_eq!(harness.layout_rect("#cell").height, 70.0);
+}


### PR DESCRIPTION
## Summary

Fix table cells becoming too tall when the `floats` feature is enabled and the cell's block-start padding exceeds its inline content height.

## Root cause

Inline layout creates a float sub-context offset by `container_pb.top`. The resulting `floated_content_height_contribution()` is content-box-relative, but the BFC height calculation added `container_pb.top` to it again. The final outer-size calculation subsequently adds `content_box_inset`, so block-start padding was counted twice.

For example, a table cell with a 20px line box, 40px top padding, and 10px bottom padding was laid out at 90px instead of 70px.

## Changes

- Remove the duplicate `container_pb.top` contribution from inline BFC height calculation.
- Enable the `floats` feature in the Blitz integration test crate so this path is exercised by the normal test suite.
- Add a regression test covering padded table-cell inline content.

## Validation

```text
cargo test -p blitz-tests
passed

cargo clippy -p blitz-tests --test inline_bfc_padding --no-deps -- -D warnings
passed

cargo fmt --all -- --check
passed
```

<!-- wpt-results-start -->
## WPT results

**7** newly passing, **0** newly failing (net +7).

<details>
<summary>Full diff (7 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/css1/c5525-fltmult-000.xht
+ Fail => Pass css/CSS2/linebox/inline-formatting-context-011.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-border-padding-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-155.xht
+ Fail => Pass css/css-contain/contain-animation-001.html
+ Fail => Pass css/css-grid/grid-items/grid-items-percentage-paddings-001.html
+ Fail => Pass css/css-grid/grid-items/grid-items-percentage-paddings-002.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31350887103).</sub>
<!-- wpt-results-end -->
