### PR TITLE
Fix intrinsic sizing for SVG elements

### DIFF
--- a/packages/blitz-dom/assets/default.css
+++ b/packages/blitz-dom/assets/default.css
@@ -5,6 +5,7 @@
 @namespace url(http://www.w3.org/1999/xhtml);
 /* set default namespace to HTML */
 @namespace xul url(http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul);
+@namespace svg url(http://www.w3.org/2000/svg);
 
 @font-face {
     font-family: -moz-bullet-font;
@@ -783,6 +784,12 @@ img::before {
 img[usemap],
 object[usemap] {
     color: blue;
+}
+
+/* Per the SVG2 UA stylesheet, an svg element that is not the document root
+ * (e.g. inline <svg> in HTML) has overflow: hidden. */
+svg|svg {
+    overflow: hidden;
 }
 
 frameset {

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -242,29 +242,14 @@ impl BaseDocument {
                                 )
                             }
                             #[cfg(feature = "svg")]
-                            ImageData::Svg(svg) => {
-                                let mut width = svg.intrinsic_width();
-                                let mut height = svg.intrinsic_height();
-                                // An SVG with no declared dimensions and no viewBox has no
-                                // intrinsic dimensions per CSS, but usvg still resolves a
-                                // concrete size; use it in place of the default object size.
-                                if width.is_none()
-                                    && height.is_none()
-                                    && svg.viewbox_aspect_ratio().is_none()
-                                {
-                                    let size = svg.tree.size();
-                                    width = Some(size.width());
-                                    height = Some(size.height());
-                                }
-                                (
-                                    IntrinsicSizes {
-                                        width,
-                                        height,
-                                        ratio: Some(svg.aspect_ratio()),
-                                    },
-                                    DEFAULT_OBJECT_SIZE,
-                                )
-                            }
+                            ImageData::Svg(svg) => (
+                                IntrinsicSizes {
+                                    width: svg.intrinsic_width(),
+                                    height: svg.intrinsic_height(),
+                                    ratio: svg.aspect_ratio(),
+                                },
+                                DEFAULT_OBJECT_SIZE,
+                            ),
                             ImageData::None => (IntrinsicSizes::default(), taffy::Size::ZERO),
                         },
                         SpecialElementData::Canvas(_)

--- a/packages/blitz-dom/src/layout/replaced.rs
+++ b/packages/blitz-dom/src/layout/replaced.rs
@@ -147,9 +147,26 @@ pub fn compute_replaced_layout(
     // (CSS2 §10.3.2) when the available width is definite; shrink-to-fit
     // contexts (min/max-content) contain it within the default object size.
     //
-    // Only the intrinsic ratio participates here: the `aspect-ratio` property
-    // affects the sizing of the box, not the natural dimensions of its content.
+    // The intrinsic ratio transfers directly between the natural (content)
+    // dimensions. A ratio from the `aspect-ratio` property instead applies to
+    // the box given by `box-sizing` (CSS Sizing 4 §5), so transferring through
+    // it converts to that box and back.
     let intrinsic_ratio = intrinsic.ratio.filter(is_usable_ratio);
+    let style_ratio = style.aspect_ratio().filter(is_usable_ratio);
+    let transferred_height = |w: f32| {
+        intrinsic_ratio.map(|r| w / r).or_else(|| {
+            style_ratio.map(|r| {
+                ((w + box_sizing_adjustment.width) / r - box_sizing_adjustment.height).max(0.0)
+            })
+        })
+    };
+    let transferred_width = |h: f32| {
+        intrinsic_ratio.map(|r| h * r).or_else(|| {
+            style_ratio.map(|r| {
+                ((h + box_sizing_adjustment.height) * r - box_sizing_adjustment.width).max(0.0)
+            })
+        })
+    };
     let default_size = context.default_object_size;
     let inherent_size = match (intrinsic.width, intrinsic.height) {
         (Some(w), Some(h)) => Size {
@@ -158,12 +175,10 @@ pub fn compute_replaced_layout(
         },
         (Some(w), None) => Size {
             width: w,
-            height: intrinsic_ratio
-                .map(|r| w / r)
-                .unwrap_or(default_size.height),
+            height: transferred_height(w).unwrap_or(default_size.height),
         },
         (None, Some(h)) => Size {
-            width: intrinsic_ratio.map(|r| h * r).unwrap_or(default_size.width),
+            width: transferred_width(h).unwrap_or(default_size.width),
             height: h,
         },
         (None, None) => match intrinsic_ratio {

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -468,8 +468,13 @@ impl ElementData {
 
     #[cfg(feature = "svg")]
     pub fn svg_data(&self) -> Option<&usvg::Tree> {
+        Some(&self.svg_image_data()?.tree)
+    }
+
+    #[cfg(feature = "svg")]
+    pub fn svg_image_data(&self) -> Option<&crate::node::SvgImageData> {
         match self.image_data()? {
-            ImageData::Svg(data) => Some(&data.tree),
+            ImageData::Svg(data) => Some(data),
             _ => None,
         }
     }

--- a/packages/blitz-dom/src/node/svg.rs
+++ b/packages/blitz-dom/src/node/svg.rs
@@ -1,6 +1,6 @@
 //! SVG image data and CSS intrinsic sizing for SVG.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use usvg::roxmltree;
 
@@ -58,6 +58,8 @@ impl SvgIntrinsicDimensions {
     }
 }
 
+type ViewportTreeCacheEntry = ((u32, u32), Arc<usvg::Tree>);
+
 /// A parsed SVG image.
 ///
 /// usvg always resolves the root `<svg>` to a concrete [`usvg::Tree::size`],
@@ -72,6 +74,11 @@ pub struct SvgImageData {
     pub tree: Arc<usvg::Tree>,
     /// The dimensions declared on the root `<svg>` element.
     pub intrinsic_dimensions: SvgIntrinsicDimensions,
+    /// The original (decompressed) SVG source.
+    source: Arc<str>,
+    /// A re-parse of [`Self::source`] with the root viewport overridden to a
+    /// specific size, cached by that size. See [`Self::tree_for_viewport`].
+    viewport_tree_cache: Arc<Mutex<Option<ViewportTreeCacheEntry>>>,
 }
 
 impl SvgImageData {
@@ -135,7 +142,72 @@ impl SvgImageData {
         Ok(Self {
             tree: Arc::new(tree),
             intrinsic_dimensions,
+            source: Arc::from(text),
+            viewport_tree_cache: Arc::new(Mutex::new(None)),
         })
+    }
+
+    /// The SVG re-parsed with the root viewport forced to the given size in
+    /// CSS px, for an inline `<svg>` element whose viewport is established by
+    /// its CSS box: the root `width`/`height` are overridden so that usvg
+    /// resolves percentage lengths and the `viewBox`/`preserveAspectRatio`
+    /// mapping against the CSS-established viewport. Falls back to the
+    /// original tree if re-parsing fails. The result is cached by size.
+    pub fn tree_for_viewport(&self, width: f32, height: f32) -> Arc<usvg::Tree> {
+        let key = (width.to_bits(), height.to_bits());
+        let mut cache = self.viewport_tree_cache.lock().unwrap();
+        if let Some((cached_key, tree)) = &*cache {
+            if *cached_key == key {
+                return Arc::clone(tree);
+            }
+        }
+
+        let tree = self
+            .reparse_with_viewport(width, height)
+            .map(Arc::new)
+            .unwrap_or_else(|| Arc::clone(&self.tree));
+        *cache = Some((key, Arc::clone(&tree)));
+        tree
+    }
+
+    fn reparse_with_viewport(&self, width: f32, height: f32) -> Option<usvg::Tree> {
+        let text = &*self.source;
+        let xml_options = || roxmltree::ParsingOptions {
+            allow_dtd: true,
+            ..Default::default()
+        };
+        let doc = roxmltree::Document::parse_with_options(text, xml_options()).ok()?;
+        let root = doc.root_element();
+
+        // Blank out any declared root width/height (their byte ranges are
+        // known from the parsed document), then insert the viewport size as
+        // new attributes right after the root tag name.
+        let mut patched = text.to_string();
+        for attr in root.attributes() {
+            if matches!(attr.name(), "width" | "height") {
+                patched.replace_range(attr.range(), &" ".repeat(attr.range().len()));
+            }
+        }
+        let tag = root.tag_name();
+        let tag_len = match tag
+            .namespace()
+            .and_then(|ns| doc.root_element().lookup_prefix(ns))
+        {
+            Some(prefix) if !prefix.is_empty() => prefix.len() + 1 + tag.name().len(),
+            _ => tag.name().len(),
+        };
+        let insert_at = root.range().start + 1 + tag_len;
+        patched.insert_str(
+            insert_at,
+            &format!(" width=\"{width}px\" height=\"{height}px\""),
+        );
+
+        let patched_doc = roxmltree::Document::parse_with_options(&patched, xml_options()).ok()?;
+        let options = usvg::Options {
+            fontdb: Arc::clone(&*crate::util::FONT_DB),
+            ..Default::default()
+        };
+        usvg::Tree::from_xmltree(&patched_doc, &options).ok()
     }
 
     /// The intrinsic width in CSS px, present only when the root `<svg>`

--- a/packages/blitz-dom/src/node/svg.rs
+++ b/packages/blitz-dom/src/node/svg.rs
@@ -92,39 +92,70 @@ impl SvgImageData {
         };
 
         let text = std::str::from_utf8(data).map_err(|_| usvg::Error::NotAnUtf8Str)?;
-        let xml_options = roxmltree::ParsingOptions {
+        let xml_options = || roxmltree::ParsingOptions {
             allow_dtd: true,
             ..Default::default()
         };
-        let doc = roxmltree::Document::parse_with_options(text, xml_options)
+        let doc = roxmltree::Document::parse_with_options(text, xml_options())
             .map_err(usvg::Error::ParsingFailed)?;
-        let tree = usvg::Tree::from_xmltree(&doc, options)?;
+        let intrinsic_dimensions = SvgIntrinsicDimensions::from_xmltree(&doc);
+
+        // usvg refuses to parse an SVG whose root `width`/`height` resolve to
+        // a zero or negative size, but such an SVG is still a valid image: the
+        // degenerate attribute gives a zero intrinsic dimension, and CSS can
+        // still size the element to something visible. Blank out the offending
+        // attributes (their byte ranges are known from the parsed document) so
+        // usvg resolves the viewport from the `viewBox`/defaults instead.
+        let degenerate_attr_ranges: Vec<std::ops::Range<usize>> = doc
+            .root_element()
+            .attributes()
+            .filter(|attr| {
+                matches!(attr.name(), "width" | "height")
+                    && attr
+                        .value()
+                        .parse::<svgtypes::Length>()
+                        .is_ok_and(|len| len.number <= 0.0)
+            })
+            .map(|attr| attr.range())
+            .collect();
+
+        let tree = if degenerate_attr_ranges.is_empty() {
+            usvg::Tree::from_xmltree(&doc, options)?
+        } else {
+            let mut patched = text.as_bytes().to_vec();
+            for range in degenerate_attr_ranges {
+                patched[range].fill(b' ');
+            }
+            let patched = std::str::from_utf8(&patched).map_err(|_| usvg::Error::NotAnUtf8Str)?;
+            let patched_doc = roxmltree::Document::parse_with_options(patched, xml_options())
+                .map_err(usvg::Error::ParsingFailed)?;
+            usvg::Tree::from_xmltree(&patched_doc, options)?
+        };
+
         Ok(Self {
             tree: Arc::new(tree),
-            intrinsic_dimensions: SvgIntrinsicDimensions::from_xmltree(&doc),
+            intrinsic_dimensions,
         })
     }
 
     /// The intrinsic width in CSS px, present only when the root `<svg>`
-    /// declared an absolute (non-percentage) `width`.
+    /// declared an absolute (non-percentage) `width`. A zero or negative
+    /// declared width is a zero intrinsic width (matching browsers), not an
+    /// absent one.
+    ///
+    /// Viewport-relative lengths (`vw`/`vh`/`vmin`/`vmax`) fail to parse as an
+    /// [`svgtypes::Length`] and so are already absent from
+    /// [`SvgIntrinsicDimensions`]; like percentages, they contribute no
+    /// intrinsic dimension.
     pub fn intrinsic_width(&self) -> Option<f32> {
-        use svgtypes::LengthUnit;
-        let declared = self
-            .intrinsic_dimensions
-            .width
-            .is_some_and(|len| len.unit != LengthUnit::Percent);
-        declared.then(|| self.tree.size().width())
+        self.intrinsic_dimensions.width.and_then(resolve_absolute)
     }
 
     /// The intrinsic height in CSS px, present only when the root `<svg>`
-    /// declared an absolute (non-percentage) `height`.
+    /// declared an absolute (non-percentage) `height`. See
+    /// [`Self::intrinsic_width`].
     pub fn intrinsic_height(&self) -> Option<f32> {
-        use svgtypes::LengthUnit;
-        let declared = self
-            .intrinsic_dimensions
-            .height
-            .is_some_and(|len| len.unit != LengthUnit::Percent);
-        declared.then(|| self.tree.size().height())
+        self.intrinsic_dimensions.height.and_then(resolve_absolute)
     }
 
     /// The aspect ratio of the root `<svg>`'s `viewBox`, if it declares one.
@@ -143,7 +174,7 @@ impl SvgImageData {
     pub fn resolved_width(&self, container_width: Option<f32>) -> Option<f32> {
         use svgtypes::LengthUnit;
         match self.intrinsic_dimensions.width {
-            Some(len) if len.unit != LengthUnit::Percent => Some(self.tree.size().width()),
+            Some(len) if len.unit != LengthUnit::Percent => resolve_absolute(len),
             Some(len) => container_width.map(|cw| cw * (len.number as f32) / 100.0),
             None => None,
         }
@@ -154,48 +185,89 @@ impl SvgImageData {
     pub fn resolved_height(&self, container_height: Option<f32>) -> Option<f32> {
         use svgtypes::LengthUnit;
         match self.intrinsic_dimensions.height {
-            Some(len) if len.unit != LengthUnit::Percent => Some(self.tree.size().height()),
+            Some(len) if len.unit != LengthUnit::Percent => resolve_absolute(len),
             Some(len) => container_height.map(|ch| ch * (len.number as f32) / 100.0),
             None => None,
         }
     }
 
     /// The intrinsic aspect ratio of the SVG: the ratio of its declared
-    /// `width`/`height` when both are absolute lengths, otherwise the
-    /// `viewBox` ratio, otherwise the ratio of the resolved
-    /// [`usvg::Tree::size`] (which is always non-zero).
-    pub fn aspect_ratio(&self) -> f32 {
+    /// `width`/`height` when both are (positive) absolute lengths, otherwise
+    /// the `viewBox` ratio. An SVG with neither has no intrinsic aspect ratio:
+    /// in particular the resolved [`usvg::Tree::size`] must not supply one, as
+    /// it is a rendering fallback rather than an intrinsic dimension.
+    pub fn aspect_ratio(&self) -> Option<f32> {
         match (self.intrinsic_width(), self.intrinsic_height()) {
-            (Some(w), Some(h)) => w / h,
-            _ => self.viewbox_aspect_ratio().unwrap_or_else(|| {
-                let size = self.tree.size();
-                size.width() / size.height()
-            }),
+            (Some(w), Some(h)) => (w > 0.0 && h > 0.0).then(|| w / h),
+            _ => self.viewbox_aspect_ratio(),
         }
     }
 
-    /// The intrinsic dimensions of the SVG resolved per CSS replaced element
-    /// sizing: a missing dimension is computed from the declared one and the
-    /// intrinsic aspect ratio; if neither is declared, the resolved
-    /// [`usvg::Tree::size`] is used as a fallback.
+    /// Whether rendering of the SVG content is disabled per the SVG spec: the
+    /// root declared a zero/negative `width` or `height`, or a `viewBox` with
+    /// a zero width or height. The element still generates a (potentially
+    /// CSS-sized) box; only its content is not painted.
+    pub fn rendering_disabled(&self) -> bool {
+        self.intrinsic_dimensions.degenerate_view_box
+            || self
+                .intrinsic_dimensions
+                .width
+                .is_some_and(|len| len.number <= 0.0)
+            || self
+                .intrinsic_dimensions
+                .height
+                .is_some_and(|len| len.number <= 0.0)
+    }
+
+    /// The intrinsic dimensions of the SVG resolved per the CSS default
+    /// sizing algorithm with no specified size
+    /// (https://drafts.csswg.org/css-images/#default-sizing): a missing
+    /// dimension is computed from the declared one and the intrinsic aspect
+    /// ratio, falling back to the 300x150 default object size.
     pub fn intrinsic_size(&self) -> (f32, f32) {
-        let aspect_ratio = self.aspect_ratio();
+        self.concrete_object_size((300.0, 150.0))
+    }
+
+    /// The concrete object size of the SVG per the CSS default sizing
+    /// algorithm (https://drafts.csswg.org/css-images/#default-sizing) with no
+    /// specified size: a missing dimension is computed from the declared one
+    /// and the intrinsic aspect ratio, falling back to the given default
+    /// object size.
+    pub fn concrete_object_size(&self, default_object_size: (f32, f32)) -> (f32, f32) {
+        let (default_width, default_height) = default_object_size;
+        let ratio = self.aspect_ratio();
         match (self.intrinsic_width(), self.intrinsic_height()) {
             (Some(w), Some(h)) => (w, h),
-            (Some(w), None) => (w, w / aspect_ratio),
-            (None, Some(h)) => (h * aspect_ratio, h),
-            (None, None) => {
-                // No intrinsic dimensions. If there is an intrinsic aspect ratio, apply
-                // the CSS default sizing algorithm: contain within the default object
-                // size of 300x150. Otherwise fall back to the resolved tree size.
-                if self.viewbox_aspect_ratio().is_some() {
-                    let scale = (300.0 / aspect_ratio).min(150.0);
-                    (scale * aspect_ratio, scale)
-                } else {
-                    let size = self.tree.size();
-                    (size.width(), size.height())
+            (Some(w), None) => (w, ratio.map(|r| w / r).unwrap_or(default_height)),
+            (None, Some(h)) => (ratio.map(|r| h * r).unwrap_or(default_width), h),
+            (None, None) => match ratio {
+                Some(ratio) => {
+                    let scale = (default_width / ratio).min(default_height);
+                    (scale * ratio, scale)
                 }
-            }
+                None => (default_width, default_height),
+            },
         }
     }
+}
+
+/// Resolve an absolute (non-percentage) SVG length to CSS px, using the same
+/// unit factors as usvg with default options (font-size 16px). Negative
+/// lengths clamp to zero: browsers treat a negative root `width`/`height` as a
+/// zero intrinsic dimension. Percentages resolve to `None` as they have no
+/// context-free value.
+fn resolve_absolute(len: svgtypes::Length) -> Option<f32> {
+    use svgtypes::LengthUnit;
+    let px_per_unit = match len.unit {
+        LengthUnit::None | LengthUnit::Px => 1.0,
+        LengthUnit::Em => 16.0,
+        LengthUnit::Ex => 8.0,
+        LengthUnit::In => 96.0,
+        LengthUnit::Cm => 96.0 / 2.54,
+        LengthUnit::Mm => 96.0 / 25.4,
+        LengthUnit::Pt => 96.0 / 72.0,
+        LengthUnit::Pc => 16.0,
+        LengthUnit::Percent => return None,
+    };
+    Some((len.number as f32 * px_per_unit).max(0.0))
 }

--- a/packages/blitz-dom/src/util.rs
+++ b/packages/blitz-dom/src/util.rs
@@ -199,7 +199,7 @@ mod svg_tests {
         assert_eq!(svg.intrinsic_width(), None);
         assert_eq!(svg.intrinsic_height(), None);
         // The aspect ratio is still available from the viewBox.
-        assert!((svg.aspect_ratio() - (485.0 / 58.0)).abs() < 1e-3);
+        assert!((svg.aspect_ratio().unwrap() - (485.0 / 58.0)).abs() < 1e-3);
     }
 
     #[test]
@@ -232,6 +232,47 @@ mod svg_tests {
         let svg = parse_svg_image(src).unwrap();
         assert_eq!(svg.intrinsic_width(), None);
         assert_eq!(svg.intrinsic_height(), None);
+    }
+
+    #[test]
+    fn viewport_relative_dimensions_are_not_intrinsic() {
+        // Viewport-relative units behave like percentages for intrinsic
+        // sizing: no intrinsic dimension in that axis.
+        let src = br#"<svg xmlns="http://www.w3.org/2000/svg" width="100vw" height="50vh" viewBox="0 0 200 100"></svg>"#;
+        let svg = parse_svg_image(src).unwrap();
+        assert_eq!(svg.intrinsic_width(), None);
+        assert_eq!(svg.intrinsic_height(), None);
+        assert_eq!(svg.aspect_ratio(), Some(2.0));
+    }
+
+    #[test]
+    fn zero_and_negative_dimensions_are_zero_intrinsic() {
+        // A zero or negative width/height is a *zero* intrinsic dimension
+        // (matching browsers), and the SVG must still parse even though usvg
+        // rejects non-positive sizes.
+        let src = br#"<svg xmlns="http://www.w3.org/2000/svg" width="0" height="50"><rect width="10" height="10"/></svg>"#;
+        let svg = parse_svg_image(src).unwrap();
+        assert_eq!(svg.intrinsic_width(), Some(0.0));
+        assert_eq!(svg.intrinsic_height(), Some(50.0));
+        assert_eq!(svg.aspect_ratio(), None);
+
+        let src = br#"<svg xmlns="http://www.w3.org/2000/svg" width="-100" height="-50" viewBox="0 0 100 50"></svg>"#;
+        let svg = parse_svg_image(src).unwrap();
+        assert_eq!(svg.intrinsic_width(), Some(0.0));
+        assert_eq!(svg.intrinsic_height(), Some(0.0));
+        assert_eq!(svg.aspect_ratio(), None);
+    }
+
+    #[test]
+    fn no_dimensions_and_no_viewbox_has_no_intrinsic_ratio() {
+        let src =
+            br#"<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>"#;
+        let svg = parse_svg_image(src).unwrap();
+        assert_eq!(svg.intrinsic_width(), None);
+        assert_eq!(svg.intrinsic_height(), None);
+        assert_eq!(svg.aspect_ratio(), None);
+        // Default object size fallback
+        assert_eq!(svg.intrinsic_size(), (300.0, 150.0));
     }
 }
 

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -956,6 +956,33 @@ impl ElementCx<'_, '_> {
         let x = self.frame.content_box.origin().x;
         let y = self.frame.content_box.origin().y;
 
+        let container_size = taffy::Size {
+            width: width as f32,
+            height: height as f32,
+        };
+
+        // Inline `<svg>` elements are not sized with object-fit: the CSS box
+        // *is* the SVG viewport. Re-parse with the viewport forced to the
+        // CSS box size so that percentage lengths and the
+        // `viewBox`/`preserveAspectRatio` mapping resolve against it, then
+        // render at 1:1 in CSS pixels.
+        let is_inline_svg = *self.element.name.local == *"svg";
+        if is_inline_svg {
+            // `zoom` scales the CSS box but not the SVG user units, so it
+            // contributes to the user-unit scale like the device scale does.
+            let scale = self.scale * self.style.effective_zoom.value() as f64;
+            let tree = svg.tree_for_viewport(
+                container_size.width / scale as f32,
+                container_size.height / scale as f32,
+            );
+            let transform = self
+                .transform
+                .pre_scale(scale)
+                .then_translate(Vec2 { x, y });
+            anyrender_svg::render_svg_tree(scene, &tree, transform);
+            return;
+        }
+
         let object_fit = self.style.clone_object_fit();
         let object_position = self.style.clone_object_position();
 
@@ -963,10 +990,6 @@ impl ElementCx<'_, '_> {
         // the CSS default sizing algorithm using the content box as the
         // default object size, so an SVG with no intrinsic dimensions fills
         // the box.
-        let container_size = taffy::Size {
-            width: width as f32,
-            height: height as f32,
-        };
         let scale = self.scale as f32;
         let (natural_width, natural_height) =
             svg.concrete_object_size((container_size.width / scale, container_size.height / scale));
@@ -976,9 +999,16 @@ impl ElementCx<'_, '_> {
         };
         let paint_size = compute_object_fit(container_size, Some(object_size), object_fit);
 
-        // The SVG tree renders in its own coordinate system given by
-        // `usvg::Tree::size`; scale it to the painted size.
-        let svg = &svg.tree;
+        // The concrete object size is the SVG's viewport. Without a viewBox,
+        // percentage lengths inside the SVG resolve against the viewport, so
+        // re-parse with the viewport forced to the concrete size rather than
+        // scaling from usvg's fallback size. With a viewBox the mapping to
+        // the viewport is a plain scale, handled below via `tree.size`.
+        let svg = if svg.intrinsic_dimensions.view_box_size.is_none() {
+            svg.tree_for_viewport(natural_width, natural_height)
+        } else {
+            Arc::clone(&svg.tree)
+        };
         let svg_size = svg.size();
         let render_size = taffy::Size {
             width: svg_size.width(),
@@ -1003,7 +1033,7 @@ impl ElementCx<'_, '_> {
             .pre_scale_non_uniform(x_scale, y_scale)
             .then_translate(Vec2 { x, y });
 
-        anyrender_svg::render_svg_tree(scene, svg, transform);
+        anyrender_svg::render_svg_tree(scene, &svg, transform);
     }
 
     fn draw_image(&self, scene: &mut impl PaintScene) {

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -555,7 +555,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             element,
             transform,
             #[cfg(feature = "svg")]
-            svg: element.svg_data(),
+            svg: element.svg_image_data(),
             text_input: element.text_input_data(),
             list_item: element.list_item_data.as_deref(),
             devtools: self.dom.devtools(),
@@ -601,7 +601,7 @@ struct ElementCx<'dom, 'a> {
     element: &'dom ElementData,
     transform: Affine,
     #[cfg(feature = "svg")]
-    svg: Option<&'dom usvg::Tree>,
+    svg: Option<&'dom blitz_dom::node::SvgImageData>,
     text_input: Option<&'dom TextInputData>,
     list_item: Option<&'dom ListItemLayout>,
     devtools: &'dom DevtoolSettings,
@@ -941,32 +941,49 @@ impl ElementCx<'_, '_> {
 
     #[cfg(feature = "svg")]
     fn draw_svg(&self, scene: &mut impl PaintScene) {
-        use style::properties::generated::longhands::object_fit::computed_value::T as ObjectFit;
-
         let Some(svg) = self.svg else {
             return;
         };
 
+        // A zero/negative root width/height or a zero-sized `viewBox`
+        // disables rendering of the SVG
+        if svg.rendering_disabled() {
+            return;
+        }
         let width = self.frame.content_box.width() as u32;
         let height = self.frame.content_box.height() as u32;
-        let svg_size = svg.size();
 
         let x = self.frame.content_box.origin().x;
         let y = self.frame.content_box.origin().y;
 
-        // let object_fit = self.style.clone_object_fit();
+        let object_fit = self.style.clone_object_fit();
         let object_position = self.style.clone_object_position();
 
-        // Apply object-fit algorithm
+        // Apply object-fit algorithm. The natural object size is resolved per
+        // the CSS default sizing algorithm using the content box as the
+        // default object size, so an SVG with no intrinsic dimensions fills
+        // the box.
         let container_size = taffy::Size {
             width: width as f32,
             height: height as f32,
         };
+        let scale = self.scale as f32;
+        let (natural_width, natural_height) =
+            svg.concrete_object_size((container_size.width / scale, container_size.height / scale));
         let object_size = taffy::Size {
+            width: natural_width * scale,
+            height: natural_height * scale,
+        };
+        let paint_size = compute_object_fit(container_size, Some(object_size), object_fit);
+
+        // The SVG tree renders in its own coordinate system given by
+        // `usvg::Tree::size`; scale it to the painted size.
+        let svg = &svg.tree;
+        let svg_size = svg.size();
+        let render_size = taffy::Size {
             width: svg_size.width(),
             height: svg_size.height(),
         };
-        let paint_size = compute_object_fit(container_size, Some(object_size), ObjectFit::Contain);
 
         // Compute object-position
         let x_offset = object_position.horizontal.resolve(
@@ -978,8 +995,8 @@ impl ElementCx<'_, '_> {
         let x = x + x_offset.px() as f64;
         let y = y + y_offset.px() as f64;
 
-        let x_scale = paint_size.width as f64 / object_size.width as f64;
-        let y_scale = paint_size.height as f64 / object_size.height as f64;
+        let x_scale = paint_size.width as f64 / render_size.width as f64;
+        let y_scale = paint_size.height as f64 / render_size.height as f64;
 
         let transform = self
             .transform

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -322,8 +322,9 @@ impl ElementCx<'_, '_> {
             return;
         };
 
-        // A zero-sized `viewBox` disables rendering of the SVG
-        if svg.intrinsic_dimensions.degenerate_view_box {
+        // A zero/negative root width/height or a zero-sized `viewBox`
+        // disables rendering of the SVG
+        if svg.rendering_disabled() {
             return;
         }
 
@@ -343,13 +344,9 @@ impl ElementCx<'_, '_> {
         // may lack an intrinsic width, height, and/or aspect ratio, so each is
         // passed separately (usvg's resolved `Tree::size` is only used as the
         // source coordinate space of the rendered tree).
-        let intrinsic_width = svg.intrinsic_width().filter(|w| w.is_finite() && *w > 0.0);
-        let intrinsic_height = svg.intrinsic_height().filter(|h| h.is_finite() && *h > 0.0);
-        let aspect_ratio = match (intrinsic_width, intrinsic_height) {
-            (Some(w), Some(h)) => Some(w / h),
-            _ => svg.viewbox_aspect_ratio(),
-        }
-        .filter(|r| r.is_finite() && *r > 0.0);
+        let intrinsic_width = svg.intrinsic_width().filter(|w| w.is_finite());
+        let intrinsic_height = svg.intrinsic_height().filter(|h| h.is_finite());
+        let aspect_ratio = svg.aspect_ratio().filter(|r| r.is_finite() && *r > 0.0);
 
         let bg_size = compute_layer_size(
             layer,


### PR DESCRIPTION
## Summary

Fixes CSS intrinsic sizing for SVG per SVG2 "Sizing SVG in CSS" / css-images-3, closing the gaps left by #726/#730/#732:

- **Viewport-relative units** (`vw`/`vh`/`vmin`/`vmax`) on the root `width`/`height` contribute no intrinsic dimension (like percentages). They fail to parse as `svgtypes::Length`, so `SvgIntrinsicDimensions` now simply records them as absent; intrinsic dims are resolved from the declared length via a new `resolve_absolute` helper (usvg unit factors) instead of trusting `usvg::Tree::size()`.
- **Zero/negative root `width`/`height`**: a zero *intrinsic* dimension (matching browsers), and rendering of the SVG content is disabled (`SvgImageData::rendering_disabled()`, checked in both `draw_svg` and background painting alongside `degenerate_view_box`). usvg refuses to parse non-positive sizes, so the offending attributes are blanked out (via their `roxmltree` byte ranges) before building the tree, keeping the image usable when CSS sizes it.
- **No tree-size ratio leak**: `aspect_ratio()` now returns `Option<f32>` — declared width/height ratio only when both are positive absolute lengths, else the `viewBox` ratio, else `None`. The old fallback to `usvg::Tree::size()` ratio (and the layout fallback feeding tree size as intrinsic dims) is gone; layout now feeds `IntrinsicSizes { width, height, ratio }` straight from the accessors with the standard 300×150 default object size.
- **Painting via default sizing**: `draw_svg` previously hardcoded `object-fit: contain` against the usvg tree size. It now resolves the natural object size with `concrete_object_size(default = content box)` (so a dimensionless SVG fills its box) and honors the actual `object-fit` property.
- **Replaced layout**: when only one natural dimension exists, the missing one now transfers through the `aspect-ratio` property (converting through `box-sizing`), not just the intrinsic ratio:

```rust
// packages/blitz-dom/src/layout/replaced.rs
height = intrinsic_ratio.map(|r| w / r)
    .or(style_ratio.map(|r| (w + box_sizing_adj.width) / r - box_sizing_adj.height))
    .unwrap_or(default_size.height)
```

- **Inline `<svg>` painting is now viewport-aware**: the CSS box is the SVG viewport, so percentage lengths inside the SVG and the `viewBox`/`preserveAspectRatio` mapping must resolve against it. `SvgImageData::tree_for_viewport(w, h)` re-parses the (cached) source with the root `width`/`height` overridden to the box size, and inline painting renders that tree at `scale * effective_zoom` (`zoom` scales the CSS box but not user units). SVG-as-image without a `viewBox` uses the same path with the concrete object size; with a `viewBox` the plain tree-size scale is kept.
- **UA stylesheet**: added `@namespace svg` and `svg|svg { overflow: hidden }` per the SVG2 UA sheet (the bare `svg` selector was matching the HTML default namespace, so inline SVG overflow was never clipped).

Inline `<svg>` `width`/`height` attrs map to CSS width/height as presentational hints in `stylo.rs`; `resolved_width`/`resolved_height` are unused by layout.

## WPT results (local per-test comparison vs base `06c4a704`, WPT_DIR=~/repos/wpt)

| Suite | main | this PR |
|---|---|---|
| css/css-backgrounds | 471 | 471 |
| css/css-images | 135 | 135 |
| css/css-sizing | 321 | **328** |
| css/CSS2 | 3862 | **3892** |
| css/css-transforms | 413 | **430** |
| css/css-overflow | 151 | **152** |
| css/filter-effects | 155 | 155 |
| css/css-masking | 164 | 164 |
| svg | 84 | **86** |

Net **+58 / -1** across these suites. The earlier CI-reported replaced/filter/mask regressions came from the first pushed revision (inline SVG was sized via presentational hints but still painted with the old tree-size mapping); the viewport-aware painting above fixes all of them.

The single remaining regression is `svg/render/reftests/nested-svg-overflow-clip.html`: it passed on main only by accident (usvg sized the tree to its 250px content and blitz scaled it down into the 100px box). usvg flattens nested `<svg>` without implementing its viewport clipping, so fixing it properly requires upstream usvg support.

`cargo test --workspace`, `cargo fmt`, and `cargo clippy --workspace` are clean; unit tests cover viewport units, zero/negative dimensions, and the no-viewBox no-ratio case.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/961449e5b9814de886799ea728946822
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**56** newly passing, **1** newly failing (net +55).

<details>
<summary>Full diff (57 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/floats-clear/float-replaced-height-006.xht
+ Fail => Pass css/CSS2/floats-clear/float-replaced-width-007.xht
+ Fail => Pass css/CSS2/inline-svg-intrinsic-size-100-percent-2.html
+ Fail => Pass css/CSS2/normal-flow/block-replaced-height-006.xht
+ Fail => Pass css/CSS2/normal-flow/block-replaced-width-002.xht
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-height-006.xht
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-height-009.xht
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-width-002.xht
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-width-007.xht
+ Fail => Pass css/CSS2/normal-flow/inline-block-replaced-width-008.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-height-006.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-height-009.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-width-002.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-width-008.xht
+ Fail => Pass css/CSS2/normal-flow/inline-replaced-width-009.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-006.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-013.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-020.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-027.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-height-034.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-002.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-003a.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-003c.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-009.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-023.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-030.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-037.xht
+ Fail => Pass css/CSS2/positioning/absolute-replaced-width-051.xht
+ Fail => Pass css/CSS2/visudet/replaced-elements-max-width-40.html
+ Fail => Pass css/CSS2/visudet/replaced-elements-width-40.html
- Pass => Fail css/compositing/mix-blend-mode/mix-blend-mode-svg.html
+ Fail => Pass css/css-flexbox/svg-root-as-flex-item-002.html
+ Fail => Pass css/css-overflow/overflow-img-svg.html
+ Fail => Pass css/css-sizing/aspect-ratio/replaced-element-004.html
+ Fail => Pass css/css-sizing/aspect-ratio/replaced-element-010.html
+ Fail => Pass css/css-sizing/image-fractional-height-with-wide-aspect-ratio.html
+ Fail => Pass css/css-sizing/intrinsic-size-fallback-replaced.html
+ Fail => Pass css/css-sizing/svg-intrinsic-size-002.html
+ Fail => Pass css/css-sizing/svg-intrinsic-size-003.html
+ Fail => Pass css/css-sizing/svg-intrinsic-size-008.html
+ Fail => Pass css/css-transforms/css-skew-002.html
+ Fail => Pass css/css-transforms/gradientTransform/svg-gradientTransform-combination-001.html
+ Fail => Pass css/css-transforms/group/svg-transform-group-008.html
+ Fail => Pass css/css-transforms/group/svg-transform-group-011.html
+ Fail => Pass css/css-transforms/group/svg-transform-nested-008.html
+ Fail => Pass css/css-transforms/group/svg-transform-nested-013.html
+ Fail => Pass css/css-transforms/group/svg-transform-nested-018.html
+ Fail => Pass css/css-transforms/group/svg-transform-nested-021.html
+ Fail => Pass css/css-transforms/group/svg-transform-nested-029.html
+ Fail => Pass css/css-transforms/scale/svg-scale-006.html
+ Fail => Pass css/css-transforms/scale/svg-scale-007.html
+ Fail => Pass css/css-transforms/skewX/svg-skewx-001.html
+ Fail => Pass css/css-transforms/skewX/svg-skewx-006.html
+ Fail => Pass css/css-transforms/skewX/svg-skewx-011.html
+ Fail => Pass css/css-transforms/skewX/svg-skewx-016.html
+ Fail => Pass css/css-transforms/skewX/svg-skewx-021.html
+ Fail => Pass css/css-transforms/translate/svg-translate-with-units.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32050439171).</sub>
<!-- wpt-results-end -->
