### PR TITLE
Respect the origin box when painting SVG image layers (`mask-origin`/`background-origin`)

### DIFF
--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -322,14 +322,14 @@ impl ElementCx<'_, '_> {
             return;
         };
 
-        let (area_rect, base_transform) = if self.layer_is_fixed(layer) {
+        let (origin_rect, base_transform) = if self.layer_is_fixed(layer) {
             self.fixed_positioning_area()
         } else {
-            (self.frame.padding_box, self.transform)
+            (self.box_rect(layer.origin), self.transform)
         };
 
-        let frame_w = (area_rect.width() / self.scale) as f32;
-        let frame_h = (area_rect.height() / self.scale) as f32;
+        let frame_w = (origin_rect.width() / self.scale) as f32;
+        let frame_h = (origin_rect.height() / self.scale) as f32;
 
         let svg_size = svg.tree.size();
 
@@ -370,7 +370,10 @@ impl ElementCx<'_, '_> {
         );
 
         let transform = base_transform
-            * kurbo::Affine::translate((bg_pos.x * self.scale, bg_pos.y * self.scale))
+            * kurbo::Affine::translate((
+                origin_rect.x0 + bg_pos.x * self.scale,
+                origin_rect.y0 + bg_pos.y * self.scale,
+            ))
             * Affine::scale_non_uniform(x_ratio, y_ratio);
 
         anyrender_svg::render_svg_tree(scene, &svg.tree, transform);


### PR DESCRIPTION
## Summary

`mask-origin`/`mask-clip` (and `background-origin`) were already wired into `ImageLayerStyles`, and raster/gradient layers honoured them — but `draw_svg_image_layer` hardcoded the positioning area to the padding box and also dropped the area's offset entirely, so any SVG `mask-image`/`background-image` on an element with borders/padding was sized against the wrong box and drawn at the border-box origin:

```diff
- let (area_rect, _) = (self.frame.padding_box, self.transform);
+ let (origin_rect, _) = (self.box_rect(layer.origin), self.transform);
  ...
  let transform = base_transform
-     * Affine::translate((bg_pos.x * scale, bg_pos.y * scale))
+     * Affine::translate((origin_rect.x0 + bg_pos.x * scale, origin_rect.y0 + bg_pos.y * scale))
      * Affine::scale_non_uniform(x_ratio, y_ratio);
```

Since the `mask-clip`/`mask-origin` WPT tests all use SVG mask images, this makes the box-model values (`border-box`/`padding-box`/`content-box`) of both properties work.

WPT results (0 regressions):
- `css/css-backgrounds`: 273 → 377 tests passing (+104)
- `css/css-masking`: +5 (`mask-origin-1`, `mask-size-contain-clip-border`, `mask-size-contain-clip-padding`, `mask-size-cover`, `mask-image-url-image`), −1 (`mask-clip-8`, which previously passed vacuously — test and ref both rendered wrong identically; it tests SVG geometry-box fallbacks)

Not covered (out of scope per discussion): the mask-only `no-clip`/`fill-box`/`stroke-box`/`view-box` values, which are gecko-gated in stylo's servo build and fail at parse time.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/366b44a558d04868a74aa0c1be97a2bf
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**115** newly passing, **1** newly failing (net +114).

<details>
<summary>Full diff (116 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/backgrounds/background-intrinsic-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-intrinsic-004.xht
+ Fail => Pass css/CSS2/backgrounds/background-intrinsic-005.xht
+ Fail => Pass css/CSS2/backgrounds/background-intrinsic-007.xht
+ Fail => Pass css/CSS2/backgrounds/background-intrinsic-008.xht
+ Fail => Pass css/CSS2/backgrounds/background-intrinsic-009.xht
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-001.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-002.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-003.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-005.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-007.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-009.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-011.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-013.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-015.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-019.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-020.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-021.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-023.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-025.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-027.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-029.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto--percent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto--percent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--percent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--percent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--nonpercent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--nonpercent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--nonpercent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--nonpercent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--omitted-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--omitted-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--omitted-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--percent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--percent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--nonpercent-width-nonpercent-height--crisp.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--nonpercent-width-nonpercent-height-viewbox--crisp.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--nonpercent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--nonpercent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--nonpercent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--nonpercent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--omitted-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--omitted-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--omitted-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--omitted-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--omitted-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--omitted-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--percent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--percent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--percent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--percent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--percent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--percent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--width.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--nonpercent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--nonpercent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--nonpercent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--nonpercent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--percent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--percent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--nonpercent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--nonpercent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--nonpercent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--nonpercent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--omitted-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--omitted-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--omitted-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--percent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--percent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--nonpercent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--nonpercent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--nonpercent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--nonpercent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--percent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--percent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--nonpercent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--nonpercent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--nonpercent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--nonpercent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--omitted-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--omitted-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--omitted-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--percent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--percent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--nonpercent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--nonpercent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--nonpercent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--nonpercent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--omitted-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--omitted-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--omitted-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--omitted-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--percent-width-nonpercent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--percent-width-omitted-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--percent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--width.html
- Pass => Fail css/css-masking/mask-image/mask-clip-8.html
+ Fail => Pass css/css-masking/mask-image/mask-image-url-image.html
+ Fail => Pass css/css-masking/mask-image/mask-origin-1.html
+ Fail => Pass css/css-masking/mask-image/mask-size-contain-clip-border.html
+ Fail => Pass css/css-masking/mask-image/mask-size-contain-clip-padding.html
+ Fail => Pass css/css-masking/mask-image/mask-size-cover.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31976057950).</sub>
<!-- wpt-results-end -->
