### PR TITLE
Add Android HTTP cache support

### DIFF
--- a/apps/browser/Cargo.toml
+++ b/apps/browser/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [features]
 default = ["hybrid", "cookies", "cache", "screenshot", "apple-font-embolden", "scrollbars"]
-android-defaults = ["skia", "cookies"]
+android-defaults = ["skia", "cookies", "cache"]
 
 screenshot = ["dep:anyrender_vello_cpu", "dep:blitz-paint", "dep:png", "dep:peniko", "dep:rfd"]
 capture = ["dep:anyrender_serialize", "dep:blitz-paint", "dep:png", "dep:peniko", "dep:rfd"]

--- a/packages/blitz-net/src/lib.rs
+++ b/packages/blitz-net/src/lib.rs
@@ -36,27 +36,28 @@ type RequestBuilder = reqwest_middleware::RequestBuilder;
 type RequestBuilder = reqwest::RequestBuilder;
 
 #[cfg(feature = "cache")]
-fn get_cache_path() -> std::path::PathBuf {
+fn default_cache_dir() -> Option<std::path::PathBuf> {
     // iOS apps are sandboxed with a per-app Caches directory, and the sandbox
     // only permits paths that case-match its canonical layout, so the
     // ProjectDirs convention (a mixed-case bundle-id directory) cannot be
     // created. Use a subdirectory of the app's own Caches directory instead.
     #[cfg(target_os = "ios")]
-    let path = {
-        let home = std::env::var_os("HOME").expect("Failed to find cache directory");
-        std::path::PathBuf::from(home).join("Library/Caches/http-cache")
-    };
-    #[cfg(not(target_os = "ios"))]
-    let path = {
+    {
+        let home = std::env::var_os("HOME")?;
+        Some(std::path::PathBuf::from(home).join("Library/Caches/http-cache"))
+    }
+    // On Android the cache directory can only be determined from the app's
+    // Context, so embedders must supply it via `Provider::with_cache_dir`.
+    #[cfg(target_os = "android")]
+    {
+        None
+    }
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    {
         use directories::ProjectDirs;
-        ProjectDirs::from("com", "DioxusLabs", "Blitz")
-            .expect("Failed to find cache directory")
-            .cache_dir()
-            .to_owned()
-    };
-    #[cfg(feature = "tracing")]
-    tracing::info!(path = ?path.display(), "Using cache dir");
-    path
+        let dirs = ProjectDirs::from("com", "DioxusLabs", "Blitz")?;
+        Some(dirs.cache_dir().to_owned())
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -80,40 +81,66 @@ pub struct Provider {
     waker: Arc<dyn NetWaker>,
     per_host_limits: HostLimits,
     #[cfg(feature = "cache")]
-    cache_manager: CACacheManager,
+    cache_manager: Option<CACacheManager>,
 }
 impl Provider {
     pub fn new(waker: Option<Arc<dyn NetWaker>>) -> Self {
+        #[cfg(feature = "cache")]
+        let cache_dir = default_cache_dir();
+        #[cfg(not(feature = "cache"))]
+        let cache_dir = None;
+        Self::with_cache_dir(waker, cache_dir)
+    }
+
+    /// Create a Provider that stores its HTTP cache in `cache_dir`. Use this on
+    /// platforms where the cache location must be obtained from the app (e.g.
+    /// Android's `Context.getCacheDir()`). Ignored unless the `cache` feature
+    /// is enabled. `None` disables HTTP caching.
+    pub fn with_cache_dir(
+        waker: Option<Arc<dyn NetWaker>>,
+        cache_dir: Option<std::path::PathBuf>,
+    ) -> Self {
+        #[cfg(not(feature = "cache"))]
+        let _ = cache_dir;
+
         let builder = reqwest::Client::builder();
         #[cfg(feature = "cookies")]
         let builder = builder.cookie_store(true);
         let client = builder.build().unwrap();
 
         #[cfg(feature = "cache")]
-        let cache_manager = CACacheManager::new(get_cache_path(), true);
+        let cache_manager = cache_dir.map(|dir| {
+            #[cfg(feature = "tracing")]
+            tracing::info!(path = ?dir.display(), "Using cache dir");
+            CACacheManager::new(dir, true)
+        });
 
         #[cfg(feature = "cache")]
-        let client = reqwest_middleware::ClientBuilder::new(client)
-            .with(Cache(HttpCache {
-                mode: CacheMode::Default,
-                manager: cache_manager.clone(),
-                options: HttpCacheOptions {
-                    // Evaluate cache policy as a single-user (private) cache, like a
-                    // real browser, rather than a shared/proxy cache. The default
-                    // (`shared: true`) treats any response carrying `Set-Cookie` without
-                    // an explicit `Cache-Control: public`/`immutable` as immediately
-                    // stale, forcing a revalidation request to the server on every load.
-                    // Many CDNs (e.g. Wikimedia image hosts) serve images this way, so
-                    // the shared-cache default defeats disk caching and gets us rate
-                    // limited. A private cache honours heuristic freshness instead.
-                    cache_options: Some(CacheOptions {
-                        shared: false,
+        let client = {
+            let mut builder = reqwest_middleware::ClientBuilder::new(client);
+            if let Some(cache_manager) = &cache_manager {
+                builder = builder.with(Cache(HttpCache {
+                    mode: CacheMode::Default,
+                    manager: cache_manager.clone(),
+                    options: HttpCacheOptions {
+                        // Evaluate cache policy as a single-user (private) cache, like a
+                        // real browser, rather than a shared/proxy cache. The default
+                        // (`shared: true`) treats any response carrying `Set-Cookie` without
+                        // an explicit `Cache-Control: public`/`immutable` as immediately
+                        // stale, forcing a revalidation request to the server on every load.
+                        // Many CDNs (e.g. Wikimedia image hosts) serve images this way, so
+                        // the shared-cache default defeats disk caching and gets us rate
+                        // limited. A private cache honours heuristic freshness instead.
+                        cache_options: Some(CacheOptions {
+                            shared: false,
+                            ..Default::default()
+                        }),
                         ..Default::default()
-                    }),
-                    ..Default::default()
-                },
-            }))
-            .build();
+                    },
+                }));
+            }
+            builder.build()
+        };
 
         let waker = waker.unwrap_or(Arc::new(DummyNetWaker));
         Self {
@@ -136,7 +163,10 @@ impl Provider {
 
     #[cfg(feature = "cache")]
     pub async fn clear_cache(&self) {
-        if let Err(e) = self.cache_manager.clear().await {
+        let Some(cache_manager) = &self.cache_manager else {
+            return;
+        };
+        if let Err(e) = cache_manager.clear().await {
             #[cfg(feature = "tracing")]
             tracing::error!("Failed to clear HTTP cache: {:?}", e);
             #[cfg(not(feature = "tracing"))]

--- a/packages/blitz-shell/src/lib.rs
+++ b/packages/blitz-shell/src/lib.rs
@@ -84,6 +84,17 @@ pub fn current_android_app() -> android_activity::AndroidApp {
     ANDROID_APP.get().unwrap().clone()
 }
 
+#[cfg(target_os = "android")]
+#[cfg_attr(docsrs, doc(cfg(target_os = "android")))]
+/// Get a directory suitable for storing the HTTP cache, derived from the
+/// app's internal data path (`<internal_data_path>/../cache` is the app's
+/// `Context.getCacheDir()`). Returns `None` if the android activity has not
+/// been set up with [`set_android_app`].
+pub fn android_http_cache_dir() -> Option<std::path::PathBuf> {
+    let data_path = ANDROID_APP.get()?.internal_data_path()?;
+    Some(data_path.parent()?.join("cache").join("http-cache"))
+}
+
 pub struct BlitzShellProvider {
     window: Arc<dyn Window>,
     proxy: BlitzShellProxy,

--- a/packages/dioxus-native/src/assets.rs
+++ b/packages/dioxus-native/src/assets.rs
@@ -17,7 +17,12 @@ impl DioxusNativeNetProvider {
         #[cfg(any(feature = "data-uri", feature = "net"))]
         let net_waker = Some(Arc::new(proxy) as _);
 
-        #[cfg(feature = "net")]
+        #[cfg(all(feature = "net", target_os = "android"))]
+        let inner_net_provider = Some(Arc::new(blitz_net::Provider::with_cache_dir(
+            net_waker.clone(),
+            blitz_shell::android_http_cache_dir(),
+        )) as Arc<dyn NetProvider>);
+        #[cfg(all(feature = "net", not(target_os = "android")))]
         let inner_net_provider = Some(blitz_net::Provider::shared(net_waker.clone()));
         #[cfg(all(feature = "data-uri", not(feature = "net")))]
         let inner_net_provider = Some(blitz_shell::DataUriNetProvider::shared(net_waker.clone()));

--- a/packages/dioxus-native/src/lib.rs
+++ b/packages/dioxus-native/src/lib.rs
@@ -185,6 +185,12 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
     #[cfg(all(feature = "net", not(target_arch = "wasm32")))]
     let net_provider = {
         let net_waker = Some(Arc::new(proxy.clone()) as _);
+        #[cfg(target_os = "android")]
+        let inner_net_provider = Arc::new(blitz_net::Provider::with_cache_dir(
+            net_waker,
+            blitz_shell::android_http_cache_dir(),
+        ));
+        #[cfg(not(target_os = "android"))]
         let inner_net_provider = Arc::new(blitz_net::Provider::new(net_waker));
         vdom.provide_root_context(Arc::clone(&inner_net_provider));
 


### PR DESCRIPTION
## Summary

Stacked on #737 (iOS cache-dir fix). Adds HTTP cache support on Android, where the cache directory can't be derived from conventions like `ProjectDirs` — it must come from the app's `Context` (`Context.getCacheDir()`).

- `blitz-net`: `Provider`'s cache manager becomes `Option<CACacheManager>`, and a new constructor lets embedders supply the cache location (with `None` disabling caching rather than panicking):
  ```rust
  impl Provider {
      pub fn new(waker) -> Self { Self::with_cache_dir(waker, default_cache_dir()) }
      pub fn with_cache_dir(waker, cache_dir: Option<PathBuf>) -> Self { ... }
  }
  ```
  `default_cache_dir()` returns `None` on Android (no way to know the dir without the app `Context`); iOS/desktop behavior is unchanged from #737.
- `blitz-shell`: new `android_http_cache_dir()` derives the cache dir from the registered `AndroidApp`'s `internal_data_path()` (`<internal_data_path>/../cache/http-cache`, i.e. inside `Context.getCacheDir()`).
- `dioxus-native`: on Android, constructs the provider via `Provider::with_cache_dir(waker, blitz_shell::android_http_cache_dir())`; other platforms keep using `Provider::new`.
- `browser`: `android-defaults` now enables the `cache` feature.

Verified via `cargo check -p browser --no-default-features --features android-defaults --target aarch64-linux-android` (no Android emulator available for a runtime test), plus workspace clippy/check and the iOS sim target.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/4cdd57b070834fc8af874a8aed768c65
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32147419608).</sub>
<!-- wpt-results-end -->
