### PR TITLE
Update taffy to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=7eddc45ac29edf40e9301aeaf522e6b4546aa268#7eddc45ac29edf40e9301aeaf522e6b4546aa268"
+source = "git+https://github.com/DioxusLabs/taffy?rev=02820e54b7a0a38cc2443eb9d2d24a44db36f235#02820e54b7a0a38cc2443eb9d2d24a44db36f235"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "7eddc45ac29edf40e9301aeaf522e6b4546aa268", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "02820e54b7a0a38cc2443eb9d2d24a44db36f235", default-features = false, features = [
     "std",
     "flexbox",
     "grid",


### PR DESCRIPTION
## Summary

Bump the pinned `taffy` git rev `7eddc45a` → `02820e54` (latest main). Pulls in:

- Block: clamp and synthesize scroll-container baselines (DioxusLabs/taffy#1126)
- Flexbox: generate container baseline from visually startmost line/item for reverse containers (DioxusLabs/taffy#1127)
- Grid: exclude items with auto block-axis margins from baseline alignment (DioxusLabs/taffy#1125)

No code changes required; `cargo check --workspace` and `cargo test --workspace` pass, and WPT results (css/CSS2, css-flexbox, css-grid) are unchanged vs the previous rev.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e9fbc6900f2c469d84ca90d71a628d7b
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32199964702).</sub>
<!-- wpt-results-end -->
