### PR TITLE
Upgrade taffy for last-baseline support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=0e33e961c4ecd36a38d5103f57f305fbe37d749f#0e33e961c4ecd36a38d5103f57f305fbe37d749f"
+source = "git+https://github.com/DioxusLabs/taffy?rev=a0471381c63cd84622295f93a13b306034e392f4#a0471381c63cd84622295f93a13b306034e392f4"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "0e33e961c4ecd36a38d5103f57f305fbe37d749f", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a0471381c63cd84622295f93a13b306034e392f4", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -3,10 +3,10 @@ use parley::{AlignmentOptions, IndentOptions};
 use style::values::specified::box_::DisplayOutside;
 use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
 use taffy::{
-    AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
-    CoreStyle as _, Direction, LayoutInput, LayoutOutput, LayoutPartialTree as _, MaybeMath as _,
-    MaybeResolve as _, Overflow, Point, Position, RequestedAxis, ResolveOrZero as _, RunMode, Size,
-    SizingMode,
+    AvailableSpace, Baselines, BlockContext, BlockFormattingContext, BoxSizing,
+    CollapsibleMarginSet, CoreStyle as _, Direction, LayoutInput, LayoutOutput,
+    LayoutPartialTree as _, MaybeMath as _, MaybeResolve as _, Overflow, Point, Position,
+    RequestedAxis, ResolveOrZero as _, RunMode, Size, SizingMode,
 };
 
 #[cfg(feature = "floats")]
@@ -817,6 +817,11 @@ impl BaseDocument {
             .lines()
             .next()
             .map(|line| (line.metrics().baseline / scale) + container_pb.top);
+        let last_baseline = inline_layout
+            .layout
+            .lines()
+            .next_back()
+            .map(|line| (line.metrics().baseline / scale) + container_pb.top);
 
         // Put layout back
         self.nodes[node_id]
@@ -839,7 +844,10 @@ impl BaseDocument {
                     bottom: content_extent.height,
                 }
             },
-            baselines: taffy::Baselines::from_first(first_baseline),
+            baselines: taffy::Baselines {
+                first: first_baseline,
+                last: last_baseline,
+            },
             top_margin: CollapsibleMarginSet::ZERO,
             bottom_margin: CollapsibleMarginSet::ZERO,
             margins_can_collapse_through: !has_styles_preventing_being_collapsed_through

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -3,10 +3,10 @@ use parley::{AlignmentOptions, IndentOptions};
 use style::values::specified::box_::DisplayOutside;
 use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
 use taffy::{
-    AvailableSpace, Baselines, BlockContext, BlockFormattingContext, BoxSizing,
-    CollapsibleMarginSet, CoreStyle as _, Direction, LayoutInput, LayoutOutput,
-    LayoutPartialTree as _, MaybeMath as _, MaybeResolve as _, Overflow, Point, Position,
-    RequestedAxis, ResolveOrZero as _, RunMode, Size, SizingMode,
+    AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
+    CoreStyle as _, Direction, LayoutInput, LayoutOutput, LayoutPartialTree as _, MaybeMath as _,
+    MaybeResolve as _, Overflow, Point, Position, RequestedAxis, ResolveOrZero as _, RunMode, Size,
+    SizingMode,
 };
 
 #[cfg(feature = "floats")]

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -414,9 +414,7 @@ pub fn item_alignment(input: stylo::AlignFlags, is_horiz_rtl: bool) -> Option<ta
         stylo::AlignFlags::RIGHT => Some(taffy::AlignItems::END),
         stylo::AlignFlags::CENTER => Some(taffy::AlignItems::CENTER),
         stylo::AlignFlags::BASELINE => Some(taffy::AlignItems::BASELINE),
-        // Taffy does not support last-baseline alignment, so map it to its
-        // fallback alignment of `self-end` (https://www.w3.org/TR/css-align-3/#baseline-values)
-        stylo::AlignFlags::LAST_BASELINE => Some(taffy::AlignItems::END),
+        stylo::AlignFlags::LAST_BASELINE => Some(taffy::AlignItems::LAST_BASELINE),
         // Should never be hit. But no real reason to panic here.
         _ => None,
     }?;


### PR DESCRIPTION
## Summary

Bumps taffy to the tip of [taffy#1113](https://github.com/DioxusLabs/taffy/pull/1113) (`3e4d5943`, top of the stacked series #1110 → #1111 → #1113, rebased on taffy main `e661b359`) and adapts Blitz to the new last-baseline APIs:

- Inline layout now reports both first and last Parley line baselines via `LayoutOutput::baselines: Baselines { first, last }` (previously only the first, via `Baselines::from_first`).
- `stylo::AlignFlags::LAST_BASELINE` now maps to the real `taffy::AlignItems::LAST_BASELINE` instead of falling back to `END`.

Rebased on Blitz main (which already pins taffy `4863877b`), so the diff is just the rev bump plus the two behavioral changes above.

Should merge only after the taffy stack lands; the `rev` should ideally then be bumped to the merge commit.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/c0a80d9344d54e918b37cacfb71a2128
Requested by: @nicoburns

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/da7669e341814cc7976e4ebf32b7eacb
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/da7669e341814cc7976e4ebf32b7eacb?variant=devin-insiders

<!-- wpt-results-start -->
## WPT results

Subtests: **61** newly passing, **8** newly failing (net +53).

<details>
<summary>Full diff (32 changed tests)</summary>

```diff
+ FAIL => FAIL    [1/6]  +1  css/css-flexbox/alignment/flex-align-baseline-004.html
+ FAIL => FAIL    [2/3]  +2  css/css-flexbox/alignment/flex-align-baseline-005.html
+ FAIL => FAIL  [42/48]  +9  css/css-flexbox/alignment/flex-align-baseline-flex-001.html
+ FAIL => PASS  [16/16]  +6  css/css-flexbox/alignment/flex-align-baseline-flex-003.html
+ FAIL => FAIL  [10/12]  +2  css/css-flexbox/alignment/flex-align-baseline-grid-001.html
+ FAIL => FAIL  [21/26]  +2  css/css-flexbox/alignment/flex-align-baseline-line-clamp-001.tentative.html
+ FAIL => PASS  [12/12]  +4  css/css-flexbox/alignment/flex-align-baseline-overflow-001.html
- FAIL => FAIL    [3/8]  -1  css/css-flexbox/alignment/flex-align-baseline-table-001.html
+ FAIL => PASS    [1/1]  +1  css/css-flexbox/flexbox-align-self-baseline-horiz-007.xhtml
- PASS => FAIL    [0/1]  -1  css/css-grid/abspos/grid-abspos-staticpos-align-self-last-baseline-001.html
- PASS => FAIL    [0/1]  -1  css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-last-baseline-001.html
- PASS => FAIL    [0/1]  -1  css/css-grid/abspos/grid-abspos-staticpos-align-self-rtl-last-baseline-002.html
- PASS => FAIL    [0/1]  -1  css/css-grid/abspos/grid-abspos-staticpos-justify-self-last-baseline-001.html
- PASS => FAIL    [0/1]  -1  css/css-grid/abspos/grid-abspos-staticpos-justify-self-rtl-last-baseline-001.html
- PASS => FAIL    [0/1]  -1  css/css-grid/abspos/grid-abspos-staticpos-justify-self-rtl-last-baseline-002.html
+ FAIL => FAIL    [2/3]  +1  css/css-grid/alignment/grid-align-baseline-003.html
+ FAIL => PASS    [2/2]  +1  css/css-grid/alignment/grid-align-baseline-004.html
+ FAIL => FAIL  [42/48]  +9  css/css-grid/alignment/grid-align-baseline-flex-001.html
+ FAIL => PASS  [16/16]  +6  css/css-grid/alignment/grid-align-baseline-flex-003.html
+ FAIL => FAIL  [10/12]  +2  css/css-grid/alignment/grid-align-baseline-grid-001.html
+ FAIL => FAIL  [21/26]  +2  css/css-grid/alignment/grid-align-baseline-line-clamp-001.tentative.html
+ FAIL => PASS  [12/12]  +4  css/css-grid/alignment/grid-align-baseline-overflow-001.html
- FAIL => FAIL    [3/8]  -1  css/css-grid/alignment/grid-align-baseline-table-001.html
+ FAIL => FAIL    [7/9]  +1  css/css-grid/alignment/grid-align-baseline.html
+ FAIL => PASS    [1/1]  +1  css/css-grid/alignment/grid-self-alignment-baseline-gfc-001.html
+ FAIL => PASS    [1/1]  +1  css/css-grid/alignment/grid-self-alignment-baseline-with-grid-001.html
+ FAIL => PASS    [1/1]  +1  css/css-grid/alignment/grid-self-alignment-baseline-with-grid-002.html
+ FAIL => PASS    [1/1]  +1  css/css-grid/alignment/grid-self-alignment-baseline-with-grid-003.html
+ FAIL => PASS    [1/1]  +1  css/css-grid/alignment/grid-self-alignment-baseline-with-grid-004.html
+ FAIL => PASS    [1/1]  +1  css/css-grid/alignment/self-baseline/grid-self-baseline-008.html
+ FAIL => PASS    [2/2]  +1  css/css-grid/subgrid/subgrid-baseline-011.html
+ FAIL => FAIL    [1/8]  +1  css/css-grid/subgrid/subgrid-baseline-017.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/35644154709).</sub>
<!-- wpt-results-end -->
