### PR TITLE
Fix spurious ~34px horizontal scroll on csskit.rs (bump taffy)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=864b4fd02e344bf9676f653e945161011cf93c0d#864b4fd02e344bf9676f653e945161011cf93c0d"
+source = "git+https://github.com/DioxusLabs/taffy?rev=15de7486a4168ee5ad00c9ea5e0a9389dee7c90a#15de7486a4168ee5ad00c9ea5e0a9389dee7c90a"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "864b4fd02e344bf9676f653e945161011cf93c0d", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "15de7486a4168ee5ad00c9ea5e0a9389dee7c90a", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -823,10 +823,7 @@ impl BaseDocument {
         LayoutOutput {
             size: final_size,
             content_size: measured_size + padding.sum_axes(),
-            first_baselines: Point {
-                x: None,
-                y: first_baseline,
-            },
+            baselines: taffy::Baselines::from_first(first_baseline),
             top_margin: CollapsibleMarginSet::ZERO,
             bottom_margin: CollapsibleMarginSet::ZERO,
             margins_can_collapse_through: !has_styles_preventing_being_collapsed_through

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -289,7 +289,7 @@ impl BaseDocument {
                     return taffy::LayoutOutput {
                         size: computed,
                         content_size: computed,
-                        first_baselines: taffy::Point::NONE,
+                        baselines: taffy::Baselines::NONE,
                         top_margin: CollapsibleMarginSet::ZERO,
                         bottom_margin: CollapsibleMarginSet::ZERO,
                         margins_can_collapse_through: false,


### PR DESCRIPTION
## Summary

https://csskit.rs showed a spurious ~34px horizontal scroll at a 1200px viewport. Root cause: taffy's block/grid (and flexbox) algorithms unconditionally added a container's own end-side padding to its `content_size`, even for boxes that are not scroll containers. The page's `footer` (a padded block whose child `<p>` has negative horizontal margins pulling it into the padding) reported `content_size.width = 1234`, which propagated to the root and made the document scrollable (`scroll_width = 34`).

Fixed upstream in DioxusLabs/taffy#1114: end-side padding is now only included in `content_size` when the container is a scroll container, matching browser scrollable-overflow semantics. This PR bumps the taffy rev to pick that up (the pinned rev is the fix commit on the PR branch; can be re-pinned once the taffy PR merges), and adapts to taffy's `LayoutOutput::first_baselines` → `baselines: Baselines` rename that landed on taffy main in between:

```rust
// packages/blitz-dom/src/layout/{mod,inline}.rs
- first_baselines: Point { x: None, y: first_baseline },
+ baselines: taffy::Baselines::from_first(first_baseline),
```

Verified with the screenshot example: the csskit.rs root goes from `content_size=1234x3246, scroll_width=34` to `content_size=1200x3246, scroll_width=0`, with rendering unchanged. `cargo test --workspace`, clippy and fmt pass.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b6f5529e9a3e4823b603788b475ab109
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31979405290).</sub>
<!-- wpt-results-end -->
