### PR TITLE
Upgrade to Taffy with sizing keyword support on `width`, `height`, and `flex-basis`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=284dbcb8d7179daf9760f77b78ba44c9ae637323#284dbcb8d7179daf9760f77b78ba44c9ae637323"
+source = "git+https://github.com/DioxusLabs/taffy?rev=62cee2de23a6f3c2b51ddc1518302610f0e2ed32#62cee2de23a6f3c2b51ddc1518302610f0e2ed32"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=2e4dbc55bf27a6d6f1464267d44d4d4a47e5da8c#2e4dbc55bf27a6d6f1464267d44d4d4a47e5da8c"
+source = "git+https://github.com/DioxusLabs/taffy?rev=b84d11b09eaa414153a7d4054bfbeda4ec5fcd23#b84d11b09eaa414153a7d4054bfbeda4ec5fcd23"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=62cee2de23a6f3c2b51ddc1518302610f0e2ed32#62cee2de23a6f3c2b51ddc1518302610f0e2ed32"
+source = "git+https://github.com/DioxusLabs/taffy?rev=b0bb6afcb5d580dd05c883a5d68f5861c1a3fab3#b0bb6afcb5d580dd05c883a5d68f5861c1a3fab3"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=b84d11b09eaa414153a7d4054bfbeda4ec5fcd23#b84d11b09eaa414153a7d4054bfbeda4ec5fcd23"
+source = "git+https://github.com/DioxusLabs/taffy?rev=d6ee98d79895ee7416a3811fd336aa131a0030da#d6ee98d79895ee7416a3811fd336aa131a0030da"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=d6ee98d79895ee7416a3811fd336aa131a0030da#d6ee98d79895ee7416a3811fd336aa131a0030da"
+source = "git+https://github.com/DioxusLabs/taffy?rev=6a5096e90d98e89f5bf132f033f2d2aab1b71913#6a5096e90d98e89f5bf132f033f2d2aab1b71913"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=6a5096e90d98e89f5bf132f033f2d2aab1b71913#6a5096e90d98e89f5bf132f033f2d2aab1b71913"
+source = "git+https://github.com/DioxusLabs/taffy?rev=67be0f628d2e8103ac877bfdbf63f409ff50c7ec#67be0f628d2e8103ac877bfdbf63f409ff50c7ec"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=b6ee2433ea513278f523d8209930d6b4226b13b0#b6ee2433ea513278f523d8209930d6b4226b13b0"
+source = "git+https://github.com/DioxusLabs/taffy?rev=284dbcb8d7179daf9760f77b78ba44c9ae637323#284dbcb8d7179daf9760f77b78ba44c9ae637323"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=67be0f628d2e8103ac877bfdbf63f409ff50c7ec#67be0f628d2e8103ac877bfdbf63f409ff50c7ec"
+source = "git+https://github.com/DioxusLabs/taffy?rev=b6ee2433ea513278f523d8209930d6b4226b13b0#b6ee2433ea513278f523d8209930d6b4226b13b0"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b84d11b09eaa414153a7d4054bfbeda4ec5fcd23", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d6ee98d79895ee7416a3811fd336aa131a0030da", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "2e4dbc55bf27a6d6f1464267d44d4d4a47e5da8c", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b84d11b09eaa414153a7d4054bfbeda4ec5fcd23", default-features = false, features = [
     "std",
     "flexbox",
     "grid",
@@ -301,3 +301,5 @@ tracing-subscriber = "0.3"
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d6ee98d79895ee7416a3811fd336aa131a0030da", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "6a5096e90d98e89f5bf132f033f2d2aab1b71913", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "67be0f628d2e8103ac877bfdbf63f409ff50c7ec", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b6ee2433ea513278f523d8209930d6b4226b13b0", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "62cee2de23a6f3c2b51ddc1518302610f0e2ed32", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b0bb6afcb5d580dd05c883a5d68f5861c1a3fab3", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "6a5096e90d98e89f5bf132f033f2d2aab1b71913", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "67be0f628d2e8103ac877bfdbf63f409ff50c7ec", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b6ee2433ea513278f523d8209930d6b4226b13b0", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "284dbcb8d7179daf9760f77b78ba44c9ae637323", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "284dbcb8d7179daf9760f77b78ba44c9ae637323", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "62cee2de23a6f3c2b51ddc1518302610f0e2ed32", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -79,13 +79,22 @@ pub fn dimension(val: &stylo::Size) -> taffy::Dimension {
         stylo::Size::LengthPercentage(val) => length_percentage(&val.0).into(),
         stylo::Size::Auto => taffy::Dimension::AUTO,
 
-        // TODO: implement other values in Taffy
-        stylo::Size::MaxContent => taffy::Dimension::AUTO,
-        stylo::Size::MinContent => taffy::Dimension::AUTO,
-        stylo::Size::FitContent => taffy::Dimension::AUTO,
-        stylo::Size::FitContentFunction(_) => taffy::Dimension::AUTO,
-        stylo::Size::Stretch => taffy::Dimension::AUTO,
-        stylo::Size::WebkitFillAvailable => taffy::Dimension::AUTO,
+        stylo::Size::MaxContent => taffy::Dimension::max_content(),
+        stylo::Size::MinContent => taffy::Dimension::min_content(),
+        stylo::Size::FitContent => taffy::Dimension::fit_content(),
+        stylo::Size::FitContentFunction(val) => match val.0.unpack() {
+            stylo::UnpackedLengthPercentage::Length(len) => {
+                taffy::Dimension::fit_content_px(len.px())
+            }
+            stylo::UnpackedLengthPercentage::Percentage(percentage) => {
+                taffy::Dimension::fit_content_percent(percentage.0)
+            }
+            // TODO: support calc values as fit-content() limits in Taffy
+            stylo::UnpackedLengthPercentage::Calc(_) => taffy::Dimension::AUTO,
+        },
+
+        stylo::Size::Stretch => taffy::Dimension::stretch(),
+        stylo::Size::WebkitFillAvailable => taffy::Dimension::stretch(),
 
         // Anchor positioning will be flagged off for time being
         stylo::Size::AnchorSizeFunction(_) => unreachable!(),
@@ -94,18 +103,38 @@ pub fn dimension(val: &stylo::Size) -> taffy::Dimension {
 }
 
 #[inline]
-pub fn max_size_dimension(val: &stylo::MaxSize) -> taffy::Dimension {
+pub fn min_size(val: &stylo::Size) -> taffy::LengthPercentageAuto {
+    match val {
+        stylo::Size::LengthPercentage(val) => length_percentage(&val.0).into(),
+        stylo::Size::Auto => taffy::LengthPercentageAuto::AUTO,
+
+        // Sizing keywords are not supported for min/max size properties in Taffy
+        stylo::Size::MaxContent => taffy::LengthPercentageAuto::AUTO,
+        stylo::Size::MinContent => taffy::LengthPercentageAuto::AUTO,
+        stylo::Size::FitContent => taffy::LengthPercentageAuto::AUTO,
+        stylo::Size::FitContentFunction(_) => taffy::LengthPercentageAuto::AUTO,
+        stylo::Size::Stretch => taffy::LengthPercentageAuto::AUTO,
+        stylo::Size::WebkitFillAvailable => taffy::LengthPercentageAuto::AUTO,
+
+        // Anchor positioning will be flagged off for time being
+        stylo::Size::AnchorSizeFunction(_) => unreachable!(),
+        stylo::Size::AnchorContainingCalcFunction(_) => unreachable!(),
+    }
+}
+
+#[inline]
+pub fn max_size(val: &stylo::MaxSize) -> taffy::LengthPercentageAuto {
     match val {
         stylo::MaxSize::LengthPercentage(val) => length_percentage(&val.0).into(),
-        stylo::MaxSize::None => taffy::Dimension::AUTO,
+        stylo::MaxSize::None => taffy::LengthPercentageAuto::AUTO,
 
-        // TODO: implement other values in Taffy
-        stylo::MaxSize::MaxContent => taffy::Dimension::AUTO,
-        stylo::MaxSize::MinContent => taffy::Dimension::AUTO,
-        stylo::MaxSize::FitContent => taffy::Dimension::AUTO,
-        stylo::MaxSize::FitContentFunction(_) => taffy::Dimension::AUTO,
-        stylo::MaxSize::Stretch => taffy::Dimension::AUTO,
-        stylo::MaxSize::WebkitFillAvailable => taffy::Dimension::AUTO,
+        // Sizing keywords are not supported for min/max size properties in Taffy
+        stylo::MaxSize::MaxContent => taffy::LengthPercentageAuto::AUTO,
+        stylo::MaxSize::MinContent => taffy::LengthPercentageAuto::AUTO,
+        stylo::MaxSize::FitContent => taffy::LengthPercentageAuto::AUTO,
+        stylo::MaxSize::FitContentFunction(_) => taffy::LengthPercentageAuto::AUTO,
+        stylo::MaxSize::Stretch => taffy::LengthPercentageAuto::AUTO,
+        stylo::MaxSize::WebkitFillAvailable => taffy::LengthPercentageAuto::AUTO,
 
         // Anchor positioning will be flagged off for time being
         stylo::MaxSize::AnchorSizeFunction(_) => unreachable!(),
@@ -400,9 +429,8 @@ pub(crate) fn text_align(input: stylo::TextAlign) -> taffy::TextAlign {
 #[inline]
 #[cfg(feature = "flexbox")]
 pub fn flex_basis(input: &stylo::FlexBasis) -> taffy::Dimension {
-    // TODO: Support flex-basis: content in Taffy
     match input {
-        stylo::FlexBasis::Content => taffy::Dimension::AUTO,
+        stylo::FlexBasis::Content => taffy::Dimension::content(),
         stylo::FlexBasis::Size(size) => dimension(size),
     }
 }
@@ -695,12 +723,12 @@ pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style<Atom> {
             height: self::dimension(&pos.height),
         },
         min_size: taffy::Size {
-            width: self::dimension(&pos.min_width),
-            height: self::dimension(&pos.min_height),
+            width: self::min_size(&pos.min_width),
+            height: self::min_size(&pos.min_height),
         },
         max_size: taffy::Size {
-            width: self::max_size_dimension(&pos.max_width),
-            height: self::max_size_dimension(&pos.max_height),
+            width: self::max_size(&pos.max_width),
+            height: self::max_size(&pos.max_height),
         },
         aspect_ratio: self::aspect_ratio(pos.aspect_ratio),
 

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -94,20 +94,20 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
     }
 
     #[inline]
-    fn min_size(&self) -> taffy::Size<taffy::Dimension> {
+    fn min_size(&self) -> taffy::Size<taffy::LengthPercentageAuto> {
         let position_styles = self.0.get_position();
         taffy::Size {
-            width: convert::dimension(&position_styles.min_width),
-            height: convert::dimension(&position_styles.min_height),
+            width: convert::min_size(&position_styles.min_width),
+            height: convert::min_size(&position_styles.min_height),
         }
     }
 
     #[inline]
-    fn max_size(&self) -> taffy::Size<taffy::Dimension> {
+    fn max_size(&self) -> taffy::Size<taffy::LengthPercentageAuto> {
         let position_styles = self.0.get_position();
         taffy::Size {
-            width: convert::max_size_dimension(&position_styles.max_width),
-            height: convert::max_size_dimension(&position_styles.max_height),
+            width: convert::max_size(&position_styles.max_width),
+            height: convert::max_size(&position_styles.max_height),
         }
     }
 


### PR DESCRIPTION
## Summary

Maps the Stylo sizing keywords to the new Taffy `Dimension` values added in DioxusLabs/taffy#1099 / DioxusLabs/taffy#1103, so Blitz resolves `min-content`, `max-content`, `fit-content`, `fit-content(<length-percentage>)` and `stretch` on `width`/`height`, and `content` on `flex-basis` (all previously mapped to `Dimension::AUTO`).

- Pins `taffy` to the taffy main merge commit containing DioxusLabs/taffy#1099 and DioxusLabs/taffy#1103:

```rust
// stylo_taffy::convert::dimension
stylo::Size::MaxContent => taffy::Dimension::max_content(),
stylo::Size::MinContent => taffy::Dimension::min_content(),
stylo::Size::FitContent => taffy::Dimension::fit_content(),
stylo::Size::FitContentFunction(val) => /* fit_content_px / fit_content_percent; calc → AUTO */,
stylo::Size::Stretch => taffy::Dimension::stretch(),
// flex-basis
stylo::FlexBasis::Content => taffy::Dimension::content(),
```

- Taffy's `min_size`/`max_size` are now `Size<LengthPercentageAuto>` (keywords deliberately unsupported there): new `min_size`/`max_size` converters map keyword min/max sizes to `auto`.
- Adds the new required `known_dimensions_are_definite` field to the two `taffy::LayoutInput` initializers in `blitz-dom/src/layout/inline.rs` (set to `true`, matching prior behavior).

This makes grid containers with `width: fit-content` (as used by the WPT alignment tests via `width-keyword-classes.css`) shrink-wrap correctly. WPT `css/css-grid/alignment/`: 660/1533 subtests pass (vs 590 on main); full-suite results below.

<!-- wpt-results-start -->
## WPT results

**157** newly passing, **25** newly failing (net +132).

<details>
<summary>Full diff (182 changed tests)</summary>

```diff
- Pass => Fail css/css-box/margin-trim/flex-inline-end-trimmed-only.html
- Pass => Fail css/css-box/margin-trim/flex-row-style-change-triggers-layout-inline-end.html
+ Fail => Pass css/css-contain/content-visibility/content-visibility-auto-intrinsic-width.html
+ Fail => Pass css/css-flexbox/flex-item-percentage-in-nested-flex-bsize-001.html
+ Fail => Pass css/css-flexbox/flex-item-percentage-in-nested-flex-bsize-002.html
+ Fail => Pass css/css-flexbox/flexbox-flex-basis-content-001a.html
+ Fail => Pass css/css-flexbox/flexbox-flex-basis-content-001b.html
+ Fail => Pass css/css-flexbox/flexbox-flex-basis-content-002a.html
+ Fail => Pass css/css-flexbox/flexbox-flex-basis-content-002b.html
+ Fail => Pass css/css-flexbox/gap-015.html
+ Fail => Pass css/css-flexbox/gap-016.html
+ Fail => Pass css/css-flexbox/gap-019.html
+ Fail => Pass css/css-flexbox/gap-020.html
+ Fail => Pass css/css-flexbox/gap-021.html
+ Fail => Pass css/css-flexbox/image-nested-within-definite-column-flexbox.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-001.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-002.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-003.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-004.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-005.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-006.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-007.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-008.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-010.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-011.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-012.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-013.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-014.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-015.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-016.html
+ Fail => Pass css/css-flexbox/intrinsic-size/col-wrap-020.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-006.html
+ Fail => Pass css/css-flexbox/intrinsic-size/row-wrap-002.tentative.html
+ Fail => Pass css/css-flexbox/orthogonal-writing-modes-and-intrinsic-sizing.html
+ Fail => Pass css/css-flexbox/table-as-flex-item-max-content.html
+ Fail => Pass css/css-grid/abspos/empty-grid-001.html
+ Fail => Pass css/css-grid/alignment/grid-align-justify-margin-border-padding.html
+ Fail => Pass css/css-grid/alignment/grid-align-justify-overflow.html
+ Fail => Pass css/css-grid/alignment/grid-container-auto-margins-scrollbars-001.html
+ Fail => Pass css/css-grid/alignment/grid-item-auto-margins-alignment.html
+ Fail => Pass css/css-grid/child-border-box-and-max-content-001.html
+ Fail => Pass css/css-grid/child-border-box-and-max-content-002.html
+ Fail => Pass css/css-grid/grid-definition/grid-auto-repeat-intrinsic-001.html
+ Fail => Pass css/css-grid/grid-item-non-auto-height-stretch-001.html
+ Fail => Pass css/css-grid/grid-item-non-auto-height-stretch-002.html
+ Fail => Pass css/css-grid/grid-item-non-auto-height-stretch-003.html
+ Fail => Pass css/css-grid/grid-item-non-auto-height-stretch-004.html
+ Fail => Pass css/css-grid/grid-lanes/intrinsic-sizing/grid-lanes-contain-intrinsic-size-row-005.html
+ Fail => Pass css/css-grid/grid-lanes/intrinsic-sizing/grid-lanes-intrinsic-size-dynamic-block-size-column.html
+ Fail => Pass css/css-grid/grid-lanes/intrinsic-sizing/grid-lanes-intrinsic-size-dynamic-block-size-row.html
+ Fail => Pass css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/column-item-percentage-width-001.html
+ Fail => Pass css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/gap/column-subgrid-grid-gap-008.html
+ Fail => Pass css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/row-subgrid-button.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/column-subgrid-with-row-standalone-axis-size-001.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/column-subgrid-with-row-standalone-axis-size-002.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/column-subgrid-with-row-standalone-axis-size-003.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/column-subgrid-with-row-standalone-axis-size-004.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/column-subgrid-with-row-standalone-axis-size-006.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/column-subgrid-with-row-standalone-axis-size-007.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/column-subgrid-with-row-standalone-axis-size-008.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/track-sizing/column-subgrid-with-row-standalone-axis-size-009.html
+ Fail => Pass css/css-grid/grid-model/compute-intrinsic-widths-scrollbar-001.html
+ Fail => Pass css/css-grid/grid-model/grid-container-margin-border-padding-scrollbar-001.html
+ Fail => Pass css/css-grid/grid-model/grid-container-sizing-constraints-001.html
+ Fail => Pass css/css-grid/grid-model/grid-gutters-as-percentage-001.html
+ Fail => Pass css/css-grid/grid-model/grid-max-content-size-with-max-content-item.html
+ Fail => Pass css/css-grid/layout-algorithm/flex-and-intrinsic-sizes-001.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-container-percentage-002.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-fit-content-width-percent-height-aspect-ratio-001.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-item-margin-auto-columns-rows-001.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-max-content-width-percent-height-aspect-ratio-001.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-min-content-width-percent-height-aspect-ratio-001.html
+ Fail => Pass css/css-grid/subgrid/standalone-axis-size-001.html
+ Fail => Pass css/css-grid/subgrid/standalone-axis-size-002.html
+ Fail => Pass css/css-grid/subgrid/standalone-axis-size-005.html
- Pass => Fail css/css-grid/subgrid/standalone-axis-size-010.html
- Pass => Fail css/css-grid/subgrid/standalone-axis-size-011.html
- Pass => Fail css/css-grid/subgrid/standalone-axis-size-012.html
- Pass => Fail css/css-grid/subgrid/standalone-axis-size-013.html
+ Fail => Pass css/css-layout-api/fallback-intrinsic-sizes/bad-return.https.html
+ Fail => Pass css/css-layout-api/fallback-intrinsic-sizes/constructor-error.https.html
+ Fail => Pass css/css-layout-api/fallback-intrinsic-sizes/error.https.html
+ Fail => Pass css/css-layout-api/fallback-intrinsic-sizes/invalid-child.https.html
+ Fail => Pass css/css-layout-api/fallback-intrinsic-sizes/no-promise.https.html
+ Fail => Pass css/css-layout-api/fallback-intrinsic-sizes/unresolved-promise.https.html
+ Fail => Pass css/css-layout-api/intrinsic-sizes/negative-max.https.html
+ Fail => Pass css/css-layout-api/intrinsic-sizes/negative-min.https.html
- Pass => Fail css/css-multicol/intrinsic-width-change-column-count.html
+ Fail => Pass css/css-position/position-absolute-replaced-no-intrinsic-size.tentative.html
+ Fail => Pass css/css-sizing/aspect-ratio/flex-aspect-ratio-021.html
+ Fail => Pass css/css-sizing/aspect-ratio/flex-aspect-ratio-022.html
+ Fail => Pass css/css-sizing/aspect-ratio/grid-aspect-ratio-015.html
+ Fail => Pass css/css-sizing/aspect-ratio/grid-aspect-ratio-016.html
+ Fail => Pass css/css-sizing/aspect-ratio/grid-aspect-ratio-017.html
+ Fail => Pass css/css-sizing/aspect-ratio/grid-aspect-ratio-025.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-001.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-002.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-005.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-006.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-007.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-014.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-015.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-020.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-021.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-022.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-023.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-024.html
+ Fail => Pass css/css-sizing/aspect-ratio/intrinsic-size-025.html
- Pass => Fail css/css-sizing/block-size-with-min-or-max-content-1a.html
+ Fail => Pass css/css-sizing/border-box-and-max-content-001.html
+ Fail => Pass css/css-sizing/border-box-and-max-content-002.html
+ Fail => Pass css/css-sizing/border-box-and-max-content-003.html
+ Fail => Pass css/css-sizing/calc-margins-percent-flex.html
+ Fail => Pass css/css-sizing/div-fit-content-auto-margin-bottom.tentative.html
+ Fail => Pass css/css-sizing/div-fit-content-auto-margin-top.tentative.html
+ Fail => Pass css/css-sizing/div-fit-content-auto-margin.tentative.html
+ Fail => Pass css/css-sizing/div-fit-content-block-size.tentative.html
+ Fail => Pass css/css-sizing/div-fit-content-orthogonal-auto-margin-left.tentative.html
+ Fail => Pass css/css-sizing/div-fit-content-orthogonal-auto-margin-right.tentative.html
+ Fail => Pass css/css-sizing/div-fit-content-orthogonal-auto-margin.tentative.html
+ Fail => Pass css/css-sizing/div-fit-content-orthogonal-block-size.tentative.html
+ Fail => Pass css/css-sizing/div-max-content-auto-margin-bottom.tentative.html
+ Fail => Pass css/css-sizing/div-max-content-auto-margin-top.tentative.html
+ Fail => Pass css/css-sizing/div-max-content-auto-margin.tentative.html
+ Fail => Pass css/css-sizing/div-max-content-block-size.tentative.html
+ Fail => Pass css/css-sizing/div-max-content-orthogonal-auto-margin-left.tentative.html
+ Fail => Pass css/css-sizing/div-max-content-orthogonal-auto-margin-right.tentative.html
+ Fail => Pass css/css-sizing/div-max-content-orthogonal-auto-margin.tentative.html
+ Fail => Pass css/css-sizing/div-max-content-orthogonal-block-size.tentative.html
+ Fail => Pass css/css-sizing/div-min-content-auto-margin-bottom.tentative.html
+ Fail => Pass css/css-sizing/div-min-content-auto-margin-top.tentative.html
+ Fail => Pass css/css-sizing/div-min-content-auto-margin.tentative.html
+ Fail => Pass css/css-sizing/div-min-content-block-size.tentative.html
+ Fail => Pass css/css-sizing/div-min-content-orthogonal-auto-margin-left.tentative.html
+ Fail => Pass css/css-sizing/div-min-content-orthogonal-auto-margin-right.tentative.html
+ Fail => Pass css/css-sizing/div-min-content-orthogonal-auto-margin.tentative.html
+ Fail => Pass css/css-sizing/div-min-content-orthogonal-block-size.tentative.html
+ Fail => Pass css/css-sizing/div-orthogonal-left-and-non-auto-margin.tentative.html
- Pass => Fail css/css-sizing/dynamic-change-inline-size-004.html
+ Fail => Pass css/css-sizing/fit-content-block-size-fixedpos.html
+ Fail => Pass css/css-sizing/fit-content-length-percentage-001.html
+ Fail => Pass css/css-sizing/fit-content-length-percentage-002.html
+ Fail => Pass css/css-sizing/fit-content-length-percentage-003.html
+ Fail => Pass css/css-sizing/fit-content-length-percentage-004.html
+ Fail => Pass css/css-sizing/fit-content-length-percentage-005.html
+ Fail => Pass css/css-sizing/fit-content-length-percentage-006.html
+ Fail => Pass css/css-sizing/fit-content-length-percentage-011.html
+ Fail => Pass css/css-sizing/fit-content-length-percentage-014.html
+ Fail => Pass css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-001.html
+ Fail => Pass css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-002.html
+ Fail => Pass css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-003.html
+ Fail => Pass css/css-sizing/float-clearance-with-margin-collapse-and-fit-content-and-padding-percentage-004.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-012.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-013.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-015.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-016.html
+ Fail => Pass css/css-sizing/percentage-min-width.html
+ Fail => Pass css/css-sizing/stretch/abspos-1.html
+ Fail => Pass css/css-sizing/stretch/abspos-2.html
+ Fail => Pass css/css-sizing/stretch/cache-miss-002.html
+ Fail => Pass css/css-sizing/stretch/flex-basis-1.html
+ Fail => Pass css/css-sizing/stretch/flex-item-height-001.html
+ Fail => Pass css/css-sizing/stretch/flex-item-height-002.html
+ Fail => Pass css/css-sizing/stretch/positioned-replaced-2.html
+ Fail => Pass css/css-sizing/stretch/stretch-float-with-sibling.html
+ Fail => Pass css/css-sizing/stretch/stretch-float.html
+ Fail => Pass css/css-text/overflow-wrap/overflow-wrap-min-content-size-005.html
+ Fail => Pass css/css-text/overflow-wrap/overflow-wrap-min-content-size-006.html
+ Fail => Pass css/css-text/overflow-wrap/overflow-wrap-min-content-size-007.html
+ Fail => Pass css/css-text/white-space/white-space-intrinsic-size-005.html
+ Fail => Pass css/css-text/white-space/white-space-intrinsic-size-006.html
- Pass => Fail css/css-text/word-break/auto-phrase/word-break-auto-phrase-001.html
- Pass => Fail css/css-text/word-break/auto-phrase/word-break-auto-phrase-003.html
- Pass => Fail css/css-text/word-break/auto-phrase/word-break-auto-phrase-004.html
- Pass => Fail css/css-text/word-break/auto-phrase/word-break-auto-phrase-005.html
- Pass => Fail css/css-text/word-break/auto-phrase/word-break-auto-phrase-006.html
+ Fail => Pass css/css-text/word-break/word-break-keep-all-011.html
+ Fail => Pass css/css-values/calc-size/calc-size-grid-repeat.html
- Pass => Fail css/css-values/calc-size/calc-size-min-max-sizes-003.html
- Pass => Fail css/css-values/calc-size/calc-size-min-max-sizes-006.html
+ Fail => Pass css/css-viewport/zoom/contain-intrinsic-width.html
- Pass => Fail css/css-writing-modes/two-levels-of-orthogonal-flows.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31794394937).</sub>
<!-- wpt-results-end -->


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e6b2abe65ab14b1aa2971b32ffb71c9f
Requested by: @nicoburns