### PR TITLE
Generalize sub-documents to any Document impl and add polling plumbing

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -39,7 +39,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, RwLockReadGuard, RwLockWriteGuard};
-use std::task::Context as TaskContext;
+use std::task::{Context as TaskContext, Waker};
 use style::Atom;
 use style::animation::DocumentAnimationSet;
 use style::attr::{AttrIdentifier, AttrValue};
@@ -563,6 +563,11 @@ impl BaseDocument {
         self.url = DocumentUrl::from(Url::parse(url).unwrap());
     }
 
+    /// The base url used for resolving linked resources (stylesheets, images, fonts, etc)
+    pub fn base_url(&self) -> &Url {
+        &self.url
+    }
+
     pub fn guard(&self) -> &SharedRwLock {
         &self.guard
     }
@@ -761,6 +766,28 @@ impl BaseDocument {
         if let Some(load) = self.iframe_loads.remove(&node_id) {
             load.abort_controller.abort();
         }
+    }
+
+    /// Poll all sub-documents (see [`Document::poll`]), allowing them to make progress
+    /// on any pending async operations (e.g. JavaScript timers). Hosts which poll a
+    /// wrapper around a [`BaseDocument`] should call this from their `poll` implementation.
+    ///
+    /// Returns `true` if any sub-document reported changes.
+    pub fn poll_subdocuments(&mut self, waker: Option<&Waker>) -> bool {
+        let mut has_changes = false;
+        let node_ids: Vec<NodeId> = self.sub_document_nodes.iter().copied().collect();
+        for node_id in node_ids {
+            let Some(sub_doc) = self
+                .nodes
+                .get_mut(node_id)
+                .and_then(|node| node.subdoc_mut())
+            else {
+                continue;
+            };
+            let task_context = waker.map(TaskContext::from_waker);
+            has_changes |= sub_doc.poll(task_context);
+        }
+        has_changes
     }
 
     #[cfg(feature = "custom-widget")]

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -775,8 +775,7 @@ impl BaseDocument {
     /// Returns `true` if any sub-document reported changes.
     pub fn poll_subdocuments(&mut self, waker: Option<&Waker>) -> bool {
         let mut has_changes = false;
-        let node_ids: Vec<NodeId> = self.sub_document_nodes.iter().copied().collect();
-        for node_id in node_ids {
+        for node_id in self.sub_document_nodes.iter().copied() {
             let Some(sub_doc) = self
                 .nodes
                 .get_mut(node_id)

--- a/packages/dioxus-native-dom/src/dioxus_document.rs
+++ b/packages/dioxus-native-dom/src/dioxus_document.rs
@@ -218,15 +218,25 @@ impl Document for DioxusDocument {
     }
 
     fn poll(&mut self, cx: Option<TaskContext>) -> bool {
+        static NOOP_WAKER: LazyLock<Waker> = LazyLock::new(noop_waker);
+        let waker = cx
+            .as_ref()
+            .map(|cx| cx.waker().clone())
+            .unwrap_or_else(|| NOOP_WAKER.clone());
+
+        // Poll any sub-documents, which may have pending async operations of
+        // their own (e.g. JavaScript timers when the sub-document is a
+        // `ScriptDocument` from blitz-script)
+        let subdoc_changes = self.inner.borrow_mut().poll_subdocuments(Some(&waker));
+
         {
             let fut = self.vdom.wait_for_work();
             let mut pinned_fut = pin!(fut);
 
-            static NOOP_WAKER: LazyLock<Waker> = LazyLock::new(noop_waker);
-            let mut cx = cx.unwrap_or_else(|| TaskContext::from_waker(&NOOP_WAKER));
+            let mut cx = TaskContext::from_waker(&waker);
             match pinned_fut.as_mut().poll(&mut cx) {
                 std::task::Poll::Ready(_) => {}
-                std::task::Poll::Pending => return false,
+                std::task::Poll::Pending => return subdoc_changes,
             }
         }
 

--- a/packages/dioxus-native-dom/src/mutation_writer.rs
+++ b/packages/dioxus-native-dom/src/mutation_writer.rs
@@ -1,6 +1,6 @@
 //! Integration between Dioxus and Blitz
 use crate::{NodeId, qual_name, trace, write_once_attr::WriteOnceAttr};
-use blitz_dom::{BaseDocument, Document as _, DocumentMutator, PlainDocument, Widget};
+use blitz_dom::{BaseDocument, Document, DocumentMutator, Widget};
 use blitz_traits::events::DomEventKind;
 use dioxus_core::{
     AttributeValue, ElementId, Template, TemplateAttribute, TemplateNode, WriteMutations,
@@ -229,7 +229,7 @@ impl WriteMutations for MutationWriter<'_> {
                 AttributeValue::Any(value) => {
                     if let Some(value) = value
                         .as_any()
-                        .downcast_ref::<WriteOnceAttr<Box<PlainDocument>>>()
+                        .downcast_ref::<WriteOnceAttr<Box<dyn Document>>>()
                         && let Some(mut sub_document) = value.take()
                     {
                         sub_document

--- a/packages/dioxus-native-dom/src/write_once_attr.rs
+++ b/packages/dioxus-native-dom/src/write_once_attr.rs
@@ -1,14 +1,17 @@
 use std::{cell::RefCell, rc::Rc, sync::atomic::AtomicUsize};
 
-use blitz_dom::{BaseDocument, PlainDocument, Widget};
+use blitz_dom::{Document, Widget};
 use dioxus_core::{AttributeValue, IntoAttributeValue};
 
 #[derive(Clone, PartialEq)]
-pub struct SubDocumentAttr(WriteOnceAttr<Box<PlainDocument>>);
+pub struct SubDocumentAttr(WriteOnceAttr<Box<dyn Document>>);
 
 impl SubDocumentAttr {
-    pub fn new(doc: BaseDocument) -> Self {
-        Self(WriteOnceAttr::new(doc.id(), Box::new(PlainDocument(doc))))
+    /// Accepts any [`Document`] implementation, e.g. a plain [`BaseDocument`](blitz_dom::BaseDocument)
+    /// or a `ScriptDocument` from `blitz-script`.
+    pub fn new(doc: impl Document) -> Self {
+        let id = doc.id();
+        Self(WriteOnceAttr::new(id, Box::new(doc) as Box<dyn Document>))
     }
 }
 


### PR DESCRIPTION
## Summary

Extracted from #738 (independent of blitz-script). Lets any custom `Document` implementation (not just `PlainDocument`) be used as a sub-document, and gives such documents a way to make progress on their own async work (timers, script jobs, etc):

- `SubDocumentAttr::new` now accepts `impl Document` and stores `Box<dyn Document>` instead of `Box<PlainDocument>` (existing callers passing a `BaseDocument` keep working since `BaseDocument: Document`).
- New `BaseDocument::poll_subdocuments(waker)` — polls each sub-document's `Document::poll`, returning `true` if any reported changes. `DioxusDocument::poll` now calls it (and no longer swallows sub-document changes when the vdom has no work: `Pending => return subdoc_changes`).
- New `BaseDocument::base_url()` accessor (read counterpart to `set_base_url`).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0382bf211c6147f1afc6a4f727093c56
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32166314488).</sub>
<!-- wpt-results-end -->
