### PR TITLE
Size SVG background images per the CSS default sizing algorithm

### DIFF
--- a/packages/blitz-dom/src/node/svg.rs
+++ b/packages/blitz-dom/src/node/svg.rs
@@ -17,6 +17,9 @@ pub struct SvgIntrinsicDimensions {
     pub height: Option<svgtypes::Length>,
     /// The root `viewBox` width/height, if declared and valid.
     pub view_box_size: Option<(f32, f32)>,
+    /// Whether the root declared a `viewBox` with a zero width or height,
+    /// which disables rendering of the element per the SVG spec.
+    pub degenerate_view_box: bool,
 }
 
 impl SvgIntrinsicDimensions {
@@ -31,16 +34,26 @@ impl SvgIntrinsicDimensions {
         let parse_length = |name: &str| -> Option<svgtypes::Length> {
             root.attribute(name)?.parse::<svgtypes::Length>().ok()
         };
-        let view_box_size = root
-            .attribute("viewBox")
-            .and_then(|s| s.parse::<svgtypes::ViewBox>().ok())
-            .filter(|vb| vb.w.is_finite() && vb.w > 0.0 && vb.h.is_finite() && vb.h > 0.0)
-            .map(|vb| (vb.w as f32, vb.h as f32));
+        // Parsed manually rather than via `svgtypes::ViewBox`, which rejects
+        // zero sizes: a zero `viewBox` width/height is distinguished from an
+        // invalid `viewBox` as it disables rendering of the element.
+        let view_box_dims = root.attribute("viewBox").and_then(|s| {
+            let mut numbers = svgtypes::NumberListParser::from(s);
+            let _x = numbers.next()?.ok()?;
+            let _y = numbers.next()?.ok()?;
+            let w = numbers.next()?.ok()? as f32;
+            let h = numbers.next()?.ok()? as f32;
+            (numbers.next().is_none() && w.is_finite() && h.is_finite() && w >= 0.0 && h >= 0.0)
+                .then_some((w, h))
+        });
+        let view_box_size = view_box_dims.filter(|&(w, h)| w > 0.0 && h > 0.0);
+        let degenerate_view_box = view_box_dims.is_some_and(|(w, h)| w == 0.0 || h == 0.0);
 
         Self {
             width: parse_length("width"),
             height: parse_length("height"),
             view_box_size,
+            degenerate_view_box,
         }
     }
 }

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -322,6 +322,11 @@ impl ElementCx<'_, '_> {
             return;
         };
 
+        // A zero-sized `viewBox` disables rendering of the SVG
+        if svg.intrinsic_dimensions.degenerate_view_box {
+            return;
+        }
+
         let (origin_rect, base_transform) = if self.layer_is_fixed(layer) {
             self.fixed_positioning_area()
         } else {
@@ -333,32 +338,33 @@ impl ElementCx<'_, '_> {
 
         let svg_size = svg.tree.size();
 
-        // Compute the SVG's concrete object size per the CSS default sizing
-        // algorithm. usvg resolves an SVG that lacks explicit `width`/`height`
-        // to its `viewBox` size, but such an image has only an intrinsic aspect
-        // ratio (no intrinsic dimensions). Passing this size to
-        // `compute_layer_size` for the `background-size: auto` case supplies
-        // both the concrete size (used verbatim for `auto`) and the aspect
-        // ratio (used by `cover`/`contain` and single-`auto` sizes).
-        let aspect_ratio = svg.aspect_ratio();
-        let (object_w, object_h) = match (svg.intrinsic_width(), svg.intrinsic_height()) {
-            (Some(w), Some(h)) => (w, h),
-            (Some(w), None) => (w, w / aspect_ratio),
-            (None, Some(h)) => (h * aspect_ratio, h),
-            (None, None) => {
-                // No intrinsic dimensions: scale the aspect ratio to fit
-                // ("contain") within the background positioning area.
-                let scale = (frame_w / svg_size.width()).min(frame_h / svg_size.height());
-                (svg_size.width() * scale, svg_size.height() * scale)
-            }
-        };
+        // Size the SVG per the CSS default sizing algorithm
+        // (https://drafts.csswg.org/css-images/#default-sizing). An SVG image
+        // may lack an intrinsic width, height, and/or aspect ratio, so each is
+        // passed separately (usvg's resolved `Tree::size` is only used as the
+        // source coordinate space of the rendered tree).
+        let intrinsic_width = svg.intrinsic_width().filter(|w| w.is_finite() && *w > 0.0);
+        let intrinsic_height = svg.intrinsic_height().filter(|h| h.is_finite() && *h > 0.0);
+        let aspect_ratio = match (intrinsic_width, intrinsic_height) {
+            (Some(w), Some(h)) => Some(w / h),
+            _ => svg.viewbox_aspect_ratio(),
+        }
+        .filter(|r| r.is_finite() && *r > 0.0);
 
         let bg_size = compute_layer_size(
             layer,
             frame_w,
             frame_h,
-            BackgroundSizeComputeMode::Size(object_w, object_h),
+            BackgroundSizeComputeMode::Intrinsic {
+                width: intrinsic_width,
+                height: intrinsic_height,
+                ratio: aspect_ratio,
+            },
         );
+
+        if bg_size.width <= 0.0 || bg_size.height <= 0.0 {
+            return;
+        }
 
         let x_ratio = (bg_size.width / svg_size.width() as f64) * self.scale;
         let y_ratio = (bg_size.height / svg_size.height() as f64) * self.scale;
@@ -624,6 +630,7 @@ fn compute_layer_size(
                     match mode {
                         BackgroundSizeComputeMode::Auto => (width, height),
                         BackgroundSizeComputeMode::Size(_, _) => (width, height),
+                        BackgroundSizeComputeMode::Intrinsic { .. } => (width, height),
                     }
                 }
                 (Lpa::LengthPercentage(width), Lpa::Auto) => {
@@ -631,6 +638,10 @@ fn compute_layer_size(
                     let height = match mode {
                         BackgroundSizeComputeMode::Auto => container_h,
                         BackgroundSizeComputeMode::Size(bg_w, bg_h) => bg_h / bg_w * width,
+                        BackgroundSizeComputeMode::Intrinsic { height, ratio, .. } => ratio
+                            .map(|ratio| width / ratio)
+                            .or(height)
+                            .unwrap_or(container_h),
                     };
                     (width, height)
                 }
@@ -639,12 +650,21 @@ fn compute_layer_size(
                     let width = match mode {
                         BackgroundSizeComputeMode::Auto => container_w,
                         BackgroundSizeComputeMode::Size(bg_w, bg_h) => bg_w / bg_h * height,
+                        BackgroundSizeComputeMode::Intrinsic { width, ratio, .. } => ratio
+                            .map(|ratio| height * ratio)
+                            .or(width)
+                            .unwrap_or(container_w),
                     };
                     (width, height)
                 }
                 (Lpa::Auto, Lpa::Auto) => match mode {
                     BackgroundSizeComputeMode::Auto => (container_w, container_h),
                     BackgroundSizeComputeMode::Size(bg_w, bg_h) => (bg_w, bg_h),
+                    BackgroundSizeComputeMode::Intrinsic {
+                        width,
+                        height,
+                        ratio,
+                    } => default_sizing(width, height, ratio, container_w, container_h),
                 },
             }
         }
@@ -655,6 +675,15 @@ fn compute_layer_size(
                 let ratio = (container_w / bg_w).max(container_h / bg_h);
                 (bg_w * ratio, bg_h * ratio)
             }
+            BackgroundSizeComputeMode::Intrinsic { ratio, .. } => match ratio {
+                // Scale the aspect ratio to the smallest size that covers both axes
+                Some(ratio) => {
+                    let scale = (container_w / ratio).max(container_h);
+                    (scale * ratio, scale)
+                }
+                // No intrinsic aspect ratio: fill the positioning area
+                None => (container_w, container_h),
+            },
         },
         BackgroundSize::Contain => match mode {
             BackgroundSizeComputeMode::Auto => (container_w, container_h),
@@ -663,6 +692,15 @@ fn compute_layer_size(
                 let ratio = (container_w / bg_w).min(container_h / bg_h);
                 (bg_w * ratio, bg_h * ratio)
             }
+            BackgroundSizeComputeMode::Intrinsic { ratio, .. } => match ratio {
+                // Scale the aspect ratio to the largest size contained by both axes
+                Some(ratio) => {
+                    let scale = (container_w / ratio).min(container_h);
+                    (scale * ratio, scale)
+                }
+                // No intrinsic aspect ratio: fill the positioning area
+                None => (container_w, container_h),
+            },
         },
     };
 
@@ -675,6 +713,39 @@ fn compute_layer_size(
 enum BackgroundSizeComputeMode {
     Auto,
     Size(f32, f32),
+    /// Intrinsic dimensions of an image which may lack an intrinsic width,
+    /// height, and/or aspect ratio (e.g. SVG), sized per the CSS default
+    /// sizing algorithm (https://drafts.csswg.org/css-images/#default-sizing)
+    Intrinsic {
+        width: Option<f32>,
+        height: Option<f32>,
+        ratio: Option<f32>,
+    },
+}
+
+/// The CSS default sizing algorithm for the unconstrained (`auto auto`) case:
+/// resolve the concrete object size from whichever intrinsic dimensions exist,
+/// falling back to the default object size (the background positioning area).
+fn default_sizing(
+    width: Option<f32>,
+    height: Option<f32>,
+    ratio: Option<f32>,
+    container_w: f32,
+    container_h: f32,
+) -> (f32, f32) {
+    match (width, height) {
+        (Some(w), Some(h)) => (w, h),
+        (Some(w), None) => (w, ratio.map(|r| w / r).unwrap_or(container_h)),
+        (None, Some(h)) => (ratio.map(|r| h * r).unwrap_or(container_w), h),
+        (None, None) => match ratio {
+            // Intrinsic aspect ratio only: size as if `contain` were specified
+            Some(ratio) => {
+                let scale = (container_w / ratio).min(container_h);
+                (scale * ratio, scale)
+            }
+            None => (container_w, container_h),
+        },
+    }
 }
 
 /// The placement and tiling of a background layer along one axis: a


### PR DESCRIPTION
## Summary

SVG background images were sized via a pre-computed "concrete object size" fed into the raster-image path (`BackgroundSizeComputeMode::Size`), which loses the distinction between "no intrinsic dimension" and an actual dimension. This broke most of `css/css-backgrounds/background-size/vector/*`.

`draw_svg_image_layer` now passes the SVG's intrinsic dimensions individually (each possibly absent) and `compute_layer_size` implements the [CSS default sizing algorithm](https://drafts.csswg.org/css-images/#default-sizing) directly:

```rust
enum BackgroundSizeComputeMode {
    Auto,
    Size(f32, f32),                    // raster images (unchanged)
    Intrinsic { width: Option<f32>, height: Option<f32>, ratio: Option<f32> },
}
```

- `auto <len>` / `<len> auto`: missing dimension from `ratio`, else the intrinsic dimension, else the positioning area
- `auto auto`: `default_sizing()` — intrinsic dims if present; ratio-only sizes as `contain`; nothing → positioning area
- `contain`/`cover`: fit/cover the aspect ratio; with no ratio, fill the positioning area

Additionally, a root `viewBox` with zero width/height disables rendering per the SVG spec (the `zero-*-ratio-*` tests expect nothing painted). `SvgIntrinsicDimensions` now parses the `viewBox` manually (svgtypes' `ViewBox` rejects zero sizes) and records `degenerate_view_box`, which `draw_svg_image_layer` checks before painting.

## WPT results (`css/css-backgrounds`)

- Before: 377/722 pass. After: **471/722** (+94, no regressions).
- All `background-size/vector/*` tests now pass except 4 known-hard cases:
  - `background-size-{contain,cover}-svg-view.html`: require SVG fragment (`#view`) support, which usvg doesn't provide
  - `background-size-near-zero-svg.html`: requires tiling SVG backgrounds (`background-repeat` is currently not implemented for SVG layers; would need ~250k tiles here, same as the gradient FIXME)
  - `vector/diagonal-percentage-vector-background.html`: percentage lengths inside the SVG need re-resolving against the concrete object size, but usvg resolves them once at parse time

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/c1c75f0597374e00a4cd8e5af8971df1
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**96** newly passing, **0** newly failing (net +96).

<details>
<summary>Full diff (96 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/backgrounds/background-intrinsic-001.xht
+ Fail => Pass css/CSS2/backgrounds/background-intrinsic-003.xht
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-004.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-006.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-008.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-010.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-012.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-014.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-016.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-017.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-018.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-022.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-024.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-026.html
+ Fail => Pass css/css-backgrounds/background-size/vector/background-size-vector-028.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto--omitted-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto--percent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto--percent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto--percent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto--percent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--nonpercent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--omitted-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--percent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--percent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--percent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--auto-32px--percent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--nonpercent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--nonpercent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--omitted-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--omitted-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--omitted-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--percent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--percent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--percent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--contain--percent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--nonpercent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/tall--cover--nonpercent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--nonpercent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--nonpercent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--omitted-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--percent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--percent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--percent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--12px-auto--percent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--nonpercent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--nonpercent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--omitted-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--omitted-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--omitted-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--percent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--percent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--percent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto--percent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--nonpercent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--nonpercent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--omitted-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--percent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--percent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--percent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--auto-32px--percent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--nonpercent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--nonpercent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--omitted-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--omitted-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--omitted-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--percent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--percent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--percent-width-percent-height-viewbox.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--contain--percent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--nonpercent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--nonpercent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--omitted-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--omitted-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--percent-width-nonpercent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--percent-width-omitted-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/wide--cover--percent-width-percent-height.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-height-ratio-5px-auto.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-height-ratio-auto-auto.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-height-ratio-contain.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-height-ratio-cover.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-ratio-no-dimensions-5px-auto.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-ratio-no-dimensions-auto-5px.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-ratio-no-dimensions-auto-auto.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-ratio-no-dimensions-contain.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-ratio-no-dimensions-cover.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-width-ratio-5px-auto.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-width-ratio-auto-auto.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-width-ratio-contain.html
+ Fail => Pass css/css-backgrounds/background-size/vector/zero-width-ratio-cover.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31978883670).</sub>
<!-- wpt-results-end -->
