### PR TITLE
Fix max-content width of inline boxes following a forced line break

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -1,5 +1,5 @@
 use blitz_traits::node_id::NodeId;
-use parley::{AlignmentOptions, IndentOptions};
+use parley::{AlignmentOptions, ContentWidths, IndentOptions};
 use style::values::specified::box_::DisplayOutside;
 use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
 use taffy::{
@@ -16,6 +16,37 @@ use taffy::{Clear, Float, prelude::TaffyMaxContent};
 
 use super::resolve_calc_value;
 use crate::BaseDocument;
+use crate::node::TextLayout;
+
+/// Characters which force a mandatory line break (UAX #14 classes BK, CR, LF, NL)
+fn is_mandatory_break_char(c: char) -> bool {
+    matches!(
+        c,
+        '\n' | '\r' | '\u{000B}' | '\u{000C}' | '\u{0085}' | '\u{2028}' | '\u{2029}'
+    )
+}
+
+/// Compute the min-content and max-content widths of an inline layout.
+///
+/// Parley's `calculate_content_widths` detects a mandatory line break via the boundary
+/// flag on the text cluster *after* the break. Inline boxes between the break and that
+/// cluster have already been accumulated by then, so their widths are attributed to the
+/// line *before* the break and the width of the line after the break is under-reported.
+/// When a layout contains both inline boxes and mandatory breaks, fall back to measuring
+/// trial line-breaking passes, which use the same breaking logic as the final layout.
+fn calculate_content_widths(text_layout: &mut TextLayout) -> ContentWidths {
+    let has_inline_boxes = !text_layout.layout.inline_boxes().is_empty();
+    if has_inline_boxes && text_layout.text.contains(is_mandatory_break_char) {
+        let layout = &mut text_layout.layout;
+        layout.break_all_lines(Some(0.0));
+        let min = layout.width();
+        layout.break_all_lines(None);
+        let max = layout.width();
+        ContentWidths { min, max }
+    } else {
+        text_layout.layout.calculate_content_widths()
+    }
+}
 
 impl BaseDocument {
     pub(crate) fn compute_inline_layout(
@@ -342,7 +373,7 @@ impl BaseDocument {
                 // This is a little tricky as the size of the inline boxes may depend on whether we are sizing under
                 // and a min-content or max-content constraint. So if we want to compute both widths in one pass then
                 // we need to store both a min-content and max-content size on each box.
-                let content_sizes = inline_layout.layout.calculate_content_widths();
+                let content_sizes = calculate_content_widths(&mut inline_layout);
                 let min_content_width = content_sizes.min;
                 let max_content_width = content_sizes.max;
 

--- a/tests/blitz-tests/tests/inline_box_after_br.rs
+++ b/tests/blitz-tests/tests/inline_box_after_br.rs
@@ -1,0 +1,53 @@
+//! Inline boxes (e.g. `display: inline-block` links) that follow a forced line
+//! break (`<br>`) must all contribute to the max-content width of the line
+//! they end up on.
+//!
+//! Regression test: parley's `calculate_content_widths` detects a mandatory
+//! break via the boundary flag on the text cluster *after* the break, so
+//! inline boxes between the break and that cluster were attributed to the line
+//! *before* the break, under-reporting the max-content width. In a
+//! shrink-to-fit container this caused the last inline-block to wrap onto a
+//! new line even though there was enough space (seen with the "Get Started" /
+//! "Source Code" / "Sponsor" links on <https://freyaui.dev> at 800px wide).
+
+use blitz_dom::{DocumentConfig, FontContext};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn layout_doc(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            font_ctx: Some(FontContext::new()),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+#[test]
+fn inline_blocks_after_br_stay_on_one_line() {
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="display:flex; flex-direction:column; align-items:center;">
+                <div>
+                    Some leading text<br>
+                    <a id="a" style="display:inline-block; width:100px; height:30px;">A</a>
+                    <a id="b" style="display:inline-block; width:100px; height:30px;">B</a>
+                    <a id="c" style="display:inline-block; width:100px; height:30px;">C</a>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    let y = |sel: &str| {
+        let id = doc.query_selector(sel).unwrap().unwrap();
+        doc.get_node(id).unwrap().final_layout().location.y
+    };
+    let (a, b, c) = (y("#a"), y("#b"), y("#c"));
+    assert_eq!(a, b, "second inline-block wrapped to a new line");
+    assert_eq!(b, c, "third inline-block wrapped to a new line");
+}


### PR DESCRIPTION
## Summary

Fixes the "Get Started" / "Source Code" / "Sponsor" links on https://freyaui.dev wrapping onto two lines at 800px viewport width (Chrome keeps them on one line).

Root cause: parley's `calculate_content_widths` only detects a mandatory break via the `Boundary::Mandatory` flag on the *text cluster after* the break. Inline boxes between the `\n` and that cluster are accumulated into `running_max_width` *before* the reset fires, so their width is attributed to the line before the break:

```
items: TextRun("\n"), Box(100), TextRun(" "), Box(100), TextRun(" "), Box(100)
                      ^^^ added pre-reset          reported max = 210 (actual = 310)
```

The freya hero is a shrink-to-fit flex item containing `text…<br>` followed by three `inline-block` links, so the under-reported max-content width made the container too narrow and the last link wrapped.

Workaround in `compute_inline_layout`: when a layout contains both inline boxes and mandatory-break characters, compute content widths via trial line-breaking passes (`break_all_lines(Some(0.0))` for min, `break_all_lines(None)` for max), which use the same breaking logic as the final layout and are therefore consistent by construction. All other layouts keep the cheap `calculate_content_widths` path. (The underlying bug should also be fixed upstream in parley.)

Rendering of freyaui.dev at 800px after the fix:

![freya buttons after fix](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvYTVmNjQ5MTAtMjczNi00ZmExLWFiMzItYWNjYWE1YTQ3YjRlIiwiaWF0IjoxNzg2NjUxNjYyLCJleHAiOjE3ODcyNTY0NjIsImZpbGVuYW1lIjoiZnJleWFfYnV0dG9uc19hZnRlci5wbmcifQ.-XEt6Uo2vUd3O34-JJmT0ThNe2KVKmfiNA1d0fY-wUw)

Added a regression test (`inline_box_after_br.rs`) which fails without the fix.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/5da2da1c45d24bd89a90d920fd698681
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31739307748).</sub>
<!-- wpt-results-end -->
