### PR TITLE
Fix squashed rendering on iOS (safe-area surface size mismatch)

### DIFF
--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -160,7 +160,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         if let Some(bg_color) = background_color {
             let bg_color = bg_color.as_srgb_color();
             let rect = Rect::from_origin_size(
-                (self.initial_x * self.scale, self.initial_y * self.scale),
+                (self.initial_x, self.initial_y),
                 (bg_width as f64, bg_height as f64),
             );
             scene.fill(Fill::NonZero, Affine::IDENTITY, bg_color, None, &rect);

--- a/packages/blitz-shell/src/window.rs
+++ b/packages/blitz-shell/src/window.rs
@@ -155,7 +155,6 @@ impl<Rend: WindowRenderer> View<Rend> {
         }
 
         // Create viewport
-        // TODO: account for the "safe area"
         let scale = winit_window.scale_factor() as f32;
         let mut size = winit_window.surface_size();
         if (size.width == 0 || size.height == 0)
@@ -181,7 +180,14 @@ impl<Rend: WindowRenderer> View<Rend> {
         let safe_area_insets = get_safe_area_insets(&*winit_window);
         let theme = winit_window.theme().unwrap_or(Theme::Light);
         let color_scheme = theme_to_color_scheme(theme);
-        let viewport = Viewport::new(size.width, size.height, scale, color_scheme);
+        // The viewport is the window surface minus the safe area insets
+        let viewport_width = size
+            .width
+            .saturating_sub(safe_area_insets.left + safe_area_insets.right);
+        let viewport_height = size
+            .height
+            .saturating_sub(safe_area_insets.top + safe_area_insets.bottom);
+        let viewport = Viewport::new(viewport_width, viewport_height, scale, color_scheme);
 
         // Create shell provider
         let shell_provider = BlitzShellProvider::new(winit_window.clone(), proxy.clone());
@@ -297,6 +303,11 @@ impl<Rend: WindowRenderer> View<Rend> {
             inner.viewport().window_size
         };
 
+        // The render surface covers the entire window, including the safe area
+        let insets = self.safe_area_insets;
+        let width = width + insets.left + insets.right;
+        let height = height + insets.top + insets.bottom;
+
         let proxy = self.proxy.clone();
         self.renderer
             .resume(Arc::new(self.window.clone()), width, height, move || {
@@ -323,12 +334,16 @@ impl<Rend: WindowRenderer> View<Rend> {
         inner.resolve(animation_time);
         let (width, height) = inner.viewport().window_size;
         let scale = inner.viewport().scale_f64();
-        let insets = self.safe_area_insets.to_logical(scale);
+        let insets = self.safe_area_insets;
 
         #[cfg(feature = "custom-widget")]
         inner.can_create_surfaces(&mut self.renderer as _);
 
-        self.renderer.set_size(width, height);
+        // The render surface covers the entire window, including the safe area
+        self.renderer.set_size(
+            width + insets.left + insets.right,
+            height + insets.top + insets.bottom,
+        );
 
         self.renderer.render(|scene| {
             paint_scene(
@@ -401,7 +416,7 @@ impl<Rend: WindowRenderer> View<Rend> {
         let scale = inner.viewport().scale_f64();
         let is_animating = inner.is_animating();
         let is_blocked = inner.has_pending_critical_resources();
-        let insets = self.safe_area_insets.to_logical(scale);
+        let insets = self.safe_area_insets;
 
         if !is_blocked && is_visible {
             self.renderer.render(|scene| {


### PR DESCRIPTION
## Summary

On iOS the rendered content appeared vertically squashed. The root cause was a size mismatch between the document viewport and the render surface: `SurfaceResized` already sets the document viewport to `surface_size - safe_area_insets` (and `with_viewport` sizes the renderer at `viewport + insets`), but the initial `View::init` viewport and `resume`/`complete_resume` used inconsistent sizes. The wgpu surface ended up configured at the inset-adjusted height while covering the full window, so Vello's output was stretched/squashed to fit.

Fix (all in `blitz-shell/src/window.rs`):
- `init`: create the initial `Viewport` at `surface_size - safe_area_insets` instead of the full surface size, matching what `SurfaceResized` later computes.
- `resume`/`complete_resume`: size the render surface at `viewport + insets` (the full window), matching `with_viewport`.
- `complete_resume`/`redraw`: pass **physical** insets to `paint_scene` instead of `insets.to_logical(scale)` — `initial_x`/`initial_y` are consumed as physical pixels (see the unit note in `debug_overlay.rs`), so logical values placed content under the notch on 3x displays.

Also in `blitz-paint/src/render.rs`: the background rect used `initial_x * scale`, double-scaling the already-physical offset; now uses `initial_x`/`initial_y` directly, consistent with the element transform path.

No behavior change on platforms with zero safe-area insets (including macOS, where insets are hardcoded to zero).

Verified on an iPhone 17 simulator (3x scale, insets top=186/bottom=102 physical):

| Before | After |
|---|---|
| ![before](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvYzM5YTczNzgtYTExZi00YmFiLWFkYTAtMjkwOWE0OTVmOTM1IiwiaWF0IjoxNzg2OTczNjMyLCJleHAiOjE3ODc1Nzg0MzIsImZpbGVuYW1lIjoiaW9zX2JlZm9yZS5wbmcifQ.vcEcHTystaHQlxWXVrXXUqFPd7nneVtBWkycPw3FSvU) | ![after](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvNmM5YmRjMWUtMDU2My00NDQ2LWE4Y2YtYzNmOTNlYzhlNWRlIiwiaWF0IjoxNzg2OTczNjMyLCJleHAiOjE3ODc1Nzg0MzIsImZpbGVuYW1lIjoiaW9zX2FmdGVyMi5wbmcifQ.9AD5qO3mhUjjxB3D5cilH8AiMF1cRv0KRyZkHmgE-Ag) |


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/4cdd57b070834fc8af874a8aed768c65
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32035761195).</sub>
<!-- wpt-results-end -->
