### PR TITLE
blitz-shell: fix custom-widget build in complete_resume

### DIFF
--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -326,7 +326,7 @@ impl<Rend: WindowRenderer> View<Rend> {
         let insets = self.safe_area_insets.to_logical(scale);
 
         #[cfg(feature = "custom-widget")]
-        inner.can_create_surfaces(&self.renderer as _);
+        inner.can_create_surfaces(&mut self.renderer as _);
 
         self.renderer.set_size(width, height);
 


### PR DESCRIPTION
## Summary
`BaseDocument::can_create_surfaces` takes `&mut dyn RenderContext`, but the `custom-widget`-gated call in `complete_resume` coerced a shared reference, so the feature failed to compile (`E0605`).

```diff
- inner.can_create_surfaces(&self.renderer as _);
+ inner.can_create_surfaces(&mut self.renderer as _);
```

Fixes #679.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/39f944c324494ec8b8e6b0b33e0877bf
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31413249147).</sub>
<!-- wpt-results-end -->
