### PR TITLE
Update taffy pin: grid container height transferred from width via aspect-ratio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=d4a2b3bf17ed268e4ea5fc1f5a7c76430ad9c499#d4a2b3bf17ed268e4ea5fc1f5a7c76430ad9c499"
+source = "git+https://github.com/DioxusLabs/taffy?rev=f1ded456732506c5a794077d02f4c0be405aa59e#f1ded456732506c5a794077d02f4c0be405aa59e"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=f1ded456732506c5a794077d02f4c0be405aa59e#f1ded456732506c5a794077d02f4c0be405aa59e"
+source = "git+https://github.com/DioxusLabs/taffy?rev=b2fa1048fe4652f5afc66e62679d4026b80eb81c#b2fa1048fe4652f5afc66e62679d4026b80eb81c"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d4a2b3bf17ed268e4ea5fc1f5a7c76430ad9c499", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "f1ded456732506c5a794077d02f4c0be405aa59e", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "f1ded456732506c5a794077d02f4c0be405aa59e", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b2fa1048fe4652f5afc66e62679d4026b80eb81c", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -953,6 +953,10 @@ fn layout_abspos_child(
             node_id,
             taffy::LayoutInput {
                 known_dimensions,
+                known_dimensions_are_definite: taffy::Size {
+                    width: true,
+                    height: true,
+                },
                 parent_size: area_size.map(Some),
                 available_space: Size {
                     width: AvailableSpace::Definite(
@@ -978,6 +982,10 @@ fn layout_abspos_child(
         node_id,
         taffy::LayoutInput {
             known_dimensions: final_size.map(Some),
+            known_dimensions_are_definite: taffy::Size {
+                width: true,
+                height: true,
+            },
             parent_size: area_size.map(Some),
             available_space: Size {
                 width: AvailableSpace::Definite(


### PR DESCRIPTION
## Summary

Bumps the taffy pin to include DioxusLabs/taffy#1098, which transfers a grid container's automatic height from its used width via `aspect-ratio` (previously the height was derived from the row sum, ignoring the aspect ratio).

Fixes WPT `css/css-grid/grid-definition/grid-auto-repeat-aspect-ratio-001.html`:

```html
<div style="display: inline-grid; aspect-ratio: 1/1; min-height: 60px;
            grid-template-columns: repeat(auto-fill, 50px);"></div>
```

The min-height transferred through the aspect ratio already produced the correct 2 auto-fill repetitions (100px width), but the used height then came out as 60px (`max(row sum = 0, min-height)`) instead of 100px transferred from the width.

The new taffy revision also includes the `LayoutInput::known_dimensions_are_definite` field from taffy#1091's follow-ups; the two `LayoutInput` constructions in `blitz-dom`'s inline layout (for absolutely-positioned inline boxes, which always have a definite containing block) set it to `true` for both axes, matching taffy's own call sites.

Full flexbox+grid WPT comparison vs main: +2 passes (`grid-auto-repeat-aspect-ratio-001.html`, `percentage-heights-008.html`), no regressions.

Note: `grid-auto-repeat-aspect-ratio-002.html` still fails — it additionally requires `width: min-content`, and intrinsic sizing keywords are currently converted to `auto` in `stylo_taffy` (taffy's `Dimension` has no representation for them).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d23708053506499cbb8d4515549f1753
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**2** newly passing, **0** newly failing (net +2).

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
+ Fail => Pass css/css-grid/grid-definition/grid-auto-repeat-aspect-ratio-001.html
+ Fail => Pass css/css-sizing/aspect-ratio/grid-aspect-ratio-align-items-center.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31760831905).</sub>
<!-- wpt-results-end -->
