### PR TITLE
Re-pin parley for negative half-leading fix (WPT Group B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "fontique"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
+source = "git+https://github.com/DioxusLabs/parley?rev=99ec3e5e9767be970234c8a46634a53a92f2f545#99ec3e5e9767be970234c8a46634a53a92f2f545"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -5337,12 +5337,12 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
+source = "git+https://github.com/DioxusLabs/parley?rev=99ec3e5e9767be970234c8a46634a53a92f2f545#99ec3e5e9767be970234c8a46634a53a92f2f545"
 
 [[package]]
 name = "parley"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
+source = "git+https://github.com/DioxusLabs/parley?rev=99ec3e5e9767be970234c8a46634a53a92f2f545#99ec3e5e9767be970234c8a46634a53a92f2f545"
 dependencies = [
  "fontique",
  "hashbrown 0.17.1",
@@ -5355,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "parley_data"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
+source = "git+https://github.com/DioxusLabs/parley?rev=99ec3e5e9767be970234c8a46634a53a92f2f545#99ec3e5e9767be970234c8a46634a53a92f2f545"
 dependencies = [
  "icu_properties",
 ]
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "parley_engine"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
+source = "git+https://github.com/DioxusLabs/parley?rev=99ec3e5e9767be970234c8a46634a53a92f2f545#99ec3e5e9767be970234c8a46634a53a92f2f545"
 dependencies = [
  "fontique",
  "harfrust 0.10.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,9 +2902,8 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -2914,7 +2913,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts 0.39.2",
+ "read-fonts 0.40.2",
  "roxmltree 0.21.1",
  "smallvec",
  "windows",
@@ -3396,13 +3395,13 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
+checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
- "read-fonts 0.39.2",
+ "read-fonts 0.40.2",
  "smallvec",
 ]
 
@@ -5338,17 +5337,36 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
 
 [[package]]
 name = "parley"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
 dependencies = [
  "fontique",
- "harfrust 0.8.4",
+ "hashbrown 0.17.1",
+ "linebender_resource_handle",
+ "parlance",
+ "parley_engine",
+ "skrifa 0.43.2",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
+dependencies = [
+ "icu_properties",
+]
+
+[[package]]
+name = "parley_engine"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb#9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb"
+dependencies = [
+ "fontique",
+ "harfrust 0.10.0",
  "hashbrown 0.17.1",
  "icu_normalizer",
  "icu_properties",
@@ -5356,16 +5374,7 @@ dependencies = [
  "linebender_resource_handle",
  "parlance",
  "parley_data",
- "skrifa 0.42.1",
-]
-
-[[package]]
-name = "parley_data"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
-dependencies = [
- "icu_properties",
+ "skrifa 0.43.2",
 ]
 
 [[package]]
@@ -5956,6 +5965,17 @@ checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
  "font-types 0.11.3",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
+dependencies = [
+ "bytemuck",
+ "font-types 0.12.2",
+ "once_cell",
 ]
 
 [[package]]
@@ -6677,6 +6697,16 @@ checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
  "read-fonts 0.39.2",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.40.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d4a2b3bf17ed268e4e
     "calc",
     "detailed_layout_info",
 ] }
-parley = { git = "https://github.com/DioxusLabs/parley", rev = "9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb", default-features = false, features = ["std"] }
+parley = { git = "https://github.com/DioxusLabs/parley", rev = "99ec3e5e9767be970234c8a46634a53a92f2f545", default-features = false, features = ["std"] }
 skrifa = { version = "0.42", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d4a2b3bf17ed268e4e
     "calc",
     "detailed_layout_info",
 ] }
-parley = { version = "0.10", default-features = false, features = ["std"] }
+parley = { git = "https://github.com/DioxusLabs/parley", rev = "9c41a4d0b9aa1aae7b8fdad8cf31728c9c3476bb", default-features = false, features = ["std"] }
 skrifa = { version = "0.42", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -1114,6 +1114,7 @@ pub(crate) fn build_inline_layout_into(
                                 // Width and height are set during layout
                                 width: 0.0,
                                 height: 0.0,
+                                baseline: None,
                             });
                         } else if *tag_name == local_name!("br") {
                             // node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
@@ -1194,6 +1195,7 @@ pub(crate) fn build_inline_layout_into(
                             // Width and height are set during layout
                             width: 0.0,
                             height: 0.0,
+                            baseline: None,
                         });
                     }
                 };

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -587,7 +587,14 @@ impl BaseDocument {
                         // dbg!(&layout.size);
                         // dbg!(&layout.location);
 
-                        state.append_inline_box_to_line(box_break_data.advance, 0.0, 0.0, false);
+                        // Negative infinity extents so the float contributes nothing to the
+                        // line box's height.
+                        state.append_inline_box_to_line(
+                            box_break_data.advance,
+                            f32::NEG_INFINITY,
+                            f32::NEG_INFINITY,
+                            false,
+                        );
 
                         // if float.is_floated() {
                         //     println!("INLINE FLOATED BOX ({}) {:?}", ibox.id, float);

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -305,6 +305,10 @@ impl BaseDocument {
                 ibox.height = 0.0;
             } else {
                 let output = self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
+                ibox.baseline = output
+                    .first_baselines
+                    .y
+                    .map(|baseline| (margin.top + baseline) * scale);
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
                 // Vertical margins adjust the space the box reserves in the line, but the
                 // reserved space cannot be negative.

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -583,7 +583,7 @@ impl BaseDocument {
                         // dbg!(&layout.size);
                         // dbg!(&layout.location);
 
-                        state.append_inline_box_to_line(box_break_data.advance, 0.0);
+                        state.append_inline_box_to_line(box_break_data.advance, 0.0, 0.0, false);
 
                         // if float.is_floated() {
                         //     println!("INLINE FLOATED BOX ({}) {:?}", ibox.id, float);

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1263,8 +1263,8 @@ impl Node {
                 if let Some((cluster, _side)) =
                     Cluster::from_point_exact(layout, x * scale, y * scale)
                 {
-                    let style_index = cluster.glyphs().next()?.style_index();
-                    let node_id = layout.styles()[style_index].brush.id;
+                    let style_index = cluster.style_index();
+                    let node_id = layout.styles()[usize::from(style_index)].brush.id;
                     let text_pointer_events_none = self
                         .with(node_id)
                         .primary_styles()

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -49,7 +49,7 @@ pub(crate) fn draw_inline_backgrounds<'a>(
                 continue;
             }
 
-            let metrics = glyph_run.run().metrics();
+            let metrics = glyph_run.run().font_metrics();
             let x = glyph_run.offset() as f64;
             let w = glyph_run.advance() as f64;
             let baseline = glyph_run.baseline() as f64;
@@ -75,7 +75,7 @@ pub(crate) fn stroke_text<'a>(
                 let run = glyph_run.run();
                 let font = run.font();
                 let font_size = run.font_size();
-                let metrics = run.metrics();
+                let metrics = run.font_metrics();
                 let style = glyph_run.style();
                 let synthesis = run.synthesis();
                 let glyph_xform = synthesis
@@ -109,11 +109,17 @@ pub(crate) fn stroke_text<'a>(
                     kurbo::Vec2::default()
                 };
 
+                let normalized_coords: Vec<i16> = run
+                    .normalized_coords()
+                    .iter()
+                    .map(|coord| coord.to_bits())
+                    .collect();
+
                 scene.draw_glyphs(
-                    font,
+                    &font.font,
                     font_size,
                     !FONT_EMBOLDEN_ENABLED, // hint
-                    run.normalized_coords(),
+                    &normalized_coords,
                     embolden,
                     Fill::NonZero,
                     &anyrender::Paint::from(text_color),


### PR DESCRIPTION
## Summary

Consumes DioxusLabs/parley#8 (rev `99ec3e5`), which stops clamping negative line box extents produced by negative half-leading (`line-height < ascent + descent`), fixing the `css/CSS2/linebox/line-height-0xx` WPT regression cluster on this branch.

Parley's line extents now start at `f32::NEG_INFINITY` (resolved to 0 for lines with no contributing content) instead of 0, so `max`-accumulation no longer floors legitimately-negative `over`/`under` at zero. Out-of-flow inline boxes contribute `NEG_INFINITY` extents (no-op) instead of `0.0`; correspondingly, the float placement path in `inline.rs` now passes `NEG_INFINITY` ascent/descent to `append_inline_box_to_line` so floats no longer floor the line's extents (previously masked by the zero default, and would otherwise regress `line-height-oof-descendants-001.html`).

WPT (`css/CSS2` + `css/css-fonts` + `css/css-text`, vs this branch without the fix): **4685 → 4720 passing (+35 fixed, 0 regressions)**. Fixed: the `line-height-0xx` cluster, `visudet/line-height-201.html`, `first-available-font-003/004.html`. Not covered: `inline-formatting-context-011.xht` (passes on `main`, still fails on this branch — it depends on inline-block/vertical-align line metrics, outside this fix's scope).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/be0138f98f55445c85962594d089b88d
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**33** newly passing, **53** newly failing (net -20).

<details>
<summary>Full diff (86 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/bidi-text/bidi-001.xht
+ Fail => Pass css/CSS2/css1/c414-flt-fit-004.xht
- Pass => Fail css/CSS2/floats-clear/float-003.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-006.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-008.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-009.xht
- Pass => Fail css/CSS2/floats-clear/float-replaced-width-011.xht
- Pass => Fail css/CSS2/floats-clear/floats-141.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-left-overflow.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-left-table.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-right-overflow.xht
- Pass => Fail css/CSS2/floats/floats-wrap-bfc-002-right-table.xht
- Pass => Fail css/CSS2/fonts/font-family-applies-to-005.xht
- Pass => Fail css/CSS2/linebox/baseline-block-with-overflow-001.html
- Pass => Fail css/CSS2/linebox/inline-formatting-context-011.xht
- Pass => Fail css/CSS2/linebox/inline-formatting-context-013.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-replaced-width-001.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-replaced-width-003.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-replaced-width-006.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-width-001.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-width-003.xht
- Pass => Fail css/CSS2/normal-flow/inline-replaced-width-006.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-036.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-047.xht
- Pass => Fail css/CSS2/normal-flow/max-width-percentage-001.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-036.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-047.xht
- Pass => Fail css/CSS2/normal-flow/min-width-percentage-001.xht
- Pass => Fail css/CSS2/normal-flow/width-percentage-001.xht
- Pass => Fail css/CSS2/normal-flow/width-percentage-002.xht
- Pass => Fail css/CSS2/positioning/absolute-non-replaced-height-008.xht
- Pass => Fail css/CSS2/positioning/absolute-non-replaced-max-height-008.xht
+ Fail => Pass css/CSS2/visudet/content-height-001.html
+ Fail => Pass css/CSS2/visudet/content-height-002.html
+ Fail => Pass css/CSS2/visudet/content-height-003.html
- Pass => Fail css/css-align/baseline-of-scrollable-1a.html
- Pass => Fail css/css-align/baseline-of-scrollable-1b.html
- Pass => Fail css/css-align/baseline-of-scrollable-2.html
+ Fail => Pass css/css-align/baseline-rules/synthesized-baseline-flexbox-001.html
+ Fail => Pass css/css-align/baseline-rules/synthesized-baseline-grid-001.html
+ Fail => Pass css/css-align/baseline-rules/synthesized-baseline-inline-block-001.html
- Pass => Fail css/css-backgrounds/background-size-027.html
- Pass => Fail css/css-backgrounds/background-size-028.html
- Pass => Fail css/css-backgrounds/background-size-030.html
- Pass => Fail css/css-backgrounds/background-size-031.html
- Pass => Fail css/css-break/ruby-003.html
- Pass => Fail css/css-contain/contain-layout-baseline-001.html
- Pass => Fail css/css-contain/contain-layout-flexbox-001.html
- Pass => Fail css/css-contain/contain-layout-grid-001.html
+ Fail => Pass css/css-contain/contain-paint-022.html
+ Fail => Pass css/css-flexbox/flexbox-align-self-horiz-001-block.xhtml
+ Fail => Pass css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001.html
+ Fail => Pass css/css-flexbox/flexbox-baseline-multi-item-vert-001a.html
+ Fail => Pass css/css-flexbox/flexbox-baseline-multi-item-vert-001b.html
- Pass => Fail css/css-flexbox/flexbox-baseline-multi-line-horiz-004.html
+ Fail => Pass css/css-flexbox/flexbox-basic-canvas-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-canvas-vert-001v.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-iframe-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-img-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-textarea-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-video-vert-001.xhtml
- Pass => Fail css/css-flexbox/percentage-size-subitems-001.html
- Pass => Fail css/css-grid/alignment/grid-baseline-001.html
- Pass => Fail css/css-grid/alignment/grid-baseline-002.html
- Pass => Fail css/css-grid/alignment/grid-inline-baseline.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-001.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-003.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-lr-001.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-rl-001.html
- Pass => Fail css/css-grid/grid-items/grid-inline-items-002.html
- Pass => Fail css/css-grid/grid-items/percentage-size-replaced-subitems-001.html
- Pass => Fail css/css-grid/grid-items/percentage-size-subitems-001.html
- Pass => Fail css/css-grid/subgrid/scrollbar-gutter-001.html
- Pass => Fail css/css-grid/subgrid/scrollbar-gutter-002.html
- Pass => Fail css/css-images/object-view-box-fit-contain-canvas.html
- Pass => Fail css/css-images/object-view-box-fit-contain-img.html
- Pass => Fail css/css-images/object-view-box-fit-contain-svg.html
- Pass => Fail css/css-images/object-view-box-fit-none-img.html
- Pass => Fail css/css-images/object-view-box-fit-none-svg.html
+ Fail => Pass css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html
- Pass => Fail css/css-ruby/br-clear-all-000.html
+ Fail => Pass css/css-text/line-breaking/line-breaking-atomic-009.html
+ Fail => Pass css/css-values/ch-unit-001.html
+ Fail => Pass css/css-writing-modes/baseline-with-orthogonal-flow-001.html
+ Fail => Pass css/css-writing-modes/text-combine-upright-shadow.html
+ Fail => Pass css/filter-effects/effect-reference-after-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31445696424).</sub>
<!-- wpt-results-end -->
