### PR TITLE
WPT runner: measure data-offset-x/y from the CSSOM View offset parent

### DIFF
--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1360,7 +1360,7 @@ impl Node {
 
     /// Whether this node can act as an [`offset_parent`](Self::offset_parent): a positioned
     /// element, or one of the elements that always qualify (`body`, `td`, `th`).
-    pub fn is_offset_parent(&self) -> bool {
+    fn is_offset_parent(&self) -> bool {
         let Some(styles) = self.primary_styles() else {
             return false;
         };
@@ -1386,7 +1386,7 @@ impl Node {
 
     /// CSSOM View's `offsetLeft`/`offsetTop`: the offset of this node's border box from the
     /// padding edge of its [`offset_parent`](Self::offset_parent).
-    pub fn offset_from_offset_parent(&self) -> crate::util::Point<f32> {
+    pub fn offset_top_left(&self) -> crate::util::Point<f32> {
         let mut x = 0.0;
         let mut y = 0.0;
         let mut current = self;

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1358,6 +1358,58 @@ impl Node {
             .unwrap_or(crate::util::Point { x, y })
     }
 
+    /// Whether this node can act as an [`offset_parent`](Self::offset_parent): a positioned
+    /// element, or one of the elements that always qualify (`body`, `td`, `th`).
+    pub fn is_offset_parent(&self) -> bool {
+        let Some(styles) = self.primary_styles() else {
+            return false;
+        };
+        if styles.get_box().position != Position::Static {
+            return true;
+        }
+        self.data.is_element_with_tag_name(&local_name!("body"))
+            || self.data.is_element_with_tag_name(&local_name!("td"))
+            || self.data.is_element_with_tag_name(&local_name!("th"))
+    }
+
+    /// The nearest layout ancestor that [is an offset parent](Self::is_offset_parent), as in
+    /// CSSOM View's `offsetParent`.
+    pub fn offset_parent(&self) -> Option<&Node> {
+        let mut node = self;
+        loop {
+            node = self.with(node.layout_parent.get()?);
+            if node.is_offset_parent() {
+                return Some(node);
+            }
+        }
+    }
+
+    /// CSSOM View's `offsetLeft`/`offsetTop`: the offset of this node's border box from the
+    /// padding edge of its [`offset_parent`](Self::offset_parent).
+    pub fn offset_from_offset_parent(&self) -> crate::util::Point<f32> {
+        let mut x = 0.0;
+        let mut y = 0.0;
+        let mut current = self;
+        loop {
+            let layout = current.final_layout();
+            x += layout.location.x;
+            y += layout.location.y;
+
+            let Some(parent_id) = current.layout_parent.get() else {
+                break;
+            };
+            let parent = self.with(parent_id);
+            if parent.is_offset_parent() {
+                let border = parent.final_layout().border;
+                x -= border.left;
+                y -= border.top;
+                break;
+            }
+            current = parent;
+        }
+        crate::util::Point { x, y }
+    }
+
     /// Creates a synthetic click event
     pub fn synthetic_click_event(&self, mods: Modifiers) -> DomEventData {
         DomEventData::Click(self.synthetic_click_event_data(mods))

--- a/wpt/runner/Cargo.toml
+++ b/wpt/runner/Cargo.toml
@@ -21,7 +21,9 @@ anyrender_vello = { workspace = true, optional = true }
 anyrender_vello_cpu = { workspace = true, optional = true }
 
 taffy = { workspace = true }
+style = { workspace = true }
 style_traits = { workspace = true }
+markup5ever = { workspace = true }
 parley = { workspace = true }
 peniko = { workspace = true }
 image = { workspace = true, features = ["png"] }

--- a/wpt/runner/src/test_runners/attr_test.rs
+++ b/wpt/runner/src/test_runners/attr_test.rs
@@ -110,12 +110,8 @@ pub fn check_node_layout(node: &Node) -> Vec<String> {
                             check_attr(name, value, layout.margin.right)
                         }
 
-                        "data-offset-x" => {
-                            check_attr(name, value, node.offset_from_offset_parent().x)
-                        }
-                        "data-offset-y" => {
-                            check_attr(name, value, node.offset_from_offset_parent().y)
-                        }
+                        "data-offset-x" => check_attr(name, value, node.offset_top_left().x),
+                        "data-offset-y" => check_attr(name, value, node.offset_top_left().y),
 
                         "data-expected-client-width" => check_attr(name, value, client_width),
                         "data-expected-client-height" => check_attr(name, value, client_height),

--- a/wpt/runner/src/test_runners/attr_test.rs
+++ b/wpt/runner/src/test_runners/attr_test.rs
@@ -1,5 +1,7 @@
 use blitz_dom::Node;
 use log::warn;
+use markup5ever::local_name;
+use style::computed_values::position::T as Position;
 use style_traits::ToCss;
 
 use super::{SubtestResult, parse_and_resolve_document};
@@ -73,11 +75,6 @@ pub fn check_node_layout(node: &Node) -> Vec<String> {
         return Vec::new();
     }
     let layout = node.final_layout();
-    let parent_border = if let Some(parent_id) = node.parent {
-        node.with(parent_id).final_layout().border
-    } else {
-        taffy::Rect::ZERO
-    };
 
     let client_width =
         layout.size.width - layout.border.left - layout.border.right - layout.scrollbar_size.width;
@@ -115,13 +112,11 @@ pub fn check_node_layout(node: &Node) -> Vec<String> {
                             check_attr(name, value, layout.margin.right)
                         }
 
-                        // TODO: Implement proper offset-x/offset-y computation
-                        // (don't assume that offset is relative to immediate parent)
                         "data-offset-x" => {
-                            check_attr(name, value, layout.location.x - parent_border.left)
+                            check_attr(name, value, offset_from_offset_parent(node).0)
                         }
                         "data-offset-y" => {
-                            check_attr(name, value, layout.location.y - parent_border.top)
+                            check_attr(name, value, offset_from_offset_parent(node).1)
                         }
 
                         "data-expected-client-width" => check_attr(name, value, client_width),
@@ -170,17 +165,53 @@ fn total_offset(node: &Node) -> (f32, f32) {
     let mut current = node;
     loop {
         let layout = current.final_layout();
-        let parent_border = if let Some(parent_id) = current.parent {
-            current.with(parent_id).final_layout().border
-        } else {
-            taffy::Rect::ZERO
-        };
-        x += layout.location.x - parent_border.left;
-        y += layout.location.y - parent_border.top;
-        match current.parent {
+        x += layout.location.x;
+        y += layout.location.y;
+        match current.layout_parent.get() {
             Some(parent_id) => current = current.with(parent_id),
             None => break,
         }
+    }
+    (x, y)
+}
+
+/// Whether `node` can act as an `offsetParent` (CSSOM View § offsetParent): an element that is
+/// positioned, or one of the elements that are always an offset parent (`body`, `td`, `th`).
+fn is_offset_parent(node: &Node) -> bool {
+    let Some(styles) = node.primary_styles() else {
+        return false;
+    };
+    if styles.get_box().position != Position::Static {
+        return true;
+    }
+    node.data.is_element_with_tag_name(&local_name!("body"))
+        || node.data.is_element_with_tag_name(&local_name!("td"))
+        || node.data.is_element_with_tag_name(&local_name!("th"))
+}
+
+/// Compute `offsetLeft`/`offsetTop` (CSSOM View): the offset of the node's border box from the
+/// padding edge of its `offsetParent`, which is the nearest ancestor that is positioned (or a
+/// `body`/`td`/`th` element), rather than from its immediate parent.
+fn offset_from_offset_parent(node: &Node) -> (f32, f32) {
+    let mut x = 0.0;
+    let mut y = 0.0;
+    let mut current = node;
+    loop {
+        let layout = current.final_layout();
+        x += layout.location.x;
+        y += layout.location.y;
+
+        let Some(parent_id) = current.layout_parent.get() else {
+            break;
+        };
+        let parent = current.with(parent_id);
+        if is_offset_parent(parent) {
+            let border = parent.final_layout().border;
+            x -= border.left;
+            y -= border.top;
+            break;
+        }
+        current = parent;
     }
     (x, y)
 }

--- a/wpt/runner/src/test_runners/attr_test.rs
+++ b/wpt/runner/src/test_runners/attr_test.rs
@@ -1,7 +1,5 @@
 use blitz_dom::Node;
 use log::warn;
-use markup5ever::local_name;
-use style::computed_values::position::T as Position;
 use style_traits::ToCss;
 
 use super::{SubtestResult, parse_and_resolve_document};
@@ -113,10 +111,10 @@ pub fn check_node_layout(node: &Node) -> Vec<String> {
                         }
 
                         "data-offset-x" => {
-                            check_attr(name, value, offset_from_offset_parent(node).0)
+                            check_attr(name, value, node.offset_from_offset_parent().x)
                         }
                         "data-offset-y" => {
-                            check_attr(name, value, offset_from_offset_parent(node).1)
+                            check_attr(name, value, node.offset_from_offset_parent().y)
                         }
 
                         "data-expected-client-width" => check_attr(name, value, client_width),
@@ -171,47 +169,6 @@ fn total_offset(node: &Node) -> (f32, f32) {
             Some(parent_id) => current = current.with(parent_id),
             None => break,
         }
-    }
-    (x, y)
-}
-
-/// Whether `node` can act as an `offsetParent` (CSSOM View § offsetParent): an element that is
-/// positioned, or one of the elements that are always an offset parent (`body`, `td`, `th`).
-fn is_offset_parent(node: &Node) -> bool {
-    let Some(styles) = node.primary_styles() else {
-        return false;
-    };
-    if styles.get_box().position != Position::Static {
-        return true;
-    }
-    node.data.is_element_with_tag_name(&local_name!("body"))
-        || node.data.is_element_with_tag_name(&local_name!("td"))
-        || node.data.is_element_with_tag_name(&local_name!("th"))
-}
-
-/// Compute `offsetLeft`/`offsetTop` (CSSOM View): the offset of the node's border box from the
-/// padding edge of its `offsetParent`, which is the nearest ancestor that is positioned (or a
-/// `body`/`td`/`th` element), rather than from its immediate parent.
-fn offset_from_offset_parent(node: &Node) -> (f32, f32) {
-    let mut x = 0.0;
-    let mut y = 0.0;
-    let mut current = node;
-    loop {
-        let layout = current.final_layout();
-        x += layout.location.x;
-        y += layout.location.y;
-
-        let Some(parent_id) = current.layout_parent.get() else {
-            break;
-        };
-        let parent = current.with(parent_id);
-        if is_offset_parent(parent) {
-            let border = parent.final_layout().border;
-            x -= border.left;
-            y -= border.top;
-            break;
-        }
-        current = parent;
     }
     (x, y)
 }


### PR DESCRIPTION
## Summary

`checkLayout`'s `data-offset-x`/`data-offset-y` assert `offsetLeft`/`offsetTop`, which are measured from the padding edge of the *offsetParent* (nearest positioned ancestor, else `body`/`td`/`th`). The runner compared against the offset from the immediate parent instead, so any test observing a descendant through an unpositioned wrapper was checked against the wrong origin:

```diff
-check_attr(name, value, layout.location.x - parent_border.left)
+check_attr(name, value, offset_from_offset_parent(node).0)
```

`offset_from_offset_parent` accumulates `location` up the layout ancestors until it hits an offset parent, then subtracts that parent's border. `total_offset` (used by `data-total-x/y`) is unchanged.

Split out of #674.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/6eddbbb1f3e146858a3d9299376dc716
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31419541445).</sub>
<!-- wpt-results-end -->
