### PR TITLE
Make anyrender crates regular git dependencies instead of patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "anyrender"
 version = "0.12.0"
-source = "git+https://github.com/DioxusLabs/anyrender?branch=devin%2F1785858394-usvg-048#dcd219746ff13a5832beab552f3f7f494d1bd84d"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "kurbo",
  "peniko",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "anyrender_svg"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/anyrender?branch=devin%2F1785858394-usvg-048#dcd219746ff13a5832beab552f3f7f494d1bd84d"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "anyrender",
  "image",
@@ -7894,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "usvg"
 version = "0.48.1"
-source = "git+https://github.com/DioxusLabs/resvg?branch=devin%2F1785858271-intrinsic-dimensions#3289a9b0c3d3352692bf5acdf5f6e6949cdb57b5"
+source = "git+https://github.com/DioxusLabs/resvg?rev=3289a9b0c3d3352692bf5acdf5f6e6949cdb57b5#3289a9b0c3d3352692bf5acdf5f6e6949cdb57b5"
 dependencies = [
  "base64 0.23.1",
  "data-url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,8 +317,7 @@ dependencies = [
 [[package]]
 name = "anyrender_serialize"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63cb21f769a5cec45e3910516dae38d7d4958ffd83a6b506142d872909baabfd"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "anyrender",
  "image",
@@ -336,8 +335,7 @@ dependencies = [
 [[package]]
 name = "anyrender_skia"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48a6838555582902ff1d9e54187b1c541cfbedb6c1ffe9b97a2661aa531b9131"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "anyrender",
  "ash",
@@ -376,8 +374,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5866f70e89d198c3ccc070bcada52863145d3de6ba54a5cbd1ccfb2a98118380"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -395,8 +392,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello_cpu"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1f023da10af98c41042bb628bb7ff292d5d1058585a06fa54ccfcc592d3180"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -412,8 +408,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello_hybrid"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2789c41d9e636dc601b325ebe27ce321b523a11a71a1bf15f4044a34966d1ed2"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5514,8 +5509,7 @@ dependencies = [
 [[package]]
 name = "pixels_window_renderer"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8446b6281adf257c7454da61707febd23a9eff0c85e32ed20b0fccafd1539a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6832,8 +6826,7 @@ dependencies = [
 [[package]]
 name = "softbuffer_window_renderer"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c4e49c75480bbcdf7e2eea6fdfbe434e4169996b35c8600357e1a67ec651f1"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8617,8 +8610,7 @@ dependencies = [
 [[package]]
 name = "wgpu_context"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a38e949769bc7768792f366599430ee91da60101dc1612cfd84f7b69ebc3c0"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=dcd219746ff13a5832beab552f3f7f494d1bd84d#dcd219746ff13a5832beab552f3f7f494d1bd84d"
 dependencies = [
  "futures-intrusive",
  "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ anyrender_skia = { version = "0.10.0" }
 anyrender_vello = { version = "0.13.0" }
 anyrender_vello_cpu = { version = "0.15.0" }
 anyrender_vello_hybrid = { version = "0.9.0" }
-anyrender_svg = { version = "0.13.0" }
+anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
 wgpu_context = { version = "0.8.0" }
 
 # Linebender + Fontations + WGPU + SVG
@@ -270,12 +270,14 @@ color = { workspace = true }
 env_logger = "0.11"
 tracing-subscriber = "0.3"
 
-# TODO: remove these patches once `usvg` (with `Tree::intrinsic_dimensions`) and
-# `anyrender_svg` (with the usvg 0.48 bump) are released.
+# TODO: remove these patches (and the `anyrender_svg` git dependency above) once `usvg`
+# (with `Tree::intrinsic_dimensions`) and `anyrender_svg` (with the usvg 0.48 bump) are released.
+# These must remain patches (rather than regular git dependencies) because they need to apply to
+# transitive dependencies: `anyrender` is depended on by the crates.io `anyrender_*` backends,
+# and `usvg` is depended on by `anyrender_svg`.
 [patch.crates-io]
-usvg = { git = "https://github.com/DioxusLabs/resvg", branch = "devin/1785858271-intrinsic-dimensions" }
-anyrender = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
-anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", branch = "devin/1785858394-usvg-048" }
+usvg = { git = "https://github.com/DioxusLabs/resvg", rev = "3289a9b0c3d3352692bf5acdf5f6e6949cdb57b5" }
+anyrender = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
 
 # [patch.crates-io]
 # anyrender = { path = "../anyrender/crates/anyrender" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,14 +111,16 @@ skrifa = { version = "0.42", default-features = false, features = [
 ] } # Should match parley and vello versions
 
 # AnyRender
-anyrender = { version = "0.12.0" }
-anyrender_serialize = { version = "0.6.0" }
-anyrender_skia = { version = "0.10.0" }
-anyrender_vello = { version = "0.13.0" }
-anyrender_vello_cpu = { version = "0.15.0" }
-anyrender_vello_hybrid = { version = "0.9.0" }
+# TODO: switch back to crates.io versions once `anyrender_svg` (with the usvg 0.48 bump) is released.
+# All anyrender crates must come from the same source so that types unify across them.
+anyrender = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
+anyrender_serialize = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
+anyrender_skia = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
+anyrender_vello = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
+anyrender_vello_cpu = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
+anyrender_vello_hybrid = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
 anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
-wgpu_context = { version = "0.8.0" }
+wgpu_context = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
 
 # Linebender + Fontations + WGPU + SVG
 color = "0.3"
@@ -270,14 +272,11 @@ color = { workspace = true }
 env_logger = "0.11"
 tracing-subscriber = "0.3"
 
-# TODO: remove these patches (and the `anyrender_svg` git dependency above) once `usvg`
-# (with `Tree::intrinsic_dimensions`) and `anyrender_svg` (with the usvg 0.48 bump) are released.
-# These must remain patches (rather than regular git dependencies) because they need to apply to
-# transitive dependencies: `anyrender` is depended on by the crates.io `anyrender_*` backends,
-# and `usvg` is depended on by `anyrender_svg`.
+# TODO: remove this patch once `usvg` (with `Tree::intrinsic_dimensions`) is released.
+# This must remain a patch (rather than a regular git dependency) because it needs to apply to
+# `anyrender_svg`'s transitive `usvg` dependency.
 [patch.crates-io]
 usvg = { git = "https://github.com/DioxusLabs/resvg", rev = "3289a9b0c3d3352692bf5acdf5f6e6949cdb57b5" }
-anyrender = { git = "https://github.com/DioxusLabs/anyrender", rev = "dcd219746ff13a5832beab552f3f7f494d1bd84d" }
 
 # [patch.crates-io]
 # anyrender = { path = "../anyrender/crates/anyrender" }


### PR DESCRIPTION
## Summary
All `anyrender_*` workspace dependencies (including `wgpu_context`) now point at the same git rev of DioxusLabs/anyrender instead of crates.io + a `[patch.crates-io]` override for `anyrender`/`anyrender_svg`. Since every anyrender crate (and the `softbuffer_window_renderer`/`pixels_window_renderer` pulled in via backend features) lives in that repo and resolves via path deps, types unify without a patch.

Only the `usvg` patch remains — it must stay a patch because it needs to apply to `anyrender_svg`'s transitive `usvg` dependency. Both git references are pinned to `rev` for reproducibility. All of this reverts to crates.io versions once `usvg` and the usvg-0.48 `anyrender_svg` are released.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/4738e997ce9a49a8a2ad845308ecb1ce
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31609977600).</sub>
<!-- wpt-results-end -->
