### PR TITLE
blitz-dom: add CSSOM View box-metric queries to Node

### DIFF
--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1417,6 +1417,40 @@ impl Node {
         crate::util::Point { x, y }
     }
 
+    /// CSSOM View's `clientWidth`: the width of the padding box (border box minus
+    /// borders and scrollbar)
+    pub fn client_width(&self) -> f32 {
+        let layout = self.final_layout();
+        layout.size.width - layout.border.left - layout.border.right - layout.scrollbar_size.width
+    }
+
+    /// CSSOM View's `clientHeight`: the height of the padding box (border box minus
+    /// borders and scrollbar)
+    pub fn client_height(&self) -> f32 {
+        let layout = self.final_layout();
+        layout.size.height - layout.border.top - layout.border.bottom - layout.scrollbar_size.height
+    }
+
+    /// CSSOM View's `scrollWidth`: the width of the node's content, including
+    /// content not visible due to overflow
+    pub fn scroll_width(&self) -> f32 {
+        self.client_width()
+            .max(self.final_layout().content_size.width)
+    }
+
+    /// CSSOM View's `scrollHeight`: the height of the node's content, including
+    /// content not visible due to overflow
+    pub fn scroll_height(&self) -> f32 {
+        self.client_height()
+            .max(self.final_layout().content_size.height)
+    }
+
+    /// Does the node generate any boxes? (e.g. `getClientRects()` returns an empty
+    /// list for boxless nodes, such as `display: none` or detached elements)
+    pub fn has_boxes(&self) -> bool {
+        self.flags.is_in_document() && self.style().display != taffy::Display::None
+    }
+
     /// Creates a synthetic click event
     pub fn synthetic_click_event(&self, mods: Modifiers) -> DomEventData {
         DomEventData::Click(self.synthetic_click_event_data(mods))

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1446,9 +1446,17 @@ impl Node {
     }
 
     /// Does the node generate any boxes? (e.g. `getClientRects()` returns an empty
-    /// list for boxless nodes, such as `display: none` or detached elements)
+    /// list for boxless nodes, such as `display: none`, `display: contents`, or
+    /// detached elements)
     pub fn has_boxes(&self) -> bool {
-        self.flags.is_in_document() && self.style().display != taffy::Display::None
+        self.flags.is_in_document()
+            && !self.display_style().is_some_and(|display| {
+                matches!(
+                    display.inside(),
+                    style::values::specified::box_::DisplayInside::None
+                        | style::values::specified::box_::DisplayInside::Contents
+                )
+            })
     }
 
     /// Creates a synthetic click event


### PR DESCRIPTION
## Summary

Pushed down from #738's blitz-script bindings into `blitz_dom::Node`, next to the existing `offset_parent()`/`offset_top_left()` helpers:

- `client_width()` / `client_height()` — padding-box size (border box minus borders and scrollbar), as for `clientWidth`/`clientHeight`
- `scroll_width()` / `scroll_height()` — `max(client size, content_size)`, as for `scrollWidth`/`scrollHeight`
- `has_boxes()` — whether the node generates any boxes (in-document and not `display: none`), which `getClientRects()`-style APIs use to return an empty list for boxless nodes

Together with the existing `final_layout()`, `offset_top_left()`, `get_client_bounding_rect()`, and `node_client_rects()`, this makes the full set of CSSOM View element box metrics available to any embedder without Boa/JS types.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0382bf211c6147f1afc6a4f727093c56
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32165052830).</sub>
<!-- wpt-results-end -->
