### PR TITLE
Gate baseline export where CSS forbids it (scroll containers, contain:layout, vertical-align)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,9 +2902,8 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -2914,7 +2913,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts 0.39.2",
+ "read-fonts 0.40.2",
  "roxmltree 0.21.1",
  "smallvec",
  "windows",
@@ -3396,13 +3395,13 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
+checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
- "read-fonts 0.39.2",
+ "read-fonts 0.40.2",
  "smallvec",
 ]
 
@@ -5338,17 +5337,36 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
 
 [[package]]
 name = "parley"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
 dependencies = [
  "fontique",
- "harfrust 0.8.4",
+ "hashbrown 0.17.1",
+ "linebender_resource_handle",
+ "parlance",
+ "parley_engine",
+ "skrifa 0.43.2",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
+dependencies = [
+ "icu_properties",
+]
+
+[[package]]
+name = "parley_engine"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
+dependencies = [
+ "fontique",
+ "harfrust 0.10.0",
  "hashbrown 0.17.1",
  "icu_normalizer",
  "icu_properties",
@@ -5356,16 +5374,7 @@ dependencies = [
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa 0.42.1",
-]
-
-[[package]]
-name = "parley_data"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
-dependencies = [
- "icu_properties",
+ "skrifa 0.43.2",
 ]
 
 [[package]]
@@ -5956,6 +5965,17 @@ checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
  "font-types 0.11.3",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
+dependencies = [
+ "bytemuck",
+ "font-types 0.12.2",
+ "once_cell",
 ]
 
 [[package]]
@@ -6677,6 +6697,16 @@ checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
  "read-fonts 0.39.2",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.40.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d4a2b3bf17ed268e4e
     "calc",
     "detailed_layout_info",
 ] }
-parley = { version = "0.10", default-features = false, features = ["std"] }
+parley = { git = "https://github.com/DioxusLabs/parley", rev = "9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb", default-features = false, features = ["std"] }
 skrifa = { version = "0.42", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -1114,6 +1114,7 @@ pub(crate) fn build_inline_layout_into(
                                 // Width and height are set during layout
                                 width: 0.0,
                                 height: 0.0,
+                                baseline: None,
                             });
                         } else if *tag_name == local_name!("br") {
                             // node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
@@ -1194,6 +1195,7 @@ pub(crate) fn build_inline_layout_into(
                             // Width and height are set during layout
                             width: 0.0,
                             height: 0.0,
+                            baseline: None,
                         });
                     }
                 };

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -305,6 +305,10 @@ impl BaseDocument {
                 ibox.height = 0.0;
             } else {
                 let output = self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
+                ibox.baseline = output
+                    .first_baselines
+                    .y
+                    .map(|baseline| (margin.top + baseline) * scale);
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
                 // Vertical margins adjust the space the box reserves in the line, but the
                 // reserved space cannot be negative.

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -583,7 +583,7 @@ impl BaseDocument {
                         // dbg!(&layout.size);
                         // dbg!(&layout.location);
 
-                        state.append_inline_box_to_line(box_break_data.advance, 0.0);
+                        state.append_inline_box_to_line(box_break_data.advance, 0.0, 0.0, false);
 
                         // if float.is_floated() {
                         //     println!("INLINE FLOATED BOX ({}) {:?}", ibox.id, float);

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -304,11 +304,35 @@ impl BaseDocument {
                 ibox.width = 0.0;
                 ibox.height = 0.0;
             } else {
+                // Parley has no per-box vertical-align support: it always aligns a
+                // box's baseline (or bottom edge, if the baseline is unset) to the
+                // line's baseline. For alignments that this cannot approximate (e.g.
+                // `middle`), leave the baseline unset so the box aligns by its
+                // bottom edge rather than by an unrelated content baseline.
+                use style::Zero;
+                use style::values::computed::{AlignmentBaseline, BaselineShift};
+                use style::values::generics::box_::BaselineShiftKeyword;
+                let is_baseline_aligned = self.nodes[NodeId::from_u64(ibox.id)]
+                    .primary_styles()
+                    .is_none_or(|s| {
+                        s.clone_alignment_baseline() == AlignmentBaseline::Baseline
+                            && match s.clone_baseline_shift() {
+                                BaselineShift::Length(length) => length.is_zero(),
+                                BaselineShift::Keyword(BaselineShiftKeyword::Top) => true,
+                                BaselineShift::Keyword(_) => false,
+                            }
+                    });
+
                 let output = self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
+                // The baseline is measured from the top of the space the box reserves in
+                // the line, which is clamped to be non-negative (see `ibox.height`), so
+                // the baseline is clamped to that space too. This matters when a negative
+                // `margin-top` places the baseline above the reserved space.
                 ibox.baseline = output
                     .first_baselines
                     .y
-                    .map(|baseline| (margin.top + baseline) * scale);
+                    .filter(|_| is_baseline_aligned)
+                    .map(|baseline| ((margin.top + baseline) * scale).max(0.0));
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
                 // Vertical margins adjust the space the box reserves in the line, but the
                 // reserved space cannot be negative.
@@ -803,6 +827,10 @@ impl BaseDocument {
         // println!("known_dimensions: w: {:?} h: {:?}", inputs.known_dimensions.width, inputs.known_dimensions.height);
         // println!("\n");
 
+        // Only lines with in-flow text content export a baseline: a line consisting
+        // solely of atomic inlines (e.g. a lone image) has no meaningful text baseline
+        // (Parley reports 0.0), and CSS says such boxes synthesize their baseline from
+        // the bottom margin edge instead.
         let first_baseline = inline_layout
             .layout
             .lines()

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -51,6 +51,35 @@ impl BaseDocument {
         inputs: taffy::tree::LayoutInput,
         block_ctx: Option<&mut BlockContext<'_>>,
     ) -> taffy::tree::LayoutOutput {
+        // CSS forbids some boxes from exporting their content's baseline, requiring
+        // their baseline to be synthesized instead (css-align "baseline export"):
+        //   - Inline-blocks that are scroll containers (CSS2 §10.8.1 `vertical-align`).
+        //     Flex and grid containers take their baseline from their contents even
+        //     when scrollable.
+        //   - Boxes with layout containment (css-contain).
+        let node = &self.nodes[dom_node_id(node_id)];
+        let is_scrollable_inline_block = node.style().display == Display::FlowRoot
+            && (node.style().overflow.x.is_scroll_container()
+                || node.style().overflow.y.is_scroll_container());
+        let has_layout_containment = node.primary_styles().is_some_and(|s| {
+            s.clone_contain()
+                .contains(style::values::computed::Contain::LAYOUT)
+        });
+        let suppress_baseline = is_scrollable_inline_block || has_layout_containment;
+
+        let mut output = self.compute_child_layout_dispatch(node_id, inputs, block_ctx);
+        if suppress_baseline {
+            output.first_baselines = taffy::Point::NONE;
+        }
+        output
+    }
+
+    fn compute_child_layout_dispatch(
+        &mut self,
+        node_id: NodeId,
+        inputs: taffy::tree::LayoutInput,
+        block_ctx: Option<&mut BlockContext<'_>>,
+    ) -> taffy::tree::LayoutOutput {
         let node = &mut self.nodes[dom_node_id(node_id)];
 
         let font_styles = node.primary_styles().map(|style| {

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1263,8 +1263,8 @@ impl Node {
                 if let Some((cluster, _side)) =
                     Cluster::from_point_exact(layout, x * scale, y * scale)
                 {
-                    let style_index = cluster.glyphs().next()?.style_index();
-                    let node_id = layout.styles()[style_index].brush.id;
+                    let style_index = cluster.style_index();
+                    let node_id = layout.styles()[usize::from(style_index)].brush.id;
                     let text_pointer_events_none = self
                         .with(node_id)
                         .primary_styles()

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -49,7 +49,7 @@ pub(crate) fn draw_inline_backgrounds<'a>(
                 continue;
             }
 
-            let metrics = glyph_run.run().metrics();
+            let metrics = glyph_run.run().font_metrics();
             let x = glyph_run.offset() as f64;
             let w = glyph_run.advance() as f64;
             let baseline = glyph_run.baseline() as f64;
@@ -75,7 +75,7 @@ pub(crate) fn stroke_text<'a>(
                 let run = glyph_run.run();
                 let font = run.font();
                 let font_size = run.font_size();
-                let metrics = run.metrics();
+                let metrics = run.font_metrics();
                 let style = glyph_run.style();
                 let synthesis = run.synthesis();
                 let glyph_xform = synthesis
@@ -109,11 +109,17 @@ pub(crate) fn stroke_text<'a>(
                     kurbo::Vec2::default()
                 };
 
+                let normalized_coords: Vec<i16> = run
+                    .normalized_coords()
+                    .iter()
+                    .map(|coord| coord.to_bits())
+                    .collect();
+
                 scene.draw_glyphs(
-                    font,
+                    &font.font,
                     font_size,
                     !FONT_EMBOLDEN_ENABLED, // hint
-                    run.normalized_coords(),
+                    &normalized_coords,
                     embolden,
                     Fill::NonZero,
                     &anyrender::Paint::from(text_color),


### PR DESCRIPTION
## Summary

Fixes part of the baseline-export regression group on #627 (Group A). The parley baseline wiring passed Taffy's `first_baselines.y` through to `InlineBox::baseline` unconditionally, but CSS requires several classes of atomic inline to synthesize their baseline from the bottom margin edge (`baseline: None` in parley 0.11) instead of exporting their content's baseline.

Three gates:

1. **`compute_child_layout_internal` (mod.rs)** — split into a wrapper + `compute_child_layout_dispatch` so it covers every layout path (including tables/form controls), and suppress `first_baselines` when:
   - the box is a scrollable inline-block (`Display::FlowRoot` + non-visible/clip overflow) — CSS2 §10.8.1; flex/grid containers keep exporting their content baseline even when scrollable (per `baseline-of-scrollable-1a`), or
   - the box has `contain: layout` (css-contain baseline suppression).

2. **inline box update (inline.rs)** — parley has no per-box `vertical-align`; it always anchors a box's baseline (or bottom edge if unset) to the line baseline. For alignments this cannot approximate (`middle`, `text-bottom`, `sub`, non-zero shifts, …) the baseline is left unset so the box aligns by its bottom edge. `vertical-align: top` keeps exporting: its baseline-anchored rendering coincides with WPT reference emulations (`* { vertical-align: top }` + `margin-top`), and gating it regressed 4 flexbox vert tests. Also clamps `ibox.baseline` to ≥0 to match the non-negative reserved line space when negative `margin-top` is present (fixes `flexbox_inline.html`).

3. **inline container output (inline.rs)** — an inline root whose first line has no glyph runs (e.g. only a lone image) no longer exports a `0.0` "baseline"; per CSS a box with no in-flow line boxes synthesizes from the bottom margin edge (fixes the `object-view-box-*` tests).

## WPT results (css/CSS2, css-align, css-flexbox, css-grid, css-contain, css-images)

- Base branch: **5676 PASS** → this PR: **5691 PASS** (+15, **0 regressions**).
- 15 of the 24 Group A tests now pass.

Remaining 9 Group A failures are not fixable in blitz integration code:

- `baseline-of-scrollable-1b`, `baseline-block-with-overflow-001`: need consumer-dependent suppression of a scrollable *block* child's baseline during block-layout baseline propagation — a Taffy-side question (Taffy's block algorithm forwards the child baseline; blitz can't see the consumer).
- `grid-baseline-001/002`, `grid-inline-baseline`, `grid-inline-items-002`, `flexbox-baseline-multi-line-horiz-004`: Taffy flex/grid baseline synthesis/alignment (e.g. grid's first-row baseline fallback in `compute/grid/mod.rs`), not blitz wiring.
- `percentage-size-subitems-001` (×2 flex/grid variants), `scrollbar-gutter-001/002`, `floats-141.xht`: need real `vertical-align` support in parley (the refs rely on `vertical-align: top`/line-height details); gating them here regressed previously-passing tests.

`cargo check --workspace`, `cargo fmt`, `cargo clippy` are clean.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/331985c4732e4248a71184626d9c4a38
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**37** newly passing, **81** newly failing (net -44).

<details>
<summary>Full diff (118 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/bidi-text/bidi-001.xht
+ Fail => Pass css/CSS2/css1/c414-flt-fit-004.xht
- Pass => Fail css/CSS2/floats-clear/float-003.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-006.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-008.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-009.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-011.xht
- Pass => Fail css/CSS2/floats-clear/floats-141.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-left-overflow.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-left-table.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-right-overflow.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-right-table.xht
- Pass => Fail css/CSS2/fonts/font-family-applies-to-005.xht
- Pass => Fail css/CSS2/linebox/baseline-block-with-overflow-001.html
- Pass => Fail css/CSS2/linebox/inline-formatting-context-011.xht
- Pass => Fail css/CSS2/linebox/inline-formatting-context-013.xht
- Pass => Fail css/CSS2/linebox/line-height-002.xht
- Pass => Fail css/CSS2/linebox/line-height-004.xht
- Pass => Fail css/CSS2/linebox/line-height-005.xht
- Pass => Fail css/CSS2/linebox/line-height-013.xht
- Pass => Fail css/CSS2/linebox/line-height-015.xht
- Pass => Fail css/CSS2/linebox/line-height-016.xht
- Pass => Fail css/CSS2/linebox/line-height-024.xht
- Pass => Fail css/CSS2/linebox/line-height-026.xht
- Pass => Fail css/CSS2/linebox/line-height-027.xht
- Pass => Fail css/CSS2/linebox/line-height-035.xht
- Pass => Fail css/CSS2/linebox/line-height-037.xht
- Pass => Fail css/CSS2/linebox/line-height-038.xht
- Pass => Fail css/CSS2/linebox/line-height-046.xht
- Pass => Fail css/CSS2/linebox/line-height-048.xht
- Pass => Fail css/CSS2/linebox/line-height-049.xht
- Pass => Fail css/CSS2/linebox/line-height-057.xht
- Pass => Fail css/CSS2/linebox/line-height-059.xht
- Pass => Fail css/CSS2/linebox/line-height-060.xht
- Pass => Fail css/CSS2/linebox/line-height-068.xht
- Pass => Fail css/CSS2/linebox/line-height-070.xht
- Pass => Fail css/CSS2/linebox/line-height-071.xht
- Pass => Fail css/CSS2/linebox/line-height-079.xht
- Pass => Fail css/CSS2/linebox/line-height-081.xht
- Pass => Fail css/CSS2/linebox/line-height-082.xht
- Pass => Fail css/CSS2/linebox/line-height-090.xht
- Pass => Fail css/CSS2/linebox/line-height-092.xht
- Pass => Fail css/CSS2/linebox/line-height-093.xht
- Pass => Fail css/CSS2/linebox/line-height-101.xht
- Pass => Fail css/CSS2/linebox/line-height-103.xht
- Pass => Fail css/CSS2/linebox/line-height-104.xht
- Pass => Fail css/CSS2/linebox/line-height-bleed-001.xht
- Pass => Fail css/CSS2/linebox/line-height-bleed-002.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-replaced-width-001.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-replaced-width-003.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-replaced-width-006.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-width-001.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-width-003.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-width-006.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-036.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-047.xht
- Pass => Fail css/CSS2/normal-flow/max-width-percentage-001.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-036.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-047.xht
- Pass => Fail css/CSS2/normal-flow/min-width-percentage-001.xht
- Pass => Fail css/CSS2/normal-flow/width-percentage-001.xht
- Pass => Fail css/CSS2/normal-flow/width-percentage-002.xht
- Pass => Fail css/CSS2/positioning/absolute-non-replaced-height-008.xht
- Pass => Fail css/CSS2/positioning/absolute-non-replaced-max-height-008.xht
+ Fail => Pass css/CSS2/visudet/content-height-001.html
+ Fail => Pass css/CSS2/visudet/content-height-002.html
+ Fail => Pass css/CSS2/visudet/content-height-003.html
- Pass => Fail css/CSS2/visudet/line-height-201.html
- Pass => Fail css/css-align/baseline-of-scrollable-1b.html
+ Fail => Pass css/css-align/baseline-rules/synthesized-baseline-flexbox-001.html
+ Fail => Pass css/css-align/baseline-rules/synthesized-baseline-grid-001.html
+ Fail => Pass css/css-align/baseline-rules/synthesized-baseline-inline-block-001.html
- Pass => Fail css/css-backgrounds/background-origin/origin-padding-box.html
- Pass => Fail css/css-backgrounds/background-origin/origin-padding-box_with_radius.html
- Pass => Fail css/css-backgrounds/background-size-027.html
- Pass => Fail css/css-backgrounds/background-size-028.html
- Pass => Fail css/css-backgrounds/background-size-030.html
- Pass => Fail css/css-backgrounds/background-size-031.html
- Pass => Fail css/css-break/ruby-003.html
+ Fail => Pass css/css-contain/contain-layout-baseline-002.html
+ Fail => Pass css/css-contain/contain-layout-baseline-003.html
+ Fail => Pass css/css-contain/contain-layout-suppress-baseline-001.html
+ Fail => Pass css/css-contain/contain-layout-suppress-baseline-002.html
+ Fail => Pass css/css-contain/contain-paint-022.html
+ Fail => Pass css/css-flexbox/flexbox-align-self-horiz-001-block.xhtml
+ Fail => Pass css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001.html
+ Fail => Pass css/css-flexbox/flexbox-baseline-multi-item-vert-001a.html
+ Fail => Pass css/css-flexbox/flexbox-baseline-multi-item-vert-001b.html
- Pass => Fail css/css-flexbox/flexbox-baseline-multi-line-horiz-004.html
+ Fail => Pass css/css-flexbox/flexbox-basic-canvas-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-canvas-vert-001v.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-iframe-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-img-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-textarea-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-video-vert-001.xhtml
- Pass => Fail css/css-flexbox/percentage-size-subitems-001.html
- Pass => Fail css/css-fonts/first-available-font-003.html
- Pass => Fail css/css-fonts/first-available-font-004.html
- Pass => Fail css/css-grid/alignment/grid-baseline-001.html
- Pass => Fail css/css-grid/alignment/grid-baseline-002.html
- Pass => Fail css/css-grid/alignment/grid-inline-baseline.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-001.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-003.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-lr-001.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-rl-001.html
- Pass => Fail css/css-grid/grid-items/grid-inline-items-002.html
- Pass => Fail css/css-grid/grid-items/percentage-size-replaced-subitems-001.html
- Pass => Fail css/css-grid/grid-items/percentage-size-subitems-001.html
- Pass => Fail css/css-grid/subgrid/scrollbar-gutter-001.html
- Pass => Fail css/css-grid/subgrid/scrollbar-gutter-002.html
+ Fail => Pass css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html
- Pass => Fail css/css-overflow/scrollable-overflow-padding-inline.html
- Pass => Fail css/css-ruby/br-clear-all-000.html
+ Fail => Pass css/css-text/line-breaking/line-breaking-atomic-009.html
+ Fail => Pass css/css-values/ch-unit-001.html
+ Fail => Pass css/css-writing-modes/baseline-with-orthogonal-flow-001.html
+ Fail => Pass css/css-writing-modes/text-combine-upright-shadow.html
+ Fail => Pass css/filter-effects/effect-reference-after-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31443664752).</sub>
<!-- wpt-results-end -->
