### PR TITLE
blitz-dom: add find_element_by_tag_name and body/head document lookups

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -26,7 +26,7 @@ use blitz_traits::node_id::NodeId;
 use blitz_traits::shell::{ColorScheme, DummyShellProvider, ShellProvider, Viewport};
 use cursor_icon::CursorIcon;
 use linebender_resource_handle::Blob;
-use markup5ever::local_name;
+use markup5ever::{LocalName, local_name};
 use parley::{FontContext, PlainEditorDriver};
 use selectors::{Element, matching::QuirksMode};
 use smallvec::SmallVec;
@@ -2427,14 +2427,41 @@ impl BaseDocument {
         Some(rects)
     }
 
-    pub fn find_title_node(&self) -> Option<&Node> {
-        TreeTraverser::new(self)
-            .find(|node_id| {
-                self.nodes[*node_id]
-                    .data
-                    .is_element_with_tag_name(&local_name!("title"))
+    /// The first element in tree order with the given tag name. The root element and
+    /// its children are checked first as a fast path before a full tree search, making
+    /// this suitable for the `documentElement`/`head`/`body` document accessors.
+    pub fn find_element_by_tag_name(&self, tag: &LocalName) -> Option<&Node> {
+        let root = self.try_root_element()?;
+        if root.data.is_element_with_tag_name(tag) {
+            return Some(root);
+        }
+        root.children
+            .iter()
+            .copied()
+            .find(|child_id| {
+                self.get_node(*child_id)
+                    .is_some_and(|child| child.data.is_element_with_tag_name(tag))
+            })
+            .or_else(|| {
+                TreeTraverser::new(self)
+                    .find(|node_id| self.nodes[*node_id].data.is_element_with_tag_name(tag))
             })
             .map(|node_id| &self.nodes[node_id])
+    }
+
+    /// The document's `body` element, as for `document.body`
+    pub fn find_body_node(&self) -> Option<&Node> {
+        self.find_element_by_tag_name(&local_name!("body"))
+    }
+
+    /// The document's `head` element, as for `document.head`
+    pub fn find_head_node(&self) -> Option<&Node> {
+        self.find_element_by_tag_name(&local_name!("head"))
+    }
+
+    /// The document's `title` element
+    pub fn find_title_node(&self) -> Option<&Node> {
+        self.find_element_by_tag_name(&local_name!("title"))
     }
 
     pub fn with_text_input(


### PR DESCRIPTION
## Summary

Pushed down from #738's blitz-script `document` bindings into `BaseDocument`:

- `find_element_by_tag_name(&LocalName) -> Option<&Node>` — first element in tree order with the given tag, fast-pathing the root element and its children before a full `TreeTraverser` search
- `find_body_node()` / `find_head_node()` — `document.body` / `document.head` lookups on top of it
- `find_title_node()` rewritten as `find_element_by_tag_name(&local_name!("title"))`, consolidating with the new helper (behavior unchanged: first `<title>` in tree order)

`documentElement` needs no new API — `try_root_element()` already covers it.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0382bf211c6147f1afc6a4f727093c56
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**18** newly passing, **0** newly failing (net +18).

<details>
<summary>Full diff (18 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/positioning/bottom-103.xht
+ Fail => Pass css/CSS2/positioning/bottom-104.xht
+ Fail => Pass css/CSS2/positioning/bottom-113.xht
+ Fail => Pass css/CSS2/positioning/position-relative-nested-001.xht
+ Fail => Pass css/CSS2/positioning/top-103.xht
+ Fail => Pass css/CSS2/positioning/top-104.xht
+ Fail => Pass css/CSS2/positioning/top-113.xht
+ Fail => Pass css/CSS2/visuren/top-114.xht
+ Fail => Pass css/css-flexbox/flexbox_align-items-stretch-4.html
+ Fail => Pass css/css-flexbox/percentage-heights-001.html
+ Fail => Pass css/css-flexbox/percentage-heights-015.html
+ Fail => Pass css/css-flexbox/position-relative-percentage-top-002.html
+ Fail => Pass css/css-flexbox/position-relative-percentage-top-003.html
+ Fail => Pass css/css-grid/relative-grandchild.html
+ Fail => Pass css/css-position/position-relative-001.html
+ Fail => Pass css/css-position/position-relative-007.html
+ Fail => Pass css/css-values/calc-offsets-relative-bottom-1.html
+ Fail => Pass css/css-values/calc-offsets-relative-top-1.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32164323619).</sub>
<!-- wpt-results-end -->
