### PR TITLE
Upgrade Taffy to 864b4fd (reverts `contain` support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=20f04b9f7ebe37e5d661e3fb82e1bd4d9ca37147#20f04b9f7ebe37e5d661e3fb82e1bd4d9ca37147"
+source = "git+https://github.com/DioxusLabs/taffy?rev=864b4fd02e344bf9676f653e945161011cf93c0d#864b4fd02e344bf9676f653e945161011cf93c0d"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "20f04b9f7ebe37e5d661e3fb82e1bd4d9ca37147", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "864b4fd02e344bf9676f653e945161011cf93c0d", default-features = false, features = [
     "std",
     "flexbox",
     "grid",
@@ -301,5 +301,4 @@ tracing-subscriber = "0.3"
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
-
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,3 +302,4 @@ tracing-subscriber = "0.3"
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
 
+

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -219,7 +219,6 @@ pub(crate) fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) 
         if old_box.display != new_box.display
             || old_box.float != new_box.float
             || old_box.position != new_box.position
-            || old_box.contain != new_box.contain
             || old.clone_visibility() != new.clone_visibility()
         {
             return true;

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -10,9 +10,7 @@ pub(crate) mod stylo {
     pub(crate) use style::properties::longhands::position::computed_value::T as Position;
     pub(crate) use style::values::computed::length_percentage::CalcLengthPercentage;
     pub(crate) use style::values::computed::length_percentage::Unpacked as UnpackedLengthPercentage;
-    pub(crate) use style::values::computed::{
-        BorderSideWidth, Contain, LengthPercentage, Percentage,
-    };
+    pub(crate) use style::values::computed::{BorderSideWidth, LengthPercentage, Percentage};
     pub(crate) use style::values::generics::NonNegative;
     pub(crate) use style::values::generics::length::{
         GenericLengthPercentageOrNormal, GenericMargin, GenericMaxSize, GenericSize,
@@ -262,41 +260,6 @@ pub fn position(input: stylo::Position) -> taffy::Position {
         stylo::Position::Fixed => taffy::Position::Absolute,
         stylo::Position::Sticky => taffy::Position::Relative,
     }
-}
-
-/// Convert stylo's containment to Taffy's `Contain`, which only represents the layout-affecting
-/// parts of the `contain` property.
-///
-/// Only the explicitly specified `contain` property is mapped. The containment implied by
-/// `container-type` (Gecko-mode stylo folds this into `clone_effective_containment()`; Servo-mode
-/// does not compute it) is not applied for now.
-///
-/// Stylo's `STYLE` bit does not affect layout and its `BLOCK_SIZE` bit is not supported by
-/// Taffy, so these are dropped.
-///
-/// Containment does not apply to non-atomic inline-level boxes.
-/// <https://drafts.csswg.org/css-contain-2/#contain-property>
-#[inline]
-pub fn contain(contain: stylo::Contain, display: stylo::Display) -> taffy::Contain {
-    let is_non_atomic_inline = display.outside() == stylo::DisplayOutside::Inline
-        && display.inside() == stylo::DisplayInside::Flow;
-    if is_non_atomic_inline {
-        return taffy::Contain::NONE;
-    }
-
-    let mut output = taffy::Contain::NONE;
-    if contain.contains(stylo::Contain::SIZE) {
-        output |= taffy::Contain::SIZE;
-    } else if contain.contains(stylo::Contain::INLINE_SIZE) {
-        output |= taffy::Contain::INLINE_SIZE;
-    }
-    if contain.contains(stylo::Contain::LAYOUT) {
-        output |= taffy::Contain::LAYOUT;
-    }
-    if contain.contains(stylo::Contain::PAINT) {
-        output |= taffy::Contain::PAINT;
-    }
-    output
 }
 
 #[inline]
@@ -749,7 +712,6 @@ pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style<Atom> {
         },
         direction: self::direction(style.clone_direction()),
         scrollbar_width: 0.0,
-        contain: self::contain(style.clone_contain(), display),
 
         #[cfg(feature = "floats")]
         float: self::float(style.clone_float()),

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -69,12 +69,6 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
     }
 
     #[inline]
-    fn contain(&self) -> taffy::Contain {
-        let box_styles = self.0.get_box();
-        convert::contain(box_styles.contain, box_styles.display)
-    }
-
-    #[inline]
     fn position(&self) -> taffy::Position {
         convert::position(self.0.get_box().position)
     }


### PR DESCRIPTION
## Summary

Bumps the pinned Taffy rev to `864b4fd0`. The only upstream commit in the range is a revert of Taffy's layout `contain` support, so `taffy::Contain`, `CoreStyle::contain()` and `Style::contain` no longer exist and the stylo→Taffy containment mapping added in #718 has to come out with it:

- `stylo_taffy::convert::contain()` and the `contain:` field in `to_taffy_style` — removed
- `TaffyStyloStyle::contain()` — removed
- the `contain` comparison in `compute_layout_damage` — removed (it only existed to feed the mapping above)

The fieldset/legend UA stylesheet rules from #718 are unrelated to Taffy and are kept.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/4a069f871cd64976be1ab993aca3bafd
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**6** newly passing, **44** newly failing (net -38).

<details>
<summary>Full diff (50 changed tests)</summary>

```diff
- Pass => Fail css/css-contain/contain-content-001.html
- Pass => Fail css/css-contain/contain-content-002.html
- Pass => Fail css/css-contain/contain-inline-size-fieldset.html
- Pass => Fail css/css-contain/contain-inline-size-flex.html
- Pass => Fail css/css-contain/contain-inline-size-flexitem.html
- Pass => Fail css/css-contain/contain-inline-size-grid.html
- Pass => Fail css/css-contain/contain-inline-size-legend.html
- Pass => Fail css/css-contain/contain-inline-size-regular-container.html
+ Fail => Pass css/css-contain/contain-layout-dynamic-004.html
+ Fail => Pass css/css-contain/contain-layout-dynamic-005.html
- Pass => Fail css/css-contain/contain-layout-formatting-context-float-001.html
- Pass => Fail css/css-contain/contain-layout-formatting-context-margin-001.html
- Pass => Fail css/css-contain/contain-layout-ifc-022.html
- Pass => Fail css/css-contain/contain-layout-independent-formatting-context-001.html
- Pass => Fail css/css-contain/contain-layout-suppress-baseline-002.html
+ Fail => Pass css/css-contain/contain-paint-dynamic-004.html
+ Fail => Pass css/css-contain/contain-paint-dynamic-005.html
- Pass => Fail css/css-contain/contain-paint-formatting-context-float-001.html
- Pass => Fail css/css-contain/contain-paint-ifc-011.html
- Pass => Fail css/css-contain/contain-paint-independent-formatting-context-001.html
- Pass => Fail css/css-contain/contain-size-025.html
- Pass => Fail css/css-contain/contain-size-027.html
- Pass => Fail css/css-contain/contain-size-block-001.html
- Pass => Fail css/css-contain/contain-size-block-002.html
- Pass => Fail css/css-contain/contain-size-block-003.html
- Pass => Fail css/css-contain/contain-size-block-004.html
- Pass => Fail css/css-contain/contain-size-borders.html
- Pass => Fail css/css-contain/contain-size-button-001.html
- Pass => Fail css/css-contain/contain-size-button-002.html
- Pass => Fail css/css-contain/contain-size-fieldset-001.html
- Pass => Fail css/css-contain/contain-size-fieldset-002.html
- Pass => Fail css/css-contain/contain-size-fieldset-003.html
- Pass => Fail css/css-contain/contain-size-fieldset-004.html
- Pass => Fail css/css-contain/contain-size-flex-001.html
- Pass => Fail css/css-contain/contain-size-flexbox-001.html
- Pass => Fail css/css-contain/contain-size-grid-001.html
- Pass => Fail css/css-contain/contain-size-grid-004.html
- Pass => Fail css/css-contain/contain-size-grid-005.html
- Pass => Fail css/css-contain/contain-size-grid-006.html
- Pass => Fail css/css-contain/contain-size-inline-block-001.html
- Pass => Fail css/css-contain/contain-size-inline-block-002.html
- Pass => Fail css/css-contain/contain-size-inline-block-003.html
- Pass => Fail css/css-contain/contain-size-inline-block-004.html
- Pass => Fail css/css-contain/contain-size-inline-flex-001.html
- Pass => Fail css/css-contain/contain-size-multicol-002.html
- Pass => Fail css/css-contain/contain-size-multicol-003.html
- Pass => Fail css/css-contain/contain-size-scrollbars-002.html
- Pass => Fail css/css-contain/contain-size-scrollbars-003.html
+ Fail => Pass css/css-viewport/zoom/contain-intrinsic-height.html
+ Fail => Pass css/css-viewport/zoom/contain-intrinsic-width.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31854232163).</sub>
<!-- wpt-results-end -->
