### PR TITLE
Fix static position of absolutely positioned inline boxes

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -713,13 +713,21 @@ impl BaseDocument {
                                 s.get_box().original_display.outside() == DisplayOutside::Inline
                             })
                             .unwrap_or(true);
+                        // Inline-level boxes are placed at the top of the line box they would
+                        // have occupied (`ibox.y` is the baseline as out-of-flow boxes are
+                        // zero-sized), and block-level boxes below it.
+                        let line_metrics = line.metrics();
                         let static_position = taffy::Point {
                             x: if is_inline_level {
-                                ibox.x
+                                (ibox.x / scale) + container_pb.left
                             } else {
                                 container_pb.left
                             },
-                            y: ibox.y,
+                            y: if is_inline_level {
+                                (line_metrics.block_min_coord / scale) + container_pb.top
+                            } else {
+                                (line_metrics.block_max_coord / scale) + container_pb.top
+                            },
                         };
 
                         layout_abspos_child(


### PR DESCRIPTION
## Summary
Fixes the `§` anchor links on docs.rs (e.g. https://docs.rs/iced) rendering too far down the page. Rustdoc's `.anchor` is `position: absolute` with only `left` set, so its vertical position comes from the static position — which had two bugs in inline layout (`compute_inline_layout` in `blitz-dom/src/layout/inline.rs`):

1. **Scale not removed**: `static_position` used raw parley coordinates (`ibox.x`/`ibox.y`), which are in scale-multiplied units, and omitted the container's padding/border offset. The in-flow branch correctly does `(ibox.x / scale) + container_pb.left`; the abspos branch now does the same.
2. **Baseline used instead of line top**: out-of-flow inline boxes are zero-sized, so parley reports `ibox.y = baseline - 0 = baseline`. The abspos box was therefore anchored a full ascent too low. Now uses the line box's `block_min_coord` (line top) for inline-level boxes, matching browser behavior, and `block_max_coord` (below the line) for block-level hypothetical boxes.

```diff
 let static_position = taffy::Point {
-    x: if is_inline_level { ibox.x } else { container_pb.left },
-    y: ibox.y,
+    x: if is_inline_level { (ibox.x / scale) + container_pb.left } else { container_pb.left },
+    y: if is_inline_level {
+        (line_metrics.block_min_coord / scale) + container_pb.top
+    } else {
+        (line_metrics.block_max_coord / scale) + container_pb.top
+    },
 };
```

Before / after on a minimal rustdoc-style header test (`h2.section-header` with `.anchor { position: absolute; left: -15px }`):

| Before | After |
|---|---|
| ![before](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvYmRlMGI1N2YtYTMyYS00NzVmLWJlYmEtZjk4MDNiMjk0MjFhIiwiaWF0IjoxNzg2NjUxNTkzLCJleHAiOjE3ODcyNTYzOTMsImZpbGVuYW1lIjoiYW5jaG9yX2Nyb3AucG5nIn0.HxrZ0hLRx6jnoFY0YauZHkKBMmuQ0P9o-0lxPUozoKs) | ![after](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvOTM1ODNlODktZjNlZS00NzQyLTg1ZjItZjE3ZTBlOWEwZWM1IiwiaWF0IjoxNzg2NjUxNTkzLCJleHAiOjE3ODcyNTYzOTMsImZpbGVuYW1lIjoiYW5jaG9yX2Nyb3AzLnBuZyJ9.kA-tCY84tq29meirVG3zHkMlRDqNtp_3fYrmfrXtxi4) |

Verified no WPT status changes in `css/css-position`, `css/CSS2/abspos`, and `css/CSS2/positioning` (before/after report diff is empty). `cargo fmt`, `clippy --workspace`, and `blitz-dom` unit tests pass.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/8748954ac2954413b493b2cfb3aaf786
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**8** newly passing, **0** newly failing (net +8).

<details>
<summary>Full diff (8 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/text/text-indent-013.xht
+ Fail => Pass css/css-backgrounds/border-left-width-medium.html
+ Fail => Pass css/css-backgrounds/border-left-width-thick.html
+ Fail => Pass css/css-backgrounds/border-left-width-thin.html
+ Fail => Pass css/css-backgrounds/border-right-width-medium.html
+ Fail => Pass css/css-backgrounds/border-right-width-thick.html
+ Fail => Pass css/css-backgrounds/border-right-width-thin.html
+ Fail => Pass css/css-text/line-breaking/line-breaking-016.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31739214769).</sub>
<!-- wpt-results-end -->
