### PR TITLE
Don't subtract static body's border in offsetLeft/offsetTop

### DIFF
--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1372,6 +1372,16 @@ impl Node {
             || self.data.is_element_with_tag_name(&local_name!("th"))
     }
 
+    /// Whether this node is a non-positioned `body` element. When such an element is the
+    /// `offsetParent`, `offsetLeft`/`offsetTop` are measured from the initial containing
+    /// block origin rather than from the `body`'s padding edge.
+    fn is_static_body(&self) -> bool {
+        self.data.is_element_with_tag_name(&local_name!("body"))
+            && self
+                .primary_styles()
+                .is_some_and(|styles| styles.get_box().position == Position::Static)
+    }
+
     /// The nearest layout ancestor that [is an offset parent](Self::is_offset_parent), as in
     /// CSSOM View's `offsetParent`.
     pub fn offset_parent(&self) -> Option<&Node> {
@@ -1399,7 +1409,7 @@ impl Node {
                 break;
             };
             let parent = self.with(parent_id);
-            if parent.is_offset_parent() {
+            if parent.is_offset_parent() && !parent.is_static_body() {
                 let border = parent.final_layout().border;
                 x -= border.left;
                 y -= border.top;


### PR DESCRIPTION
## Summary

Root-cause fix for the WPT `css/css-flexbox/align-content-horiz-001a/002` failures (0/72 → 72/72 each): the failures were not in flexbox layout at all, but in the CSSOM `offsetLeft`/`offsetTop` used by the tests' `data-offset-x/y` checks.

Per CSSOM View, when the `offsetParent` is a non-positioned `body`, `offsetLeft`/`offsetTop` are measured from the initial containing block origin — the `body`'s border is *not* subtracted. The tests use `body { border: 8px solid }`, so every offset was reported 8px too small (`expected 8 got 0`).

`Node::offset_top_left()` now walks past a statically positioned `body` without subtracting its border, via a new `is_static_body()` check:

```rust
if parent.is_offset_parent() && !parent.is_static_body() {
    x -= border.left; y -= border.top; break;
}
```

`offset_parent()` itself is unchanged (a static `body` is still returned as the `offsetParent`, matching browsers).

The companion `align-content-horiz-001b.html` test additionally needs DioxusLabs/taffy#1101 (flex wrapping against `max-width` when the container width is indefinite); with both changes all six `align-content-{horiz,vert}-*` tests pass 72/72, and the full `css/css-flexbox` suite goes from 2005 to 2468 passing subtests with no per-test regressions.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/71b2a4272c6846039ac4d12a586ecc6c
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**7** newly passing, **0** newly failing (net +7).

<details>
<summary>Full diff (7 changed tests)</summary>

```diff
+ Fail => Pass css/css-box/margin-trim/computed-margin-values/flexbox-column-style-change-triggers-layout-block-start.html
+ Fail => Pass css/css-flexbox/align-content-horiz-001a.html
+ Fail => Pass css/css-flexbox/align-content-horiz-002.html
+ Fail => Pass css/css-flexbox/align-content-vert-001a.html
+ Fail => Pass css/css-flexbox/align-content-vert-001b.html
+ Fail => Pass css/css-flexbox/align-content-vert-002.html
+ Fail => Pass css/css-flexbox/align-items-baseline-row-horz.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31759852800).</sub>
<!-- wpt-results-end -->
