### PR TITLE
Bump taffy to pick up indefinite-width flex wrap fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=74f8b2cab9b06ab6f4c9ebfd75bffecdda1ce511#74f8b2cab9b06ab6f4c9ebfd75bffecdda1ce511"
+source = "git+https://github.com/DioxusLabs/taffy?rev=2e4dbc55bf27a6d6f1464267d44d4d4a47e5da8c#2e4dbc55bf27a6d6f1464267d44d4d4a47e5da8c"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "74f8b2cab9b06ab6f4c9ebfd75bffecdda1ce511", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "2e4dbc55bf27a6d6f1464267d44d4d4a47e5da8c", default-features = false, features = [
     "std",
     "flexbox",
     "grid",


### PR DESCRIPTION
## Summary

Bumps the `taffy` git dependency from `74f8b2ca` to `2e4dbc55` to pick up DioxusLabs/taffy#1101 (wrapping flex containers with an indefinite main size now wrap against their max main size).

Together with #713 this makes `css/css-flexbox/align-content-horiz-001b.html` pass 72/72 (its flex containers are floats with `width: auto; max-width: 20px`, so their width is indefinite). Verified locally with the WPT runner; the full `css/css-flexbox` suite shows no per-test regressions.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/71b2a4272c6846039ac4d12a586ecc6c
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**2** newly passing, **0** newly failing (net +2).

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
+ Fail => Pass css/css-flexbox/align-content-horiz-001b.html
+ Fail => Pass css/css-flexbox/flexbox-flex-wrap-horiz-002.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31760323385).</sub>
<!-- wpt-results-end -->
