### PR TITLE
Fix hit testing on stale derived paint lists after node removal

### DIFF
--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -821,23 +821,46 @@ impl<'doc> DocumentMutator<'doc> {
         self.flush_eager_ops();
     }
 
-    /// Eagerly remove `node_id` (and hoisted entries for nodes in its subtree)
-    /// from the derived paint lists: the layout parent's `paint_children` and
+    /// Eagerly remove the subtree rooted at `node_id` from the derived paint
+    /// lists: the `paint_children` of layout parents outside the subtree and
     /// the hoisted children of the nearest stacking-context root. These lists
     /// are rebuilt during `resolve()`, but hit tests may run between a DOM
     /// mutation and the next resolve, and must not see ids for removed nodes.
+    ///
+    /// Usually only the subtree root has a layout parent outside the subtree,
+    /// but `display: contents` (and the anonymous boxes it can flatten into)
+    /// gives descendants layout parents outside the subtree too, so every
+    /// subtree node's layout parent is considered.
     ///
     /// Must be called while the node's parent links are still intact.
     fn remove_from_derived_paint_lists(&mut self, node_id: NodeId) {
         let doc = &mut *self.doc;
 
-        // Remove the node from its layout parent's `paint_children`.
-        let layout_parent_id = doc.nodes[node_id].layout_parent.get();
-        if let Some(parent_id) = layout_parent_id {
-            if let Some(parent) = doc.nodes.get(parent_id) {
-                if let Some(paint_children) = parent.paint_children.borrow_mut().as_mut() {
-                    paint_children.retain(|id| *id != node_id);
-                }
+        // Collect the ids of all nodes in the removed subtree.
+        let mut subtree = HashSet::new();
+        let mut stack = vec![node_id];
+        while let Some(id) = stack.pop() {
+            subtree.insert(id);
+            if let Some(node) = doc.nodes.get(id) {
+                stack.extend(node.children.iter().copied());
+            }
+        }
+
+        // Remove subtree nodes from the `paint_children` of any layout parent
+        // outside the subtree.
+        let mut cleaned_parents: Vec<NodeId> = Vec::new();
+        for &id in &subtree {
+            let Some(parent_id) = doc.nodes.get(id).and_then(|node| node.layout_parent.get())
+            else {
+                continue;
+            };
+            if subtree.contains(&parent_id) || cleaned_parents.contains(&parent_id) {
+                continue;
+            }
+            cleaned_parents.push(parent_id);
+            if let Some(paint_children) = doc.nodes[parent_id].paint_children.borrow_mut().as_mut()
+            {
+                paint_children.retain(|child_id| !subtree.contains(child_id));
             }
         }
 
@@ -845,7 +868,7 @@ impl<'doc> DocumentMutator<'doc> {
         // the nearest stacking-context root outside the subtree. Walk up to it
         // and drop any entries for nodes within the subtree.
         let mut sc_root_id = None;
-        let mut current = layout_parent_id;
+        let mut current = doc.nodes[node_id].layout_parent.get();
         while let Some(id) = current {
             let Some(node) = doc.nodes.get(id) else { break };
             if node.stacking_context.is_some() {
@@ -856,31 +879,15 @@ impl<'doc> DocumentMutator<'doc> {
         }
         let Some(sc_root_id) = sc_root_id else { return };
 
-        fn in_subtree(doc: &BaseDocument, mut id: NodeId, root_id: NodeId) -> bool {
-            loop {
-                if id == root_id {
-                    return true;
-                }
-                match doc.nodes.get(id).and_then(|node| node.parent) {
-                    Some(parent_id) => id = parent_id,
-                    None => return false,
-                }
-            }
+        if let Some(sc) = doc.nodes[sc_root_id].stacking_context.as_mut() {
+            sc.children
+                .retain(|child| !subtree.contains(&child.node_id));
+            sc.negative_z_count = sc
+                .children
+                .iter()
+                .take_while(|child| child.z_index < 0)
+                .count() as u32;
         }
-
-        // Take the stacking context out so `in_subtree` can borrow the nodes
-        // while we filter its children.
-        let Some(mut sc) = doc.nodes[sc_root_id].stacking_context.take() else {
-            return;
-        };
-        sc.children
-            .retain(|child| !in_subtree(doc, child.node_id, node_id));
-        sc.negative_z_count = sc
-            .children
-            .iter()
-            .take_while(|child| child.z_index < 0)
-            .count() as u32;
-        doc.nodes[sc_root_id].stacking_context = Some(sc);
     }
 
     fn process_removed_subtree(&mut self, node_id: NodeId) {

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -492,6 +492,7 @@ impl DocumentMutator<'_> {
         // interaction state referencing removed nodes can retarget to the
         // nearest surviving ancestor.
         self.process_removed_subtree(node_id);
+        self.remove_from_derived_paint_lists(node_id);
 
         let node = &mut self.doc.nodes[node_id];
 
@@ -520,6 +521,7 @@ impl DocumentMutator<'_> {
     ) -> Option<Node> {
         let node_is_in_document = self.doc.nodes[node_id].flags.is_in_document();
         self.process_removed_subtree(node_id);
+        self.remove_from_derived_paint_lists(node_id);
 
         let node = self.doc.drop_node_ignoring_parent_with(node_id, on_drop);
         self.mutations_occurred |= node_is_in_document;
@@ -569,6 +571,7 @@ impl DocumentMutator<'_> {
         self.mutations_occurred |= parent_is_in_doc && !children.is_empty();
         for child_id in children {
             self.process_removed_subtree(child_id);
+            self.remove_from_derived_paint_lists(child_id);
             let _ = self.doc.drop_node_ignoring_parent(child_id);
         }
         self.maybe_record_node(node_id);
@@ -628,6 +631,10 @@ impl DocumentMutator<'_> {
             let child = &mut self.doc.nodes[child_id];
             let child_was_in_doc = child.flags.is_in_document();
             self.mutations_occurred |= child_was_in_doc;
+            if child.parent.is_some() {
+                self.remove_from_derived_paint_lists(child_id);
+            }
+            let child = &mut self.doc.nodes[child_id];
             let Some(old_parent_id) = child.parent.take() else {
                 continue;
             };
@@ -812,6 +819,68 @@ impl<'doc> DocumentMutator<'doc> {
         });
 
         self.flush_eager_ops();
+    }
+
+    /// Eagerly remove `node_id` (and hoisted entries for nodes in its subtree)
+    /// from the derived paint lists: the layout parent's `paint_children` and
+    /// the hoisted children of the nearest stacking-context root. These lists
+    /// are rebuilt during `resolve()`, but hit tests may run between a DOM
+    /// mutation and the next resolve, and must not see ids for removed nodes.
+    ///
+    /// Must be called while the node's parent links are still intact.
+    fn remove_from_derived_paint_lists(&mut self, node_id: NodeId) {
+        let doc = &mut *self.doc;
+
+        // Remove the node from its layout parent's `paint_children`.
+        let layout_parent_id = doc.nodes[node_id].layout_parent.get();
+        if let Some(parent_id) = layout_parent_id {
+            if let Some(parent) = doc.nodes.get(parent_id) {
+                if let Some(paint_children) = parent.paint_children.borrow_mut().as_mut() {
+                    paint_children.retain(|id| *id != node_id);
+                }
+            }
+        }
+
+        // Hoisted (z-indexed) entries for nodes in the removed subtree live in
+        // the nearest stacking-context root outside the subtree. Walk up to it
+        // and drop any entries for nodes within the subtree.
+        let mut sc_root_id = None;
+        let mut current = layout_parent_id;
+        while let Some(id) = current {
+            let Some(node) = doc.nodes.get(id) else { break };
+            if node.stacking_context.is_some() {
+                sc_root_id = Some(id);
+                break;
+            }
+            current = node.layout_parent.get();
+        }
+        let Some(sc_root_id) = sc_root_id else { return };
+
+        fn in_subtree(doc: &BaseDocument, mut id: NodeId, root_id: NodeId) -> bool {
+            loop {
+                if id == root_id {
+                    return true;
+                }
+                match doc.nodes.get(id).and_then(|node| node.parent) {
+                    Some(parent_id) => id = parent_id,
+                    None => return false,
+                }
+            }
+        }
+
+        // Take the stacking context out so `in_subtree` can borrow the nodes
+        // while we filter its children.
+        let Some(mut sc) = doc.nodes[sc_root_id].stacking_context.take() else {
+            return;
+        };
+        sc.children
+            .retain(|child| !in_subtree(doc, child.node_id, node_id));
+        sc.negative_z_count = sc
+            .children
+            .iter()
+            .take_while(|child| child.z_index < 0)
+            .count() as u32;
+        doc.nodes[sc_root_id].stacking_context = Some(sc);
     }
 
     fn process_removed_subtree(&mut self, node_id: NodeId) {

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1218,12 +1218,14 @@ impl Node {
         if matches_hoisted_content {
             if let Some(hoisted) = &self.stacking_context {
                 for hoisted_child in hoisted.pos_z_hoisted_children().rev() {
+                    // Hoisted children are derived data (rebuilt during resolve), so
+                    // ids may be stale if nodes were removed since the last resolve.
+                    let Some(child) = self.tree().get(hoisted_child.node_id) else {
+                        continue;
+                    };
                     let x = x - hoisted_child.position.x;
                     let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self
-                        .with(hoisted_child.node_id)
-                        .hit_inner(x, y, scale, scrollbar)
-                    {
+                    if let Some(hit) = child.hit_inner(x, y, scale, scrollbar) {
                         return Some(hit);
                     }
                 }
@@ -1231,8 +1233,13 @@ impl Node {
         }
 
         // Call `.hit()` on each child in turn. If any return `Some` then return that value. Else return `Some(self.id).
+        // `paint_children` is derived data (rebuilt during resolve), so ids may be
+        // stale if nodes were removed since the last resolve.
         for child_id in self.paint_children.borrow().iter().flatten().rev() {
-            if let Some(hit) = self.with(*child_id).hit_inner(x, y, scale, scrollbar) {
+            let Some(child) = self.tree().get(*child_id) else {
+                continue;
+            };
+            if let Some(hit) = child.hit_inner(x, y, scale, scrollbar) {
                 return Some(hit);
             }
         }
@@ -1241,12 +1248,12 @@ impl Node {
         if matches_hoisted_content {
             if let Some(hoisted) = &self.stacking_context {
                 for hoisted_child in hoisted.neg_z_hoisted_children().rev() {
+                    let Some(child) = self.tree().get(hoisted_child.node_id) else {
+                        continue;
+                    };
                     let x = x - hoisted_child.position.x;
                     let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self
-                        .with(hoisted_child.node_id)
-                        .hit_inner(x, y, scale, scrollbar)
-                    {
+                    if let Some(hit) = child.hit_inner(x, y, scale, scrollbar) {
                         return Some(hit);
                     }
                 }
@@ -1265,10 +1272,14 @@ impl Node {
                 {
                     let style_index = cluster.glyphs().next()?.style_index();
                     let node_id = layout.styles()[style_index].brush.id;
-                    let text_pointer_events_none = self
-                        .with(node_id)
-                        .primary_styles()
-                        .is_some_and(|style| style.clone_pointer_events() == PointerEvents::None);
+                    // The inline layout is derived data too: the text node may have
+                    // been removed since the last resolve.
+                    let text_node = self.tree().get(node_id);
+                    let text_pointer_events_none = text_node.is_none_or(|node| {
+                        node.primary_styles().is_some_and(|style| {
+                            style.clone_pointer_events() == PointerEvents::None
+                        })
+                    });
                     if !text_pointer_events_none {
                         return Some(HitResult {
                             node_id,

--- a/tests/blitz-tests/tests/hit_test_after_remove_node.rs
+++ b/tests/blitz-tests/tests/hit_test_after_remove_node.rs
@@ -1,0 +1,159 @@
+//! Regression tests for https://github.com/DioxusLabs/blitz/issues/624:
+//! `paint_children` and stacking-context hoisted children are derived data
+//! rebuilt during `resolve()`, so after `DocumentMutator::remove_and_drop_node`
+//! (and before the next resolve) they can contain stale NodeIds. A hit test
+//! run in that window must skip the stale ids rather than panic in
+//! `Node::hit_inner` on `self.tree().get(id).unwrap()`.
+
+use blitz_test_harness::{Harness, HarnessOptions};
+
+#[test]
+fn hit_test_after_remove_and_drop_node_does_not_panic() {
+    let mut harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            .container { width: 200px; height: 200px; position: relative; }
+            .child { width: 100px; height: 100px; background: #ccc; }
+        </style></head><body>
+            <div class="container" id="container">
+                <div class="child" id="child-a">A</div>
+                <div class="child" id="child-b">B</div>
+            </div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 400,
+            height: 400,
+            ..Default::default()
+        },
+    );
+
+    // First pump: layout + paint_children are built.
+    harness.pump();
+
+    let child_a = harness.node("#child-a");
+
+    // Remove child-a from the DOM without pumping (paint_children is stale).
+    harness.base_mut().mutate().remove_and_drop_node(child_a);
+
+    // Hit test in the area where child-a used to be. This must not panic even
+    // though paint_children still contains child-a's id.
+    let hit = harness.hit(50.0, 50.0);
+    assert!(
+        hit.is_some(),
+        "hit test should succeed without panicking after node removal"
+    );
+    assert_ne!(hit.unwrap().node_id, child_a);
+}
+
+#[test]
+fn hit_test_after_removing_hoisted_child_does_not_panic() {
+    // A child with z-index is hoisted into its parent stacking context's
+    // pos_z_hoisted_children list. Removing such a child and then hit-testing
+    // must not panic on the stale hoisted child id.
+    let mut harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            .container { width: 200px; height: 200px; position: relative; }
+            .child { width: 100px; height: 100px; position: absolute; }
+            #child-a { top: 0; left: 0; background: #ccc; z-index: 10; }
+            #child-b { top: 0; left: 100px; background: #ddd; z-index: 10; }
+        </style></head><body>
+            <div class="container" id="container">
+                <div class="child" id="child-a">A</div>
+                <div class="child" id="child-b">B</div>
+            </div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 400,
+            height: 400,
+            ..Default::default()
+        },
+    );
+
+    harness.pump();
+
+    let child_a = harness.node("#child-a");
+    harness.base_mut().mutate().remove_and_drop_node(child_a);
+
+    // Hit test where child-a used to be. The hoisted children list in the
+    // container's stacking context may still reference child-a's id.
+    let hit = harness.hit(50.0, 50.0);
+    assert!(
+        hit.is_some(),
+        "hit test should succeed without panicking after hoisted child removal"
+    );
+    assert_ne!(hit.unwrap().node_id, child_a);
+}
+
+#[test]
+fn hit_test_after_removing_neg_z_hoisted_child_does_not_panic() {
+    // A child with negative z-index is hoisted into the neg_z_hoisted_children
+    // list of its parent's stacking context. Removing such a child and then
+    // hit-testing must not panic on the stale hoisted child id.
+    let mut harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            .container { width: 200px; height: 200px; position: relative; z-index: 0; }
+            .child { width: 100px; height: 100px; position: absolute; }
+            #child-a { top: 0; left: 0; background: #ccc; z-index: -1; }
+            #child-b { top: 0; left: 100px; background: #ddd; z-index: 1; }
+        </style></head><body>
+            <div class="container" id="container">
+                <div class="child" id="child-a">A</div>
+                <div class="child" id="child-b">B</div>
+            </div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 400,
+            height: 400,
+            ..Default::default()
+        },
+    );
+
+    harness.pump();
+
+    let child_a = harness.node("#child-a");
+    harness.base_mut().mutate().remove_and_drop_node(child_a);
+
+    // Hit test where child-a used to be. The neg_z_hoisted_children list
+    // in the container's stacking context may still reference child-a's id.
+    let hit = harness.hit(50.0, 50.0);
+    assert!(
+        hit.is_some(),
+        "hit test should succeed without panicking after neg-z hoisted child removal"
+    );
+    assert_ne!(hit.unwrap().node_id, child_a);
+}
+
+#[test]
+fn hit_test_after_removing_text_node_does_not_panic() {
+    // The inline layout (built during resolve) references text node ids. After
+    // removing a text node's parent, hit-testing over the old text area must
+    // not panic or return the stale text node id.
+    let mut harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            #container { width: 200px; height: 200px; font-size: 20px; }
+        </style></head><body>
+            <div id="container"><span id="text-span">Hello world</span></div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 400,
+            height: 400,
+            ..Default::default()
+        },
+    );
+
+    harness.pump();
+
+    let span = harness.node("#text-span");
+    harness.base_mut().mutate().remove_and_drop_node(span);
+
+    // Hit test over where the text used to be.
+    let hit = harness.hit(10.0, 10.0);
+    assert!(
+        hit.is_some(),
+        "hit test should succeed without panicking after text node removal"
+    );
+    assert_ne!(hit.unwrap().node_id, span);
+}

--- a/tests/blitz-tests/tests/hit_test_after_remove_node.rs
+++ b/tests/blitz-tests/tests/hit_test_after_remove_node.rs
@@ -198,6 +198,47 @@ fn hit_test_after_detaching_hoisted_node_does_not_hit_detached_node() {
 }
 
 #[test]
+fn hit_test_after_detaching_display_contents_node_does_not_hit_descendants() {
+    // A `display: contents` node is transparent for box generation, so its
+    // children's layout parent (and paint_children entries) live *outside*
+    // the removed subtree. Detaching the contents node must eagerly clean up
+    // entries for its descendants, not just the removed root itself.
+    let mut harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            .container { width: 200px; height: 200px; position: relative; }
+            #contents { display: contents; }
+            #child-a { width: 100px; height: 100px; background: #ccc; }
+        </style></head><body>
+            <div class="container" id="container">
+                <div id="contents">
+                    <div id="child-a">A</div>
+                </div>
+            </div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 400,
+            height: 400,
+            ..Default::default()
+        },
+    );
+
+    harness.pump();
+
+    let contents = harness.node("#contents");
+    let child_a = harness.node("#child-a");
+    let container = harness.node("#container");
+    harness.base_mut().mutate().remove_node(contents);
+
+    let hit = harness.hit(50.0, 50.0).expect("hit test should succeed");
+    assert_ne!(
+        hit.node_id, child_a,
+        "hit test must not return a descendant of a detached display:contents node"
+    );
+    assert_eq!(hit.node_id, container);
+}
+
+#[test]
 fn hit_test_after_removing_text_node_does_not_panic() {
     // The inline layout (built during resolve) references text node ids. After
     // removing a text node's parent, hit-testing over the old text area must

--- a/tests/blitz-tests/tests/hit_test_after_remove_node.rs
+++ b/tests/blitz-tests/tests/hit_test_after_remove_node.rs
@@ -126,6 +126,78 @@ fn hit_test_after_removing_neg_z_hoisted_child_does_not_panic() {
 }
 
 #[test]
+fn hit_test_after_detaching_node_does_not_hit_detached_node() {
+    // `remove_node` detaches a node without dropping it, so its id remains
+    // live in the tree. The derived paint lists must be eagerly cleaned so a
+    // hit test does not return the detached node at its stale position.
+    let mut harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            .container { width: 200px; height: 200px; position: relative; }
+            .child { width: 100px; height: 100px; background: #ccc; }
+        </style></head><body>
+            <div class="container" id="container">
+                <div class="child" id="child-a">A</div>
+            </div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 400,
+            height: 400,
+            ..Default::default()
+        },
+    );
+
+    harness.pump();
+
+    let child_a = harness.node("#child-a");
+    let container = harness.node("#container");
+    harness.base_mut().mutate().remove_node(child_a);
+
+    let hit = harness.hit(50.0, 50.0).expect("hit test should succeed");
+    assert_ne!(
+        hit.node_id, child_a,
+        "hit test must not return a node that has been detached from the DOM"
+    );
+    assert_eq!(hit.node_id, container);
+}
+
+#[test]
+fn hit_test_after_detaching_hoisted_node_does_not_hit_detached_node() {
+    // Same as above, but for a z-indexed child hoisted into its parent
+    // stacking context's hoisted children list.
+    let mut harness = Harness::from_html_with(
+        r#"<html><head><style>
+            html, body { margin: 0; height: 100%; }
+            .container { width: 200px; height: 200px; position: relative; }
+            #child-a { width: 100px; height: 100px; position: absolute;
+                       top: 0; left: 0; background: #ccc; z-index: 10; }
+        </style></head><body>
+            <div class="container" id="container">
+                <div id="child-a">A</div>
+            </div>
+        </body></html>"#,
+        HarnessOptions {
+            width: 400,
+            height: 400,
+            ..Default::default()
+        },
+    );
+
+    harness.pump();
+
+    let child_a = harness.node("#child-a");
+    let container = harness.node("#container");
+    harness.base_mut().mutate().remove_node(child_a);
+
+    let hit = harness.hit(50.0, 50.0).expect("hit test should succeed");
+    assert_ne!(
+        hit.node_id, child_a,
+        "hit test must not return a node that has been detached from the DOM"
+    );
+    assert_eq!(hit.node_id, container);
+}
+
+#[test]
 fn hit_test_after_removing_text_node_does_not_panic() {
     // The inline layout (built during resolve) references text node ids. After
     // removing a text node's parent, hit-testing over the old text area must


### PR DESCRIPTION
## Summary

Fixes #624.

`paint_children`, stacking-context hoisted children, and inline layout data are derived data rebuilt during `resolve()`. `DocumentMutator::remove_and_drop_node` updates `parent.children` but not these lists, so a hit test between the removal and the next resolve iterated stale NodeIds and panicked in `Node::hit_inner` via `self.with(id)` (`tree().get(id).unwrap()`).

`hit_inner` now does a fallible lookup and skips ids that are no longer live, in all four places that consume derived ids:

```rust
// pos/neg z hoisted children + paint_children:
- self.with(id).hit_inner(...)
+ let Some(child) = self.tree().get(id) else { continue };
+ child.hit_inner(...)

// inline text hits: a stale text node id is no longer returned as a HitResult
```

Regression tests in `tests/blitz-tests/tests/hit_test_after_remove_node.rs` cover all four paths (plain child, positive/negative z-index hoisted child, inline text); each panicked before the fix.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/30a37a9f486c4e0e8ba8c6cb5197c1fc
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31704184544).</sub>
<!-- wpt-results-end -->
