### PR TITLE
Refactor replaced_measure_function to accept IntrinsicSizes

### DIFF
--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -26,22 +26,44 @@ pub(crate) mod list;
 pub(crate) mod replaced;
 pub(crate) mod table;
 
-use self::replaced::{ReplacedContext, is_replaced_element, replaced_measure_function};
+use self::replaced::{
+    IntrinsicSizes, ReplacedContext, is_replaced_element, replaced_measure_function,
+};
 use self::table::TableTreeWrapper;
 
-fn default_object_size(
+/// The default object size for replaced elements
+/// (https://drafts.csswg.org/css-images/#default-object-size).
+const DEFAULT_OBJECT_SIZE: taffy::Size<f32> = taffy::Size {
+    width: 300.0,
+    height: 150.0,
+};
+
+/// The intrinsic dimensions and default object size for a replaced element
+/// whose intrinsic dimensions are determined by its tag: an image with no
+/// loaded resource has no intrinsic dimensions and a zero default object size;
+/// a canvas has an intrinsic size and aspect ratio given by its width/height
+/// attributes (defaulting to 300x150); other replaced elements (video, iframe,
+/// embed) have no intrinsic dimensions and the 300x150 default object size.
+fn tag_intrinsic_sizes(
     tag_name: &LocalName,
     attr_size: taffy::Size<Option<f32>>,
-) -> (taffy::Size<f32>, Option<f32>) {
+) -> (IntrinsicSizes, taffy::Size<f32>) {
     if *tag_name == local_name!("img") || *tag_name == local_name!("svg") {
-        return (taffy::Size::ZERO, None);
+        return (IntrinsicSizes::default(), taffy::Size::ZERO);
     }
-    let size = taffy::Size {
-        width: attr_size.width.unwrap_or(300.0),
-        height: attr_size.height.unwrap_or(150.0),
-    };
-    let ratio = (*tag_name == local_name!("canvas")).then(|| size.width / size.height);
-    (size, ratio)
+    if *tag_name == local_name!("canvas") {
+        let width = attr_size.width.unwrap_or(300.0);
+        let height = attr_size.height.unwrap_or(150.0);
+        return (
+            IntrinsicSizes {
+                width: Some(width),
+                height: Some(height),
+                ratio: Some(width / height),
+            },
+            DEFAULT_OBJECT_SIZE,
+        );
+    }
+    (IntrinsicSizes::default(), DEFAULT_OBJECT_SIZE)
 }
 
 pub(crate) fn resolve_calc_value(calc_ptr: *const (), parent_size: f32) -> f32 {
@@ -204,15 +226,19 @@ impl BaseDocument {
                             .and_then(|val| val.parse::<f32>().ok()),
                     };
 
-                    // Get the element's intrinsic size and aspect ratio
-                    let (inherent_size, inherent_ratio) = match &element_data.special_data {
+                    // Get the element's intrinsic dimensions and default object size
+                    let (intrinsic_sizes, default_object_size) = match &element_data.special_data {
                         SpecialElementData::Image(image_data) => match &**image_data {
                             ImageData::Raster(image) => {
-                                let size = taffy::Size {
-                                    width: image.width as f32,
-                                    height: image.height as f32,
-                                };
-                                (size, Some(size.width / size.height))
+                                let (width, height) = (image.width as f32, image.height as f32);
+                                (
+                                    IntrinsicSizes {
+                                        width: Some(width),
+                                        height: Some(height),
+                                        ratio: Some(width / height),
+                                    },
+                                    DEFAULT_OBJECT_SIZE,
+                                )
                             }
                             #[cfg(feature = "svg")]
                             ImageData::Svg(svg) => {
@@ -226,54 +252,56 @@ impl BaseDocument {
                                         height: svg.resolved_height(inputs.parent_size.height),
                                     };
                                 }
-                                let (mut width, mut height) = svg.intrinsic_size();
-                                // A replaced element with only an intrinsic aspect ratio uses the
-                                // stretch-fit width in normal flow (CSS2 §10.3.2): fill the
-                                // definite available width and derive the height from the ratio.
-                                // Shrink-to-fit contexts (floats, abspos) keep the default object
-                                // size that `intrinsic_size` already applied.
-                                if svg.intrinsic_width().is_none()
-                                    && svg.intrinsic_height().is_none()
+                                let mut width = svg.intrinsic_width();
+                                let mut height = svg.intrinsic_height();
+                                // An SVG with no declared dimensions and no viewBox has no
+                                // intrinsic dimensions per CSS, but usvg still resolves a
+                                // concrete size; use it in place of the default object size.
+                                if width.is_none()
+                                    && height.is_none()
+                                    && svg.viewbox_aspect_ratio().is_none()
                                 {
-                                    if let (
-                                        Some(ratio),
-                                        AvailableSpace::Definite(available_width),
-                                    ) =
-                                        (svg.viewbox_aspect_ratio(), inputs.available_space.width)
-                                    {
-                                        width = available_width;
-                                        height = available_width / ratio;
-                                    }
+                                    let size = svg.tree.size();
+                                    width = Some(size.width());
+                                    height = Some(size.height());
                                 }
-                                (taffy::Size { width, height }, Some(svg.aspect_ratio()))
+                                (
+                                    IntrinsicSizes {
+                                        width,
+                                        height,
+                                        ratio: Some(svg.aspect_ratio()),
+                                    },
+                                    DEFAULT_OBJECT_SIZE,
+                                )
                             }
-                            ImageData::None => (taffy::Size::ZERO, None),
+                            ImageData::None => (IntrinsicSizes::default(), taffy::Size::ZERO),
                         },
-                        // Canvas has an intrinsic size and aspect ratio given by its
-                        // width/height attributes, defaulting to 300x150. Other replaced
-                        // elements without intrinsic dimensions (video, iframe, embed) use
-                        // the 300x150 default object size but have no intrinsic ratio.
                         SpecialElementData::Canvas(_)
                         | SpecialElementData::SubDocument(_)
                         | SpecialElementData::None => {
-                            default_object_size(&element_data.name.local, attr_size)
+                            tag_intrinsic_sizes(&element_data.name.local, attr_size)
                         }
                         #[cfg(feature = "custom-widget")]
                         SpecialElementData::CustomWidget(widget_data) => {
-                            let (size, ratio) =
-                                default_object_size(&element_data.name.local, attr_size);
+                            let (fallback, default_object_size) =
+                                tag_intrinsic_sizes(&element_data.name.local, attr_size);
+                            let widget_size = widget_data.widget.intrinsic_size();
                             (
-                                widget_data.widget.intrinsic_size().unwrap_or(size),
-                                widget_data.widget.aspect_ratio().or(ratio),
+                                IntrinsicSizes {
+                                    width: widget_size.map(|s| s.width).or(fallback.width),
+                                    height: widget_size.map(|s| s.height).or(fallback.height),
+                                    ratio: widget_data.widget.aspect_ratio().or(fallback.ratio),
+                                },
+                                default_object_size,
                             )
                         }
                         _ => unreachable!(),
                     };
 
                     let replaced_context = ReplacedContext {
-                        inherent_size,
+                        intrinsic_sizes,
                         attr_size,
-                        inherent_ratio,
+                        default_object_size,
                     };
 
                     let computed = replaced_measure_function(

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -19,14 +19,26 @@ pub(crate) fn is_replaced_element(tag_name: &LocalName) -> bool {
         || *tag_name == local_name!("iframe")
 }
 
+/// The intrinsic dimensions of a replaced element per CSS Images 3
+/// (https://drafts.csswg.org/css-images/#intrinsic-dimensions): an intrinsic
+/// width, an intrinsic height, and an intrinsic aspect ratio, each of which
+/// may independently be absent.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IntrinsicSizes {
+    pub width: Option<f32>,
+    pub height: Option<f32>,
+    pub ratio: Option<f32>,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ReplacedContext {
-    pub inherent_size: taffy::Size<f32>,
+    /// The element's intrinsic dimensions, each possibly absent.
+    pub intrinsic_sizes: IntrinsicSizes,
     pub attr_size: taffy::Size<Option<f32>>,
-    /// The element's intrinsic aspect ratio, if it has one. Some replaced elements
-    /// (iframe, embed, video without loaded media) have a default object size but
-    /// no intrinsic aspect ratio.
-    pub inherent_ratio: Option<f32>,
+    /// The default object size (https://drafts.csswg.org/css-images/#default-object-size)
+    /// used to fill in dimensions the intrinsic sizes leave unresolved. 300x150
+    /// for most replaced elements; zero for an image with no loaded resource.
+    pub default_object_size: taffy::Size<f32>,
 }
 
 /// Whether a height/width value is violating it's min- and max- constraints
@@ -50,8 +62,6 @@ pub fn replaced_measure_function(
     sizing_mode: SizingMode,
     requested_axis: RequestedAxis,
 ) -> taffy::Size<f32> {
-    let inherent_size = image_context.inherent_size;
-
     let padding = style
         .padding()
         .resolve_or_zero(parent_size.width, resolve_calc_value);
@@ -80,10 +90,58 @@ pub fn replaced_measure_function(
     // replaced element), and only if both are degenerate or absent does the
     // element get no preferred aspect ratio at all.
     let is_usable_ratio = |ratio: &f32| ratio.is_finite() && *ratio > 0.0;
+    let intrinsic = image_context.intrinsic_sizes;
     let aspect_ratio: Option<f32> = style
         .aspect_ratio
         .filter(is_usable_ratio)
-        .or(image_context.inherent_ratio.filter(is_usable_ratio));
+        .or(intrinsic.ratio.filter(is_usable_ratio));
+
+    // Concrete object size per the CSS default sizing algorithm with no
+    // specified size (https://drafts.csswg.org/css-images/#default-sizing):
+    // missing intrinsic dimensions are derived from the aspect ratio when
+    // possible, otherwise taken from the default object size. An element with
+    // only an intrinsic aspect ratio uses the stretch-fit width in normal flow
+    // (CSS2 §10.3.2) when the available width is definite; shrink-to-fit
+    // contexts (min/max-content) contain it within the default object size.
+    //
+    // Only the intrinsic ratio participates here: the `aspect-ratio` property
+    // affects the sizing of the box, not the natural dimensions of its content.
+    let intrinsic_ratio = intrinsic.ratio.filter(is_usable_ratio);
+    let default_size = image_context.default_object_size;
+    let inherent_size = match (intrinsic.width, intrinsic.height) {
+        (Some(w), Some(h)) => Size {
+            width: w,
+            height: h,
+        },
+        (Some(w), None) => Size {
+            width: w,
+            height: intrinsic_ratio
+                .map(|r| w / r)
+                .unwrap_or(default_size.height),
+        },
+        (None, Some(h)) => Size {
+            width: intrinsic_ratio.map(|r| h * r).unwrap_or(default_size.width),
+            height: h,
+        },
+        (None, None) => match intrinsic_ratio {
+            Some(ratio) => {
+                if let AvailableSpace::Definite(available_width) = available_space.width {
+                    Size {
+                        width: available_width,
+                        height: available_width / ratio,
+                    }
+                } else {
+                    // Contain within the default object size
+                    let scale = (default_size.width / ratio).min(default_size.height);
+                    Size {
+                        width: scale * ratio,
+                        height: scale,
+                    }
+                }
+            }
+            None => default_size,
+        },
+    };
 
     // See https://www.w3.org/TR/css-sizing-3/#replaced-percentage-min-contribution
     let basis_for_max_and_preferred = Size {


### PR DESCRIPTION
## Summary

Follow-up to #726: model replaced-element intrinsic dimensions in layout the same way as the CSS Images spec (and the new background-sizing code), instead of pre-resolving them to a concrete size at each call site.

```rust
// packages/blitz-dom/src/layout/replaced.rs
pub struct IntrinsicSizes {          // per css-images §4: each independently optional
    pub width: Option<f32>,
    pub height: Option<f32>,
    pub ratio: Option<f32>,
}

pub struct ReplacedContext {
-   pub inherent_size: taffy::Size<f32>,   // pre-concretized at call site
-   pub inherent_ratio: Option<f32>,
+   pub intrinsic_sizes: IntrinsicSizes,
+   pub default_object_size: taffy::Size<f32>,  // 300x150, or zero for an unloaded image
    pub attr_size: taffy::Size<Option<f32>>,
}
```

`replaced_measure_function` now computes the concrete object size internally per the [CSS default sizing algorithm](https://drafts.csswg.org/css-images/#default-sizing): missing intrinsic dimensions are derived from the intrinsic ratio when present, otherwise filled from the default object size; a ratio-only element (e.g. viewBox-only SVG) uses the stretch-fit width (CSS2 §10.3.2) when available width is definite, and is contained within the default object size in min/max-content contexts. This moves the SVG stretch-fit special case out of `layout/mod.rs` and generalizes it to any replaced element with only an intrinsic ratio.

Call-site construction in `layout/mod.rs` is simplified to just supplying intrinsic data per element kind (`tag_intrinsic_sizes` handles unloaded img/svg → zero, canvas → attr-based size+ratio, video/iframe/embed → no intrinsics with 300x150 default; custom widgets layer their reported size/ratio over the tag fallback).

This is a pure refactor: WPT results for `css/css-backgrounds` (471), `css/css-images` (135), and `css/css-sizing` (321) are identical before and after (zero per-test status changes), and all `blitz-tests`/`blitz-dom` tests pass.

One deliberate quirk kept for now (flagged with a comment): an SVG with no declared dimensions and no viewBox passes usvg's resolved size as its intrinsic size rather than having none — dropping that in favor of the pure spec behavior regressed several `object-view-box-*` and `intrinsic-percent-replaced-*` tests, so it's preserved.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/c1c75f0597374e00a4cd8e5af8971df1
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32015790731).</sub>
<!-- wpt-results-end -->
