### PR TITLE
Implement the clipping effect of `contain: paint`

### DIFF
--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -32,7 +32,8 @@ use style::{
         style_structs::Font,
     },
     values::{
-        computed::{CSSPixelLength, Overflow},
+        computed::{CSSPixelLength, Contain, Overflow},
+        specified::box_::{DisplayInside, DisplayOutside},
         specified::image::ImageRendering,
     },
 };
@@ -262,6 +263,16 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         // TODO: account for overflow_x vs overflow_y
         let overflow_x = styles.get_box().overflow_x;
         let overflow_y = styles.get_box().overflow_y;
+        // `contain: paint` (and stronger values like `strict`/`content`) clips the element's
+        // contents to its padding box. Paint containment does not apply to non-atomic inlines
+        // or internal table boxes other than table-cell.
+        let contain_paint = styles.get_box().clone_contain().contains(Contain::PAINT) && {
+            let display = styles.clone_display();
+            let is_internal_table_box_other_than_cell = display.outside()
+                == DisplayOutside::InternalTable
+                && display.inside() != DisplayInside::TableCell;
+            !display.is_inline_flow() && !is_internal_table_box_other_than_cell
+        };
         let is_image = node
             .element_data()
             .and_then(|e| e.raster_image_data())
@@ -281,6 +292,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             && (is_image
                 || is_sub_doc
                 || is_text_input
+                || contain_paint
                 || !matches!(overflow_x, Overflow::Visible)
                 || !matches!(overflow_y, Overflow::Visible));
 


### PR DESCRIPTION
## Summary

Elements with paint containment (`contain: paint`, or the stronger `strict`/`content` values) now clip their contents to their padding box, by including `contain_paint` in the existing `should_clip` condition in `render_element` (so it reuses the same padding-box clip layer as `overflow: hidden`).

Per spec, paint containment is not applied when the element is a non-atomic inline (`display: inline`) or an internal table box other than `table-cell`:

```rust
let contain_paint = styles.get_box().clone_contain().contains(Contain::PAINT) && {
    let display = styles.clone_display();
    !display.is_inline_flow() && !is_internal_table_box_other_than_cell
};
```

Note: stylo's `effective_containment` (which folds in `content-visibility`/`container-type`) is gecko-only, so this reads `contain` directly.

WPT `css/css-contain/contain-paint*`: 43 passing vs 31 on main (+15 newly passing, including the `contain-paint-clip-*` and internal-table/inline "ignored cases" tests). 3 `contain-paint-dynamic-*` tests flip PASS→FAIL, but those passes were spurious: they require script (unsupported by the WPT runner), and previously both test and ref rendered identically-unclipped; now the ref correctly clips while the script-driven test page cannot.

Other effects of paint containment (establishing a stacking context, acting as containing block for absolute/fixed descendants, creating an independent formatting context) are out of scope for this PR.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/09a9a4d76cfa4af8b311462e4db846ec
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**12** newly passing, **5** newly failing (net +7).

<details>
<summary>Full diff (17 changed tests)</summary>

```diff
+ Fail => Pass css/css-contain/contain-paint-001.html
+ Fail => Pass css/css-contain/contain-paint-004.html
+ Fail => Pass css/css-contain/contain-paint-014.html
+ Fail => Pass css/css-contain/contain-paint-019.html
+ Fail => Pass css/css-contain/contain-paint-026.html
+ Fail => Pass css/css-contain/contain-paint-048.html
+ Fail => Pass css/css-contain/contain-paint-clip-002.html
+ Fail => Pass css/css-contain/contain-paint-clip-006.html
+ Fail => Pass css/css-contain/contain-paint-clip-016.html
+ Fail => Pass css/css-contain/contain-paint-clip-017.html
+ Fail => Pass css/css-contain/contain-paint-clip-018.html
+ Fail => Pass css/css-contain/contain-paint-clip-019.html
- Pass => Fail css/css-contain/contain-paint-dynamic-002.html
- Pass => Fail css/css-contain/contain-paint-dynamic-004.html
- Pass => Fail css/css-contain/contain-paint-dynamic-005.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-paint-containment-001.html
- Pass => Fail css/css-position/position-relative-004.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31976920047).</sub>
<!-- wpt-results-end -->
