### PR TITLE
Don't resolve styles/layout while render-blocking resources are pending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,7 @@ dependencies = [
  "dioxus-native-dom",
  "keyboard-types 0.7.0",
  "markup5ever",
+ "stylo",
  "usvg",
 ]
 

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -53,6 +53,19 @@ impl BaseDocument {
         // Process messages that have been sent to our message channel (e.g. loaded resource)
         self.handle_messages();
 
+        // While render-blocking resources (e.g. stylesheets linked from the `<head>`) are
+        // still loading, don't resolve styles or layout (matching how browsers block
+        // rendering). Resolving styles before the document's stylesheets have loaded would
+        // give elements computed styles based on an incomplete cascade, and a later restyle
+        // (once the stylesheet loads) would treat those as genuine "before-change styles",
+        // spuriously starting CSS transitions from unstyled values. See issue #689.
+        //
+        // `handle_messages` above must still run so that loaded resources are ingested and
+        // this state can clear.
+        if self.has_pending_critical_resources() {
+            return;
+        }
+
         self.resolve_scroll_animation();
 
         // Drop scrollbar-activity entries whose fade-out has finished (also

--- a/tests/blitz-tests/Cargo.toml
+++ b/tests/blitz-tests/Cargo.toml
@@ -26,6 +26,7 @@ dioxus = { workspace = true }
 dioxus-core = { workspace = true }
 
 # Other dependencies
+style = { workspace = true }
 accesskit = { workspace = true }
 markup5ever = { workspace = true }
 keyboard-types = { workspace = true }

--- a/tests/blitz-tests/tests/render_blocking_stylesheet.rs
+++ b/tests/blitz-tests/tests/render_blocking_stylesheet.rs
@@ -1,0 +1,82 @@
+//! Regression test for https://github.com/DioxusLabs/blitz/issues/689
+//!
+//! Style resolution must not run while render-blocking stylesheets are still
+//! loading. If it does, elements get computed styles from an incomplete
+//! cascade, and the restyle triggered by the stylesheet's arrival spuriously
+//! starts CSS transitions from those unstyled values (e.g. `visibility:
+//! visible` -> `hidden`), leaving transitioned properties stuck at their
+//! pre-stylesheet values in one-shot renders.
+
+use blitz_dom::DocumentConfig;
+use blitz_html::HtmlDocument;
+use blitz_traits::net::{Bytes, NetHandler, NetProvider, Request};
+use std::sync::{Arc, Mutex};
+use style::properties::generated::longhands::visibility::computed_value::T as Visibility;
+
+/// A `NetProvider` which records requests so the test can deliver
+/// responses at a time of its choosing.
+#[derive(Default)]
+struct ManualNetProvider {
+    requests: Mutex<Vec<(String, Box<dyn NetHandler>)>>,
+}
+
+impl NetProvider for ManualNetProvider {
+    fn fetch(&self, _doc_id: usize, request: Request, handler: Box<dyn NetHandler>) {
+        self.requests
+            .lock()
+            .unwrap()
+            .push((request.url.to_string(), handler));
+    }
+}
+
+const HTML: &str = r#"<!doctype html>
+<html>
+  <head><link rel="stylesheet" href="case.css"></head>
+  <body><p id="transitioned">text</p></body>
+</html>"#;
+
+const CSS: &str = "#transitioned { transition: all 0.2s; visibility: hidden }";
+
+#[test]
+fn transition_does_not_start_from_pre_stylesheet_styles() {
+    let net = Arc::new(ManualNetProvider::default());
+
+    let mut doc = HtmlDocument::from_html(
+        HTML,
+        DocumentConfig {
+            base_url: Some("http://example.com/".to_string()),
+            net_provider: Some(Arc::clone(&net) as _),
+            ..Default::default()
+        },
+    );
+
+    // The stylesheet fetch should have been issued and be tracked as a
+    // pending critical resource.
+    assert!(doc.has_pending_critical_resources());
+
+    // Resolve while the stylesheet is still loading. This must not give
+    // elements computed styles (which would later be treated as
+    // before-change styles and start spurious transitions).
+    doc.resolve(0.0);
+
+    // Deliver the stylesheet and resolve again.
+    let (url, handler) = net.requests.lock().unwrap().pop().expect("css requested");
+    assert!(url.ends_with("case.css"));
+    handler.bytes(url, Bytes::from_static(CSS.as_bytes()));
+    doc.resolve(1.0);
+    assert!(!doc.has_pending_critical_resources());
+
+    // The element must be hidden immediately: no transition from the
+    // pre-stylesheet `visibility: visible` should have started.
+    let node_id = doc.get_element_by_id("transitioned").unwrap();
+    let node = doc.get_node(node_id).unwrap();
+    let styles = node.primary_styles().unwrap();
+    assert_eq!(
+        styles.get_inherited_box().clone_visibility(),
+        Visibility::Hidden,
+        "transitioned property should have its stylesheet value, not the pre-stylesheet value"
+    );
+
+    // And nothing should be animating.
+    assert!(!doc.is_animating());
+}


### PR DESCRIPTION
## Summary

Fixes #689.

`BaseDocument::resolve` now early-returns (after `handle_messages()`) while `has_pending_critical_resources()`:

```rust
self.handle_messages();
if self.has_pending_critical_resources() {
    return;
}
```

Previously only *painting* was gated on pending critical resources, so styles were resolved against an incomplete cascade while a `<head>` stylesheet was still loading. When the sheet arrived, stylo treated those pre-stylesheet computed styles as genuine before-change styles and started CSS transitions from them (e.g. `visibility: visible → hidden` for any property named by `transition`), leaving the property at its pre-stylesheet value in one-shot renders and causing a spurious "transition from unstyled" flash in interactive ones.

### Relation to other engines

This matches the **Servo/Gecko** approach: render-blocking sheets block the whole update-the-rendering cycle (style + layout), not just paint — Servo's `Document::update_the_rendering` asserts `!is_render_blocked()`, and Gecko defers initial styling until render-blocking sheets have loaded, so no pre-sheet before-change styles ever exist.

**Chrome's** approach is possible **future work**: Blink keeps resolving styles early but disallows transitions from them — in `CSSAnimations::CalculateTransitionUpdate`, an old style computed before rendering began (`RenderingHadBegunForLastStyleUpdate()`) is nulled out for transition-starting purposes. For Blitz this would preserve early discovery of `background-image`/`mask-image` resources from already-loaded sheets while another sheet is pending, and would keep transitions correct even if an embedder opt-out of render-blocking is added later — but it requires a hook into stylo's servo animation path (or clearing element style data when a critical sheet lands pre-first-paint).

Notes:
- `handle_messages()` still runs so resource responses are ingested and the pending state can clear; net handlers already `request_redraw()` on arrival.
- Nested resource discovery (`@import`, `@font-face`) is unaffected — it happens at CSS parse time, not during style resolution.
- Embedders with a no-op net provider are unaffected: critical resources are only registered when `!net_provider.is_noop()`.
- Known pre-existing gap (now also blocking styling, not just paint): net-provider-level fetch failures never call back and leave the resource pending forever — tracked separately in #694.

Regression test: `tests/blitz-tests/tests/render_blocking_stylesheet.rs` delivers a stylesheet via a manual `NetProvider` after an initial `resolve()`, then asserts the transitioned element computes `visibility: hidden` immediately and nothing is animating (fails before this change).

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31604631600).</sub>
<!-- wpt-results-end -->

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/81ff3ef329c7461bb029a8a6c91116ae
Requested by: @nicoburns