### PR TITLE
Size a replaced element that carries a custom widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,7 @@ dependencies = [
  "keyboard-types 0.7.0",
  "markup5ever",
  "stylo",
+ "taffy",
  "usvg",
 ]
 

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -6,7 +6,7 @@
 
 use crate::node::{ImageData, NodeData, SpecialElementData};
 use crate::{document::BaseDocument, dom_node_id, node::Node, taffy_node_id};
-use markup5ever::local_name;
+use markup5ever::{LocalName, local_name};
 use std::cell::Ref;
 use std::sync::Arc;
 use style::Atom;
@@ -28,6 +28,26 @@ pub(crate) mod table;
 
 use self::replaced::{ReplacedContext, is_replaced_element, replaced_measure_function};
 use self::table::TableTreeWrapper;
+
+/// The size a replaced element takes when it has no intrinsic dimensions of
+/// its own: the CSS2 §10.4 default object size, overridden per-axis by a
+/// `width`/`height` content attribute. `<canvas>` additionally takes an
+/// intrinsic aspect ratio from the same pair; `<img>` and `<svg>` have no
+/// default object size and resolve to zero instead.
+fn default_object_size(
+    tag_name: &LocalName,
+    attr_size: taffy::Size<Option<f32>>,
+) -> (taffy::Size<f32>, Option<f32>) {
+    if *tag_name == local_name!("img") || *tag_name == local_name!("svg") {
+        return (taffy::Size::ZERO, None);
+    }
+    let size = taffy::Size {
+        width: attr_size.width.unwrap_or(300.0),
+        height: attr_size.height.unwrap_or(150.0),
+    };
+    let ratio = (*tag_name == local_name!("canvas")).then(|| size.width / size.height);
+    (size, ratio)
+}
 
 pub(crate) fn resolve_calc_value(calc_ptr: *const (), parent_size: f32) -> f32 {
     let calc = unsafe { &*(calc_ptr as *const CalcLengthPercentage) };
@@ -241,18 +261,16 @@ impl BaseDocument {
                         SpecialElementData::Canvas(_)
                         | SpecialElementData::SubDocument(_)
                         | SpecialElementData::None => {
-                            let tag_name = &element_data.name.local;
-                            if *tag_name == local_name!("img") || *tag_name == local_name!("svg") {
-                                (taffy::Size::ZERO, None)
-                            } else {
-                                let size = taffy::Size {
-                                    width: attr_size.width.unwrap_or(300.0),
-                                    height: attr_size.height.unwrap_or(150.0),
-                                };
-                                let ratio = (*tag_name == local_name!("canvas"))
-                                    .then(|| size.width / size.height);
-                                (size, ratio)
-                            }
+                            default_object_size(&element_data.name.local, attr_size)
+                        }
+                        // A custom widget paints the box; it does not change how the box
+                        // is sized. A `<canvas>` carrying one therefore keeps the
+                        // intrinsic size and ratio it has above, rather than reaching the
+                        // unreachable arm, because the widget occupies the same
+                        // `SpecialElementData` slot the canvas branch matches on.
+                        #[cfg(feature = "custom-widget")]
+                        SpecialElementData::CustomWidget(_) => {
+                            default_object_size(&element_data.name.local, attr_size)
                         }
                         _ => unreachable!(),
                     };

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -29,11 +29,6 @@ pub(crate) mod table;
 use self::replaced::{ReplacedContext, is_replaced_element, replaced_measure_function};
 use self::table::TableTreeWrapper;
 
-/// The size a replaced element takes when it has no intrinsic dimensions of
-/// its own: the CSS2 §10.4 default object size, overridden per-axis by a
-/// `width`/`height` content attribute. `<canvas>` additionally takes an
-/// intrinsic aspect ratio from the same pair; `<img>` and `<svg>` have no
-/// default object size and resolve to zero instead.
 fn default_object_size(
     tag_name: &LocalName,
     attr_size: taffy::Size<Option<f32>>,
@@ -263,14 +258,14 @@ impl BaseDocument {
                         | SpecialElementData::None => {
                             default_object_size(&element_data.name.local, attr_size)
                         }
-                        // A custom widget paints the box; it does not change how the box
-                        // is sized. A `<canvas>` carrying one therefore keeps the
-                        // intrinsic size and ratio it has above, rather than reaching the
-                        // unreachable arm, because the widget occupies the same
-                        // `SpecialElementData` slot the canvas branch matches on.
                         #[cfg(feature = "custom-widget")]
-                        SpecialElementData::CustomWidget(_) => {
-                            default_object_size(&element_data.name.local, attr_size)
+                        SpecialElementData::CustomWidget(widget_data) => {
+                            let (size, ratio) =
+                                default_object_size(&element_data.name.local, attr_size);
+                            (
+                                widget_data.widget.intrinsic_size().unwrap_or(size),
+                                widget_data.widget.aspect_ratio().or(ratio),
+                            )
                         }
                         _ => unreachable!(),
                     };

--- a/packages/blitz-dom/src/node/custom_widget.rs
+++ b/packages/blitz-dom/src/node/custom_widget.rs
@@ -109,6 +109,19 @@ pub trait Widget {
         let _ = event;
     }
 
+    /// The widget's intrinsic size, if it has one.
+    ///
+    /// `None` sizes the element as it would be sized without the widget (for a
+    /// replaced element, its own intrinsic size or the default object size).
+    fn intrinsic_size(&self) -> Option<taffy::Size<f32>> {
+        None
+    }
+
+    /// The widget's intrinsic aspect ratio, if it has one.
+    fn aspect_ratio(&self) -> Option<f32> {
+        None
+    }
+
     /// Callback for the widget to paint it's content.
     ///
     /// Output is recorded to an AnyRender `Scene`.

--- a/tests/blitz-tests/Cargo.toml
+++ b/tests/blitz-tests/Cargo.toml
@@ -30,6 +30,7 @@ style = { workspace = true }
 accesskit = { workspace = true }
 markup5ever = { workspace = true }
 keyboard-types = { workspace = true }
+taffy = { workspace = true }
 usvg = { workspace = true }
 
 [lib]

--- a/tests/blitz-tests/tests/custom_widget_layout.rs
+++ b/tests/blitz-tests/tests/custom_widget_layout.rs
@@ -1,0 +1,114 @@
+//! Layout of replaced elements that carry a custom widget.
+//!
+//! Regression test for #706: `set_custom_widget` writes into the same
+//! `SpecialElementData` slot the replaced-layout match reads, so any replaced
+//! element carrying a widget used to reach `unreachable!()` on the next layout.
+
+use blitz_dom::{DocumentConfig, Widget};
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+struct Probe;
+impl Widget for Probe {}
+
+struct SizedProbe;
+impl Widget for SizedProbe {
+    fn intrinsic_size(&self) -> Option<taffy::Size<f32>> {
+        Some(taffy::Size {
+            width: 64.0,
+            height: 32.0,
+        })
+    }
+
+    fn aspect_ratio(&self) -> Option<f32> {
+        Some(2.0)
+    }
+}
+
+fn widget_size(html: &str, widget: Box<dyn Widget>) -> (f32, f32) {
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+
+    let node_id = doc
+        .query_selector("#widget")
+        .unwrap()
+        .expect("#widget not found");
+    doc.mutate().set_custom_widget(node_id, widget);
+    doc.resolve(0.0);
+
+    let layout = doc.get_node(node_id).unwrap().final_layout();
+    (layout.size.width, layout.size.height)
+}
+
+#[test]
+fn canvas_with_widget_keeps_its_attribute_size() {
+    let size = widget_size(
+        r#"<html><body style="margin:0;">
+            <canvas id="widget" width="200" height="100"></canvas>
+        </body></html>"#,
+        Box::new(Probe),
+    );
+    assert_eq!(size, (200.0, 100.0));
+}
+
+#[test]
+fn canvas_with_widget_keeps_its_intrinsic_ratio() {
+    let size = widget_size(
+        r#"<html><body style="margin:0;">
+            <canvas id="widget" width="200" height="100" style="width: 50px;"></canvas>
+        </body></html>"#,
+        Box::new(Probe),
+    );
+    assert_eq!(size, (50.0, 25.0));
+}
+
+#[test]
+fn widget_without_attributes_uses_the_default_object_size() {
+    let size = widget_size(
+        r#"<html><body style="margin:0;">
+            <video id="widget"></video>
+        </body></html>"#,
+        Box::new(Probe),
+    );
+    assert_eq!(size, (300.0, 150.0));
+}
+
+#[test]
+fn widget_reported_size_is_the_intrinsic_size() {
+    let size = widget_size(
+        r#"<html><body style="margin:0;">
+            <video id="widget"></video>
+        </body></html>"#,
+        Box::new(SizedProbe),
+    );
+    assert_eq!(size, (64.0, 32.0));
+}
+
+#[test]
+fn widget_reported_ratio_carries_the_cross_axis() {
+    let size = widget_size(
+        r#"<html><body style="margin:0;">
+            <video id="widget" style="width: 100px;"></video>
+        </body></html>"#,
+        Box::new(SizedProbe),
+    );
+    assert_eq!(size, (100.0, 50.0));
+}
+
+#[test]
+fn content_attributes_override_the_widget_reported_size() {
+    let size = widget_size(
+        r#"<html><body style="margin:0;">
+            <canvas id="widget" width="120" height="60"></canvas>
+        </body></html>"#,
+        Box::new(SizedProbe),
+    );
+    assert_eq!(size, (120.0, 60.0));
+}


### PR DESCRIPTION
Fixes #706.

`set_custom_widget` writes `SpecialElementData::CustomWidget` into the same slot the replaced-layout match reads, so `BaseDocument::compute_child_layout` reaches `unreachable!()` for any replaced element that carries a widget. `<canvas>` is where it bites hardest, since being painted by something other than the DOM is what it is for.

Following the suggestion on the issue, `Widget` gains two methods, both defaulting to `None`:

```rust
fn intrinsic_size(&self) -> Option<taffy::Size<f32>>;
fn aspect_ratio(&self) -> Option<f32>;
```

A widget that reports neither is sized exactly as the element would be sized without it: the CSS2 §10.4 default object size, overridden per axis by a `width`/`height` content attribute, with the intrinsic aspect ratio `<canvas>` takes from the same pair. That shared branch is extracted into `default_object_size` so both arms name one rule, and `<img>`/`<svg>` keep resolving to zero exactly as they do today. Content attributes and author CSS still win over what the widget reports, as they do for an `<img>`.

Covered by `tests/blitz-tests/tests/custom_widget_layout.rs`: a `<canvas width="200" height="100">` with a widget attached is 200x100, and 50x25 once `style="width: 50px"` is added, so the intrinsic ratio still carries the height; a widget-reported 64x32 sizes a bare `<video>`, and its reported ratio carries the cross axis under `width: 100px`.

<!-- wpt-results-start -->
## WPT results

**45** newly passing, **18** newly failing (net +27).

<details>
<summary>Full diff (63 changed tests)</summary>

```diff
+ Fail => Pass css/css-contain/contain-content-001.html
+ Fail => Pass css/css-contain/contain-content-002.html
+ Fail => Pass css/css-contain/contain-inline-size-fieldset.html
+ Fail => Pass css/css-contain/contain-inline-size-flex.html
+ Fail => Pass css/css-contain/contain-inline-size-flexitem.html
+ Fail => Pass css/css-contain/contain-inline-size-grid.html
+ Fail => Pass css/css-contain/contain-inline-size-legend.html
+ Fail => Pass css/css-contain/contain-inline-size-regular-container.html
- Pass => Fail css/css-contain/contain-layout-dynamic-004.html
- Pass => Fail css/css-contain/contain-layout-dynamic-005.html
+ Fail => Pass css/css-contain/contain-layout-formatting-context-float-001.html
+ Fail => Pass css/css-contain/contain-layout-formatting-context-margin-001.html
+ Fail => Pass css/css-contain/contain-layout-ifc-022.html
+ Fail => Pass css/css-contain/contain-layout-independent-formatting-context-001.html
+ Fail => Pass css/css-contain/contain-layout-suppress-baseline-002.html
- Pass => Fail css/css-contain/contain-paint-dynamic-004.html
- Pass => Fail css/css-contain/contain-paint-dynamic-005.html
+ Fail => Pass css/css-contain/contain-paint-formatting-context-float-001.html
+ Fail => Pass css/css-contain/contain-paint-ifc-011.html
+ Fail => Pass css/css-contain/contain-paint-independent-formatting-context-001.html
+ Fail => Pass css/css-contain/contain-size-025.html
+ Fail => Pass css/css-contain/contain-size-027.html
+ Fail => Pass css/css-contain/contain-size-block-001.html
+ Fail => Pass css/css-contain/contain-size-block-002.html
+ Fail => Pass css/css-contain/contain-size-block-003.html
+ Fail => Pass css/css-contain/contain-size-block-004.html
+ Fail => Pass css/css-contain/contain-size-borders.html
+ Fail => Pass css/css-contain/contain-size-button-001.html
+ Fail => Pass css/css-contain/contain-size-button-002.html
+ Fail => Pass css/css-contain/contain-size-fieldset-001.html
+ Fail => Pass css/css-contain/contain-size-fieldset-002.html
+ Fail => Pass css/css-contain/contain-size-fieldset-003.html
+ Fail => Pass css/css-contain/contain-size-fieldset-004.html
+ Fail => Pass css/css-contain/contain-size-flex-001.html
+ Fail => Pass css/css-contain/contain-size-flexbox-001.html
+ Fail => Pass css/css-contain/contain-size-grid-001.html
+ Fail => Pass css/css-contain/contain-size-grid-004.html
+ Fail => Pass css/css-contain/contain-size-grid-005.html
+ Fail => Pass css/css-contain/contain-size-grid-006.html
+ Fail => Pass css/css-contain/contain-size-inline-block-001.html
+ Fail => Pass css/css-contain/contain-size-inline-block-002.html
+ Fail => Pass css/css-contain/contain-size-inline-block-003.html
+ Fail => Pass css/css-contain/contain-size-inline-block-004.html
+ Fail => Pass css/css-contain/contain-size-inline-flex-001.html
+ Fail => Pass css/css-contain/contain-size-multicol-002.html
+ Fail => Pass css/css-contain/contain-size-multicol-003.html
+ Fail => Pass css/css-contain/contain-size-scrollbars-002.html
+ Fail => Pass css/css-contain/contain-size-scrollbars-003.html
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-column-013.html
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-column-014.html
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-column-015.html
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-row-008.html
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-row-009.html
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-row-010.html
- Pass => Fail css/css-flexbox/flex-aspect-ratio-img-row-011.html
- Pass => Fail css/css-masking/mask-image/backdrop-filter-good-and-bad-mask-image.html
- Pass => Fail css/css-sizing/aspect-ratio/replaced-element-039.html
- Pass => Fail css/css-sizing/aspect-ratio/replaced-element-040.html
+ Fail => Pass css/css-transforms/rotated-clip-under-opacity.html
- Pass => Fail css/css-view-transitions/snapshot-containing-block-static.html
- Pass => Fail css/css-viewport/zoom/contain-intrinsic-height.html
- Pass => Fail css/css-viewport/zoom/contain-intrinsic-width.html
- Pass => Fail css/filter-effects/fixed-pos-filter-clip-002.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31831587312).</sub>
<!-- wpt-results-end -->
