### PR TITLE
Honor `order` on ::before/::after flex/grid items

### DIFF
--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -22,7 +22,7 @@ use style::Atom;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::properties::ComputedValues;
 use style::properties::generated::longhands::position::computed_value::T as Position;
-use style::selector_parser::{PseudoElement, RestyleDamage};
+use style::selector_parser::RestyleDamage;
 use style::servo_arc::Arc as ServoArc;
 use style::shared_lock::SharedRwLock;
 use style::stylesheets::UrlExtraData;
@@ -1056,13 +1056,10 @@ impl Node {
     }
 
     pub fn order(&self) -> i32 {
-        self.primary_styles()
-            .map(|s| match s.pseudo() {
-                Some(PseudoElement::Before) => i32::MIN,
-                Some(PseudoElement::After) => i32::MAX,
-                _ => s.clone_order(),
-            })
-            .unwrap_or(0)
+        // ::before/::after pseudos are flex/grid items and honor `order`.
+        // They sit first/last in layout_children, and the `order` sort is
+        // stable, so ties keep ::before first and ::after last.
+        self.primary_styles().map(|s| s.clone_order()).unwrap_or(0)
     }
 
     pub fn z_index(&self) -> i32 {


### PR DESCRIPTION
## Summary

`Node::order()` hard-coded `i32::MIN`/`i32::MAX` for ::before/::after pseudos, so an explicit `order` on a pseudo-element flex/grid item was ignored. Per css-flexbox-1 §flex-items, pseudos are ordinary items and honor `order`.

Now `order()` just returns `clone_order()`. The tie-break (::before first, ::after last among equal `order` values) still holds because pseudos are pushed first/last into `layout_children` and the sort in `flush_styles_to_layout_impl` is stable.

WPT: fixes `css/css-flexbox/flexbox-with-pseudo-elements-002.html` and `-003.html`; no changes to other css-flexbox or css-grid results (flexbox 803→805 passing, grid unchanged).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/17cea825d78643e298cf44b2ef9f6680
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**2** newly passing, **0** newly failing (net +2).

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
+ Fail => Pass css/css-flexbox/flexbox-with-pseudo-elements-002.html
+ Fail => Pass css/css-flexbox/flexbox-with-pseudo-elements-003.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31761544799).</sub>
<!-- wpt-results-end -->
