### PR TITLE
Read scrollbar-width/scrollbar-color from Stylo instead of hardcoding them

### DIFF
--- a/packages/blitz-dom/src/node/scrollbar.rs
+++ b/packages/blitz-dom/src/node/scrollbar.rs
@@ -32,20 +32,11 @@ pub struct ScrollbarRef {
     pub axis: AbsoluteAxis,
 }
 
-/// The computed value of `scrollbar-width` (css-scrollbars-1). A local
-/// mirror of the stylo type, which isn't exposed to the servo engine yet
-/// (servo/stylo#413).
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum ScrollbarWidth {
-    #[default]
-    Auto,
-    Thin,
-    None,
-}
+/// The computed value of `scrollbar-width` (css-scrollbars-1).
+pub use style::properties::generated::longhands::scrollbar_width::computed_value::T as ScrollbarWidth;
 
-/// The computed value of `scrollbar-color` (css-scrollbars-1). A local
-/// mirror of the stylo type, which isn't exposed to the servo engine yet
-/// (servo/stylo#413). Colors are fully resolved (no `currentColor`).
+/// The computed value of `scrollbar-color` (css-scrollbars-1), with colors
+/// fully resolved (no `currentColor`).
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum ScrollbarColor {
     #[default]
@@ -57,21 +48,29 @@ pub enum ScrollbarColor {
 }
 
 impl Node {
-    /// The node's used `scrollbar-width`.
+    /// The node's computed `scrollbar-width`.
     pub fn scrollbar_width(&self) -> ScrollbarWidth {
-        // TODO: read the computed style once stylo exposes scrollbar-width
-        // to the servo engine (servo/stylo#413):
-        // match self.primary_styles().map(|s| s.clone_scrollbar_width()) { .. }
-        ScrollbarWidth::Auto
+        self.primary_styles()
+            .map(|style| style.clone_scrollbar_width())
+            .unwrap_or(ScrollbarWidth::Auto)
     }
 
-    /// The node's used `scrollbar-color`.
+    /// The node's computed `scrollbar-color`, with colors resolved against
+    /// the element's computed `color`.
     pub fn scrollbar_color(&self) -> ScrollbarColor {
-        // TODO: read the computed style once stylo exposes scrollbar-color
-        // to the servo engine (servo/stylo#413), resolving the colors
-        // against the element's `color`:
-        // self.primary_styles().map(|s| s.clone_scrollbar_color()) { .. }
-        ScrollbarColor::Auto
+        let Some(style) = self.primary_styles() else {
+            return ScrollbarColor::Auto;
+        };
+        let current_color = style.clone_color();
+        match style.clone_scrollbar_color() {
+            style::values::computed::ScrollbarColor::Auto => ScrollbarColor::Auto,
+            style::values::computed::ScrollbarColor::Colors { thumb, track } => {
+                ScrollbarColor::Colors {
+                    thumb: thumb.resolve_to_absolute(&current_color),
+                    track: track.resolve_to_absolute(&current_color),
+                }
+            }
+        }
     }
 
     /// Whether the node shows an overlay scrollbar in the given axis:

--- a/tests/blitz-tests/tests/scrollbar_drag.rs
+++ b/tests/blitz-tests/tests/scrollbar_drag.rs
@@ -222,7 +222,6 @@ fn thumb_brightens_on_hover_and_drag() {
 }
 
 #[test]
-#[ignore = "scrollbar-color is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn white_author_thumb_still_signals_hover_and_drag() {
     // A near-white `scrollbar-color` thumb can't get lighter: hover/drag
     // feedback must blend towards the pole with contrast headroom (darken).

--- a/tests/blitz-tests/tests/scrollbars.rs
+++ b/tests/blitz-tests/tests/scrollbars.rs
@@ -123,7 +123,6 @@ fn horizontal_scroller_paints_a_thumb() {
 }
 
 #[test]
-#[ignore = "scrollbar-color is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn scrollbar_color_styles_the_thumb() {
     // Scrolled so the thumb is visible without hover.
     let px = pixel(
@@ -143,7 +142,6 @@ fn scrollbar_color_styles_the_thumb() {
 }
 
 #[test]
-#[ignore = "scrollbar-color is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn scrollbar_color_styles_the_track() {
     let px = pixel(
         r#"<html><body style="margin:0">
@@ -162,7 +160,6 @@ fn scrollbar_color_styles_the_track() {
 }
 
 #[test]
-#[ignore = "scrollbar-width is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn scrollbar_width_none_hides_the_scrollbar() {
     let px = pixel(
         r#"<html><body style="margin:0">
@@ -178,7 +175,6 @@ fn scrollbar_width_none_hides_the_scrollbar() {
 }
 
 #[test]
-#[ignore = "scrollbar-color is hardcoded to auto until stylo exposes it to the servo engine (servo/stylo#413)"]
 fn author_styled_scrollbar_still_hides_at_rest() {
     // scrollbar-color doesn't affect overlay visibility (matches how
     // Firefox/WebKit render the property).


### PR DESCRIPTION
## Summary

`Node::scrollbar_width()`/`scrollbar_color()` returned `Auto` unconditionally, because stylo didn't expose these css-scrollbars-1 properties to the servo engine. Stylo 0.20 does (both are non-gecko longhands behind `servo_pref = "layout.unimplemented"`, which blitz already enables in `Document::new`), so they now come from the computed style:

```rust
scrollbar_width -> primary_styles().map(|s| s.clone_scrollbar_width()).unwrap_or(Auto)
scrollbar_color -> clone_scrollbar_color(), each color .resolve_to_absolute(&clone_color())
```

`ScrollbarWidth` is now a re-export of stylo's generated keyword type rather than a local mirror. `ScrollbarColor` stays a local enum so it can carry `AbsoluteColor` (stylo's computed value can still be `currentColor`, which is resolved here once rather than at every paint site).

The `#[ignore]`d scrollbar-color/-width tests are un-ignored; the taffy scrollbar gutter stays 0 since blitz paints overlay scrollbars that take no layout space.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/8ece7e50c7344087a7b086a166ca3bd0
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31748192987).</sub>
<!-- wpt-results-end -->
