### PR TITLE
Fix HTTP cache directory on iOS

### DIFF
--- a/packages/blitz-net/src/lib.rs
+++ b/packages/blitz-net/src/lib.rs
@@ -37,11 +37,23 @@ type RequestBuilder = reqwest::RequestBuilder;
 
 #[cfg(feature = "cache")]
 fn get_cache_path() -> std::path::PathBuf {
-    use directories::ProjectDirs;
-    let path = ProjectDirs::from("com", "DioxusLabs", "Blitz")
-        .expect("Failed to find cache directory")
-        .cache_dir()
-        .to_owned();
+    // iOS apps are sandboxed with a per-app Caches directory, and the sandbox
+    // only permits paths that case-match its canonical layout, so the
+    // ProjectDirs convention (a mixed-case bundle-id directory) cannot be
+    // created. Use a subdirectory of the app's own Caches directory instead.
+    #[cfg(target_os = "ios")]
+    let path = {
+        let home = std::env::var_os("HOME").expect("Failed to find cache directory");
+        std::path::PathBuf::from(home).join("Library/Caches/http-cache")
+    };
+    #[cfg(not(target_os = "ios"))]
+    let path = {
+        use directories::ProjectDirs;
+        ProjectDirs::from("com", "DioxusLabs", "Blitz")
+            .expect("Failed to find cache directory")
+            .cache_dir()
+            .to_owned()
+    };
     #[cfg(feature = "tracing")]
     tracing::info!(path = ?path.display(), "Using cache dir");
     path


### PR DESCRIPTION
## Summary

On iOS the browser fails to load any page when the `cache` feature is enabled: `http-cache-reqwest`/`cacache` can't create its cache directory and every request errors with "Failed to create cache directory for temporary files".

Root cause: `get_cache_path()` uses the `ProjectDirs` convention, which yields `Library/Caches/com.DioxusLabs.Blitz` (mixed case). The iOS sandbox has already created the canonical lowercase `Library/Caches/com.dioxuslabs.blitz` directory, and on the case-insensitive-but-case-preserving sandbox FS, `create_dir_all` sees the mixed-case path as existing while file writes inside it resolve to a path the sandbox denies — so cacache's temp-file setup fails.

Fix: on iOS, use a subdirectory of the app sandbox's own Caches directory instead of the `ProjectDirs` path:

```rust
#[cfg(target_os = "ios")]
let path = PathBuf::from(env::var_os("HOME")?).join("Library/Caches/http-cache");
#[cfg(not(target_os = "ios"))]
let path = ProjectDirs::from("com", "DioxusLabs", "Blitz")?.cache_dir().to_owned();
```

Non-iOS platforms are unchanged.

Verified on the iPhone 17 simulator (iOS 26.5): example.com loads with caching enabled and the cacache store is created under the app's `Library/Caches/http-cache`.

Android cache support is implemented on top of this in a follow-up PR.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/4cdd57b070834fc8af874a8aed768c65
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32147169971).</sub>
<!-- wpt-results-end -->
