### PR TITLE
Adapt to taffy's scrollable_overflow_rect API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=481fb8feba4fefdf3b968f85735553df6a4fb3ac#481fb8feba4fefdf3b968f85735553df6a4fb3ac"
+source = "git+https://github.com/DioxusLabs/taffy?rev=3d89b3f9930490b9e40e0790110a77d548b400e4#3d89b3f9930490b9e40e0790110a77d548b400e4"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=f3eaa5f85ae1bfd4ae774a65e8e29bc42d2d31e9#f3eaa5f85ae1bfd4ae774a65e8e29bc42d2d31e9"
+source = "git+https://github.com/DioxusLabs/taffy?rev=197780f682edea48c1382a4126a9143ed7b67634#197780f682edea48c1382a4126a9143ed7b67634"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=f834a3132750948a53fcc7eb2495631a4e2a1f4d#f834a3132750948a53fcc7eb2495631a4e2a1f4d"
+source = "git+https://github.com/DioxusLabs/taffy?rev=481fb8feba4fefdf3b968f85735553df6a4fb3ac#481fb8feba4fefdf3b968f85735553df6a4fb3ac"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=a53c73b599877370f014e3c61f70604f5eeeae2b#a53c73b599877370f014e3c61f70604f5eeeae2b"
+source = "git+https://github.com/DioxusLabs/taffy?rev=f834a3132750948a53fcc7eb2495631a4e2a1f4d#f834a3132750948a53fcc7eb2495631a4e2a1f4d"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=3d89b3f9930490b9e40e0790110a77d548b400e4#3d89b3f9930490b9e40e0790110a77d548b400e4"
+source = "git+https://github.com/DioxusLabs/taffy?rev=7eddc45ac29edf40e9301aeaf522e6b4546aa268#7eddc45ac29edf40e9301aeaf522e6b4546aa268"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=197780f682edea48c1382a4126a9143ed7b67634#197780f682edea48c1382a4126a9143ed7b67634"
+source = "git+https://github.com/DioxusLabs/taffy?rev=a53c73b599877370f014e3c61f70604f5eeeae2b#a53c73b599877370f014e3c61f70604f5eeeae2b"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "f834a3132750948a53fcc7eb2495631a4e2a1f4d", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "481fb8feba4fefdf3b968f85735553df6a4fb3ac", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "481fb8feba4fefdf3b968f85735553df6a4fb3ac", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "3d89b3f9930490b9e40e0790110a77d548b400e4", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "197780f682edea48c1382a4126a9143ed7b67634", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a53c73b599877370f014e3c61f70604f5eeeae2b", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a53c73b599877370f014e3c61f70604f5eeeae2b", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "f834a3132750948a53fcc7eb2495631a4e2a1f4d", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "3d89b3f9930490b9e40e0790110a77d548b400e4", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "7eddc45ac29edf40e9301aeaf522e6b4546aa268", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "f3eaa5f85ae1bfd4ae774a65e8e29bc42d2d31e9", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "197780f682edea48c1382a4126a9143ed7b67634", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/debug.rs
+++ b/packages/blitz-dom/src/debug.rs
@@ -81,13 +81,15 @@ impl BaseDocument {
         let layout = node.final_layout();
         println!("Layout:");
         println!(
-            "  x: {x} y: {y} w: {width} h: {height} content_w: {content_width} content_h: {content_height}",
+            "  x: {x} y: {y} w: {width} h: {height} overflow: l:{ol} r:{or} t:{ot} b:{ob}",
             x = layout.location.x,
             y = layout.location.y,
             width = layout.size.width,
             height = layout.size.height,
-            content_width = layout.content_size.width,
-            content_height = layout.content_size.height,
+            ol = layout.scrollable_overflow_rect.left,
+            or = layout.scrollable_overflow_rect.right,
+            ot = layout.scrollable_overflow_rect.top,
+            ob = layout.scrollable_overflow_rect.bottom,
         );
         println!(
             "  border: l:{l} r:{r} t:{t} b:{b}",

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -2064,8 +2064,13 @@ impl BaseDocument {
                 let event = BlitzScrollEvent {
                     scroll_top: self.viewport_scroll.y,
                     scroll_left: self.viewport_scroll.x,
-                    scroll_width: layout.size.width.max(layout.content_size.width) as i32,
-                    scroll_height: layout.size.height.max(layout.content_size.height) as i32,
+                    scroll_width: layout.size.width.max(layout.scrollable_overflow_rect.right)
+                        as i32,
+                    scroll_height: layout
+                        .size
+                        .height
+                        .max(layout.scrollable_overflow_rect.bottom)
+                        as i32,
                     client_width: (self.viewport.window_size.0 as f64 / scale) as i32,
                     client_height: (self.viewport.window_size.1 as f64 / scale) as i32,
                 };
@@ -2223,8 +2228,15 @@ impl BaseDocument {
             Some(root) => {
                 let root_layout = root.final_layout();
                 (
-                    root_layout.size.width.max(root_layout.content_size.width) as f64,
-                    root_layout.size.height.max(root_layout.content_size.height) as f64,
+                    root_layout
+                        .size
+                        .width
+                        .max(root_layout.scrollable_overflow_rect.right) as f64,
+                    root_layout
+                        .size
+                        .height
+                        .max(root_layout.scrollable_overflow_rect.bottom)
+                        as f64,
                 )
             }
             None => (0.0, 0.0),

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -651,8 +651,8 @@ impl BaseDocument {
 
         // Note: `width` and `height` are content-box measurements of the inline content.
         // `known_dimensions` must not be substituted in here: those are border-box sizes, and
-        // using them for `content_size` (which adds padding below) would double-count padding,
-        // incorrectly making the container's content overflow it.
+        // using them for the scrollable overflow rect (which adds padding below) would
+        // double-count padding, incorrectly making the container's content overflow it.
         let measured_size = taffy::Size {
             width: width / scale,
             height: height / scale,
@@ -827,10 +827,18 @@ impl BaseDocument {
 
         LayoutOutput {
             size: final_size,
-            content_size: taffy::Size {
-                width: content_width,
-                height: measured_size.height,
-            } + padding.sum_axes(),
+            scrollable_overflow_rect: {
+                let content_extent = taffy::Size {
+                    width: content_width,
+                    height: measured_size.height,
+                } + padding.sum_axes();
+                taffy::Rect {
+                    left: 0.0,
+                    right: content_extent.width,
+                    top: 0.0,
+                    bottom: content_extent.height,
+                }
+            },
             baselines: taffy::Baselines::from_first(first_baseline),
             top_margin: CollapsibleMarginSet::ZERO,
             bottom_margin: CollapsibleMarginSet::ZERO,
@@ -1155,7 +1163,7 @@ fn layout_abspos_child(
         &taffy::Layout {
             order: 0, // TODO: order
             size: final_size,
-            content_size: layout_output.content_size,
+            scrollable_overflow_rect: layout_output.scrollable_overflow_rect,
             scrollbar_size,
             location,
             padding,

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -338,9 +338,15 @@ impl BaseDocument {
                     };
                     let mut output = compute_grid_layout(&mut table_wrapper, node_id, inputs);
 
-                    // HACK: Cap content size at node size to prevent scrolling
-                    output.content_size.width = output.content_size.width.min(output.size.width);
-                    output.content_size.height = output.content_size.height.min(output.size.height);
+                    // HACK: Cap scrollable overflow at node size to prevent scrolling
+                    output.scrollable_overflow_rect.left = 0.0;
+                    output.scrollable_overflow_rect.top = 0.0;
+                    output.scrollable_overflow_rect.right =
+                        output.scrollable_overflow_rect.right.min(output.size.width);
+                    output.scrollable_overflow_rect.bottom = output
+                        .scrollable_overflow_rect
+                        .bottom
+                        .min(output.size.height);
 
                     return output;
                 }

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -82,30 +82,37 @@ pub fn compute_replaced_layout(
         Size::ZERO
     };
 
-    // Content size is the scrollable-overflow extent measured from the padding-box
-    // origin: the content-box size offset by the start padding. A scroll container's
-    // own padding at the end of the content is part of its scrollable overflow
-    // region, so it is included in the content size. Boxes that are not scroll
+    // The scrollable overflow rect is measured from the scroll origin at the
+    // padding-box corner: the content-box size offset by the start padding. A
+    // scroll container's own padding at the end of the content is part of its
+    // scrollable overflow region, so it is included. Boxes that are not scroll
     // containers do not extend their overflow region by their own padding.
     let is_scroll_container = {
         let overflow = style.overflow();
         overflow.x.is_scroll_container() || overflow.y.is_scroll_container()
     };
-    let content_size_for = |content_box_size: Size<f32>| Size {
-        width: padding.left
-            + content_box_size.width
-            + if is_scroll_container {
-                padding.right
-            } else {
-                0.0
-            },
-        height: padding.top
-            + content_box_size.height
-            + if is_scroll_container {
-                padding.bottom
-            } else {
-                0.0
-            },
+    let is_rtl = style.direction() == taffy::Direction::Rtl;
+    let overflow_rect_for = |content_box_size: Size<f32>| {
+        let start_padding = if is_rtl { padding.right } else { padding.left };
+        let end_padding = if is_rtl { padding.left } else { padding.right };
+        taffy::Rect {
+            left: 0.0,
+            right: start_padding
+                + content_box_size.width
+                + if is_scroll_container {
+                    end_padding
+                } else {
+                    0.0
+                },
+            top: 0.0,
+            bottom: padding.top
+                + content_box_size.height
+                + if is_scroll_container {
+                    padding.bottom
+                } else {
+                    0.0
+                },
+        }
     };
 
     // Return early if both width and height are known
@@ -260,7 +267,7 @@ pub fn compute_replaced_layout(
             .unwrap_or(transferred.maybe_clamp(min_size, style_max_size));
 
         let size = size.map(|s| s.max(0.0));
-        return LayoutOutput::from_sizes(size + pb_sum, content_size_for(size));
+        return LayoutOutput::from_sizes(size + pb_sum, overflow_rect_for(size));
     }
 
     let unclamped_size = if style_size.width.is_some() | style_size.height.is_some() {
@@ -294,7 +301,7 @@ pub fn compute_replaced_layout(
     // Without an intrinsic aspect ratio, each axis is clamped independently
     let Some(aspect_ratio) = aspect_ratio else {
         let size = size.maybe_clamp(min_size, max_size);
-        return LayoutOutput::from_sizes(size + pb_sum, content_size_for(size));
+        return LayoutOutput::from_sizes(size + pb_sum, overflow_rect_for(size));
     };
     let inv_aspect_ratio = 1.0 / aspect_ratio;
 
@@ -387,5 +394,5 @@ pub fn compute_replaced_layout(
         }
     };
 
-    LayoutOutput::from_sizes(size + pb_sum, content_size_for(size))
+    LayoutOutput::from_sizes(size + pb_sum, overflow_rect_for(size))
 }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1161,11 +1161,11 @@ impl Node {
             || y < 0.0
             || y > size.height + self.scroll_offset().y as f32);
 
-        let content_size = self.final_layout().content_size;
+        let overflow_rect = self.final_layout().scrollable_overflow_rect;
         let matches_content = !(x < 0.0
-            || x > content_size.width + self.scroll_offset().x as f32
+            || x > overflow_rect.right + self.scroll_offset().x as f32
             || y < 0.0
-            || y > content_size.height + self.scroll_offset().y as f32);
+            || y > overflow_rect.bottom + self.scroll_offset().y as f32);
 
         let matches_hoisted_content = match &self.stacking_context {
             Some(sc) => {
@@ -1435,14 +1435,14 @@ impl Node {
     /// content not visible due to overflow
     pub fn scroll_width(&self) -> f32 {
         self.client_width()
-            .max(self.final_layout().content_size.width)
+            .max(self.final_layout().scrollable_overflow_rect.right)
     }
 
     /// CSSOM View's `scrollHeight`: the height of the node's content, including
     /// content not visible due to overflow
     pub fn scroll_height(&self) -> f32 {
         self.client_height()
-            .max(self.final_layout().content_size.height)
+            .max(self.final_layout().scrollable_overflow_rect.bottom)
     }
 
     /// Does the node generate any boxes? (e.g. `getClientRects()` returns an empty

--- a/tests/blitz-tests/tests/display_contents.rs
+++ b/tests/blitz-tests/tests/display_contents.rs
@@ -81,7 +81,7 @@ fn scroller_wrapping_contents_gets_full_scroll_size() {
         "content inside the contents wrapper must size normally"
     );
     assert_eq!(
-        ls.content_size.height, 1000.0,
+        ls.scrollable_overflow_rect.bottom, 1000.0,
         "the scroller's scrollable content size must include the hoisted content"
     );
 }

--- a/tests/blitz-tests/tests/pre_overflow_scroll.rs
+++ b/tests/blitz-tests/tests/pre_overflow_scroll.rs
@@ -28,10 +28,10 @@ fn wide_pre_makes_scroller_scrollable() {
     let pre_id = doc.query_selector("#pre").unwrap().expect("#pre");
     let pre_layout = doc.get_node(pre_id).unwrap().final_layout();
     assert!(
-        pre_layout.content_size.width > pre_layout.size.width,
-        "expected the pre's content to overflow its border box, got size={:?} content_size={:?}",
+        pre_layout.scrollable_overflow_rect.right > pre_layout.size.width,
+        "expected the pre's content to overflow its border box, got size={:?} scrollable_overflow_rect={:?}",
         pre_layout.size,
-        pre_layout.content_size
+        pre_layout.scrollable_overflow_rect
     );
 
     let scroller_id = doc.query_selector("#scroller").unwrap().expect("#scroller");

--- a/wpt/runner/src/test_runners/attr_test.rs
+++ b/wpt/runner/src/test_runners/attr_test.rs
@@ -115,12 +115,16 @@ pub fn check_node_layout(node: &Node) -> Vec<String> {
 
                         "data-expected-client-width" => check_attr(name, value, client_width),
                         "data-expected-client-height" => check_attr(name, value, client_height),
-                        "data-expected-scroll-width" => {
-                            check_attr(name, value, client_width.max(layout.content_size.width))
-                        }
-                        "data-expected-scroll-height" => {
-                            check_attr(name, value, client_height.max(layout.content_size.height))
-                        }
+                        "data-expected-scroll-width" => check_attr(
+                            name,
+                            value,
+                            client_width.max(layout.scrollable_overflow_rect.right),
+                        ),
+                        "data-expected-scroll-height" => check_attr(
+                            name,
+                            value,
+                            client_height.max(layout.scrollable_overflow_rect.bottom),
+                        ),
                         "data-expected-bounding-client-rect-width" => {
                             check_attr(name, value, layout.size.width)
                         }


### PR DESCRIPTION
## Summary

Bumps taffy to the `scrollable_overflow_rect: Rect<f32>` branch (https://github.com/DioxusLabs/taffy/pull/1118) and adapts all `content_size` usages. The rect is scroll-origin-relative and always contains the origin, so `right`/`bottom` are the reachable end-side extent — a drop-in replacement for the old `content_size.width`/`.height`:

- Reads (`document.rs` scroll event/root extent, `node.rs` hit-test bound, wpt `attr_test.rs` scrollWidth/scrollHeight, `debug.rs`): `content_size.width/.height` → `scrollable_overflow_rect.right/.bottom`.
- `LayoutOutput` construction (replaced elements, inline roots) and the table content-size cap now produce origin-anchored rects (`left: 0, right: w, top: 0, bottom: h`).

Behaviour should be unchanged; verified `scroll_width=0` on csskit.rs and bulma.io/documentation. Draft until taffy#1118 merges (rev will need re-pinning to the merged main commit).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b6f5529e9a3e4823b603788b475ab109
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32167315625).</sub>
<!-- wpt-results-end -->
