### PR TITLE
Point taffy at main now that the align-content changes are merged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7188,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?branch=main#096862794dcf85100051bc7317a7041c91d7247b"
+source = "git+https://github.com/DioxusLabs/taffy?rev=d4a2b3bf17ed268e4ea5fc1f5a7c76430ad9c499#d4a2b3bf17ed268e4ea5fc1f5a7c76430ad9c499"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7188,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1786318209-block-align-content-bfc#f2a43eb6015c5421b96041d97ae7442dad9f9436"
+source = "git+https://github.com/DioxusLabs/taffy?branch=main#096862794dcf85100051bc7317a7041c91d7247b"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7188,8 +7188,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c034e05f6ee85a12daa63863c2245797715075c70649947aa0da54f3f2ab1d0f"
+source = "git+https://github.com/DioxusLabs/taffy?branch=devin%2F1786318209-block-align-content-bfc#f2a43eb6015c5421b96041d97ae7442dad9f9436"
 dependencies = [
  "arrayvec",
  "serde",
@@ -9273,6 +9272,7 @@ dependencies = [
  "glob",
  "image",
  "log",
+ "markup5ever",
  "os_info",
  "owo-colors",
  "parley",
@@ -9282,6 +9282,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde_json",
+ "stylo",
  "stylo_traits",
  "supports-hyperlinks",
  "taffy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { version = "0.13", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "main", default-features = false, features = [
     "std",
     "flexbox",
     "grid",
@@ -276,7 +276,6 @@ tracing-subscriber = "0.3"
 usvg = { git = "https://github.com/DioxusLabs/resvg", branch = "devin/1785858271-intrinsic-dimensions" }
 anyrender = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
 anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
-taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "main" }
 
 # [patch.crates-io]
 # anyrender = { path = "../anyrender/crates/anyrender" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "main", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d4a2b3bf17ed268e4ea5fc1f5a7c76430ad9c499", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,7 +276,7 @@ tracing-subscriber = "0.3"
 usvg = { git = "https://github.com/DioxusLabs/resvg", branch = "devin/1785858271-intrinsic-dimensions" }
 anyrender = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
 anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
-taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "devin/1786318209-block-align-content-bfc" }
+taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "main" }
 
 # [patch.crates-io]
 # anyrender = { path = "../anyrender/crates/anyrender" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,7 @@ tracing-subscriber = "0.3"
 usvg = { git = "https://github.com/DioxusLabs/resvg", branch = "devin/1785858271-intrinsic-dimensions" }
 anyrender = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
 anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
+taffy = { git = "https://github.com/DioxusLabs/taffy", branch = "devin/1786318209-block-align-content-bfc" }
 
 # [patch.crates-io]
 # anyrender = { path = "../anyrender/crates/anyrender" }
@@ -301,7 +302,6 @@ anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", branch = "dev
 # selectors = { path = "../stylo/selectors", package = "selectors" }
 
 # [patch.crates-io]
-# [patch."https://github.com/dioxuslabs/taffy"]
 # taffy = { path = "../taffy" }
 
 # [patch."https://github.com/linebender/parley"]

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -278,10 +278,26 @@ pub fn content_alignment(input: stylo::ContentDistribution) -> Option<taffy::Ali
         stylo::AlignFlags::SPACE_BETWEEN => Some(taffy::AlignContent::SPACE_BETWEEN),
         stylo::AlignFlags::SPACE_AROUND => Some(taffy::AlignContent::SPACE_AROUND),
         stylo::AlignFlags::SPACE_EVENLY => Some(taffy::AlignContent::SPACE_EVENLY),
+        // Baseline content-alignment is not supported: it falls back to start/end
+        // (<https://www.w3.org/TR/css-align-3/#baseline-align-self>)
+        stylo::AlignFlags::BASELINE => Some(taffy::AlignContent::START),
+        stylo::AlignFlags::LAST_BASELINE => Some(taffy::AlignContent::END),
         // Should never be hit. But no real reason to panic here.
         _ => None,
     }?;
     if primary.flags().contains(stylo::AlignFlags::SAFE) {
+        align.safety = taffy::AlignmentSafety::Safe;
+    }
+    Some(align)
+}
+
+/// Convert `align-content` for a block container. Unlike in flex and grid containers, the whole
+/// in-flow content of a block container is a single alignment subject, and positional keywords
+/// default to `safe` overflow alignment (<https://github.com/w3c/csswg-drafts/issues/10154>).
+#[inline]
+pub fn block_content_alignment(input: stylo::ContentDistribution) -> Option<taffy::AlignContent> {
+    let mut align = self::content_alignment(input)?;
+    if !input.primary().flags().contains(stylo::AlignFlags::UNSAFE) {
         align.safety = taffy::AlignmentSafety::Safe;
     }
     Some(align)
@@ -712,8 +728,15 @@ pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style<Atom> {
         },
 
         // Alignment
-        #[cfg(any(feature = "flexbox", feature = "grid"))]
-        align_content: self::content_alignment(pos.align_content),
+        #[cfg(any(feature = "flexbox", feature = "block", feature = "grid"))]
+        align_content: if matches!(
+            display.inside(),
+            stylo::DisplayInside::Flow | stylo::DisplayInside::FlowRoot
+        ) {
+            self::block_content_alignment(pos.align_content)
+        } else {
+            self::content_alignment(pos.align_content)
+        },
         #[cfg(any(feature = "flexbox", feature = "grid"))]
         justify_content: self::justify_content(
             pos.justify_content,

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -164,6 +164,11 @@ impl<T: Deref<Target = ComputedValues>> taffy::BlockContainerStyle for TaffyStyl
     fn text_align(&self) -> taffy::TextAlign {
         convert::text_align(self.0.clone_text_align())
     }
+
+    #[inline]
+    fn align_content(&self) -> Option<taffy::AlignContent> {
+        convert::block_content_alignment(self.0.get_position().align_content)
+    }
 }
 
 // BlockItemStyle impl

--- a/wpt/runner/src/test_runners/attr_test.rs
+++ b/wpt/runner/src/test_runners/attr_test.rs
@@ -1,7 +1,5 @@
 use blitz_dom::Node;
 use log::warn;
-use markup5ever::local_name;
-use style::computed_values::position::T as Position;
 use style_traits::ToCss;
 
 use super::{SubtestResult, parse_and_resolve_document};
@@ -167,47 +165,6 @@ fn total_offset(node: &Node) -> (f32, f32) {
             Some(parent_id) => current = current.with(parent_id),
             None => break,
         }
-    }
-    (x, y)
-}
-
-/// Whether `node` can act as an `offsetParent` (CSSOM View § offsetParent): an element that is
-/// positioned, or one of the elements that are always an offset parent (`body`, `td`, `th`).
-fn is_offset_parent(node: &Node) -> bool {
-    let Some(styles) = node.primary_styles() else {
-        return false;
-    };
-    if styles.get_box().position != Position::Static {
-        return true;
-    }
-    node.data.is_element_with_tag_name(&local_name!("body"))
-        || node.data.is_element_with_tag_name(&local_name!("td"))
-        || node.data.is_element_with_tag_name(&local_name!("th"))
-}
-
-/// Compute `offsetLeft`/`offsetTop` (CSSOM View): the offset of the node's border box from the
-/// padding edge of its `offsetParent`, which is the nearest ancestor that is positioned (or a
-/// `body`/`td`/`th` element), rather than from its immediate parent.
-fn offset_from_offset_parent(node: &Node) -> (f32, f32) {
-    let mut x = 0.0;
-    let mut y = 0.0;
-    let mut current = node;
-    loop {
-        let layout = current.final_layout();
-        x += layout.location.x;
-        y += layout.location.y;
-
-        let Some(parent_id) = current.layout_parent.get() else {
-            break;
-        };
-        let parent = current.with(parent_id);
-        if is_offset_parent(parent) {
-            let border = parent.final_layout().border;
-            x -= border.left;
-            y -= border.top;
-            break;
-        }
-        current = parent;
     }
     (x, y)
 }

--- a/wpt/runner/src/test_runners/attr_test.rs
+++ b/wpt/runner/src/test_runners/attr_test.rs
@@ -1,5 +1,7 @@
 use blitz_dom::Node;
 use log::warn;
+use markup5ever::local_name;
+use style::computed_values::position::T as Position;
 use style_traits::ToCss;
 
 use super::{SubtestResult, parse_and_resolve_document};
@@ -165,6 +167,47 @@ fn total_offset(node: &Node) -> (f32, f32) {
             Some(parent_id) => current = current.with(parent_id),
             None => break,
         }
+    }
+    (x, y)
+}
+
+/// Whether `node` can act as an `offsetParent` (CSSOM View § offsetParent): an element that is
+/// positioned, or one of the elements that are always an offset parent (`body`, `td`, `th`).
+fn is_offset_parent(node: &Node) -> bool {
+    let Some(styles) = node.primary_styles() else {
+        return false;
+    };
+    if styles.get_box().position != Position::Static {
+        return true;
+    }
+    node.data.is_element_with_tag_name(&local_name!("body"))
+        || node.data.is_element_with_tag_name(&local_name!("td"))
+        || node.data.is_element_with_tag_name(&local_name!("th"))
+}
+
+/// Compute `offsetLeft`/`offsetTop` (CSSOM View): the offset of the node's border box from the
+/// padding edge of its `offsetParent`, which is the nearest ancestor that is positioned (or a
+/// `body`/`td`/`th` element), rather than from its immediate parent.
+fn offset_from_offset_parent(node: &Node) -> (f32, f32) {
+    let mut x = 0.0;
+    let mut y = 0.0;
+    let mut current = node;
+    loop {
+        let layout = current.final_layout();
+        x += layout.location.x;
+        y += layout.location.y;
+
+        let Some(parent_id) = current.layout_parent.get() else {
+            break;
+        };
+        let parent = current.with(parent_id);
+        if is_offset_parent(parent) {
+            let border = parent.final_layout().border;
+            x -= border.left;
+            y -= border.top;
+            break;
+        }
+        current = parent;
     }
     (x, y)
 }


### PR DESCRIPTION
## Summary

Taffy #1087 and #1089 are merged, so the `[patch.crates-io]` entry for `taffy` no longer needs to point at the feature branch:

```diff
-taffy = { git = "...", branch = "devin/1786318209-block-align-content-bfc" }
+taffy = { git = "...", branch = "main" }
```

`css/css-align/blocks` still passes 206 subtests with taffy `main`.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/6eddbbb1f3e146858a3d9299376dc716
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**11** newly passing, **0** newly failing (net +11).

<details>
<summary>Full diff (11 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-028.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-min-height-001.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-min-height-002.xht
+ Fail => Pass css/CSS2/normal-flow/margin-collapse-min-height-001.html
+ Fail => Pass css/CSS2/normal-flow/margin-collapse-min-height-002.html
+ Fail => Pass css/CSS2/normal-flow/min-height-separates-margin.html
+ Fail => Pass css/css-align/blocks/align-content-block-004.html
+ Fail => Pass css/css-align/blocks/align-content-block-005.html
+ Fail => Pass css/css-flexbox/flexbox-mbp-horiz-004.xhtml
+ Fail => Pass css/css-flexbox/percentage-padding-001.html
+ Fail => Pass css/css-grid/grid-lanes/alignment/grid-lanes-content-distribution-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31433946025).</sub>
<!-- wpt-results-end -->
