### PR TITLE
Support `flex-wrap: balance` and `flex-line-count` (CSS Flexbox Level 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6343,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.40.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6978,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -6990,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7016,7 +7016,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "toml",
 ]
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -7369,7 +7369,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.5.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7382,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
+source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=a075959a2b6ed55ef9035eda488b5a353ae3f725#a075959a2b6ed55ef9035eda488b5a353ae3f725"
+source = "git+https://github.com/DioxusLabs/taffy?rev=12c1a8384dcf97358e9f9253486c12c4a174ff2b#12c1a8384dcf97358e9f9253486c12c4a174ff2b"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=12c1a8384dcf97358e9f9253486c12c4a174ff2b#12c1a8384dcf97358e9f9253486c12c4a174ff2b"
+source = "git+https://github.com/DioxusLabs/taffy?rev=3d89e378a4b90743b3e21c2638d0a525981baa43#3d89e378a4b90743b3e21c2638d0a525981baa43"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6343,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.40.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6978,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -6990,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7016,7 +7016,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "toml",
 ]
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -7369,7 +7369,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.5.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7382,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
+source = "git+https://github.com/DioxusLabs/stylo?rev=f7b454d12bfc667eef7cae266e82afebb1f8cdac#f7b454d12bfc667eef7cae266e82afebb1f8cdac"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6343,8 +6343,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeee001a77567bb05e71652718d3ff76d8697c151ac523e68e9513194eb2b75a"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -6485,8 +6484,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6915,8 +6913,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebaeb0b51f5e574bf36606c4dc982430a20d7a17175bdc0deab4d43d2063040b"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6972,8 +6969,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d448de89b7d18169a160ca258d2ee63efe79bd6cb20360654101835e9b80e386"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6982,8 +6978,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cfdbf36a2d2db4fc75db0bfc1abd16e90971c360f00773cbd2501a5175dbec7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -6995,8 +6990,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346fde14a66fdc568ef79a8c81f8b6a35722a0906295bce2997df6c90c7b848f"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -7005,8 +6999,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1ee5ec323e0207ebaafff2210fec808214575d67cfe25e288d34a12010e2b3"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7023,8 +7016,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e017eb7fd506fa0fb0da653a6bc3793d9fc11edf92d4721c16b350432f8116f"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "toml",
 ]
@@ -7041,8 +7033,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a8d2ca5b29c7f5dd94ec66fbb256b274b76ecaab164417c92ce9a4586c8259"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -7163,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=b0bb6afcb5d580dd05c883a5d68f5861c1a3fab3#b0bb6afcb5d580dd05c883a5d68f5861c1a3fab3"
+source = "git+https://github.com/DioxusLabs/taffy?rev=a075959a2b6ed55ef9035eda488b5a353ae3f725#a075959a2b6ed55ef9035eda488b5a353ae3f725"
 dependencies = [
  "arrayvec",
  "serde",
@@ -7378,8 +7369,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c81cee0d28327337a94f3f32a1a77c03bbfd926510f3b42956f9d914e7810c"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7392,8 +7382,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba1f5563024b63bb6acb4558452d9ba737518c1d11fcc1861febe98d1e31cf4"
+source = "git+https://github.com/DioxusLabs/stylo?rev=27b830f582454318c13f81a431ed4b52c266daf8#27b830f582454318c13f81a431ed4b52c266daf8"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -293,7 +293,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1517,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2460,7 +2460,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2720,7 +2720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4720,7 +4720,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6186,7 +6186,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6199,7 +6199,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6343,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.40.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6766,7 +6766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6978,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -6990,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7016,7 +7016,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "toml",
 ]
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.20.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -7189,7 +7189,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7369,7 +7369,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.5.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7382,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/stylo?rev=404505d540a5c9a6d33c6dd175615299d75343d7#404505d540a5c9a6d33c6dd175615299d75343d7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=b98be013150eec9eadb30ee8cf8a0d6c0b22dca6#b98be013150eec9eadb30ee8cf8a0d6c0b22dca6"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -7743,7 +7743,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8634,7 +8634,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,12 @@ browser-persistence = { path = "./apps/browser/persistence" }
 blitz-test-harness = { path = "./packages/blitz-test-harness" }
 
 # Servo dependencies
-style = { version = "0.20.0", package = "stylo" }
-style_traits = { version = "0.20.0", package = "stylo_traits" }
-style_atoms = { version = "0.20.0", package = "stylo_atoms" }
-style_config = { version = "0.20.0", package = "stylo_static_prefs" }
-style_dom = { version = "0.20.0", package = "stylo_dom" }
-selectors = { version = "0.40.0", package = "selectors" }
+style = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo" }
+style_traits = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo_traits" }
+style_atoms = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo_atoms" }
+style_config = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo_static_prefs" }
+style_dom = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo_dom" }
+selectors = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "selectors" }
 cssparser = { version = "0.37.0" }
 
 # HTML5ever dependencies
@@ -96,9 +96,10 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b0bb6afcb5d580dd05c883a5d68f5861c1a3fab3", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a075959a2b6ed55ef9035eda488b5a353ae3f725", default-features = false, features = [
     "std",
     "flexbox",
+    "flexbox_balance",
     "grid",
     "block_layout",
     "content_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,12 @@ browser-persistence = { path = "./apps/browser/persistence" }
 blitz-test-harness = { path = "./packages/blitz-test-harness" }
 
 # Servo dependencies
-style = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo" }
-style_traits = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo_traits" }
-style_atoms = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo_atoms" }
-style_config = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo_static_prefs" }
-style_dom = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo_dom" }
-selectors = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "selectors" }
+style = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo" }
+style_traits = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo_traits" }
+style_atoms = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo_atoms" }
+style_config = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo_static_prefs" }
+style_dom = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo_dom" }
+selectors = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "selectors" }
 cssparser = { version = "0.37.0" }
 
 # HTML5ever dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a075959a2b6ed55ef9035eda488b5a353ae3f725", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "12c1a8384dcf97358e9f9253486c12c4a174ff2b", default-features = false, features = [
     "std",
     "flexbox",
     "flexbox_balance",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,12 @@ browser-persistence = { path = "./apps/browser/persistence" }
 blitz-test-harness = { path = "./packages/blitz-test-harness" }
 
 # Servo dependencies
-style = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo" }
-style_traits = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo_traits" }
-style_atoms = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo_atoms" }
-style_config = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo_static_prefs" }
-style_dom = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "stylo_dom" }
-selectors = { git = "https://github.com/DioxusLabs/stylo", rev = "27b830f582454318c13f81a431ed4b52c266daf8", package = "selectors" }
+style = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo" }
+style_traits = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo_traits" }
+style_atoms = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo_atoms" }
+style_config = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo_static_prefs" }
+style_dom = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "stylo_dom" }
+selectors = { git = "https://github.com/DioxusLabs/stylo", rev = "404505d540a5c9a6d33c6dd175615299d75343d7", package = "selectors" }
 cssparser = { version = "0.37.0" }
 
 # HTML5ever dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "12c1a8384dcf97358e9f9253486c12c4a174ff2b", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "3d89e378a4b90743b3e21c2638d0a525981baa43", default-features = false, features = [
     "std",
     "flexbox",
     "flexbox_balance",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,12 @@ browser-persistence = { path = "./apps/browser/persistence" }
 blitz-test-harness = { path = "./packages/blitz-test-harness" }
 
 # Servo dependencies
-style = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo" }
-style_traits = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo_traits" }
-style_atoms = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo_atoms" }
-style_config = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo_static_prefs" }
-style_dom = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "stylo_dom" }
-selectors = { git = "https://github.com/DioxusLabs/stylo", rev = "b98be013150eec9eadb30ee8cf8a0d6c0b22dca6", package = "selectors" }
+style = { git = "https://github.com/DioxusLabs/stylo", rev = "f7b454d12bfc667eef7cae266e82afebb1f8cdac", package = "stylo" }
+style_traits = { git = "https://github.com/DioxusLabs/stylo", rev = "f7b454d12bfc667eef7cae266e82afebb1f8cdac", package = "stylo_traits" }
+style_atoms = { git = "https://github.com/DioxusLabs/stylo", rev = "f7b454d12bfc667eef7cae266e82afebb1f8cdac", package = "stylo_atoms" }
+style_config = { git = "https://github.com/DioxusLabs/stylo", rev = "f7b454d12bfc667eef7cae266e82afebb1f8cdac", package = "stylo_static_prefs" }
+style_dom = { git = "https://github.com/DioxusLabs/stylo", rev = "f7b454d12bfc667eef7cae266e82afebb1f8cdac", package = "stylo_dom" }
+selectors = { git = "https://github.com/DioxusLabs/stylo", rev = "f7b454d12bfc667eef7cae266e82afebb1f8cdac", package = "selectors" }
 cssparser = { version = "0.37.0" }
 
 # HTML5ever dependencies

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -410,6 +410,7 @@ impl BaseDocument {
         style_config::set_pref!("layout.grid.enabled", true);
         style_config::set_pref!("layout.unimplemented", true);
         style_config::set_pref!("layout.columns.enabled", true);
+        style_config::set_pref!("layout.flexbox.balance", true);
         style_config::set_pref!("layout.css.basic-shape-shape.enabled", true);
         style_config::set_pref!("layout.threads", -1);
 

--- a/packages/stylo_taffy/Cargo.toml
+++ b/packages/stylo_taffy/Cargo.toml
@@ -17,9 +17,10 @@ style = { workspace = true }
 style_atoms = { workspace = true }
 
 [features]
-default = ["std", "block", "flexbox", "grid"]
+default = ["std", "block", "flexbox", "flexbox_balance", "grid"]
 std = ["taffy/std"]
 block = ["taffy/block_layout"]
 flexbox = ["taffy/flexbox"]
+flexbox_balance = ["flexbox", "taffy/flexbox_balance"]
 grid = ["taffy/grid"]
 floats = ["taffy/float_layout"]

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -486,18 +486,22 @@ pub fn flex_direction(input: stylo::FlexDirection) -> taffy::FlexDirection {
 #[inline]
 #[cfg(feature = "flexbox")]
 pub fn flex_wrap(input: stylo::FlexWrap) -> taffy::FlexWrap {
-    match input {
-        stylo::FlexWrap::Wrap => taffy::FlexWrap::Wrap,
-        stylo::FlexWrap::WrapReverse => taffy::FlexWrap::WrapReverse,
-        stylo::FlexWrap::Nowrap => taffy::FlexWrap::NoWrap,
+    let balance = input.contains(stylo::FlexWrap::BALANCE);
+    if input.contains(stylo::FlexWrap::WRAP_REVERSE) {
         #[cfg(feature = "flexbox_balance")]
-        stylo::FlexWrap::Balance => taffy::FlexWrap::Balance,
+        if balance {
+            return taffy::FlexWrap::BalanceReverse;
+        }
+        taffy::FlexWrap::WrapReverse
+    } else if balance {
         #[cfg(feature = "flexbox_balance")]
-        stylo::FlexWrap::WrapReverseBalance => taffy::FlexWrap::BalanceReverse,
+        return taffy::FlexWrap::Balance;
         #[cfg(not(feature = "flexbox_balance"))]
-        stylo::FlexWrap::Balance => taffy::FlexWrap::Wrap,
-        #[cfg(not(feature = "flexbox_balance"))]
-        stylo::FlexWrap::WrapReverseBalance => taffy::FlexWrap::WrapReverse,
+        taffy::FlexWrap::Wrap
+    } else if input.contains(stylo::FlexWrap::WRAP) {
+        taffy::FlexWrap::Wrap
+    } else {
+        taffy::FlexWrap::NoWrap
     }
 }
 

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -453,6 +453,14 @@ pub fn flex_wrap(input: stylo::FlexWrap) -> taffy::FlexWrap {
         stylo::FlexWrap::Wrap => taffy::FlexWrap::Wrap,
         stylo::FlexWrap::WrapReverse => taffy::FlexWrap::WrapReverse,
         stylo::FlexWrap::Nowrap => taffy::FlexWrap::NoWrap,
+        #[cfg(feature = "flexbox_balance")]
+        stylo::FlexWrap::Balance => taffy::FlexWrap::Balance,
+        #[cfg(feature = "flexbox_balance")]
+        stylo::FlexWrap::WrapReverseBalance => taffy::FlexWrap::BalanceReverse,
+        #[cfg(not(feature = "flexbox_balance"))]
+        stylo::FlexWrap::Balance => taffy::FlexWrap::Wrap,
+        #[cfg(not(feature = "flexbox_balance"))]
+        stylo::FlexWrap::WrapReverseBalance => taffy::FlexWrap::WrapReverse,
     }
 }
 
@@ -802,6 +810,8 @@ pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style<Atom> {
         flex_shrink: pos.flex_shrink.0,
         #[cfg(feature = "flexbox")]
         flex_basis: self::flex_basis(&pos.flex_basis),
+        #[cfg(all(feature = "flexbox", feature = "flexbox_balance"))]
+        flex_line_count: pos.flex_line_count.max(1) as u16,
 
         // Grid
         #[cfg(feature = "grid")]

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -198,6 +198,12 @@ impl<T: Deref<Target = ComputedValues>> taffy::FlexboxContainerStyle for TaffySt
         convert::flex_wrap(self.0.get_position().flex_wrap)
     }
 
+    #[cfg(feature = "flexbox_balance")]
+    #[inline]
+    fn flex_line_count(&self) -> u16 {
+        self.0.get_position().flex_line_count.max(1) as u16
+    }
+
     #[inline]
     fn gap(&self) -> taffy::Size<taffy::LengthPercentage> {
         let position_styles = self.0.get_position();

--- a/tests/blitz-tests/tests/flex_wrap_balance.rs
+++ b/tests/blitz-tests/tests/flex_wrap_balance.rs
@@ -1,0 +1,136 @@
+//! `flex-wrap: balance` and `flex-line-count` (CSS Flexbox Level 2).
+//!
+//! <https://drafts.csswg.org/css-flexbox-2/#flex-wrap-property>
+//! <https://drafts.csswg.org/css-flexbox-2/#flex-line-count-property>
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+fn layout_doc(html: &str) -> HtmlDocument {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+    doc
+}
+
+fn item_positions(doc: &HtmlDocument, count: usize) -> Vec<(f32, f32)> {
+    (1..=count)
+        .map(|i| {
+            let id = doc
+                .query_selector(&format!("#item{i}"))
+                .unwrap()
+                .unwrap_or_else(|| panic!("#item{i} not found"));
+            let layout = doc.get_node(id).unwrap().final_layout();
+            (layout.location.x, layout.location.y)
+        })
+        .collect()
+}
+
+fn container_html(flex_style: &str) -> String {
+    format!(
+        r#"<html><body style="margin:0">
+            <div style="display:flex; {flex_style}; width:120px; gap:10px;">
+                <div id="item1" style="width:25px; height:20px;"></div>
+                <div id="item2" style="width:25px; height:20px;"></div>
+                <div id="item3" style="width:25px; height:20px;"></div>
+                <div id="item4" style="width:25px; height:20px;"></div>
+            </div>
+        </body></html>"#
+    )
+}
+
+#[test]
+fn flex_wrap_wrap_splits_3_1() {
+    // Four 25px items with 10px gaps in a 120px container: plain `wrap`
+    // fits 3 on the first line (25*3 + 10*2 = 95 <= 120) and 1 on the second.
+    let doc = layout_doc(&container_html("flex-wrap: wrap"));
+    let pos = item_positions(&doc, 4);
+    let first_line_y = pos[0].1;
+    let lines: Vec<bool> = pos.iter().map(|p| p.1 == first_line_y).collect();
+    assert_eq!(
+        lines,
+        vec![true, true, true, false],
+        "flex-wrap: wrap should split 3/1, got positions {pos:?}"
+    );
+}
+
+#[test]
+fn flex_wrap_balance_splits_2_2() {
+    let doc = layout_doc(&container_html("flex-wrap: balance"));
+    let pos = item_positions(&doc, 4);
+    let first_line_y = pos[0].1;
+    let lines: Vec<bool> = pos.iter().map(|p| p.1 == first_line_y).collect();
+    assert_eq!(
+        lines,
+        vec![true, true, false, false],
+        "flex-wrap: balance should split 2/2, got positions {pos:?}"
+    );
+}
+
+#[test]
+fn flex_wrap_wrap_balance_splits_2_2() {
+    let doc = layout_doc(&container_html("flex-wrap: wrap balance"));
+    let pos = item_positions(&doc, 4);
+    let first_line_y = pos[0].1;
+    let lines: Vec<bool> = pos.iter().map(|p| p.1 == first_line_y).collect();
+    assert_eq!(lines, vec![true, true, false, false]);
+}
+
+#[test]
+fn flex_wrap_wrap_reverse_balance() {
+    // With wrap-reverse the balanced lines are stacked in reverse order:
+    // items 1-2 end up on the bottom line, items 3-4 on the top line.
+    let doc = layout_doc(&container_html("flex-wrap: wrap-reverse balance"));
+    let pos = item_positions(&doc, 4);
+    assert_eq!(pos[0].1, pos[1].1);
+    assert_eq!(pos[2].1, pos[3].1);
+    assert!(
+        pos[0].1 > pos[2].1,
+        "wrap-reverse balance should place the first line below the second, got {pos:?}"
+    );
+}
+
+#[test]
+fn flex_wrap_nowrap_balance_is_invalid() {
+    // `nowrap balance` is invalid and must be ignored, leaving the initial
+    // value (nowrap): all items on a single line.
+    let doc = layout_doc(&container_html("flex-wrap: nowrap balance"));
+    let pos = item_positions(&doc, 4);
+    let first_line_y = pos[0].1;
+    assert!(
+        pos.iter().all(|p| p.1 == first_line_y),
+        "invalid `nowrap balance` should fall back to nowrap, got {pos:?}"
+    );
+}
+
+#[test]
+fn flex_line_count_forces_minimum_lines() {
+    // All four items would fit on one line in a 400px container, but
+    // `flex-line-count: 2` with balance forces balancing across 2 lines.
+    let doc = layout_doc(
+        r#"<html><body style="margin:0">
+            <div style="display:flex; flex-wrap: balance; flex-line-count: 2; width:400px; gap:10px;">
+                <div id="item1" style="width:25px; height:20px;"></div>
+                <div id="item2" style="width:25px; height:20px;"></div>
+                <div id="item3" style="width:25px; height:20px;"></div>
+                <div id="item4" style="width:25px; height:20px;"></div>
+            </div>
+        </body></html>"#,
+    );
+    let pos = item_positions(&doc, 4);
+    let first_line_y = pos[0].1;
+    let lines: Vec<bool> = pos.iter().map(|p| p.1 == first_line_y).collect();
+    assert_eq!(
+        lines,
+        vec![true, true, false, false],
+        "flex-line-count: 2 should balance into two lines, got {pos:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds end-to-end support for CSS Flexbox Level 2 line balancing: `flex-wrap: balance` (and `wrap-reverse balance`) and the `flex-line-count` property, per https://drafts.csswg.org/css-flexbox-2/.

- `stylo_taffy::convert::flex_wrap` maps Stylo's bitflags `FlexWrap` (`BALANCE`, `WRAP_REVERSE | BALANCE`) to `taffy::FlexWrap::Balance`/`BalanceReverse`, and `TaffyStyloStyle` implements `FlexboxContainerStyle::flex_line_count()` (clamped to `>= 1`). Gated behind a new on-by-default `flexbox_balance` cargo feature on `stylo_taffy` (enables `taffy/flexbox_balance`, which is also added to the workspace `taffy` feature list).
- `blitz-dom` enables the `layout.flexbox.balance` Stylo pref at document init, so the new syntax parses in Blitz.
- Adds focused layout tests (`tests/blitz-tests/tests/flex_wrap_balance.rs`): four 25px items in a 120px container with 10px gaps split 3/1 with `wrap` but 2/2 with `balance`; plus `wrap balance`, `wrap-reverse balance`, invalid `nowrap balance`, and `flex-line-count` forcing extra lines.

### Dependencies

- **Taffy**: no change — `main`'s pinned rev (`c17b313c`) already contains the balancing implementation (DioxusLabs/taffy#1105).
- **Stylo**: the parsing side landed upstream in servo/stylo (`26794a40` + pref fixup `1e8d4fc1`, a port of mozilla-firefox/firefox@ff5db46b) but is **not in any release yet** (`stylo 0.21.0` predates it). Stylo deps are therefore temporarily pinned to `DioxusLabs/stylo@c28a39e0` = the `v0.21.0` tag + a clean cherry-pick of those two upstream commits (branch `v0.21.0-flex-wrap-balance`). This should be switched back to a crates.io release once stylo 0.22 ships. Pulling servo/stylo `main` directly instead would require a broader upgrade (cssparser 0.38, html5ever/markup5ever 0.40, `PerLevelTraversalData`/`process_preorder` and `font-stretch` API changes, `UserSelect::Contain`), which is out of scope here.

WPT `css/css-flexbox/balance`: 32/41 run tests pass. The 9 failures are preexisting limitations (7 need script execution which the WPT runner doesn't support, 1 needs `width: min-content` on atomic inline boxes, 1 needs `display: -webkit-box`).

Rendered verification (wrap 3/1 vs balance 2/2, wrap-reverse balance, flex-line-count: 2):

![balance demo](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvZTY4ZTk3N2YtMmZmZS00Yzc2LTg0MzEtZWY3OGExMjE5OTY0IiwiaWF0IjoxNzg2NzI4NDI1LCJleHAiOjE3ODczMzMyMjUsImZpbGVuYW1lIjoiYmFsYW5jZV9kZW1vLnBuZyJ9.E7Vi_iivIHTnrHO6XnXmSnW-jIlxZm8xMg8oDSdyAv8)


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b7bd5b365d054b87a6053872323832b2
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/b7bd5b365d054b87a6053872323832b2?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **52** newly passing, **0** newly failing (net +52).

<details>
<summary>Full diff (38 changed tests)</summary>

```diff
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-001.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-002.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-003.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-005.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-available-size-001.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-available-size-002.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-complex.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-dynamic-001.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-dynamic-002.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-dynamic-003.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-dynamic-004.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-dynamic-006.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-dynamic-007.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-flex-grow.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-line-count-intrinsic-001.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-line-count-intrinsic-003.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-line-count-intrinsic-004.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-line-count-intrinsic-005.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-line-count-intrinsic-006.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-line-count-intrinsic-007.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-min-line-count-001.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-min-line-count-002.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-min-line-count-003.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-min-line-count-004.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-min-line-count-005.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-min-line-count-006.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-negative-margin-001.html
+ FAIL => PASS  [4/4]  +3  css/css-flexbox/balance/balance-negative-margin-002.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-percentage-size-001.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-percentage-size-002.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-start-bias-001.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-start-bias-002.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-start-bias-003.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/balance/balance-zero-size.html
+ FAIL => PASS  [4/4]  +4  css/css-flexbox/balance/flex-line-count-computed.html
+ FAIL => PASS  [2/2]  +2  css/css-flexbox/balance/flex-line-count-valid.html
+ FAIL => PASS  [8/8]  +5  css/css-flexbox/balance/flex-wrap-computed.html
+ FAIL => PASS  [8/8]  +5  css/css-flexbox/balance/flex-wrap-valid.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/35262001151).</sub>
<!-- wpt-results-end -->
