### PR TITLE
Bump taffy to latest main (74f8b2ca)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=d4a2b3bf17ed268e4ea5fc1f5a7c76430ad9c499#d4a2b3bf17ed268e4ea5fc1f5a7c76430ad9c499"
+source = "git+https://github.com/DioxusLabs/taffy?rev=74f8b2cab9b06ab6f4c9ebfd75bffecdda1ce511#74f8b2cab9b06ab6f4c9ebfd75bffecdda1ce511"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d4a2b3bf17ed268e4ea5fc1f5a7c76430ad9c499", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "74f8b2cab9b06ab6f4c9ebfd75bffecdda1ce511", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -953,6 +953,10 @@ fn layout_abspos_child(
             node_id,
             taffy::LayoutInput {
                 known_dimensions,
+                known_dimensions_are_definite: taffy::Size {
+                    width: true,
+                    height: true,
+                },
                 parent_size: area_size.map(Some),
                 available_space: Size {
                     width: AvailableSpace::Definite(
@@ -978,6 +982,10 @@ fn layout_abspos_child(
         node_id,
         taffy::LayoutInput {
             known_dimensions: final_size.map(Some),
+            known_dimensions_are_definite: taffy::Size {
+                width: true,
+                height: true,
+            },
             parent_size: area_size.map(Some),
             available_space: Size {
                 width: AvailableSpace::Definite(


### PR DESCRIPTION
## Summary

Bumps taffy `d4a2b3bf` → `74f8b2ca` (current main). Upstream changes picked up:

- taffy#1097 — Grid: fix `minmax(auto, <fixed>)` tracks collapsing to zero (intrinsic track sizing was skipped when all tracks had `base_size == growth_limit`)
- taffy#1003 — Flexbox: track definiteness of known dimensions through nested layouts. **Breaking**: adds a required `known_dimensions_are_definite` field to `LayoutInput`; the two abspos `compute_child_layout` calls in `layout/inline.rs` set it to `true` for both axes, since sizes there are resolved from insets or the item's measured final size and hence definite
- taffy#1096 — Block abs-pos: resolve auto margins against the clamped (used) size
- taffy#1085 — `TaffyTree::remove`: mark the parent as dirty when removing a node
- taffy#1037 — Grid: fix infinite loop in auto-placement when span exceeds grid size estimate
- taffy#1036 — Grid: bound track sizing loops so non-finite styles cannot cause infinite loops
- taffy#1035 — Grid: fix named line numbering underflow; make repetition `line_names` length an API contract

Local WPT results (vs main):
- `css/css-grid`: 693 → 698 tests, 2125 → 2367 subtests passed; 0 regressions. Includes `grid-items/grid-items-minimum-width-001/002.html` and the `-orthogonal-*` variants going 0/44 → 44/44.
- `css/css-flexbox`: 794 → 795 tests, 2002 → 2005 subtests passed; 0 regressions.

<!-- wpt-results-start -->
## WPT results

**11** newly passing, **2** newly failing (net +9).

<details>
<summary>Full diff (13 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-height-003.xht
- Pass => Fail css/CSS2/positioning/absolute-non-replaced-height-010.xht
- Pass => Fail css/CSS2/positioning/absolute-non-replaced-max-height-010.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-max-height-011.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-width-025.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-width-027.xht
+ Fail => Pass css/css-flexbox/percentage-heights-008.html
+ Fail => Pass css/css-grid/grid-items/grid-items-minimum-height-orthogonal-001.html
+ Fail => Pass css/css-grid/grid-items/grid-items-minimum-width-001.html
+ Fail => Pass css/css-grid/grid-items/grid-items-minimum-width-002.html
+ Fail => Pass css/css-grid/grid-items/grid-items-minimum-width-orthogonal-001.html
+ Fail => Pass css/css-grid/grid-items/grid-items-minimum-width-orthogonal-002.html
+ Fail => Pass css/css-tables/absolute-tables-016.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31751105546).</sub>
<!-- wpt-results-end -->

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f4389961a60946a0a3b4330b890307a0
Requested by: @nicoburns