### PR TITLE
Include unbreakable inline overflow (e.g. white-space: pre) in content_size

### DIFF
--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -658,6 +658,11 @@ impl BaseDocument {
             height: height / scale,
         };
 
+        // Unbreakable content (e.g. `white-space: pre` text) may overflow the max advance the
+        // lines were broken at. `width` is the advance the lines were broken at, so the actual
+        // extent of the line boxes must be taken from the laid-out lines for `content_size`.
+        let content_width = f32_max(width, inline_layout.layout.width()) / scale;
+
         let clamped_size = inputs
             .known_dimensions
             .or(node_size)
@@ -822,7 +827,10 @@ impl BaseDocument {
 
         LayoutOutput {
             size: final_size,
-            content_size: measured_size + padding.sum_axes(),
+            content_size: taffy::Size {
+                width: content_width,
+                height: measured_size.height,
+            } + padding.sum_axes(),
             baselines: taffy::Baselines::from_first(first_baseline),
             top_margin: CollapsibleMarginSet::ZERO,
             bottom_margin: CollapsibleMarginSet::ZERO,

--- a/tests/blitz-tests/tests/pre_overflow_scroll.rs
+++ b/tests/blitz-tests/tests/pre_overflow_scroll.rs
@@ -1,0 +1,44 @@
+//! A wide single-line `<pre>` inside a narrower `overflow-x: auto` container
+//! must contribute its full unwrapped line width to the container's
+//! scrollable overflow so the container can scroll horizontally.
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+#[test]
+fn wide_pre_makes_scroller_scrollable() {
+    let html = r#"<html><body style="margin:0">
+        <div id="scroller" style="width: 500px; overflow-x: auto;">
+          <pre id="pre">one very long single line of text that is much wider than five hundred pixels and should cause horizontal scrolling inside the overflow-x auto container</pre>
+        </div>
+    </body></html>"#;
+
+    let mut doc = HtmlDocument::from_html(
+        html,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    );
+    doc.resolve(0.0);
+
+    let pre_id = doc.query_selector("#pre").unwrap().expect("#pre");
+    let pre_layout = doc.get_node(pre_id).unwrap().final_layout();
+    assert!(
+        pre_layout.content_size.width > pre_layout.size.width,
+        "expected the pre's content to overflow its border box, got size={:?} content_size={:?}",
+        pre_layout.size,
+        pre_layout.content_size
+    );
+
+    let scroller_id = doc.query_selector("#scroller").unwrap().expect("#scroller");
+    let layout = doc.get_node(scroller_id).unwrap().final_layout();
+    assert!(
+        layout.scroll_width() > 100.0,
+        "expected horizontal scrollable overflow, got scroll_width={}",
+        layout.scroll_width()
+    );
+}


### PR DESCRIPTION
## Summary

A wide single-line `<pre>` inside a narrower `overflow-x: auto` container could not be scrolled horizontally: the scroll container reported `scroll_width() == 0`.

Root cause: in `compute_inline_layout_inner`, the `width` used for the inline root's `content_size` is the advance the lines were *broken at* (the known/available width — e.g. the container's 500px), not the extent of the laid-out line boxes. With `white-space: pre` the line cannot break and its actual advance exceeds that max advance, but parley's true line extent (`layout.width()`) was discarded, so `content_size.width` was clamped to the container width and Taffy saw no scrollable overflow.

Fix: take the actual line-box extent into account for `content_size` (border-box `size` is unchanged):

```rust
let content_width = f32_max(width, inline_layout.layout.width()) / scale;
// content_size.width now uses content_width instead of width
```

`layout.width()` excludes trailing whitespace, so normal wrapped text (where lines can end with a preserved trailing space) contributes no spurious overflow — matching CSS scrollable-overflow behavior (the scrollable overflow of a scroll container includes the full extent of its line boxes) and Chrome's `scrollWidth`.

Verified: no diffs on WPT `css/css-overflow` and `css/css-text/white-space` vs main; `cargo test --workspace`, fmt, and clippy pass. Adds a regression test (`tests/blitz-tests/tests/pre_overflow_scroll.rs`) asserting the scroller gains horizontal scrollable overflow (scroll_width goes 0 → 690 on the example).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ede6c8d0960440569ed0b34cfa4ca0fe
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32030904413).</sub>
<!-- wpt-results-end -->
