### PR TITLE
Wire up `contain: layout` and `contain: paint` to Taffy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=52694c375e5488442d7179b8397c1f0b15bca246#52694c375e5488442d7179b8397c1f0b15bca246"
+source = "git+https://github.com/DioxusLabs/taffy?rev=4ae4219b34e0ad22fd907cb1a7fa9a68c1ea1621#4ae4219b34e0ad22fd907cb1a7fa9a68c1ea1621"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=02820e54b7a0a38cc2443eb9d2d24a44db36f235#02820e54b7a0a38cc2443eb9d2d24a44db36f235"
+source = "git+https://github.com/DioxusLabs/taffy?rev=c979f2dfd144115ab3dcb9bbaa17965c9ca4b974#c979f2dfd144115ab3dcb9bbaa17965c9ca4b974"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=674eb151003c0af33f1b4be04012d2c3565e39a9#674eb151003c0af33f1b4be04012d2c3565e39a9"
+source = "git+https://github.com/DioxusLabs/taffy?rev=52694c375e5488442d7179b8397c1f0b15bca246#52694c375e5488442d7179b8397c1f0b15bca246"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=c979f2dfd144115ab3dcb9bbaa17965c9ca4b974#c979f2dfd144115ab3dcb9bbaa17965c9ca4b974"
+source = "git+https://github.com/DioxusLabs/taffy?rev=674eb151003c0af33f1b4be04012d2c3565e39a9#674eb151003c0af33f1b4be04012d2c3565e39a9"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "c979f2dfd144115ab3dcb9bbaa17965c9ca4b974", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "674eb151003c0af33f1b4be04012d2c3565e39a9", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "52694c375e5488442d7179b8397c1f0b15bca246", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "4ae4219b34e0ad22fd907cb1a7fa9a68c1ea1621", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "674eb151003c0af33f1b4be04012d2c3565e39a9", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "52694c375e5488442d7179b8397c1f0b15bca246", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "02820e54b7a0a38cc2443eb9d2d24a44db36f235", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "c979f2dfd144115ab3dcb9bbaa17965c9ca4b974", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -219,6 +219,7 @@ pub(crate) fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) 
         if old_box.display != new_box.display
             || old_box.float != new_box.float
             || old_box.position != new_box.position
+            || old_box.contain != new_box.contain
             || old.clone_visibility() != new.clone_visibility()
         {
             return true;

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -10,7 +10,9 @@ pub(crate) mod stylo {
     pub(crate) use style::properties::longhands::position::computed_value::T as Position;
     pub(crate) use style::values::computed::length_percentage::CalcLengthPercentage;
     pub(crate) use style::values::computed::length_percentage::Unpacked as UnpackedLengthPercentage;
-    pub(crate) use style::values::computed::{BorderSideWidth, LengthPercentage, Percentage};
+    pub(crate) use style::values::computed::{
+        BorderSideWidth, Contain, LengthPercentage, Percentage,
+    };
     pub(crate) use style::values::generics::NonNegative;
     pub(crate) use style::values::generics::length::{
         GenericLengthPercentageOrNormal, GenericMargin, GenericMaxSize, GenericSize,
@@ -272,6 +274,25 @@ pub fn overflow(input: stylo::Overflow) -> taffy::Overflow {
         // TODO: Support Overflow::Auto in Taffy
         stylo::Overflow::Auto => taffy::Overflow::Scroll,
     }
+}
+
+#[inline]
+pub fn contain(input: stylo::Contain, display: stylo::Display) -> taffy::Contain {
+    // Layout and paint containment do not apply to non-atomic inline-level boxes
+    // (https://drafts.csswg.org/css-contain-1/#containment-layout)
+    if display.outside() == stylo::DisplayOutside::Inline
+        && display.inside() == stylo::DisplayInside::Flow
+    {
+        return taffy::Contain::NONE;
+    }
+    let mut result = taffy::Contain::NONE;
+    if input.contains(stylo::Contain::LAYOUT) {
+        result |= taffy::Contain::LAYOUT;
+    }
+    if input.contains(stylo::Contain::PAINT) {
+        result |= taffy::Contain::PAINT;
+    }
+    result
 }
 
 #[inline]
@@ -712,6 +733,7 @@ pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style<Atom> {
         },
         direction: self::direction(style.clone_direction()),
         scrollbar_width: 0.0,
+        contain: self::contain(style.clone_contain(), style.clone_display()),
 
         #[cfg(feature = "floats")]
         float: self::float(style.clone_float()),

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -69,6 +69,12 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
     }
 
     #[inline]
+    fn contain(&self) -> taffy::Contain {
+        let box_styles = self.0.get_box();
+        convert::contain(box_styles.contain, box_styles.display)
+    }
+
+    #[inline]
     fn position(&self) -> taffy::Position {
         convert::position(self.0.get_box().position)
     }


### PR DESCRIPTION
## Summary

Updates Taffy to a revision that includes the new `contain` style (DioxusLabs/taffy#1128) and wires up Stylo's computed `contain` to it:

- `stylo_taffy::convert::contain(input: stylo::Contain, display: stylo::Display) -> taffy::Contain` maps the `LAYOUT` and `PAINT` flags (other flags have no Taffy layout effect). Containment is not applied to non-atomic inline-level boxes (`display: inline` with `inside: flow`), per css-contain-1's applicability rules.
- `TaffyStyloStyle` implements the new `CoreStyle::contain()` accessor, and the eager `to_taffy_style` conversion sets `contain` as well.
- `compute_layout_damage` in blitz-dom now treats a change to `contain` as requiring box-tree rebuild, since containment changes formatting-context structure (float containment, margin collapsing).

WPT `css/css-contain` results: 248 tests passing vs 239 on main (+11 newly passing: independent formatting context, float containment, margin collapsing, and baseline suppression tests; -2: `contain-layout-dynamic-004/005.html`, which require JavaScript to apply containment dynamically and previously only passed vacuously because both test and ref rendered without containment).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/c903534a83f54a6daf2f68f4cc38cf72
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**11** newly passing, **2** newly failing (net +9).

<details>
<summary>Full diff (13 changed tests)</summary>

```diff
+ Fail => Pass css/css-contain/contain-content-001.html
+ Fail => Pass css/css-contain/contain-content-002.html
- Pass => Fail css/css-contain/contain-layout-dynamic-004.html
- Pass => Fail css/css-contain/contain-layout-dynamic-005.html
+ Fail => Pass css/css-contain/contain-layout-formatting-context-float-001.html
+ Fail => Pass css/css-contain/contain-layout-formatting-context-margin-001.html
+ Fail => Pass css/css-contain/contain-layout-ifc-022.html
+ Fail => Pass css/css-contain/contain-layout-independent-formatting-context-001.html
+ Fail => Pass css/css-contain/contain-layout-suppress-baseline-002.html
+ Fail => Pass css/css-contain/contain-paint-formatting-context-float-001.html
+ Fail => Pass css/css-contain/contain-paint-formatting-context-margin-001.html
+ Fail => Pass css/css-contain/contain-paint-ifc-011.html
+ Fail => Pass css/css-contain/contain-paint-independent-formatting-context-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32202634264).</sub>
<!-- wpt-results-end -->
