### PR TITLE
Keep get_element_by_id index in sync with id attribute mutations

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -29,6 +29,7 @@ use linebender_resource_handle::Blob;
 use markup5ever::local_name;
 use parley::{FontContext, PlainEditorDriver};
 use selectors::{Element, matching::QuirksMode};
+use smallvec::SmallVec;
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, Bound, HashMap, HashSet};
@@ -287,8 +288,10 @@ pub struct BaseDocument {
     /// Whether there are subdocuments that are animating (so we should re-render every frame)
     pub(crate) subdoc_is_animating: bool,
 
-    /// Map of node ID's for fast lookups
-    pub(crate) nodes_to_id: HashMap<String, NodeId>,
+    /// Map of id attribute values to node IDs for fast lookups.
+    /// May contain multiple nodes for the same id: `get_element_by_id`
+    /// returns the first in tree order.
+    pub(crate) nodes_to_id: HashMap<String, SmallVec<[NodeId; 1]>>,
     /// Map of `<style>` and `<link>` node IDs to their associated stylesheet
     pub(crate) nodes_to_stylesheet: BTreeMap<NodeId, DocumentStyleSheet>,
     /// Stylesheets added by the useragent

--- a/packages/blitz-dom/src/form.rs
+++ b/packages/blitz-dom/src/form.rs
@@ -43,8 +43,7 @@ impl BaseDocument {
         // First try explicit form attribute
         let final_owner_id = element
             .attr(local_name!("form"))
-            .and_then(|owner| self.nodes_to_id.get(owner))
-            .copied()
+            .and_then(|owner| self.get_element_by_id(owner))
             .filter(|owner_id| {
                 self.get_node(*owner_id)
                     .is_some_and(|node| node.data.is_element_with_tag_name(&local_name!("form")))

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -262,6 +262,18 @@ impl DocumentMutator<'_> {
             self.doc.nodes[node_id].mark_ancestors_dirty();
         }
 
+        if name.local == local_name!("id") && node_is_in_document {
+            if let Some(old_id) = self.doc.nodes[node_id]
+                .element_data()
+                .map(|element| element.id.clone())
+            {
+                if let Some(old_id) = old_id {
+                    self.doc.remove_from_id_map(&old_id, node_id);
+                }
+                self.doc.add_to_id_map(value, node_id);
+            }
+        }
+
         let node = &mut self.doc.nodes[node_id];
 
         let NodeData::Element(ref mut element) = node.data else {
@@ -357,6 +369,15 @@ impl DocumentMutator<'_> {
             // Mark ancestors dirty so the style traversal visits this subtree.
             // Without this, the traversal may skip nodes with pending RestyleHint/damage.
             node.mark_ancestors_dirty();
+        }
+
+        if name.local == local_name!("id") && node_is_in_document {
+            if let Some(old_id) = self.doc.nodes[node_id]
+                .element_data()
+                .and_then(|element| element.id.clone())
+            {
+                self.doc.remove_from_id_map(&old_id, node_id);
+            }
         }
 
         let node = &mut self.doc.nodes[node_id];
@@ -748,10 +769,11 @@ impl<'doc> DocumentMutator<'doc> {
             node.insert_damage(ALL_DAMAGE);
 
             // If the node has an "id" attribute, store it in the ID map.
-            if let Some(id_attr) = node.attr(local_name!("id")) {
-                doc.nodes_to_id.insert(id_attr.to_string(), node_id);
+            if let Some(id_attr) = node.attr(local_name!("id")).map(ToString::to_string) {
+                doc.add_to_id_map(&id_attr, node_id);
             }
 
+            let node = &mut doc.nodes[node_id];
             let NodeData::Element(ref mut element) = node.data else {
                 return;
             };
@@ -814,10 +836,11 @@ impl<'doc> DocumentMutator<'doc> {
             }
 
             // If the node has an "id" attribute remove it from the ID map.
-            if let Some(id_attr) = node.attr(local_name!("id")) {
-                doc.nodes_to_id.remove(id_attr);
+            if let Some(id_attr) = node.attr(local_name!("id")).map(ToString::to_string) {
+                doc.remove_from_id_map(&id_attr, node_id);
             }
 
+            let node = &mut doc.nodes[node_id];
             let NodeData::Element(ref mut element) = node.data else {
                 return;
             };
@@ -1294,6 +1317,64 @@ mod test {
             !node.element_state().contains(ElementState::ENABLED),
             "form node is enabled"
         );
+    }
+
+    #[test]
+    fn mutator_id_attribute_updates_id_map() {
+        let mut document = BaseDocument::new(DocumentConfig::default());
+        let root_id = document.root_node().id;
+
+        let node_id = {
+            let mut mutator = document.mutate();
+            let node_id = mutator.create_element(
+                qual_name!("div"),
+                vec![Attribute {
+                    name: qual_name!("id"),
+                    value: "old".into(),
+                }],
+            );
+            mutator.append_children(root_id, &[node_id]);
+            node_id
+        };
+        assert_eq!(document.get_element_by_id("old"), Some(node_id));
+
+        {
+            let mut mutator = document.mutate();
+            mutator.set_attribute(node_id, qual_name!("id"), "new");
+        }
+        assert_eq!(document.get_element_by_id("new"), Some(node_id));
+        assert_eq!(document.get_element_by_id("old"), None);
+
+        {
+            let mut mutator = document.mutate();
+            mutator.clear_attribute(node_id, qual_name!("id"));
+        }
+        assert_eq!(document.get_element_by_id("new"), None);
+    }
+
+    #[test]
+    fn get_element_by_id_duplicate_ids_first_in_tree_order_wins() {
+        let mut document = BaseDocument::new(DocumentConfig::default());
+        let root_id = document.root_node().id;
+
+        let (first_id, second_id) = {
+            let mut mutator = document.mutate();
+            let first_id = mutator.create_element(qual_name!("div"), vec![]);
+            let second_id = mutator.create_element(qual_name!("div"), vec![]);
+            mutator.append_children(root_id, &[first_id, second_id]);
+            // Assign the id to the later node first so that insertion order
+            // differs from tree order
+            mutator.set_attribute(second_id, qual_name!("id"), "dup");
+            mutator.set_attribute(first_id, qual_name!("id"), "dup");
+            (first_id, second_id)
+        };
+        assert_eq!(document.get_element_by_id("dup"), Some(first_id));
+
+        {
+            let mut mutator = document.mutate();
+            mutator.remove_node(first_id);
+        }
+        assert_eq!(document.get_element_by_id("dup"), Some(second_id));
     }
 
     #[derive(Default)]

--- a/packages/blitz-dom/src/query_selector.rs
+++ b/packages/blitz-dom/src/query_selector.rs
@@ -11,9 +11,47 @@ use style_traits::ParseError;
 use crate::{BaseDocument, Node};
 
 impl BaseDocument {
-    /// Find the node with the specified id attribute (if one exists)
+    /// Find the node with the specified id attribute (if one exists).
+    /// If multiple nodes have the same id, the first in tree order is returned.
     pub fn get_element_by_id(&self, id: &str) -> Option<NodeId> {
-        self.nodes_to_id.get(id).copied()
+        match self.nodes_to_id.get(id)?.as_slice() {
+            [] => None,
+            [node_id] => Some(*node_id),
+            candidates => self.first_in_tree_order(candidates),
+        }
+    }
+
+    /// Find the first of `candidates` in tree order
+    fn first_in_tree_order(&self, candidates: &[NodeId]) -> Option<NodeId> {
+        let mut stack = vec![self.root_node_id];
+        while let Some(node_id) = stack.pop() {
+            if candidates.contains(&node_id) {
+                return Some(node_id);
+            }
+            stack.extend(self.nodes[node_id].children.iter().rev().copied());
+        }
+        None
+    }
+
+    /// Add a node to the id-to-node map
+    pub(crate) fn add_to_id_map(&mut self, id: &str, node_id: NodeId) {
+        if id.is_empty() {
+            return;
+        }
+        let node_ids = self.nodes_to_id.entry(id.to_string()).or_default();
+        if !node_ids.contains(&node_id) {
+            node_ids.push(node_id);
+        }
+    }
+
+    /// Remove a node from the id-to-node map
+    pub(crate) fn remove_from_id_map(&mut self, id: &str, node_id: NodeId) {
+        if let Some(node_ids) = self.nodes_to_id.get_mut(id) {
+            node_ids.retain(|nid| *nid != node_id);
+            if node_ids.is_empty() {
+                self.nodes_to_id.remove(id);
+            }
+        }
     }
 
     /// Find the first node that matches the selector specified as a string


### PR DESCRIPTION
## Summary

Fixes #677: `DocumentMutator::set_attribute`/`clear_attribute` updated `ElementData.id` but not `BaseDocument::nodes_to_id`, so `get_element_by_id` returned stale results after an in-document `id` mutation.

- `set_attribute(node, "id", value)` / `clear_attribute(node, "id")` now remove the old id-map entry for the node and (for set) add the new one, when the node is in the document.
- Duplicate-id behaviour is now defined per the DOM spec: `nodes_to_id` becomes `HashMap<String, SmallVec<[NodeId; 1]>>` holding all in-document nodes with a given id, and `get_element_by_id` returns the first in tree order (resolved by a root DFS only when there is more than one candidate, so the common single-id path stays a plain map lookup).
- Subtree add/remove now go through the shared `add_to_id_map`/`remove_from_id_map` helpers; removal only drops the entry for the removed node instead of clobbering whichever node was indexed. Empty-string ids are never indexed (`getElementById("")` returns `None`).
- `reset_form_owner` now resolves the `form` attribute via `get_element_by_id` so it too gets tree-order semantics.

Includes unit tests for id mutation (the issue's repro) and duplicate-id tree-order resolution.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/646d99702a214786840437e099146d36
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31414315677).</sub>
<!-- wpt-results-end -->
