### PR TITLE
Fix panic when selection anchor node is removed from the DOM

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -2663,6 +2663,17 @@ impl BaseDocument {
             None => return Vec::new(),
         };
 
+        // Guard against stale selection endpoints: nodes may have been removed from
+        // the document (e.g. by script) since the selection was made.
+        let node_is_in_doc = |node_id: NodeId| {
+            self.nodes
+                .get(node_id)
+                .is_some_and(|node| node.flags.is_in_document())
+        };
+        if !node_is_in_doc(anchor_node) || !node_is_in_doc(focus_node) {
+            return Vec::new();
+        }
+
         // Single node selection
         if anchor_node == focus_node {
             let start = self

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -827,6 +827,14 @@ impl<'doc> DocumentMutator<'doc> {
 
             let node = &mut doc.nodes[node_id];
 
+            // Clear the text selection if one of its endpoints references this node.
+            // This prevents stale selection endpoint references.
+            if doc.text_selection.anchor.node_or_parent == Some(node_id)
+                || doc.text_selection.focus.node_or_parent == Some(node_id)
+            {
+                doc.text_selection.clear();
+            }
+
             // Remove any snapshot for this node to prevent stale snapshot references
             // during style invalidation.
             if node.has_snapshot() {


### PR DESCRIPTION
## Summary

Extracted from #738 (independent of blitz-script).

`selected_text_ranges()` could panic (or return garbage) when a selection endpoint node was removed from the document after the selection was made (easy to trigger by script or dynamic DOM mutation). Two-part fix:

- `DocumentMutator::remove_node`: clear `doc.text_selection` when the removed node is one of the selection's `node_or_parent` endpoints.
- `BaseDocument::selected_text_ranges`: guard against stale endpoints by returning no ranges if either endpoint node is no longer `is_in_document()`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0382bf211c6147f1afc6a4f727093c56
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32163587640).</sub>
<!-- wpt-results-end -->
