### PR TITLE
Drop the temporary fragment root after parsing inner HTML

### DIFF
--- a/packages/blitz-html/src/html_sink.rs
+++ b/packages/blitz-html/src/html_sink.rs
@@ -148,12 +148,12 @@ impl<'m, 'doc> DocumentHtmlParser<'m, 'doc> {
             .unwrap();
 
         // html5ever creates a new fragment root node under the document node and parses the nodes into that fragment root.
-        // So here we move the children of the fragment root to element_id and then remove the fragment root
+        // So here we move the children of the fragment root to element_id and then drop the fragment root.
         let document_id = mutr.doc.root_node().id;
         let fragment_root_id = mutr.last_child_id(document_id).unwrap();
         let child_ids = mutr.child_ids(fragment_root_id);
         mutr.append_children(element_id, &child_ids);
-        mutr.remove_node(fragment_root_id);
+        mutr.remove_and_drop_node(fragment_root_id);
     }
 }
 

--- a/tests/blitz-tests/tests/inner_html_leak.rs
+++ b/tests/blitz-tests/tests/inner_html_leak.rs
@@ -1,0 +1,49 @@
+//! Repeated `set_inner_html` calls must not leak parser fragment roots.
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+const HTML: &str = r#"<html><body><div id="target"></div></body></html>"#;
+const INNER_HTML: &str = r#"<span>one</span><span>two</span>"#;
+
+fn assert_inner_html_does_not_leak(incremental: bool) {
+    let mut doc = HtmlDocument::from_html(
+        HTML,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.set_incremental_layout(incremental);
+
+    let target_id = doc
+        .query_selector("#target")
+        .unwrap()
+        .expect("#target not found");
+
+    doc.mutate().set_inner_html(target_id, INNER_HTML);
+    let first_len = doc.tree().len();
+
+    let target = doc.get_node(target_id).expect("target was removed");
+    assert_eq!(target.children.len(), 2);
+    assert_eq!(target.text_content(), "onetwo");
+
+    for _ in 0..20 {
+        doc.mutate().set_inner_html(target_id, INNER_HTML);
+    }
+
+    assert_eq!(
+        doc.tree().len(),
+        first_len,
+        "repeated set_inner_html leaked nodes with incremental layout {incremental}"
+    );
+}
+
+#[test]
+fn repeated_set_inner_html_does_not_leak() {
+    assert_inner_html_does_not_leak(false);
+    assert_inner_html_does_not_leak(true);
+}


### PR DESCRIPTION
## Summary

Fixes #678. `parse_inner_html_into_mutator` moves the html5ever fragment root's children into the target element and then called `mutr.remove_node(fragment_root_id)`, which only unparents the node — the slab entry stayed alive, so every `set_inner_html` call leaked one detached node (`tree().len()` grew by 1 per call).

```diff
-mutr.remove_node(fragment_root_id);
+mutr.remove_and_drop_node(fragment_root_id);
```

Dropping is safe here since the children were already reparented, so the fragment root is empty.

Adds `tests/blitz-tests/tests/inner_html_leak.rs`, which repeatedly replaces the same element's children and asserts the tree size is stable (and the children are actually there), with incremental layout both on and off. It fails before the fix (10 -> 30 nodes).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/37456cca190d40ee834f697219090f84
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31413562641).</sub>
<!-- wpt-results-end -->
