### PR TITLE
Upgrade to Taffy with `contain` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=c47ab46b63bd47d33bb87ac63e2ce875b8975690#c47ab46b63bd47d33bb87ac63e2ce875b8975690"
+source = "git+https://github.com/DioxusLabs/taffy?rev=20f04b9f7ebe37e5d661e3fb82e1bd4d9ca37147#20f04b9f7ebe37e5d661e3fb82e1bd4d9ca37147"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=53d79e0cbae93beaa2482f0e8d93652edb846186#53d79e0cbae93beaa2482f0e8d93652edb846186"
+source = "git+https://github.com/DioxusLabs/taffy?rev=c47ab46b63bd47d33bb87ac63e2ce875b8975690#c47ab46b63bd47d33bb87ac63e2ce875b8975690"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=605d0c50b1543611111075ba4434e7154cba5fcb#605d0c50b1543611111075ba4434e7154cba5fcb"
+source = "git+https://github.com/DioxusLabs/taffy?rev=53d79e0cbae93beaa2482f0e8d93652edb846186#53d79e0cbae93beaa2482f0e8d93652edb846186"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=b0bb6afcb5d580dd05c883a5d68f5861c1a3fab3#b0bb6afcb5d580dd05c883a5d68f5861c1a3fab3"
+source = "git+https://github.com/DioxusLabs/taffy?rev=00e1bff9f1d5760f6efe25ad18b6847ffb53dc09#00e1bff9f1d5760f6efe25ad18b6847ffb53dc09"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=00e1bff9f1d5760f6efe25ad18b6847ffb53dc09#00e1bff9f1d5760f6efe25ad18b6847ffb53dc09"
+source = "git+https://github.com/DioxusLabs/taffy?rev=605d0c50b1543611111075ba4434e7154cba5fcb#605d0c50b1543611111075ba4434e7154cba5fcb"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "c47ab46b63bd47d33bb87ac63e2ce875b8975690", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "20f04b9f7ebe37e5d661e3fb82e1bd4d9ca37147", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "00e1bff9f1d5760f6efe25ad18b6847ffb53dc09", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "605d0c50b1543611111075ba4434e7154cba5fcb", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b0bb6afcb5d580dd05c883a5d68f5861c1a3fab3", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "00e1bff9f1d5760f6efe25ad18b6847ffb53dc09", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "53d79e0cbae93beaa2482f0e8d93652edb846186", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "c47ab46b63bd47d33bb87ac63e2ce875b8975690", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "605d0c50b1543611111075ba4434e7154cba5fcb", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "53d79e0cbae93beaa2482f0e8d93652edb846186", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/assets/default.css
+++ b/packages/blitz-dom/assets/default.css
@@ -110,6 +110,25 @@ input[type="file"] {
     background-color: transparent;
 }
 
+/* https://html.spec.whatwg.org/#the-fieldset-and-legend-elements */
+fieldset {
+    display: block;
+    margin-inline-start: 2px;
+    margin-inline-end: 2px;
+    border: 2px groove #c0c0c0;
+    padding-block-start: 0.35em;
+    padding-block-end: 0.625em;
+    padding-inline-start: 0.75em;
+    padding-inline-end: 0.75em;
+    min-inline-size: min-content;
+}
+
+legend {
+    display: block;
+    padding-inline-start: 2px;
+    padding-inline-end: 2px;
+}
+
 option {
     display: none;
 }

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -220,7 +220,6 @@ pub(crate) fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) 
             || old_box.float != new_box.float
             || old_box.position != new_box.position
             || old_box.contain != new_box.contain
-            || old_box.container_type != new_box.container_type
             || old.clone_visibility() != new.clone_visibility()
         {
             return true;

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -219,6 +219,8 @@ pub(crate) fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) 
         if old_box.display != new_box.display
             || old_box.float != new_box.float
             || old_box.position != new_box.position
+            || old_box.contain != new_box.contain
+            || old_box.container_type != new_box.container_type
             || old.clone_visibility() != new.clone_visibility()
         {
             return true;

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -11,7 +11,7 @@ pub(crate) mod stylo {
     pub(crate) use style::values::computed::length_percentage::CalcLengthPercentage;
     pub(crate) use style::values::computed::length_percentage::Unpacked as UnpackedLengthPercentage;
     pub(crate) use style::values::computed::{
-        BorderSideWidth, Contain, ContainerType, LengthPercentage, Percentage,
+        BorderSideWidth, Contain, LengthPercentage, Percentage,
     };
     pub(crate) use style::values::generics::NonNegative;
     pub(crate) use style::values::generics::length::{
@@ -267,9 +267,9 @@ pub fn position(input: stylo::Position) -> taffy::Position {
 /// Convert stylo's containment to Taffy's `Contain`, which only represents the layout-affecting
 /// parts of the `contain` property.
 ///
-/// The effective containment is computed by folding the containment implied by `container-type`
-/// into the `contain` property (Servo-mode stylo does not compute this itself; in Gecko-mode this
-/// is `clone_effective_containment()`). <https://drafts.csswg.org/css-contain-3/#container-type>
+/// Only the explicitly specified `contain` property is mapped. The containment implied by
+/// `container-type` (Gecko-mode stylo folds this into `clone_effective_containment()`; Servo-mode
+/// does not compute it) is not applied for now.
 ///
 /// Stylo's `STYLE`/`PAINT` bits do not affect layout and its `BLOCK_SIZE` bit is not supported by
 /// Taffy, so these are all dropped.
@@ -277,31 +277,20 @@ pub fn position(input: stylo::Position) -> taffy::Position {
 /// Containment does not apply to non-atomic inline-level boxes.
 /// <https://drafts.csswg.org/css-contain-2/#contain-property>
 #[inline]
-pub fn contain(
-    contain: stylo::Contain,
-    container_type: stylo::ContainerType,
-    display: stylo::Display,
-) -> taffy::Contain {
+pub fn contain(contain: stylo::Contain, display: stylo::Display) -> taffy::Contain {
     let is_non_atomic_inline = display.outside() == stylo::DisplayOutside::Inline
         && display.inside() == stylo::DisplayInside::Flow;
     if is_non_atomic_inline {
         return taffy::Contain::NONE;
     }
 
-    let mut effective = contain;
-    if container_type.intersects(stylo::ContainerType::INLINE_SIZE) {
-        effective.insert(stylo::Contain::LAYOUT | stylo::Contain::INLINE_SIZE);
-    } else if container_type.intersects(stylo::ContainerType::SIZE) {
-        effective.insert(stylo::Contain::LAYOUT | stylo::Contain::SIZE);
-    }
-
     let mut output = taffy::Contain::NONE;
-    if effective.contains(stylo::Contain::SIZE) {
+    if contain.contains(stylo::Contain::SIZE) {
         output |= taffy::Contain::SIZE;
-    } else if effective.contains(stylo::Contain::INLINE_SIZE) {
+    } else if contain.contains(stylo::Contain::INLINE_SIZE) {
         output |= taffy::Contain::INLINE_SIZE;
     }
-    if effective.contains(stylo::Contain::LAYOUT) {
+    if contain.contains(stylo::Contain::LAYOUT) {
         output |= taffy::Contain::LAYOUT;
     }
     output
@@ -757,7 +746,7 @@ pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style<Atom> {
         },
         direction: self::direction(style.clone_direction()),
         scrollbar_width: 0.0,
-        contain: self::contain(style.clone_contain(), style.clone_container_type(), display),
+        contain: self::contain(style.clone_contain(), display),
 
         #[cfg(feature = "floats")]
         float: self::float(style.clone_float()),

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -271,8 +271,8 @@ pub fn position(input: stylo::Position) -> taffy::Position {
 /// `container-type` (Gecko-mode stylo folds this into `clone_effective_containment()`; Servo-mode
 /// does not compute it) is not applied for now.
 ///
-/// Stylo's `STYLE`/`PAINT` bits do not affect layout and its `BLOCK_SIZE` bit is not supported by
-/// Taffy, so these are all dropped.
+/// Stylo's `STYLE` bit does not affect layout and its `BLOCK_SIZE` bit is not supported by
+/// Taffy, so these are dropped.
 ///
 /// Containment does not apply to non-atomic inline-level boxes.
 /// <https://drafts.csswg.org/css-contain-2/#contain-property>
@@ -292,6 +292,9 @@ pub fn contain(contain: stylo::Contain, display: stylo::Display) -> taffy::Conta
     }
     if contain.contains(stylo::Contain::LAYOUT) {
         output |= taffy::Contain::LAYOUT;
+    }
+    if contain.contains(stylo::Contain::PAINT) {
+        output |= taffy::Contain::PAINT;
     }
     output
 }

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -10,7 +10,9 @@ pub(crate) mod stylo {
     pub(crate) use style::properties::longhands::position::computed_value::T as Position;
     pub(crate) use style::values::computed::length_percentage::CalcLengthPercentage;
     pub(crate) use style::values::computed::length_percentage::Unpacked as UnpackedLengthPercentage;
-    pub(crate) use style::values::computed::{BorderSideWidth, LengthPercentage, Percentage};
+    pub(crate) use style::values::computed::{
+        BorderSideWidth, Contain, ContainerType, LengthPercentage, Percentage,
+    };
     pub(crate) use style::values::generics::NonNegative;
     pub(crate) use style::values::generics::length::{
         GenericLengthPercentageOrNormal, GenericMargin, GenericMaxSize, GenericSize,
@@ -260,6 +262,49 @@ pub fn position(input: stylo::Position) -> taffy::Position {
         stylo::Position::Fixed => taffy::Position::Absolute,
         stylo::Position::Sticky => taffy::Position::Relative,
     }
+}
+
+/// Convert stylo's containment to Taffy's `Contain`, which only represents the layout-affecting
+/// parts of the `contain` property.
+///
+/// The effective containment is computed by folding the containment implied by `container-type`
+/// into the `contain` property (Servo-mode stylo does not compute this itself; in Gecko-mode this
+/// is `clone_effective_containment()`). <https://drafts.csswg.org/css-contain-3/#container-type>
+///
+/// Stylo's `STYLE`/`PAINT` bits do not affect layout and its `BLOCK_SIZE` bit is not supported by
+/// Taffy, so these are all dropped.
+///
+/// Containment does not apply to non-atomic inline-level boxes.
+/// <https://drafts.csswg.org/css-contain-2/#contain-property>
+#[inline]
+pub fn contain(
+    contain: stylo::Contain,
+    container_type: stylo::ContainerType,
+    display: stylo::Display,
+) -> taffy::Contain {
+    let is_non_atomic_inline = display.outside() == stylo::DisplayOutside::Inline
+        && display.inside() == stylo::DisplayInside::Flow;
+    if is_non_atomic_inline {
+        return taffy::Contain::NONE;
+    }
+
+    let mut effective = contain;
+    if container_type.intersects(stylo::ContainerType::INLINE_SIZE) {
+        effective.insert(stylo::Contain::LAYOUT | stylo::Contain::INLINE_SIZE);
+    } else if container_type.intersects(stylo::ContainerType::SIZE) {
+        effective.insert(stylo::Contain::LAYOUT | stylo::Contain::SIZE);
+    }
+
+    let mut output = taffy::Contain::NONE;
+    if effective.contains(stylo::Contain::SIZE) {
+        output |= taffy::Contain::SIZE;
+    } else if effective.contains(stylo::Contain::INLINE_SIZE) {
+        output |= taffy::Contain::INLINE_SIZE;
+    }
+    if effective.contains(stylo::Contain::LAYOUT) {
+        output |= taffy::Contain::LAYOUT;
+    }
+    output
 }
 
 #[inline]
@@ -712,6 +757,7 @@ pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style<Atom> {
         },
         direction: self::direction(style.clone_direction()),
         scrollbar_width: 0.0,
+        contain: self::contain(style.clone_contain(), style.clone_container_type(), display),
 
         #[cfg(feature = "floats")]
         float: self::float(style.clone_float()),

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -71,11 +71,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
     #[inline]
     fn contain(&self) -> taffy::Contain {
         let box_styles = self.0.get_box();
-        convert::contain(
-            box_styles.contain,
-            box_styles.container_type,
-            box_styles.display,
-        )
+        convert::contain(box_styles.contain, box_styles.display)
     }
 
     #[inline]

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -69,6 +69,16 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
     }
 
     #[inline]
+    fn contain(&self) -> taffy::Contain {
+        let box_styles = self.0.get_box();
+        convert::contain(
+            box_styles.contain,
+            box_styles.container_type,
+            box_styles.display,
+        )
+    }
+
+    #[inline]
     fn position(&self) -> taffy::Position {
         convert::position(self.0.get_box().position)
     }


### PR DESCRIPTION
## Summary

Hooks up the layout-affecting parts of CSS `contain` (implemented in Taffy in DioxusLabs/taffy#1106) to stylo's computed styles, and bumps the Taffy pin to that implementation.

- `stylo_taffy`: new `convert::contain(contain, display) -> taffy::Contain`, used by both the `CoreStyle` wrapper and `to_taffy_style`. Only the explicitly specified `contain` property is mapped for now — the containment implied by `container-type` (which Gecko-mode stylo folds into `effective_containment`, Servo-mode doesn't compute) is deliberately not applied yet.
  - stylo's `SIZE`/`INLINE_SIZE`/`LAYOUT`/`PAINT` bits map to the corresponding Taffy flags (paint containment establishes an independent formatting context in Taffy, without layout containment's baseline suppression)
  - stylo's `STYLE` bit doesn't affect layout and `BLOCK_SIZE` isn't supported by Taffy, so they're dropped
  - containment does not apply to non-atomic inlines (`display: inline` + inside `flow`), per css-contain-2
- UA stylesheet: `fieldset` and `legend` previously computed as `display: inline` (never set to block), which the non-atomic-inline rule above would have exempted from containment. Added the HTML-spec rendering rules for them (`display: block`, default fieldset border/padding/margins, `min-inline-size: min-content`).
- Restyle damage: `contain` changes now trigger box reconstruction in `compute_layout_damage`, since layout containment changes formatting-context establishment (same reasoning as the existing `align-content` check).

### WPT results (`css/css-contain`)

Compared to main: **41 tests newly pass, 0 real regressions** (449 run, 270 passing vs 231 on main; unchanged by dropping the `container-type` folding). Newly passing include `contain-size-*` (block/flex/grid/inline-block/fieldset/borders/scrollbars), `contain-inline-size-*`, `contain-content-*`, and layout-containment formatting-context/margin/float/baseline tests.

Two tests that "passed" on main now fail (`contain-layout-dynamic-004/005.html`): they require JavaScript to toggle containment at runtime, which the WPT runner can't execute. They previously passed accidentally because `contain` was ignored on both the test and its reference; now the reference (which uses containment statically) renders differently from the script-less test page.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/acd2d6680ec141b5ae16b24d5f958d3e
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**47** newly passing, **11** newly failing (net +36).

<details>
<summary>Full diff (58 changed tests)</summary>

```diff
+ Fail => Pass css/css-contain/contain-content-001.html
+ Fail => Pass css/css-contain/contain-content-002.html
+ Fail => Pass css/css-contain/contain-inline-size-fieldset.html
+ Fail => Pass css/css-contain/contain-inline-size-flex.html
+ Fail => Pass css/css-contain/contain-inline-size-flexitem.html
+ Fail => Pass css/css-contain/contain-inline-size-grid.html
+ Fail => Pass css/css-contain/contain-inline-size-legend.html
+ Fail => Pass css/css-contain/contain-inline-size-regular-container.html
- Pass => Fail css/css-contain/contain-layout-dynamic-004.html
- Pass => Fail css/css-contain/contain-layout-dynamic-005.html
+ Fail => Pass css/css-contain/contain-layout-formatting-context-float-001.html
+ Fail => Pass css/css-contain/contain-layout-formatting-context-margin-001.html
+ Fail => Pass css/css-contain/contain-layout-ifc-022.html
+ Fail => Pass css/css-contain/contain-layout-independent-formatting-context-001.html
+ Fail => Pass css/css-contain/contain-layout-suppress-baseline-002.html
- Pass => Fail css/css-contain/contain-paint-dynamic-004.html
- Pass => Fail css/css-contain/contain-paint-dynamic-005.html
+ Fail => Pass css/css-contain/contain-paint-formatting-context-float-001.html
+ Fail => Pass css/css-contain/contain-paint-ifc-011.html
+ Fail => Pass css/css-contain/contain-paint-independent-formatting-context-001.html
+ Fail => Pass css/css-contain/contain-size-025.html
+ Fail => Pass css/css-contain/contain-size-027.html
+ Fail => Pass css/css-contain/contain-size-block-001.html
+ Fail => Pass css/css-contain/contain-size-block-002.html
+ Fail => Pass css/css-contain/contain-size-block-003.html
+ Fail => Pass css/css-contain/contain-size-block-004.html
+ Fail => Pass css/css-contain/contain-size-borders.html
+ Fail => Pass css/css-contain/contain-size-button-001.html
+ Fail => Pass css/css-contain/contain-size-button-002.html
+ Fail => Pass css/css-contain/contain-size-fieldset-001.html
+ Fail => Pass css/css-contain/contain-size-fieldset-002.html
+ Fail => Pass css/css-contain/contain-size-fieldset-003.html
+ Fail => Pass css/css-contain/contain-size-fieldset-004.html
+ Fail => Pass css/css-contain/contain-size-flex-001.html
+ Fail => Pass css/css-contain/contain-size-flexbox-001.html
+ Fail => Pass css/css-contain/contain-size-grid-001.html
+ Fail => Pass css/css-contain/contain-size-grid-004.html
+ Fail => Pass css/css-contain/contain-size-grid-005.html
+ Fail => Pass css/css-contain/contain-size-grid-006.html
+ Fail => Pass css/css-contain/contain-size-inline-block-001.html
+ Fail => Pass css/css-contain/contain-size-inline-block-002.html
+ Fail => Pass css/css-contain/contain-size-inline-block-003.html
+ Fail => Pass css/css-contain/contain-size-inline-block-004.html
+ Fail => Pass css/css-contain/contain-size-inline-flex-001.html
+ Fail => Pass css/css-contain/contain-size-multicol-002.html
+ Fail => Pass css/css-contain/contain-size-multicol-003.html
+ Fail => Pass css/css-contain/contain-size-scrollbars-002.html
+ Fail => Pass css/css-contain/contain-size-scrollbars-003.html
- Pass => Fail css/css-display/display-contents-dynamic-generated-content-fieldset-001.html
+ Fail => Pass css/css-flexbox/flexbox-basic-fieldset-vert-001.xhtml
- Pass => Fail css/css-sizing/aspect-ratio/fieldset-element-001.html
- Pass => Fail css/css-sizing/aspect-ratio/fieldset-element-002.html
- Pass => Fail css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-014.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-022.html
+ Fail => Pass css/css-sizing/intrinsic-percent-replaced-023.html
- Pass => Fail css/css-viewport/zoom/contain-intrinsic-height.html
- Pass => Fail css/css-viewport/zoom/contain-intrinsic-width.html
- Pass => Crash css/css-viewport/zoom/massive-zoom-viewbox-crash.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31823306685).</sub>
<!-- wpt-results-end -->
