### PR TITLE
Baseline-align in-flow atomic inlines via Parley's InlineBox::baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "fontique"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
+source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -5527,12 +5527,12 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
+source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
 
 [[package]]
 name = "parley"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
+source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
 dependencies = [
  "fontique",
  "hashbrown 0.17.1",
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "parley_data"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
+source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
 dependencies = [
  "icu_properties",
 ]
@@ -5554,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "parley_engine"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
+source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
 dependencies = [
  "fontique",
  "harfrust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "fontique"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
+source = "git+https://github.com/DioxusLabs/parley?rev=95a9ff1479533a03775b8e53587495dd41a01b74#95a9ff1479533a03775b8e53587495dd41a01b74"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -5527,12 +5527,12 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
+source = "git+https://github.com/DioxusLabs/parley?rev=95a9ff1479533a03775b8e53587495dd41a01b74#95a9ff1479533a03775b8e53587495dd41a01b74"
 
 [[package]]
 name = "parley"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
+source = "git+https://github.com/DioxusLabs/parley?rev=95a9ff1479533a03775b8e53587495dd41a01b74#95a9ff1479533a03775b8e53587495dd41a01b74"
 dependencies = [
  "fontique",
  "hashbrown 0.17.1",
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "parley_data"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
+source = "git+https://github.com/DioxusLabs/parley?rev=95a9ff1479533a03775b8e53587495dd41a01b74#95a9ff1479533a03775b8e53587495dd41a01b74"
 dependencies = [
  "icu_properties",
 ]
@@ -5554,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "parley_engine"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=98db0dd04dd380b16a86afa7f000982da2892985#98db0dd04dd380b16a86afa7f000982da2892985"
+source = "git+https://github.com/DioxusLabs/parley?rev=95a9ff1479533a03775b8e53587495dd41a01b74#95a9ff1479533a03775b8e53587495dd41a01b74"
 dependencies = [
  "fontique",
  "harfrust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,9 +2966,8 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6688bc1294fe7117d788937b6c53480169b29c566954af490830d4c09da9516a"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -5528,14 +5527,34 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
 
 [[package]]
 name = "parley"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d2ff88bd3f7d68d1d9b09c7e6209f9a8e8c05088295140a2bcf2e9b17038c5"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
+dependencies = [
+ "fontique",
+ "hashbrown 0.17.1",
+ "linebender_resource_handle",
+ "parlance",
+ "parley_engine",
+ "skrifa",
+ "smallvec",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
+dependencies = [
+ "icu_properties",
+]
+
+[[package]]
+name = "parley_engine"
+version = "0.11.0"
+source = "git+https://github.com/DioxusLabs/parley?rev=a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e#a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e"
 dependencies = [
  "fontique",
  "harfrust",
@@ -5547,15 +5566,6 @@ dependencies = [
  "parlance",
  "parley_data",
  "skrifa",
-]
-
-[[package]]
-name = "parley_data"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1567535334d6ba2d3cde19221ba9a7bd0fabb3cbd99046ddfb10ae061cfcc889"
-dependencies = [
- "icu_properties",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=0e33e961c4ecd36a38d5103f57f305fbe37d749f#0e33e961c4ecd36a38d5103f57f305fbe37d749f"
+source = "git+https://github.com/DioxusLabs/taffy?rev=a0471381c63cd84622295f93a13b306034e392f4#a0471381c63cd84622295f93a13b306034e392f4"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a0471381c63cd84622
     "calc",
     "detailed_layout_info",
 ] }
-parley = { git = "https://github.com/DioxusLabs/parley", rev = "a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e", default-features = false, features = ["std"] }
+parley = { git = "https://github.com/DioxusLabs/parley", rev = "98db0dd04dd380b16a86afa7f000982da2892985", default-features = false, features = ["std"] }
 skrifa = { version = "0.44", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a0471381c63cd84622
     "calc",
     "detailed_layout_info",
 ] }
-parley = { version = "0.11.1", default-features = false, features = ["std"] }
+parley = { git = "https://github.com/DioxusLabs/parley", rev = "a0752c7bdc3ad88dac19fc194d2b8e57e59bea2e", default-features = false, features = ["std"] }
 skrifa = { version = "0.44", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a0471381c63cd84622
     "calc",
     "detailed_layout_info",
 ] }
-parley = { git = "https://github.com/DioxusLabs/parley", rev = "98db0dd04dd380b16a86afa7f000982da2892985", default-features = false, features = ["std"] }
+parley = { git = "https://github.com/DioxusLabs/parley", rev = "95a9ff1479533a03775b8e53587495dd41a01b74", default-features = false, features = ["std"] }
 skrifa = { version = "0.44", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "0e33e961c4ecd36a38d5103f57f305fbe37d749f", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a0471381c63cd84622295f93a13b306034e392f4", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -1190,6 +1190,7 @@ pub(crate) fn build_inline_layout_into(
                                 // Width and height are set during layout
                                 width: 0.0,
                                 height: 0.0,
+                                baseline: None,
                             });
                         } else if *tag_name == local_name!("br") {
                             // node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
@@ -1270,6 +1271,7 @@ pub(crate) fn build_inline_layout_into(
                             // Width and height are set during layout
                             width: 0.0,
                             height: 0.0,
+                            baseline: None,
                         });
                     }
                 };

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -4,15 +4,16 @@ use std::sync::Arc;
 
 use markup5ever::{QualName, local_name, ns};
 use parley::{
-    FontContext, InlineBox, InlineBoxKind, LayoutContext, StyleProperty, TreeBuilder,
-    WhiteSpaceCollapse,
+    FontContext, InlineBox, InlineBoxKind, InlineBoxVerticalAlign, LayoutContext, StyleProperty,
+    TreeBuilder, WhiteSpaceCollapse,
 };
 use style::{
     computed_values::position::T as PositionProperty,
     data::ElementData as StyloElementData,
     shared_lock::StylesheetGuards,
     values::{
-        computed::{Content, ContentItem, Display, Float, TextTransform},
+        computed::{BaselineShift, Content, ContentItem, Display, Float, TextTransform},
+        generics::box_::BaselineShiftKeyword,
         specified::box_::{DisplayInside, DisplayOutside},
     },
 };
@@ -1030,11 +1031,8 @@ pub(crate) fn build_inline_layout_into(
     let root_line_height = resolve_line_height(parley_style.line_height, parley_style.font_size);
 
     // Create a parley tree builder
-    // Note: parley's opt-in line-box strut (`set_compute_strut`) is deliberately left
-    // disabled: without `vertical-align` support, baseline-aligned images gain a spurious
-    // descender gap that many WPT references (which use `vertical-align: top`) rely on
-    // suppressing.
     let mut builder = layout_ctx.tree_builder(font_ctx, scale, true, &parley_style);
+    builder.set_compute_strut(true);
 
     // Set whitespace collapsing mode
     let collapse_mode = root_node_style
@@ -1195,6 +1193,9 @@ pub(crate) fn build_inline_layout_into(
                                 width: 0.0,
                                 height: 0.0,
                                 baseline: None,
+                                vertical_align: inline_box_vertical_align(
+                                    style.map(|s| s.clone_baseline_shift()),
+                                ),
                             });
                         } else if *tag_name == local_name!("br") {
                             // node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
@@ -1276,6 +1277,9 @@ pub(crate) fn build_inline_layout_into(
                             width: 0.0,
                             height: 0.0,
                             baseline: None,
+                            vertical_align: inline_box_vertical_align(
+                                style.map(|s| s.clone_baseline_shift()),
+                            ),
                         });
                     }
                 };
@@ -1302,5 +1306,17 @@ pub(crate) fn build_inline_layout_into(
             }
             NodeData::Document(_) => unreachable!(),
         }
+    }
+}
+
+/// Map the computed `baseline-shift` (the longhand behind `vertical-align: top`/`bottom`)
+/// to parley's inline-box vertical alignment.
+fn inline_box_vertical_align(baseline_shift: Option<BaselineShift>) -> InlineBoxVerticalAlign {
+    match baseline_shift {
+        Some(BaselineShift::Keyword(BaselineShiftKeyword::Top)) => InlineBoxVerticalAlign::Top,
+        Some(BaselineShift::Keyword(BaselineShiftKeyword::Bottom)) => {
+            InlineBoxVerticalAlign::Bottom
+        }
+        _ => InlineBoxVerticalAlign::Baseline,
     }
 }

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -1031,6 +1031,7 @@ pub(crate) fn build_inline_layout_into(
 
     // Create a parley tree builder
     let mut builder = layout_ctx.tree_builder(font_ctx, scale, true, &parley_style);
+    builder.set_compute_strut(true);
 
     // Set whitespace collapsing mode
     let collapse_mode = root_node_style

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -1030,8 +1030,11 @@ pub(crate) fn build_inline_layout_into(
     let root_line_height = resolve_line_height(parley_style.line_height, parley_style.font_size);
 
     // Create a parley tree builder
+    // Note: parley's opt-in line-box strut (`set_compute_strut`) is deliberately left
+    // disabled: without `vertical-align` support, baseline-aligned images gain a spurious
+    // descender gap that many WPT references (which use `vertical-align: top`) rely on
+    // suppressing.
     let mut builder = layout_ctx.tree_builder(font_ctx, scale, true, &parley_style);
-    builder.set_compute_strut(true);
 
     // Set whitespace collapsing mode
     let collapse_mode = root_node_style

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -304,7 +304,22 @@ impl BaseDocument {
                 ibox.width = 0.0;
                 ibox.height = 0.0;
             } else {
+                let is_scroll_container = style.overflow.x.is_scroll_container()
+                    || style.overflow.y.is_scroll_container();
                 let output = self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
+                // Per CSS, an in-flow inline-block is baseline-aligned to the baseline of its
+                // last in-flow line box, unless it is a scroll container or has no in-flow line
+                // boxes, in which case its baseline is its bottom margin edge (Parley's fallback
+                // when `baseline` is `None`, since `ibox.height` includes margins).
+                ibox.baseline = if is_scroll_container {
+                    None
+                } else {
+                    output
+                        .baselines
+                        .last
+                        .or(output.baselines.first)
+                        .map(|baseline| (margin.top + baseline) * scale)
+                };
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
                 // Vertical margins adjust the space the box reserves in the line, but the
                 // reserved space cannot be negative.

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -4,9 +4,9 @@ use style::values::specified::box_::DisplayOutside;
 use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
 use taffy::{
     AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
-    CoreStyle as _, Direction, LayoutInput, LayoutOutput, LayoutPartialTree as _, MaybeMath as _,
-    MaybeResolve as _, Overflow, Point, Position, RequestedAxis, ResolveOrZero as _, RunMode, Size,
-    SizingMode,
+    CoreStyle as _, Direction, Display, LayoutInput, LayoutOutput, LayoutPartialTree as _,
+    MaybeMath as _, MaybeResolve as _, Overflow, Point, Position, RequestedAxis,
+    ResolveOrZero as _, RunMode, Size, SizingMode,
 };
 
 #[cfg(feature = "floats")]
@@ -306,24 +306,33 @@ impl BaseDocument {
             } else {
                 let is_scroll_container = style.overflow.x.is_scroll_container()
                     || style.overflow.y.is_scroll_container();
+                let display = style.display;
                 let output = self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
                 // Per CSS, an in-flow inline-block is baseline-aligned to the baseline of its
-                // last in-flow line box, unless it is a scroll container or has no in-flow line
-                // boxes, in which case its baseline is its bottom margin edge (Parley's fallback
-                // when `baseline` is `None`, since `ibox.height` includes margins).
+                // last in-flow line box, while inline flex/grid containers use their first
+                // baseline. A scroll container or a box with no natural baseline uses its
+                // bottom margin edge (Parley's fallback when `baseline` is `None`, since
+                // `ibox.height` includes margins).
+                let baseline = match display {
+                    Display::Flex | Display::Grid => output.baselines.first,
+                    _ => output.baselines.last,
+                };
                 ibox.baseline = if is_scroll_container {
                     None
                 } else {
-                    output
-                        .baselines
-                        .last
-                        .or(output.baselines.first)
-                        .map(|baseline| (margin.top + baseline) * scale)
+                    baseline.map(|baseline| (margin.top + baseline) * scale)
                 };
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
-                // Vertical margins adjust the space the box reserves in the line, but the
-                // reserved space cannot be negative.
-                ibox.height = (margin.top + margin.bottom + output.size.height).max(0.0) * scale;
+                // Vertical margins adjust the space the box reserves in the line. With an
+                // explicit baseline the ascent/descent contributions may legitimately be
+                // negative, but a bottom-aligned box (no baseline) contributes its height
+                // as ascent, and the space it reserves cannot be negative.
+                let height = margin.top + margin.bottom + output.size.height;
+                ibox.height = if ibox.baseline.is_some() {
+                    height * scale
+                } else {
+                    height.max(0.0) * scale
+                };
             }
         }
 
@@ -598,7 +607,7 @@ impl BaseDocument {
                         // dbg!(&layout.size);
                         // dbg!(&layout.location);
 
-                        state.append_inline_box_to_line(box_break_data.advance, 0.0, 0.0, false);
+                        state.append_inline_box_to_line(box_break_data.advance, None, false);
 
                         // if float.is_floated() {
                         //     println!("INLINE FLOATED BOX ({}) {:?}", ibox.id, float);
@@ -807,11 +816,18 @@ impl BaseDocument {
                         layout.size = size;
                         layout.location.x =
                             (ibox.x / scale) + margin.left + container_pb.left + inset_offset.x;
-                        // A negative `margin-top` shrinks the space the box reserves in the
-                        // line but does not move the box itself, which stays anchored to the
-                        // bottom of the reserved space.
+                        // For a baseline-aligned box, `ibox.y` is the top of the margin box,
+                        // so the border box sits `margin.top` below it. For a bottom-aligned
+                        // box (no baseline), a negative `margin-top` shrinks the space the box
+                        // reserves in the line but does not move the box itself, which stays
+                        // anchored to the bottom of the reserved space.
+                        let margin_top_offset = if ibox.baseline.is_some() {
+                            margin.top
+                        } else {
+                            margin.top.max(0.0)
+                        };
                         layout.location.y = (ibox.y / scale)
-                            + margin.top.max(0.0)
+                            + margin_top_offset
                             + container_pb.top
                             + inset_offset.y;
                         layout.padding = padding; //.map(|p| p / scale);

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -3,10 +3,10 @@ use parley::{AlignmentOptions, IndentOptions};
 use style::values::specified::box_::DisplayOutside;
 use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
 use taffy::{
-    AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
-    CoreStyle as _, Direction, LayoutInput, LayoutOutput, LayoutPartialTree as _, MaybeMath as _,
-    MaybeResolve as _, Overflow, Point, Position, RequestedAxis, ResolveOrZero as _, RunMode, Size,
-    SizingMode,
+    AvailableSpace, Baselines, BlockContext, BlockFormattingContext, BoxSizing,
+    CollapsibleMarginSet, CoreStyle as _, Direction, LayoutInput, LayoutOutput,
+    LayoutPartialTree as _, MaybeMath as _, MaybeResolve as _, Overflow, Point, Position,
+    RequestedAxis, ResolveOrZero as _, RunMode, Size, SizingMode,
 };
 
 #[cfg(feature = "floats")]
@@ -817,6 +817,11 @@ impl BaseDocument {
             .lines()
             .next()
             .map(|line| (line.metrics().baseline / scale) + container_pb.top);
+        let last_baseline = inline_layout
+            .layout
+            .lines()
+            .next_back()
+            .map(|line| (line.metrics().baseline / scale) + container_pb.top);
 
         // Put layout back
         self.nodes[node_id]
@@ -839,7 +844,10 @@ impl BaseDocument {
                     bottom: content_extent.height,
                 }
             },
-            baselines: taffy::Baselines::from_first(first_baseline),
+            baselines: taffy::Baselines {
+                first: first_baseline,
+                last: last_baseline,
+            },
             top_margin: CollapsibleMarginSet::ZERO,
             bottom_margin: CollapsibleMarginSet::ZERO,
             margins_can_collapse_through: !has_styles_preventing_being_collapsed_through

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -320,7 +320,11 @@ impl BaseDocument {
                 ibox.baseline = if is_scroll_container {
                     None
                 } else {
-                    baseline.map(|baseline| (margin.top + baseline) * scale)
+                    // Round to physical pixels so that content within the box (which is
+                    // positioned relative to the box's top edge and pixel-snapped there)
+                    // stays pixel-aligned after the box is shifted to sit on the
+                    // (pixel-snapped) line baseline.
+                    baseline.map(|baseline| ((margin.top + baseline) * scale).round())
                 };
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
                 // Vertical margins adjust the space the box reserves in the line. With an

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -3,10 +3,10 @@ use parley::{AlignmentOptions, IndentOptions};
 use style::values::specified::box_::DisplayOutside;
 use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
 use taffy::{
-    AvailableSpace, Baselines, BlockContext, BlockFormattingContext, BoxSizing,
-    CollapsibleMarginSet, CoreStyle as _, Direction, LayoutInput, LayoutOutput,
-    LayoutPartialTree as _, MaybeMath as _, MaybeResolve as _, Overflow, Point, Position,
-    RequestedAxis, ResolveOrZero as _, RunMode, Size, SizingMode,
+    AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
+    CoreStyle as _, Direction, LayoutInput, LayoutOutput, LayoutPartialTree as _, MaybeMath as _,
+    MaybeResolve as _, Overflow, Point, Position, RequestedAxis, ResolveOrZero as _, RunMode, Size,
+    SizingMode,
 };
 
 #[cfg(feature = "floats")]

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -583,7 +583,7 @@ impl BaseDocument {
                         // dbg!(&layout.size);
                         // dbg!(&layout.location);
 
-                        state.append_inline_box_to_line(box_break_data.advance, 0.0);
+                        state.append_inline_box_to_line(box_break_data.advance, 0.0, 0.0, false);
 
                         // if float.is_floated() {
                         //     println!("INLINE FLOATED BOX ({}) {:?}", ibox.id, float);

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -1,7 +1,10 @@
 use blitz_traits::node_id::NodeId;
 use parley::{AlignmentOptions, IndentOptions};
 use style::values::specified::box_::DisplayOutside;
-use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
+use style::values::{
+    computed::{CSSPixelLength, Contain},
+    generics::text::GenericTextIndent,
+};
 use taffy::{
     AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
     CoreStyle as _, Direction, Display, LayoutInput, LayoutOutput, LayoutPartialTree as _,
@@ -307,25 +310,40 @@ impl BaseDocument {
                 let is_scroll_container = style.overflow.x.is_scroll_container()
                     || style.overflow.y.is_scroll_container();
                 let display = style.display;
+                // Layout containment suppresses the box's baseline (css-contain §3)
+                let has_layout_containment = self.nodes[NodeId::from_u64(ibox.id)]
+                    .primary_styles()
+                    .is_some_and(|s| s.clone_contain().contains(Contain::LAYOUT));
                 let output = self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
                 // Per CSS, an in-flow inline-block is baseline-aligned to the baseline of its
                 // last in-flow line box, while inline flex/grid containers use their first
-                // baseline. A scroll container or a box with no natural baseline uses its
-                // bottom margin edge (Parley's fallback when `baseline` is `None`, since
-                // `ibox.height` includes margins).
+                // baseline. A box with no natural baseline uses its bottom margin edge
+                // (Parley's fallback when `baseline` is `None`, since `ibox.height`
+                // includes margins). A scroll container also uses its bottom margin edge
+                // if it is an inline-block, but flex/grid scroll containers still take
+                // their baseline from their content, clamped to the border box
+                // (css-align §9.1).
                 let baseline = match display {
                     Display::Flex | Display::Grid => output.baselines.first,
                     _ => output.baselines.last,
                 };
-                ibox.baseline = if is_scroll_container {
+                let baseline = if has_layout_containment {
                     None
+                } else if is_scroll_container {
+                    match display {
+                        Display::Flex | Display::Grid => {
+                            baseline.map(|b| b.min(output.size.height).max(0.0))
+                        }
+                        _ => None,
+                    }
                 } else {
-                    // Round to physical pixels so that content within the box (which is
-                    // positioned relative to the box's top edge and pixel-snapped there)
-                    // stays pixel-aligned after the box is shifted to sit on the
-                    // (pixel-snapped) line baseline.
-                    baseline.map(|baseline| ((margin.top + baseline) * scale).round())
+                    baseline
                 };
+                // Round to physical pixels so that content within the box (which is
+                // positioned relative to the box's top edge and pixel-snapped there)
+                // stays pixel-aligned after the box is shifted to sit on the
+                // (pixel-snapped) line baseline.
+                ibox.baseline = baseline.map(|baseline| ((margin.top + baseline) * scale).round());
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
                 // Vertical margins adjust the space the box reserves in the line. With an
                 // explicit baseline the ascent/descent contributions may legitimately be

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1260,8 +1260,8 @@ impl Node {
                 if let Some((cluster, _side)) =
                     Cluster::from_point_exact(layout, x * scale, y * scale)
                 {
-                    let style_index = cluster.glyphs().next()?.style_index();
-                    let node_id = layout.styles()[style_index].brush.id;
+                    let style_index = cluster.style_index();
+                    let node_id = layout.styles()[usize::from(style_index)].brush.id;
                     let text_pointer_events_none = self
                         .with(node_id)
                         .primary_styles()

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -54,7 +54,7 @@ pub(crate) fn draw_inline_backgrounds<'a>(
                 continue;
             }
 
-            let metrics = glyph_run.run().metrics();
+            let metrics = glyph_run.run().font_metrics();
             let x = glyph_run.offset() as f64;
             let w = glyph_run.advance() as f64;
             let baseline = glyph_run.baseline() as f64;
@@ -576,7 +576,7 @@ pub(crate) fn stroke_text<'a>(
                 let run = glyph_run.run();
                 let font = run.font();
                 let font_size = run.font_size();
-                let metrics = run.metrics();
+                let metrics = run.font_metrics();
                 let style = glyph_run.style();
                 let synthesis = run.synthesis();
                 let glyph_xform = synthesis
@@ -620,11 +620,17 @@ pub(crate) fn stroke_text<'a>(
                     kurbo::Vec2::default()
                 };
 
+                let normalized_coords: Vec<i16> = run
+                    .normalized_coords()
+                    .iter()
+                    .map(|coord| coord.to_bits())
+                    .collect();
+
                 scene.draw_glyphs(
-                    font,
+                    &font.font,
                     font_size,
                     !FONT_EMBOLDEN_ENABLED, // hint
-                    run.normalized_coords(),
+                    &normalized_coords,
                     embolden,
                     Fill::NonZero,
                     &anyrender::Paint::from(text_color),

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -655,7 +655,7 @@ pub(crate) fn stroke_text<'a>(
                     underline_offset: metrics.underline_offset,
                     underline_size: metrics.underline_size,
                     strikethrough_size: metrics.strikethrough_size,
-                    font: font.clone(),
+                    font: font.font.clone(),
                     font_size,
                     css_font_size,
                 };

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -414,9 +414,7 @@ pub fn item_alignment(input: stylo::AlignFlags, is_horiz_rtl: bool) -> Option<ta
         stylo::AlignFlags::RIGHT => Some(taffy::AlignItems::END),
         stylo::AlignFlags::CENTER => Some(taffy::AlignItems::CENTER),
         stylo::AlignFlags::BASELINE => Some(taffy::AlignItems::BASELINE),
-        // Taffy does not support last-baseline alignment, so map it to its
-        // fallback alignment of `self-end` (https://www.w3.org/TR/css-align-3/#baseline-values)
-        stylo::AlignFlags::LAST_BASELINE => Some(taffy::AlignItems::END),
+        stylo::AlignFlags::LAST_BASELINE => Some(taffy::AlignItems::LAST_BASELINE),
         // Should never be hit. But no real reason to panic here.
         _ => None,
     }?;


### PR DESCRIPTION
## Summary

Wires Taffy's baseline output through to Parley's `InlineBox::baseline` so in-flow atomic inlines are baseline-aligned per CSS instead of bottom-edge aligned, and bumps Parley to DioxusLabs/parley#7 (rev `95a9ff1`, which includes DioxusLabs/parley#10) for line-metrics fixes plus `vertical-align: top`/`bottom` support.

In `compute_inline_layout`, when updating each in-flow inline box from its Taffy layout output:

```rust
let baseline = match display {
    // Inline flex/grid containers use their *first* baseline (css-align)
    Display::Flex | Display::Grid => output.baselines.first,
    // Inline-blocks use the baseline of their *last* in-flow line box (CSS2)
    _ => output.baselines.last,
};
ibox.baseline = if is_scroll_container {
    None // Parley bottom-edge fallback = bottom margin edge, per CSS2
} else {
    // Rounded to physical pixels so content inside the box (pixel-snapped
    // relative to the box's top edge) stays pixel-aligned after the box is
    // shifted to sit on the (pixel-snapped) line baseline.
    baseline.map(|b| ((margin.top + b) * scale).round())
};
```

Taffy baselines are measured from the top border edge; Parley expects the baseline relative to the top of the inline box (which here is the margin box, since `ibox.width/height` include margins), hence `margin.top + b`. The `baselines.last` values are populated by the Taffy last-baseline work (#721), whose commits are included in this PR now that it targets `main`.

Two adjustments to existing negative-vertical-margin handling now that boxes can carry a baseline:
- The reserved line space (`ibox.height`) is only clamped to `>= 0` for bottom-aligned boxes (no baseline); with an explicit baseline the ascent/descent contributions may legitimately be negative (e.g. `margin-top: -20em` on an inline-flex).
- Positioning: for a baseline-aligned box, `ibox.y` is the margin-box top (Parley places it at `line_baseline - baseline`), so the border box goes at `ibox.y + margin.top` (unclamped); bottom-aligned boxes keep the previous `margin.top.max(0.0)` bottom-anchoring.

Parley bump to `95a9ff1` (DioxusLabs/parley#7, on top of #10) brings:
- Fix for clamping of negative half-leading in line extents (this is what fixes the 32 `line-height-*` tests below).
- Opt-in CSS2 § 10.8 line-box strut support, now **enabled** via `builder.set_compute_strut(true)`.
- `InlineBox::vertical_align` (`InlineBoxVerticalAlign::{Baseline, Top, Bottom}`). Blitz maps the computed `baseline-shift` longhand (the stylo longhand behind `vertical-align: top`/`bottom`) to it:

```rust
fn inline_box_vertical_align(baseline_shift: Option<BaselineShift>) -> InlineBoxVerticalAlign {
    match baseline_shift {
        Some(BaselineShift::Keyword(BaselineShiftKeyword::Top)) => InlineBoxVerticalAlign::Top,
        Some(BaselineShift::Keyword(BaselineShiftKeyword::Bottom)) => InlineBoxVerticalAlign::Bottom,
        _ => InlineBoxVerticalAlign::Baseline,
    }
}
```

With `vertical-align: top`/`bottom` supported, the strut no longer regresses the ~200 tests whose references use `vertical-align: top` images (spot-checked `width-006.xht`, `inline-replaced-width-001.xht`, `float-003.xht`, `width-percentage-001.xht`, `background-size-025.html`: all pass locally with strut + vertical-align).
- Its `append_inline_box_to_line` signature changed; out-of-flow floated boxes now pass `alignment: None`.

## WPT results

CI's full-suite run vs `main` reports **142 newly passing / 50 newly failing (net +92)** (full diff in the generated section below). All 50 were re-verified locally (each passes on `main` at 10606cc5 and failed on this branch before the latest commits) and triaged. 8 of the 50 are fixed by the latest commits; the remainder cluster as follows.

### Fixed in this PR (8)

- `contain-layout-baseline-001/005`, `contain-layout-flexbox-001`, `contain-layout-grid-001`: layout containment must suppress the box's baseline (css-contain §3 "no baseline"). Blitz now checks the computed `contain` value for `layout` (also covered by `strict`/`content`) and passes `baseline: None` for such atomic inlines.
- `baseline-of-scrollable-1a`: a *scrollable* inline flex/grid container still takes its baseline from its content (as if not scrolled), clamped to the border box (css-align §9.1 / w3c/csswg-drafts#7660) — only inline-*block* scroll containers synthesize from the bottom margin edge. Blitz now clamps `output.baselines.first` to `[0, height]` for flex/grid scroll containers instead of dropping it.
- `floats-141.xht` (fixed in an earlier commit): 1px glyph shift from a fractional inline-box baseline; `ibox.baseline` is now rounded to physical pixels.
- `flexbox-baseline-multi-line-horiz-004.html`, `grid-baseline-001.html`: fixed by bumping Taffy to pick up DioxusLabs/taffy#1127 (wrap-reverse container baseline from the visually startmost line) and DioxusLabs/taffy#1125 (items with auto block-axis margins don't participate in grid baseline alignment).

### Upstream Taffy baseline gaps (3 remaining)

Three Taffy fixes landed upstream (DioxusLabs/taffy#1125, #1127, #1126) and this PR's Taffy pin was bumped to a merge of taffy `main` into the last-baseline branch (`8c49a27f`), which fixed `flexbox-baseline-multi-line-horiz-004` and `grid-baseline-001` (see above). Still failing:

- `baseline-block-with-overflow-001.html`, `baseline-of-scrollable-1b.html`: taffy#1126 added block scroll-container baseline clamping/synthesis, but these still fail because Blitz's inline layout doesn't feed Taffy block-child baselines into inline-block vertical alignment for these structures (the tests wrap the scrollable boxes so the relevant baseline propagation is only partially exercised).
- `flexbox-baseline-multi-line-vert-002.html`: the vertical-writing-mode variant additionally depends on the CSS2 strut interaction (see next section).

### Spurious base passes exposed by parley#10's nbsp fix (5)

- `inline-block-zorder-002/004/005.xht`, `inline-table-zorder-001.xht`, `inline-table-width-002b.xht`: on `main`, any element whose text content is only `&nbsp;` renders completely blank (even its background), so these tests compared blank-vs-blank and "passed". Parley #10 fixes nbsp handling, so this PR actually renders them, exposing pre-existing issues: the zorder tests fail on paint order (a later sibling block's background, pulled up via negative margin, is painted *over* earlier inline-block/inline-table content, contra CSS2 Appendix E); `inline-table-width-002b` additionally involves an unrendered `inline-table`, with test/ref differing only in line spacing around the invisible box.

### CSS2 line-box strut interactions (12) — pass again with `set_compute_strut(false)`

`list-style(-image/-type)-applies-to-012/014.xht` (6 tests), `contain-size-flexbox-002.html`, `font-colorization.html`, `intrinsic-percent-replaced-008.html`, `intrinsic-percent-replaced-dynamic-005.html`, `abs-pos-with-replaced-child.html`, and (combined with the baseline wiring) `flexbox-baseline-multi-line-vert-002.html`.

The strut itself is spec-correct (CSS2 §10.8) and is what fixes the much larger set of `vertical-align: top` reference mismatches; these failures are cases where the strut interacts with other Blitz gaps rather than the strut being wrong. E.g. the `lists` tests wrap a zero-height list-item inside an inline-block: the strut now reserves a full line for the otherwise-empty line box containing the zero-height inline box, pushing the outside marker one line below where the (strut-less) reference paints it — proper handling needs marker boxes to participate in the line like browsers do. The `intrinsic-percent-replaced` / `abs-pos-with-replaced-child` refs contain text next to replaced elements whose heights now differ by the strut's leading. Individual fixes here are follow-up work in Blitz's marker/replaced-element line handling, not in this PR's wiring.

### Parley 0.11.1 → git-main upgrade behavior changes (27) — fail regardless of strut/baseline wiring

These remain failing with the strut disabled *and* the baseline wiring neutralized, so they come from the Parley upgrade itself (new CSS2 per-side line metrics from linebender/parley#639, nbsp now rendering, changed trailing-whitespace/hanging behavior), or from pre-existing Blitz issues newly exposed by it:

- Ruby (6): `css-ruby/br-clear-all-000`, `empty-ruby-base-container`, `empty-ruby-text-container-abs/-float`, `ruby-base-container-abs/-float` — empty ruby structures now contribute line height where they previously collapsed.
- Trailing/hanging whitespace (5): `trailing-ideographic-space-013/014`, `hanging-whitespace-002.tentative`, `full-width-leading-spaces-004`, `hanging-punctuation-first-002` — parley main changed trailing-space hang/measurement behavior (nearby siblings of these tests *start* passing, so it's a behavior trade within the same feature).
- Font/shaping (4): `font-family-applies-to-005`, `font-feature-settings-tibetan`, `small-caps-letter-spacing-002`, `font-colorization` — shaping/metrics changes in parley main (several other shaping tests start passing).
- `floats-149.xht`: the green block collapses to zero height — its only in-flow content is an empty inline whose children are floats; a line box containing only an empty inline + floats no longer contributes height under the new line-metrics model (CSS2 §9.4.2 empty-inline handling needed).
- `empty-span-size-002.html`: empty spans' contribution to line height changed with the new per-side line metrics.
- Misc (6): `t41-html4-keywords-a`, `contain-animation-001`, `custom-highlight-painting-inheritance-001/002`, `text-decoration-skip-spaces-001`, `css-break/ruby-003` — small text-position shifts from the new line metrics cause these paint-comparison tests to mismatch.
- Grid (2): `grid-layout-auto-tracks`, `column-subgrid-grid-gap-008` — content-sized track sizing shifted by the changed text-line heights.

Note: `flexbox-baseline-multi-item-horiz-001a.html`-style tests still fail, but for orthogonal reasons (synthesized baselines of empty/no-text flex items), not the inline-box wiring.

<!-- wpt-results-start -->
## WPT results

**144** newly passing, **43** newly failing (net +101).

<details>
<summary>Full diff (187 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/abspos/between-float-and-text.html
+ Fail => Pass css/CSS2/backgrounds/background-position-applies-to-007.xht
+ Fail => Pass css/CSS2/backgrounds/background-position-applies-to-009.xht
+ Fail => Pass css/CSS2/backgrounds/background-position-applies-to-012.xht
+ Fail => Pass css/CSS2/backgrounds/background-position-applies-to-013.xht
+ Fail => Pass css/CSS2/backgrounds/background-position-applies-to-014.xht
+ Fail => Pass css/CSS2/bidi-text/bidi-001.xht
+ Fail => Pass css/CSS2/box-display/containing-block-030.xht
+ Fail => Pass css/CSS2/css1/c414-flt-fit-004.xht
+ Fail => Pass css/CSS2/css1/c534-bgre-000.xht
+ Fail => Pass css/CSS2/css1/c534-bgre-001.xht
+ Fail => Pass css/CSS2/css1/c534-bgreps-001.xht
+ Fail => Pass css/CSS2/css1/c534-bgreps-002.xht
+ Fail => Pass css/CSS2/css1/c534-bgreps-003.xht
+ Fail => Pass css/CSS2/css1/c534-bgreps-004.xht
+ Fail => Pass css/CSS2/css1/c534-bgreps-005.xht
+ Fail => Pass css/CSS2/css1/c536-bgpos-000.xht
+ Fail => Pass css/CSS2/css1/c536-bgpos-001.xht
+ Fail => Pass css/CSS2/css1/c547-indent-000.xht
+ Fail => Pass css/CSS2/css1/c5502-mrgn-r-000.xht
+ Fail => Pass css/CSS2/css1/c5504-mrgn-l-000.xht
+ Fail => Pass css/CSS2/css1/c5505-mrgn-000.xht
+ Fail => Pass css/CSS2/css1/c5511-brdr-tw-001.xht
+ Fail => Pass css/CSS2/css1/c5513-brdr-bw-001.xht
+ Fail => Pass css/CSS2/css1/c5515-brdr-w-001.xht
+ Fail => Pass css/CSS2/css1/c5525-fltwidth-003.xht
+ Fail => Pass css/CSS2/css1/c61-rel-len-000.xht
+ Fail => Pass css/CSS2/floats-clear/clear-003.xht
+ Fail => Pass css/CSS2/floats-clear/clear-inline-001.xht
+ Fail => Pass css/CSS2/floats-clear/floats-007.xht
+ Fail => Pass css/CSS2/floats-clear/floats-031.xht
+ Fail => Pass css/CSS2/floats-clear/floats-038.xht
+ Fail => Pass css/CSS2/floats-clear/floats-040.xht
- Pass => Fail css/CSS2/floats-clear/floats-149.xht
+ Fail => Pass css/CSS2/floats-clear/margin-collapse-clear-014.xht
- Pass => Fail css/CSS2/fonts/font-family-applies-to-005.xht
+ Fail => Pass css/CSS2/fonts/font-size-124.xht
- Pass => Fail css/CSS2/linebox/baseline-block-with-overflow-001.html
+ Fail => Pass css/CSS2/linebox/line-height-127.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-001.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-002.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-003.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-004.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-007.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-008.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-009.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-012.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-013.xht
+ Fail => Pass css/CSS2/linebox/line-height-applies-to-014.xht
- Pass => Fail css/CSS2/lists/list-style-applies-to-012.xht
- Pass => Fail css/CSS2/lists/list-style-applies-to-014.xht
- Pass => Fail css/CSS2/lists/list-style-image-applies-to-012.xht
- Pass => Fail css/CSS2/lists/list-style-image-applies-to-014.xht
- Pass => Fail css/CSS2/lists/list-style-type-applies-to-012.xht
- Pass => Fail css/CSS2/lists/list-style-type-applies-to-014.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-zorder-002.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-zorder-004.xht
- Pass => Fail css/CSS2/normal-flow/inline-block-zorder-005.xht
+ Fail => Pass css/CSS2/normal-flow/inline-table-valign-001.xht
- Pass => Fail css/CSS2/normal-flow/inline-table-width-002b.xht
- Pass => Fail css/CSS2/normal-flow/inline-table-zorder-001.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-036.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-047.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-036.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-047.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-max-height-009.xht
+ Fail => Pass css/CSS2/positioning/abspos-011.xht
+ Fail => Pass css/CSS2/positioning/abspos-012.xht
+ Fail => Pass css/CSS2/text/text-indent-011.xht
+ Fail => Pass css/CSS2/text/white-space-007.xht
+ Fail => Pass css/CSS2/text/white-space-normal-003.xht
+ Fail => Pass css/CSS2/values/units-003.xht
+ Fail => Pass css/CSS2/visudet/content-height-001.html
+ Fail => Pass css/CSS2/visudet/content-height-002.html
+ Fail => Pass css/CSS2/visudet/content-height-003.html
- Pass => Fail css/css-align/baseline-of-scrollable-1b.html
+ Fail => Pass css/css-align/baseline-rules/synthesized-baseline-flexbox-001.html
+ Fail => Pass css/css-align/baseline-rules/synthesized-baseline-grid-001.html
+ Fail => Pass css/css-align/baseline-rules/synthesized-baseline-inline-block-001.html
+ Fail => Pass css/css-backgrounds/box-shadow-outset-without-border-radius-001.html
- Pass => Fail css/css-break/ruby-003.html
- Pass => Fail css/css-color/t41-html4-keywords-a.xht
- Pass => Fail css/css-contain/contain-animation-001.html
+ Fail => Pass css/css-contain/contain-layout-ink-overflow-013.html
+ Fail => Pass css/css-contain/contain-layout-ink-overflow-015.html
+ Fail => Pass css/css-contain/contain-paint-022.html
+ Fail => Pass css/css-contain/contain-paint-023.html
- Pass => Fail css/css-contain/contain-size-flexbox-002.html
+ Fail => Pass css/css-flexbox/alignment/flex-align-baseline-flex-003.html
+ Fail => Pass css/css-flexbox/alignment/flex-align-baseline-overflow-001.html
+ Fail => Pass css/css-flexbox/flexbox-align-self-baseline-horiz-007.xhtml
+ Fail => Pass css/css-flexbox/flexbox-align-self-horiz-001-block.xhtml
+ Fail => Pass css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001.html
+ Fail => Pass css/css-flexbox/flexbox-baseline-multi-item-vert-001a.html
+ Fail => Pass css/css-flexbox/flexbox-baseline-multi-item-vert-001b.html
+ Fail => Pass css/css-flexbox/flexbox-baseline-multi-line-horiz-001.html
+ Fail => Pass css/css-flexbox/flexbox-baseline-multi-line-horiz-002.html
- Pass => Fail css/css-flexbox/flexbox-baseline-multi-line-vert-002.html
+ Fail => Pass css/css-flexbox/flexbox-basic-canvas-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-canvas-vert-001v.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-iframe-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-img-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-textarea-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-basic-video-vert-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-justify-content-horiz-002.xhtml
+ Fail => Pass css/css-flexbox/flexbox-justify-content-horiz-004.xhtml
+ Fail => Pass css/css-flexbox/flexible-box-float.html
- Pass => Fail css/css-fonts/font-colorization.html
- Pass => Fail css/css-fonts/font-feature-settings-tibetan.html
- Pass => Fail css/css-fonts/small-caps-letter-spacing-002.html
+ Fail => Pass css/css-fonts/variations/font-weight-metrics.html
+ Fail => Pass css/css-grid/alignment/grid-align-baseline-004.html
+ Fail => Pass css/css-grid/alignment/grid-align-baseline-flex-003.html
+ Fail => Pass css/css-grid/alignment/grid-align-baseline-overflow-001.html
+ Fail => Pass css/css-grid/alignment/grid-baseline-004.html
+ Fail => Pass css/css-grid/alignment/grid-self-alignment-baseline-with-grid-001.html
+ Fail => Pass css/css-grid/alignment/grid-self-alignment-baseline-with-grid-002.html
+ Fail => Pass css/css-grid/alignment/grid-self-alignment-baseline-with-grid-003.html
+ Fail => Pass css/css-grid/alignment/grid-self-alignment-baseline-with-grid-004.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-008.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-001.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-003.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-lr-001.html
+ Fail => Pass css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-rl-001.html
- Pass => Fail css/css-grid/grid-definition/grid-layout-auto-tracks.html
+ Fail => Pass css/css-grid/grid-items/grid-layout-z-order-a.html
+ Fail => Pass css/css-grid/grid-items/grid-layout-z-order-b.html
- Pass => Fail css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/gap/column-subgrid-grid-gap-008.html
+ Fail => Pass css/css-grid/subgrid/subgrid-baseline-011.html
- Pass => Fail css/css-highlight-api/painting/custom-highlight-painting-inheritance-001.html
- Pass => Fail css/css-highlight-api/painting/custom-highlight-painting-inheritance-002.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-none-cross-origin.html
+ Fail => Pass css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html
- Pass => Fail css/css-inline/empty-span-size-002.html
+ Fail => Pass css/css-multicol/multicol-width-negative-001.xht
+ Fail => Pass css/css-page/monolithic-overflow-014-print.html
- Pass => Fail css/css-ruby/br-clear-all-000.html
- Pass => Fail css/css-ruby/empty-ruby-base-container.html
- Pass => Fail css/css-ruby/empty-ruby-text-container-abs.html
- Pass => Fail css/css-ruby/empty-ruby-text-container-float.html
- Pass => Fail css/css-ruby/ruby-base-container-abs.html
- Pass => Fail css/css-ruby/ruby-base-container-float.html
- Pass => Fail css/css-sizing/intrinsic-percent-replaced-008.html
- Pass => Fail css/css-sizing/intrinsic-percent-replaced-dynamic-005.html
+ Fail => Pass css/css-text-decor/text-decoration-inset-003.html
+ Fail => Pass css/css-text-decor/text-decoration-inset-008.html
- Pass => Fail css/css-text-decor/text-decoration-skip-spaces-001.html
- Pass => Fail css/css-text/hanging-punctuation/hanging-punctuation-first-002.html
+ Fail => Pass css/css-text/line-breaking/line-breaking-atomic-002.html
+ Fail => Pass css/css-text/line-breaking/line-breaking-atomic-009.html
+ Fail => Pass css/css-text/line-breaking/line-breaking-replaced-004.html
+ Fail => Pass css/css-text/overflow-wrap/overflow-wrap-min-content-size-002.html
+ Fail => Pass css/css-text/shaping/shaping-002.html
+ Fail => Pass css/css-text/shaping/shaping-003.html
+ Fail => Pass css/css-text/shaping/shaping-008.html
+ Fail => Pass css/css-text/shaping/shaping-017.html
+ Fail => Pass css/css-text/shaping/shaping-018.html
+ Fail => Pass css/css-text/shaping/shaping-021.html
+ Fail => Pass css/css-text/shaping/shaping-024.html
+ Fail => Pass css/css-text/text-align/text-align-match-parent-05.html
+ Fail => Pass css/css-text/text-encoding/shaping-tatweel-003.html
+ Fail => Pass css/css-text/white-space/control-chars-00B.html
+ Fail => Pass css/css-text/white-space/control-chars-085.html
+ Fail => Pass css/css-text/white-space/full-width-leading-spaces-002.html
+ Fail => Pass css/css-text/white-space/full-width-leading-spaces-003.html
- Pass => Fail css/css-text/white-space/full-width-leading-spaces-004.html
+ Fail => Pass css/css-text/white-space/full-width-leading-spaces-005.html
- Pass => Fail css/css-text/white-space/hanging-whitespace-002.tentative.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-006.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-007.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-009.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-012.html
- Pass => Fail css/css-text/white-space/trailing-ideographic-space-013.html
- Pass => Fail css/css-text/white-space/trailing-ideographic-space-014.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-017.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-019.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-020.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-022.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-023.html
+ Fail => Pass css/css-text/white-space/trailing-ideographic-space-025.html
+ Fail => Pass css/css-text/word-break/word-break-break-all-008.html
+ Fail => Pass css/css-values/ch-unit-001.html
+ Fail => Pass css/css-values/lh-unit-001.html
+ Fail => Pass css/css-values/lh-unit-002.html
- Pass => Fail css/css-writing-modes/abs-pos-with-replaced-child.html
+ Fail => Pass css/css-writing-modes/text-combine-upright-shadow.html
+ Fail => Pass css/filter-effects/effect-reference-after-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32477301579).</sub>
<!-- wpt-results-end -->

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/3817a3c1194f47afbc30e587ba79678f
Requested by: @nicoburns