### PR TITLE
blitz-html: add explicit XML (XHTML) parsing entry points

### DIFF
--- a/packages/blitz-html/src/html_document.rs
+++ b/packages/blitz-html/src/html_document.rs
@@ -35,8 +35,27 @@ impl Document for HtmlDocument {
 }
 
 impl HtmlDocument {
-    /// Parse HTML (or XHTML) into an [`HtmlDocument`]
-    pub fn from_html(html: &str, mut config: DocumentConfig) -> Self {
+    /// Parse HTML (or XHTML) into an [`HtmlDocument`].
+    ///
+    /// The content is sniffed to decide between HTML and XML parsing. Callers which
+    /// know the document is XHTML from out-of-band information (a `Content-Type`
+    /// header or an `.xht`/`.xhtml` file extension) should use
+    /// [`from_xml`](Self::from_xml) instead, as the sniffing cannot detect all
+    /// XHTML documents.
+    pub fn from_html(html: &str, config: DocumentConfig) -> Self {
+        Self::parse_with(html, config, DocumentHtmlParser::parse_into_mutator)
+    }
+
+    /// Parse XML (XHTML) into an [`HtmlDocument`]
+    pub fn from_xml(xml: &str, config: DocumentConfig) -> Self {
+        Self::parse_with(xml, config, DocumentHtmlParser::parse_xml_into_mutator)
+    }
+
+    fn parse_with(
+        content: &str,
+        mut config: DocumentConfig,
+        parse: impl for<'a, 'd> Fn(&'a mut blitz_dom::DocumentMutator<'d>, &str),
+    ) -> Self {
         if let Some(ss) = &mut config.ua_stylesheets {
             if !ss.iter().any(|s| s == DEFAULT_CSS) {
                 ss.push(String::from(DEFAULT_CSS));
@@ -44,7 +63,7 @@ impl HtmlDocument {
         }
         let mut doc = BaseDocument::new(config);
         let mut mutr = doc.mutate();
-        DocumentHtmlParser::parse_into_mutator(&mut mutr, html);
+        parse(&mut mutr, content);
         drop(mutr);
         HtmlDocument { inner: doc }
     }

--- a/packages/blitz-html/src/html_sink.rs
+++ b/packages/blitz-html/src/html_sink.rs
@@ -89,8 +89,6 @@ impl<'m, 'doc> DocumentHtmlParser<'m, 'doc> {
     }
 
     pub fn parse_into_mutator<'a, 'd>(mutr: &'a mut DocumentMutator<'d>, html: &str) {
-        let mut sink = DocumentHtmlParser::new(mutr);
-
         let is_xhtml_doc = html.starts_with("<?xml")
             || html.starts_with("<!DOCTYPE") && {
                 let first_line = html.lines().next().unwrap();
@@ -99,14 +97,10 @@ impl<'m, 'doc> DocumentHtmlParser<'m, 'doc> {
             || Self::root_element_has_xhtml_namespace(html);
 
         if is_xhtml_doc {
-            // Parse as XHTML
-            sink.is_xml = true;
-            xml5ever::driver::parse_document(sink, Default::default())
-                .from_utf8()
-                .read_from(&mut html.as_bytes())
-                .unwrap();
+            Self::parse_xml_into_mutator(mutr, html);
         } else {
             // Parse as HTML
+            let mut sink = DocumentHtmlParser::new(mutr);
             sink.is_xml = false;
             let opts = ParseOpts {
                 tokenizer: TokenizerOpts::default(),
@@ -123,6 +117,22 @@ impl<'m, 'doc> DocumentHtmlParser<'m, 'doc> {
                 .read_from(&mut html.as_bytes())
                 .unwrap();
         }
+    }
+
+    /// Parse the input as XML (XHTML), regardless of its content.
+    ///
+    /// [`parse_into_mutator`](Self::parse_into_mutator) sniffs the content to decide between HTML
+    /// and XML parsing, but the sniffing cannot detect all XHTML documents (e.g. ones with an
+    /// `<!DOCTYPE html>` doctype). Callers which know the document is XHTML from out-of-band
+    /// information (a `Content-Type` header or an `.xht`/`.xhtml` file extension) should use
+    /// this method instead.
+    pub fn parse_xml_into_mutator<'a, 'd>(mutr: &'a mut DocumentMutator<'d>, xml: &str) {
+        let mut sink = DocumentHtmlParser::new(mutr);
+        sink.is_xml = true;
+        xml5ever::driver::parse_document(sink, Default::default())
+            .from_utf8()
+            .read_from(&mut xml.as_bytes())
+            .unwrap();
     }
 
     pub fn parse_inner_html_into_mutator<'a, 'd>(


### PR DESCRIPTION
## Summary

Extracted from #738 (independent of blitz-script).

`parse_into_mutator` sniffs the content to decide between HTML and XML parsing, but the sniffing cannot detect all XHTML documents (e.g. ones with a plain `<!DOCTYPE html>` doctype). Callers which know the document is XHTML from out-of-band information (a `Content-Type` header or an `.xht`/`.xhtml` file extension) can now parse it explicitly:

- `DocumentHtmlParser::parse_xml_into_mutator(mutr, xml)` — always parses as XML (extracted from the existing sniffing branch, no behaviour change for `parse_into_mutator`).
- `HtmlDocument::from_xml(xml, config)` — XML counterpart to `from_html`, sharing setup via a private `parse_with` helper.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0382bf211c6147f1afc6a4f727093c56
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32163736639).</sub>
<!-- wpt-results-end -->
