### PR TITLE
Re-pin taffy to merged main commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=15de7486a4168ee5ad00c9ea5e0a9389dee7c90a#15de7486a4168ee5ad00c9ea5e0a9389dee7c90a"
+source = "git+https://github.com/DioxusLabs/taffy?rev=902aa4de8b0918c4d6c6e59aca12e243058bcda7#902aa4de8b0918c4d6c6e59aca12e243058bcda7"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "15de7486a4168ee5ad00c9ea5e0a9389dee7c90a", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "902aa4de8b0918c4d6c6e59aca12e243058bcda7", default-features = false, features = [
     "std",
     "flexbox",
     "grid",


### PR DESCRIPTION
## Summary

Follow-up to #727: the taffy rev it pinned (`15de7486`) lives on a temporary PR branch. DioxusLabs/taffy#1114 has now merged, so this re-pins to the commit on taffy `main` (`902aa4de`, the squash-merge of that PR — same code) so the dependency doesn't break if the branch is deleted.

`cargo check --workspace` passes; no code changes.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b6f5529e9a3e4823b603788b475ab109
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/31979831911).</sub>
<!-- wpt-results-end -->
