### PR TITLE
Propagate body overflow to the viewport

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -53,7 +53,7 @@ use style::servo::media_features::PointerCapabilities;
 use style::servo_arc::Arc as ServoArc;
 use style::values::GenericAtomIdent;
 use style::values::computed::ui::CursorKind;
-use style::values::computed::{Overflow, UserSelect};
+use style::values::computed::{Contain, Overflow, UserSelect};
 use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style::{
     device::Device,
@@ -811,6 +811,34 @@ impl BaseDocument {
             .unwrap()
             .as_element()
             .unwrap()
+    }
+
+    /// The element whose `overflow` is propagated to the viewport, per
+    /// <https://drafts.csswg.org/css-overflow-3/#overflow-propagation>: the root element,
+    /// or the `<body>` when the root element's overflow is `visible`. The used overflow of
+    /// that element is `visible` (it must not establish a scroll container or independent
+    /// formatting context of its own).
+    pub fn viewport_overflow_propagation_source(&self) -> Option<NodeId> {
+        let root = self.try_root_element()?;
+        let root_styles = root.primary_styles()?;
+        let root_is_visible = root_styles.clone_overflow_x() == Overflow::Visible
+            && root_styles.clone_overflow_y() == Overflow::Visible;
+        if !root_is_visible {
+            return Some(root.id);
+        }
+        let body_id = root.children.iter().copied().find(|id| {
+            self.nodes[*id]
+                .data
+                .is_element_with_tag_name(&local_name!("body"))
+        })?;
+        // Layout or paint containment on the <body> suppresses propagation
+        // (https://drafts.csswg.org/css-contain-2/#containment-types)
+        let body_styles = self.nodes[body_id].primary_styles()?;
+        let containment = body_styles.clone_contain();
+        if containment.intersects(Contain::LAYOUT | Contain::PAINT) {
+            return None;
+        }
+        Some(body_id)
     }
 
     pub fn create_node(&mut self, node_data: NodeData) -> NodeId {

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -53,7 +53,7 @@ use style::servo::media_features::PointerCapabilities;
 use style::servo_arc::Arc as ServoArc;
 use style::values::GenericAtomIdent;
 use style::values::computed::ui::CursorKind;
-use style::values::computed::{Contain, Overflow, UserSelect};
+use style::values::computed::{Overflow, UserSelect};
 use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style::{
     device::Device,
@@ -821,6 +821,11 @@ impl BaseDocument {
     pub fn viewport_overflow_propagation_source(&self) -> Option<NodeId> {
         let root = self.try_root_element()?;
         let root_styles = root.primary_styles()?;
+        // Any containment on the root element suppresses propagation
+        // (https://drafts.csswg.org/css-contain-2/#containment-types)
+        if !root_styles.clone_contain().is_empty() {
+            return None;
+        }
         let root_is_visible = root_styles.clone_overflow_x() == Overflow::Visible
             && root_styles.clone_overflow_y() == Overflow::Visible;
         if !root_is_visible {
@@ -831,11 +836,9 @@ impl BaseDocument {
                 .data
                 .is_element_with_tag_name(&local_name!("body"))
         })?;
-        // Layout or paint containment on the <body> suppresses propagation
-        // (https://drafts.csswg.org/css-contain-2/#containment-types)
+        // Any containment on the <body> likewise suppresses propagation
         let body_styles = self.nodes[body_id].primary_styles()?;
-        let containment = body_styles.clone_contain();
-        if containment.intersects(Contain::LAYOUT | Contain::PAINT) {
+        if !body_styles.clone_contain().is_empty() {
             return None;
         }
         Some(body_id)

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -434,6 +434,22 @@ impl BaseDocument {
 
     pub fn flush_styles_to_layout(&mut self, node_id: NodeId) {
         self.flush_styles_to_layout_impl(node_id, None);
+
+        // The used overflow of the element whose overflow is propagated to the viewport
+        // is `visible`: it must not establish a scroll container of its own.
+        if let Some(source_id) = self.viewport_overflow_propagation_source() {
+            let node = self.nodes.get_mut(source_id).unwrap();
+            let style = node.style_mut();
+            if style.overflow.x != taffy::Overflow::Visible
+                || style.overflow.y != taffy::Overflow::Visible
+            {
+                style.overflow = taffy::Point {
+                    x: taffy::Overflow::Visible,
+                    y: taffy::Overflow::Visible,
+                };
+                style.scrollbar_width = 0.0;
+            }
+        }
     }
 
     /// Flush a CSS image layer list (`background-image` or `mask-image`) from style

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -52,8 +52,6 @@ pub struct BlitzDomPainter<'dom, 'a> {
     pub(crate) height: u32,
     pub(crate) initial_x: f64,
     pub(crate) initial_y: f64,
-    /// The id of the document's root element (cached to avoid re-resolving it for every element)
-    pub(crate) root_element_id: Option<NodeId>,
     /// The id of the element whose overflow is propagated to the viewport (the root element,
     /// or the `<body>` when the root element's overflow is `visible`)
     pub(crate) viewport_overflow_source_id: Option<NodeId>,
@@ -88,7 +86,6 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             .collect();
 
         let layer_manager = LayerManager::default();
-        let root_element_id = dom.try_root_element().map(|el| el.id);
         let viewport_overflow_source_id = dom.viewport_overflow_propagation_source();
 
         Self {
@@ -98,7 +95,6 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             height,
             initial_x,
             initial_y,
-            root_element_id,
             viewport_overflow_source_id,
             #[cfg(feature = "scrollbars")]
             hovered_scrollbar: dom.hovered_scrollbar(),
@@ -281,9 +277,8 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             .is_some();
         // The overflow of the root element (or the <body>, when the root's overflow is
         // `visible`) is propagated to the viewport (which is clipped by the window/surface
-        // bounds), so neither that element nor the root must clip its own overflow.
-        let propagates_overflow_to_viewport = self.root_element_id == Some(node_id)
-            || self.viewport_overflow_source_id == Some(node_id);
+        // bounds), so that element must not clip its own overflow.
+        let propagates_overflow_to_viewport = self.viewport_overflow_source_id == Some(node_id);
         let should_clip = !propagates_overflow_to_viewport
             && (is_image
                 || is_sub_doc

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -54,6 +54,9 @@ pub struct BlitzDomPainter<'dom, 'a> {
     pub(crate) initial_y: f64,
     /// The id of the document's root element (cached to avoid re-resolving it for every element)
     pub(crate) root_element_id: Option<NodeId>,
+    /// The id of the element whose overflow is propagated to the viewport (the root element,
+    /// or the `<body>` when the root element's overflow is `visible`)
+    pub(crate) viewport_overflow_source_id: Option<NodeId>,
     /// Scrollbar hover/drag state, resolved once per scene like the root element
     #[cfg(feature = "scrollbars")]
     pub(crate) hovered_scrollbar: Option<blitz_dom::node::ScrollbarRef>,
@@ -86,6 +89,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
 
         let layer_manager = LayerManager::default();
         let root_element_id = dom.try_root_element().map(|el| el.id);
+        let viewport_overflow_source_id = dom.viewport_overflow_propagation_source();
 
         Self {
             dom,
@@ -95,6 +99,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             initial_x,
             initial_y,
             root_element_id,
+            viewport_overflow_source_id,
             #[cfg(feature = "scrollbars")]
             hovered_scrollbar: dom.hovered_scrollbar(),
             #[cfg(feature = "scrollbars")]
@@ -274,10 +279,12 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             .element_data()
             .and_then(|el| el.text_input_data())
             .is_some();
-        // The root element's overflow is propagated to the viewport (which is clipped by the
-        // window/surface bounds), so the root element must not clip its own overflow.
-        let is_root_element = self.root_element_id == Some(node_id);
-        let should_clip = !is_root_element
+        // The overflow of the root element (or the <body>, when the root's overflow is
+        // `visible`) is propagated to the viewport (which is clipped by the window/surface
+        // bounds), so neither that element nor the root must clip its own overflow.
+        let propagates_overflow_to_viewport = self.root_element_id == Some(node_id)
+            || self.viewport_overflow_source_id == Some(node_id);
+        let should_clip = !propagates_overflow_to_viewport
             && (is_image
                 || is_sub_doc
                 || is_text_input


### PR DESCRIPTION
## Summary

Per [CSS overflow propagation](https://drafts.csswg.org/css-overflow-3/#overflow-propagation), when the root element's overflow is `visible`, the `<body>`'s overflow is propagated to the viewport and the body's *used* overflow is `visible` — it must not become a scroll container or clip its own content. Blitz previously only special-cased the root element, so `body { overflow: hidden }` made the body itself a clipping scroll container, breaking e.g. percentage `max-height` resolution in `flexbox-definite-sizes-003/004`.

Changes:
- `BaseDocument::viewport_overflow_propagation_source()` — returns the element whose overflow is propagated to the viewport: the root element if its overflow is non-visible, otherwise the `<body>`. Any containment (`contain` != none) on the root or the body suppresses propagation entirely (per css-contain-2; covers `css/css-contain/contain-{body,html}-overflow-*`).
- `flush_styles_to_layout` resets that element's Taffy `overflow` to `Visible` (and `scrollbar_width` to 0) after style flush, so layout treats it as non-scrollable.
- `blitz-paint`'s clip logic keys clipping suppression off the propagation source instead of unconditionally exempting the root element (a contained root now clips its own overflow, e.g. `contain-html-overflow-002`).

WPT results (release runner):
- `css/css-flexbox`: 805 → 807 passing (`flexbox-definite-sizes-003/004` fixed), no regressions.
- `css/css-overflow`: +5 (`overflow-body-propagation-007/008/009/016`, `scrollable-overflow-with-nested-elements-005`), no regressions.
- `css/css-contain`: `contain-body-overflow-003/004` and `contain-html-overflow-001..004` kept passing via the containment exception (`contain-body-overflow-002` and `contain-layout-ink-overflow-013/015` fail on main too).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/17cea825d78643e298cf44b2ef9f6680
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**28** newly passing, **7** newly failing (net +21).

<details>
<summary>Full diff (35 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/visufx/overflow-propagation-001a.html
+ Fail => Pass css/css-backgrounds/background-origin/origin-border-box.html
- Pass => Fail css/css-backgrounds/background-origin/origin-border-box_with_position.html
+ Fail => Pass css/css-backgrounds/background-origin/origin-border-box_with_radius.html
+ Fail => Pass css/css-backgrounds/background-origin/origin-border-box_with_size.html
+ Fail => Pass css/css-backgrounds/border-radius-clipping-002.html
+ Fail => Pass css/css-contain/contain-size-grid-002.html
+ Fail => Pass css/css-flexbox/flexbox-definite-sizes-003.html
+ Fail => Pass css/css-flexbox/flexbox-definite-sizes-004.html
+ Fail => Pass css/css-grid/grid-items/aspect-ratio-005.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-as-flex-item-should-not-shrink-to-fit-001.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-as-flex-item-should-not-shrink-to-fit-002.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-as-flex-item-should-not-shrink-to-fit-003.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-as-flex-item-should-not-shrink-to-fit-004.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-as-flex-item-should-not-shrink-to-fit-005.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-as-flex-item-should-not-shrink-to-fit-006.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-as-flex-item-should-not-shrink-to-fit-007.html
+ Fail => Pass css/css-grid/layout-algorithm/grid-as-flex-item-should-not-shrink-to-fit-008.html
- Pass => Fail css/css-images/image-orientation/image-orientation-img-object-fit.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-none-cross-origin-canvas.html
+ Fail => Pass css/css-masking/clip-path/clip-path-scaled-video.html
+ Fail => Pass css/css-overflow/overflow-body-propagation-007.html
+ Fail => Pass css/css-overflow/overflow-body-propagation-008.html
+ Fail => Pass css/css-overflow/overflow-body-propagation-009.html
+ Fail => Pass css/css-overflow/overflow-body-propagation-016.html
+ Fail => Pass css/css-overflow/scrollable-overflow-with-nested-elements-005.html
- Pass => Fail css/css-pseudo/first-letter-width-2.html
- Pass => Fail css/css-scroll-snap/snap-after-initial-layout/scroll-snap-initial-layout-000.html
- Pass => Fail css/css-text-decor/text-decoration-overline-wavy-covers-whole-line-length-001.html
+ Fail => Pass css/css-transforms/transform-fixed-bg-006.html
+ Fail => Pass css/css-transforms/transform-inherit-001.html
+ Fail => Pass css/css-transforms/transform-transformed-td-contains-fixed-position.html
+ Fail => Pass css/css-transforms/transform-transformed-th-contains-fixed-position.html
- Pass => Fail css/cssom-view/cssom-getBoundingClientRect-vertical-rl.html
- Pass => Fail css/filter-effects/backdrop-filter-plus-mask-large.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31787083765).</sub>
<!-- wpt-results-end -->
