### PR TITLE
Implement text decoration styles (rebased)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
  "anyrender",
  "image",
  "peniko",
- "read-fonts 0.41.0",
+ "read-fonts",
  "serde",
  "serde_json",
  "sha2",
@@ -1024,7 +1024,7 @@ dependencies = [
  "kurbo",
  "parley",
  "peniko",
- "read-fonts 0.39.2",
+ "skrifa",
  "smallvec",
  "stylo",
  "taffy",
@@ -2932,9 +2932,6 @@ name = "font-types"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "font-types"
@@ -2981,7 +2978,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts 0.41.0",
+ "read-fonts",
  "roxmltree 0.21.1",
  "smallvec",
  "windows",
@@ -3469,7 +3466,7 @@ checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
- "read-fonts 0.41.0",
+ "read-fonts",
  "smallvec",
 ]
 
@@ -6162,16 +6159,6 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
-dependencies = [
- "bytemuck",
- "font-types 0.11.3",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
@@ -6897,7 +6884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
 dependencies = [
  "bytemuck",
- "read-fonts 0.41.0",
+ "read-fonts",
 ]
 
 [[package]]
@@ -9605,7 +9592,7 @@ checksum = "cae90d1d9f6d1d36ef116b0b1e651a6d7c12ba925439d4d06ff9adc94662a3d8"
 dependencies = [
  "font-types 0.12.3",
  "log",
- "read-fonts 0.41.0",
+ "read-fonts",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,7 @@ dependencies = [
  "kurbo",
  "parley",
  "peniko",
+ "read-fonts",
  "smallvec",
  "stylo",
  "taffy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
  "anyrender",
  "image",
  "peniko",
- "read-fonts",
+ "read-fonts 0.41.0",
  "serde",
  "serde_json",
  "sha2",
@@ -1024,7 +1024,7 @@ dependencies = [
  "kurbo",
  "parley",
  "peniko",
- "read-fonts",
+ "read-fonts 0.39.2",
  "smallvec",
  "stylo",
  "taffy",
@@ -2932,6 +2932,9 @@ name = "font-types"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "font-types"
@@ -2978,7 +2981,7 @@ dependencies = [
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "parlance",
- "read-fonts",
+ "read-fonts 0.41.0",
  "roxmltree 0.21.1",
  "smallvec",
  "windows",
@@ -3466,7 +3469,7 @@ checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.41.0",
  "smallvec",
 ]
 
@@ -6159,6 +6162,16 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types 0.11.3",
+]
+
+[[package]]
+name = "read-fonts"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
@@ -6884,7 +6897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.41.0",
 ]
 
 [[package]]
@@ -9592,7 +9605,7 @@ checksum = "cae90d1d9f6d1d36ef116b0b1e651a6d7c12ba925439d4d06ff9adc94662a3d8"
 dependencies = [
  "font-types 0.12.3",
  "log",
- "read-fonts",
+ "read-fonts 0.41.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,9 @@ parley = { version = "0.11.1", default-features = false, features = ["std"] }
 skrifa = { version = "0.44", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions
+read-fonts = { version = "0.39.2", default-features = false, features = [
+    "std",
+] } # Should match skrifa's read-fonts dependency
 
 # AnyRender
 anyrender = { version = "0.13.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,9 +109,6 @@ parley = { version = "0.11.1", default-features = false, features = ["std"] }
 skrifa = { version = "0.44", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions
-read-fonts = { version = "0.39.2", default-features = false, features = [
-    "std",
-] } # Should match skrifa's read-fonts dependency
 
 # AnyRender
 anyrender = { version = "0.13.0" }

--- a/examples/assets/text-decoration.html
+++ b/examples/assets/text-decoration.html
@@ -1,0 +1,428 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        font-family: sans-serif;
+        background: #f5f5f5;
+        margin: 0;
+        padding: 24px;
+        color: #222;
+        line-height: 1.6;
+    }
+    h1 {
+        margin-top: 0;
+    }
+    h2 {
+        font-size: 16px;
+        color: #555;
+        margin-bottom: 8px;
+    }
+    section {
+        background: white;
+        padding: 20px 24px;
+        margin-bottom: 24px;
+    }
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+        gap: 16px;
+    }
+    .item {
+        border: 1px solid #e0e0e0;
+        padding: 12px;
+    }
+    .sample {
+        font-size: 22px;
+        margin: 0 0 8px;
+        /* Base decoration so the sub-property examples are visible. */
+        text-decoration-line: underline;
+        text-decoration-color: #d6336c;
+    }
+    .code {
+        font-family: monospace;
+        font-size: 12px;
+        color: #666;
+    }
+
+    /* text-decoration-line */
+    .line-none { text-decoration-line: none; }
+    .line-underline { text-decoration-line: underline; }
+    .line-overline { text-decoration-line: overline; }
+    .line-through { text-decoration-line: line-through; }
+    .line-underline-overline { text-decoration-line: underline overline; }
+    .line-underline-through { text-decoration-line: underline line-through; }
+    .line-overline-through { text-decoration-line: overline line-through; }
+    .line-all { text-decoration-line: underline overline line-through; }
+
+    /* text-decoration-thickness */
+    .thick-auto { text-decoration-thickness: auto; }
+    .thick-from-font { text-decoration-thickness: from-font; }
+    .thick-1px { text-decoration-thickness: 1px; }
+    .thick-3px { text-decoration-thickness: 3px; }
+    .thick-5px { text-decoration-thickness: 5px; }
+    .thick-0_2em { text-decoration-thickness: 0.2em; }
+
+    /* text-decoration-style */
+    .style-solid { text-decoration-style: solid; }
+    .style-double { text-decoration-style: double; }
+    .style-dotted { text-decoration-style: dotted; }
+    .style-dashed { text-decoration-style: dashed; }
+    .style-wavy { text-decoration-style: wavy; }
+
+    /* Mixed font size / weight inline runs */
+    .mixed {
+        font-size: 22px;
+        margin: 0 0 8px;
+        text-decoration-color: #d6336c;
+    }
+    .mixed .big { font-size: 36px; font-weight: 700; }
+    .mixed .small { font-size: 14px; font-weight: 400; }
+    .mixed .bold { font-weight: 800; }
+    .mixed .light { font-weight: 300; }
+
+    /* text-underline-offset */
+    .offset-auto { text-underline-offset: auto; }
+    .offset-2px { text-underline-offset: 2px; }
+    .offset-4px { text-underline-offset: 4px; }
+    .offset--2px { text-underline-offset: -2px; }
+    .offset-0_2em { text-underline-offset: 0.2em; }
+
+    /* text-underline-position */
+    .pos-auto { text-underline-position: auto; }
+    .pos-from-font { text-underline-position: from-font; }
+    .pos-under { text-underline-position: under; }
+
+    /* text-decoration-inset */
+    .inset-auto { text-decoration-inset: auto; }
+    .inset-4px { text-decoration-inset: 4px; }
+    .inset-8px { text-decoration-inset: 8px; }
+    .inset--4px { text-decoration-inset: -4px; }
+    .inset-4px-12px { text-decoration-inset: 4px 12px; }
+    .inset-10pct { text-decoration-inset: 10%; }
+
+    /* Overlines with different line-heights */
+    .overline {
+        text-decoration-line: overline;
+        text-decoration-color: #2f9e44;
+    }
+    .lh-normal { line-height: normal; }
+    .lh-1 { line-height: 1; }
+    .lh-1_2 { line-height: 1.2; }
+    .lh-1_5 { line-height: 1.5; }
+    .lh-2 { line-height: 2; }
+    .lh-3 { line-height: 3; }
+    .lh-0_8 { line-height: 0.8; }
+
+    /* Combined example */
+    .combined {
+        text-decoration-line: underline;
+        text-decoration-style: wavy;
+        text-decoration-thickness: 3px;
+        text-decoration-color: #1c7ed6;
+        text-underline-offset: 4px;
+        text-decoration-inset: 4px 12px;
+    }
+</style>
+</head>
+<body>
+    <h1>Text decoration examples</h1>
+
+    <section>
+        <h2>text-decoration-line</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="sample line-none">The quick brown fox</p>
+                <div class="code">text-decoration-line: none;</div>
+            </div>
+            <div class="item">
+                <p class="sample line-underline">The quick brown fox</p>
+                <div class="code">text-decoration-line: underline;</div>
+            </div>
+            <div class="item">
+                <p class="sample line-overline">The quick brown fox</p>
+                <div class="code">text-decoration-line: overline;</div>
+            </div>
+            <div class="item">
+                <p class="sample line-through">The quick brown fox</p>
+                <div class="code">text-decoration-line: line-through;</div>
+            </div>
+            <div class="item">
+                <p class="sample line-underline-overline">The quick brown fox</p>
+                <div class="code">text-decoration-line: underline overline;</div>
+            </div>
+            <div class="item">
+                <p class="sample line-underline-through">The quick brown fox</p>
+                <div class="code">text-decoration-line: underline line-through;</div>
+            </div>
+            <div class="item">
+                <p class="sample line-overline-through">The quick brown fox</p>
+                <div class="code">text-decoration-line: overline line-through;</div>
+            </div>
+            <div class="item">
+                <p class="sample line-all">The quick brown fox</p>
+                <div class="code">text-decoration-line: underline overline line-through;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>text-decoration-thickness</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="sample thick-auto">The quick brown fox</p>
+                <div class="code">text-decoration-thickness: auto;</div>
+            </div>
+            <div class="item">
+                <p class="sample thick-from-font">The quick brown fox</p>
+                <div class="code">text-decoration-thickness: from-font;</div>
+            </div>
+            <div class="item">
+                <p class="sample thick-1px">The quick brown fox</p>
+                <div class="code">text-decoration-thickness: 1px;</div>
+            </div>
+            <div class="item">
+                <p class="sample thick-3px">The quick brown fox</p>
+                <div class="code">text-decoration-thickness: 3px;</div>
+            </div>
+            <div class="item">
+                <p class="sample thick-5px">The quick brown fox</p>
+                <div class="code">text-decoration-thickness: 5px;</div>
+            </div>
+            <div class="item">
+                <p class="sample thick-0_2em">The quick brown fox</p>
+                <div class="code">text-decoration-thickness: 0.2em;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>text-decoration-style</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="sample style-solid">The quick brown fox</p>
+                <div class="code">text-decoration-style: solid;</div>
+            </div>
+            <div class="item">
+                <p class="sample style-double">The quick brown fox</p>
+                <div class="code">text-decoration-style: double;</div>
+            </div>
+            <div class="item">
+                <p class="sample style-dotted">The quick brown fox</p>
+                <div class="code">text-decoration-style: dotted;</div>
+            </div>
+            <div class="item">
+                <p class="sample style-dashed">The quick brown fox</p>
+                <div class="code">text-decoration-style: dashed;</div>
+            </div>
+            <div class="item">
+                <p class="sample style-wavy">The quick brown fox</p>
+                <div class="code">text-decoration-style: wavy;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>text-decoration-style with mixed font size and weight</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="mixed style-solid line-underline">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">text-decoration-style: solid;</div>
+            </div>
+            <div class="item">
+                <p class="mixed style-double line-underline">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">text-decoration-style: double;</div>
+            </div>
+            <div class="item">
+                <p class="mixed style-dotted line-underline">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">text-decoration-style: dotted;</div>
+            </div>
+            <div class="item">
+                <p class="mixed style-dashed line-underline">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">text-decoration-style: dashed;</div>
+            </div>
+            <div class="item">
+                <p class="mixed style-wavy line-underline">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">text-decoration-style: wavy;</div>
+            </div>
+            <div class="item">
+                <p class="mixed line-through style-solid">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">line-through / solid;</div>
+            </div>
+            <div class="item">
+                <p class="mixed line-through style-double">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">line-through / double;</div>
+            </div>
+            <div class="item">
+                <p class="mixed line-through style-wavy">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">line-through / wavy;</div>
+            </div>
+            <div class="item">
+                <p class="mixed line-all style-solid">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">underline overline line-through / solid;</div>
+            </div>
+            <div class="item">
+                <p class="mixed line-all style-wavy">The <span class="big">quick</span> <span class="small">brown</span> <span class="bold">fox</span> <span class="light">jumps</span> over</p>
+                <div class="code">underline overline line-through / wavy;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>text-underline-offset</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="sample offset-auto">The quick brown fox</p>
+                <div class="code">text-underline-offset: auto;</div>
+            </div>
+            <div class="item">
+                <p class="sample offset-2px">The quick brown fox</p>
+                <div class="code">text-underline-offset: 2px;</div>
+            </div>
+            <div class="item">
+                <p class="sample offset-4px">The quick brown fox</p>
+                <div class="code">text-underline-offset: 4px;</div>
+            </div>
+            <div class="item">
+                <p class="sample offset--2px">The quick brown fox</p>
+                <div class="code">text-underline-offset: -2px;</div>
+            </div>
+            <div class="item">
+                <p class="sample offset-0_2em">The quick brown fox</p>
+                <div class="code">text-underline-offset: 0.2em;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>text-underline-position</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="sample pos-auto">The quick brown fox</p>
+                <div class="code">text-underline-position: auto;</div>
+            </div>
+            <div class="item">
+                <p class="sample pos-from-font">The quick brown fox</p>
+                <div class="code">text-underline-position: from-font;</div>
+            </div>
+            <div class="item">
+                <p class="sample pos-under">The quick brown fox</p>
+                <div class="code">text-underline-position: under;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>text-decoration-inset</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="sample inset-auto">The quick brown fox</p>
+                <div class="code">text-decoration-inset: auto;</div>
+            </div>
+            <div class="item">
+                <p class="sample inset-4px">The quick brown fox</p>
+                <div class="code">text-decoration-inset: 4px;</div>
+            </div>
+            <div class="item">
+                <p class="sample inset-8px">The quick brown fox</p>
+                <div class="code">text-decoration-inset: 8px;</div>
+            </div>
+            <div class="item">
+                <p class="sample inset--4px">The quick brown fox</p>
+                <div class="code">text-decoration-inset: -4px;</div>
+            </div>
+            <div class="item">
+                <p class="sample inset-4px-12px">The quick brown fox</p>
+                <div class="code">text-decoration-inset: 4px 12px;</div>
+            </div>
+            <div class="item">
+                <p class="sample inset-10pct">The quick brown fox</p>
+                <div class="code">text-decoration-inset: 10%;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>Overlines with different line-heights</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="sample overline lh-normal">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-decoration-line: overline;<br>line-height: normal;</div>
+            </div>
+            <div class="item">
+                <p class="sample overline lh-1">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-decoration-line: overline;<br>line-height: 1;</div>
+            </div>
+            <div class="item">
+                <p class="sample overline lh-1_2">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-decoration-line: overline;<br>line-height: 1.2;</div>
+            </div>
+            <div class="item">
+                <p class="sample overline lh-1_5">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-decoration-line: overline;<br>line-height: 1.5;</div>
+            </div>
+            <div class="item">
+                <p class="sample overline lh-2">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-decoration-line: overline;<br>line-height: 2;</div>
+            </div>
+            <div class="item">
+                <p class="sample overline lh-3">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-decoration-line: overline;<br>line-height: 3;</div>
+            </div>
+            <div class="item">
+                <p class="sample overline lh-0_8">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-decoration-line: overline;<br>line-height: 0.8;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>Underlines with text-underline-position: under and different line-heights</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="sample pos-under lh-normal">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-underline-position: under;<br>line-height: normal;</div>
+            </div>
+            <div class="item">
+                <p class="sample pos-under lh-1">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-underline-position: under;<br>line-height: 1;</div>
+            </div>
+            <div class="item">
+                <p class="sample pos-under lh-1_2">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-underline-position: under;<br>line-height: 1.2;</div>
+            </div>
+            <div class="item">
+                <p class="sample pos-under lh-1_5">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-underline-position: under;<br>line-height: 1.5;</div>
+            </div>
+            <div class="item">
+                <p class="sample pos-under lh-2">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-underline-position: under;<br>line-height: 2;</div>
+            </div>
+            <div class="item">
+                <p class="sample pos-under lh-3">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-underline-position: under;<br>line-height: 3;</div>
+            </div>
+            <div class="item">
+                <p class="sample pos-under lh-0_8">The quick brown fox jumps over the lazy dog</p>
+                <div class="code">text-underline-position: under;<br>line-height: 0.8;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>Combined</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="sample combined">The quick brown fox</p>
+                <div class="code">text-decoration-line: underline;<br>
+                             text-decoration-style: wavy;<br>
+                             text-decoration-thickness: 3px;<br>
+                             text-decoration-color: #1c7ed6;<br>
+                             text-underline-offset: 4px;<br>
+                             text-decoration-inset: 4px 12px;</div>
+            </div>
+        </div>
+    </section>
+</body>
+</html>

--- a/examples/assets/text-decoration.html
+++ b/examples/assets/text-decoration.html
@@ -123,6 +123,27 @@
         text-underline-offset: 4px;
         text-decoration-inset: 4px 12px;
     }
+
+    /* Inner span overriding outer span's style/thickness */
+    .override {
+        font-size: 22px;
+        margin: 0 0 8px;
+        text-decoration-line: underline;
+        text-decoration-color: #d6336c;
+    }
+    .override .outer-solid { text-decoration-style: solid; }
+    .override .outer-double { text-decoration-style: double; }
+    .override .outer-thick { text-decoration-thickness: 3px; }
+
+    .override .inner-dotted { text-decoration-style: dotted; }
+    .override .inner-dashed { text-decoration-style: dashed; }
+    .override .inner-wavy { text-decoration-style: wavy; }
+    .override .inner-thin { text-decoration-thickness: 1px; }
+    .override .inner-thick { text-decoration-thickness: 5px; }
+    .override .inner-style-thick {
+        text-decoration-style: wavy;
+        text-decoration-thickness: 5px;
+    }
 </style>
 </head>
 <body>
@@ -406,6 +427,50 @@
             <div class="item">
                 <p class="sample pos-under lh-0_8">The quick brown fox jumps over the lazy dog</p>
                 <div class="code">text-underline-position: under;<br>line-height: 0.8;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>Inner span overriding outer span's text-decoration-style</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="override"><span class="outer-solid">The quick <span class="inner-dotted">brown</span> fox</span></p>
+                <div class="code">outer: style: solid;<br>inner: style: dotted;</div>
+            </div>
+            <div class="item">
+                <p class="override"><span class="outer-solid">The quick <span class="inner-dashed">brown</span> fox</span></p>
+                <div class="code">outer: style: solid;<br>inner: style: dashed;</div>
+            </div>
+            <div class="item">
+                <p class="override"><span class="outer-solid">The quick <span class="inner-wavy">brown</span> fox</span></p>
+                <div class="code">outer: style: solid;<br>inner: style: wavy;</div>
+            </div>
+            <div class="item">
+                <p class="override"><span class="outer-double">The quick <span class="inner-dotted">brown</span> fox</span></p>
+                <div class="code">outer: style: double;<br>inner: style: dotted;</div>
+            </div>
+            <div class="item">
+                <p class="override"><span class="outer-double">The quick <span class="inner-wavy">brown</span> fox</span></p>
+                <div class="code">outer: style: double;<br>inner: style: wavy;</div>
+            </div>
+        </div>
+    </section>
+
+    <section>
+        <h2>Inner span overriding outer span's text-decoration-thickness</h2>
+        <div class="grid">
+            <div class="item">
+                <p class="override"><span class="outer-thick">The quick <span class="inner-thin">brown</span> fox</span></p>
+                <div class="code">outer: thickness: 3px;<br>inner: thickness: 1px;</div>
+            </div>
+            <div class="item">
+                <p class="override"><span class="outer-thick">The quick <span class="inner-thick">brown</span> fox</span></p>
+                <div class="code">outer: thickness: 3px;<br>inner: thickness: 5px;</div>
+            </div>
+            <div class="item">
+                <p class="override"><span class="outer-thick">The quick <span class="inner-style-thick">brown</span> fox</span></p>
+                <div class="code">outer: thickness: 3px;<br>inner: style: wavy; thickness: 5px;</div>
             </div>
         </div>
     </section>

--- a/packages/blitz-paint/Cargo.toml
+++ b/packages/blitz-paint/Cargo.toml
@@ -38,7 +38,7 @@ taffy = { workspace = true }
 
 # Linebender + WGPU dependencies
 parley = { workspace = true }
-read-fonts = { workspace = true }
+skrifa = { workspace = true }
 color = { workspace = true }
 peniko = { workspace = true }
 kurbo = { workspace = true }

--- a/packages/blitz-paint/Cargo.toml
+++ b/packages/blitz-paint/Cargo.toml
@@ -38,6 +38,7 @@ taffy = { workspace = true }
 
 # Linebender + WGPU dependencies
 parley = { workspace = true }
+read-fonts = { workspace = true }
 color = { workspace = true }
 peniko = { workspace = true }
 kurbo = { workspace = true }

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -780,6 +780,7 @@ impl ElementCx<'_, '_> {
                 self.context.dom,
                 transform,
                 self.scale,
+                self.node.id,
             );
         }
     }
@@ -843,6 +844,7 @@ impl ElementCx<'_, '_> {
                 self.context.dom,
                 transform,
                 self.scale,
+                self.node.id,
             );
         }
     }
@@ -888,6 +890,7 @@ impl ElementCx<'_, '_> {
                 self.context.dom,
                 transform,
                 self.scale,
+                self.node.id,
             );
         }
     }

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -5,6 +5,7 @@ mod clip_path;
 mod form_controls;
 mod mask;
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -15,6 +16,7 @@ use crate::filters::convert_filters;
 use crate::kurbo_css::NonUniformRoundedRectRadii;
 use crate::layers::LayerManager;
 use crate::sizing::compute_object_fit;
+use crate::text::DrawTextContext;
 use crate::{CustomWidgetSceneMap, SELECTION_COLOR};
 use anyrender::{PaintScene, Scene};
 use blitz_dom::node::{
@@ -61,6 +63,8 @@ pub struct BlitzDomPainter<'dom, 'a> {
     #[cfg(feature = "scrollbars")]
     pub(crate) scrollbar_drag_target: Option<blitz_dom::node::ScrollbarRef>,
     pub(crate) layer_manager: LayerManager,
+    /// Reusable scratch allocations shared by all text layouts painted for this document.
+    pub(crate) draw_text_context: RefCell<DrawTextContext>,
     /// Cached selection ranges for O(1) lookup: node_id -> (start_offset, end_offset)
     pub(crate) selection_ranges: HashMap<NodeId, (usize, usize)>,
 
@@ -101,6 +105,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             #[cfg(feature = "scrollbars")]
             scrollbar_drag_target: dom.scrollbar_drag_target(),
             layer_manager,
+            draw_text_context: RefCell::new(DrawTextContext::default()),
             selection_ranges,
             custom_widget_scenes,
         }
@@ -774,6 +779,7 @@ impl ElementCx<'_, '_> {
             }
 
             // Render text
+            let mut draw_text_context = self.context.draw_text_context.borrow_mut();
             crate::text::stroke_text(
                 scene,
                 text_layout.layout.lines(),
@@ -781,6 +787,7 @@ impl ElementCx<'_, '_> {
                 transform,
                 self.scale,
                 self.node.id,
+                &mut draw_text_context,
             );
         }
     }
@@ -838,6 +845,7 @@ impl ElementCx<'_, '_> {
             }
 
             // Render text
+            let mut draw_text_context = self.context.draw_text_context.borrow_mut();
             crate::text::stroke_text(
                 scene,
                 input_data.editor.try_layout().unwrap().lines(),
@@ -845,6 +853,7 @@ impl ElementCx<'_, '_> {
                 transform,
                 self.scale,
                 self.node.id,
+                &mut draw_text_context,
             );
         }
     }
@@ -884,6 +893,7 @@ impl ElementCx<'_, '_> {
             let transform =
                 self.transform * Affine::translate((pos.x * self.scale, pos.y * self.scale));
 
+            let mut draw_text_context = self.context.draw_text_context.borrow_mut();
             crate::text::stroke_text(
                 scene,
                 layout.lines(),
@@ -891,6 +901,7 @@ impl ElementCx<'_, '_> {
                 transform,
                 self.scale,
                 self.node.id,
+                &mut draw_text_context,
             );
         }
     }

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -3,6 +3,7 @@ use blitz_dom::{BaseDocument, NodeId, node::TextBrush, util::ToColorColor};
 use kurbo::{Affine, BezPath, Cap, Circle, Rect, Stroke};
 use parley::{Affinity, Cursor, Layout, Line, PositionedLayoutItem, Selection};
 use peniko::Fill;
+use std::collections::HashMap;
 use style::properties::generated::longhands::text_decoration_style::computed_value::T as TextDecorationStyle;
 use style::values::computed::{
     Length, LengthPercentage, TextDecorationLength, TextDecorationLine, TextUnderlinePosition,
@@ -66,17 +67,31 @@ pub(crate) fn draw_inline_backgrounds<'a>(
     }
 }
 
+/// Per-font-face cache of the OS/2 `usWinAscent / unitsPerEm` ratio, keyed by the font
+/// blob's unique id and face index. `None` is cached for fonts without a usable OS/2 or
+/// head table so they aren't re-parsed either.
+type WinAscentCache = HashMap<(u64, u32), Option<f32>>;
+
 /// The font's OS/2 `usWinAscent`, in the same (device) pixels as `font_size`.
 ///
 /// This is the ascent browsers use as the top of the "em box" when positioning overlines. It
 /// is typically taller than the hhea ascent Parley exposes via [`parley::layout::run::RunMetrics`].
 /// Returns `None` when the font has no OS/2 table.
-fn win_ascent(font: &parley::FontData, font_size: f32) -> Option<f32> {
+fn win_ascent(cache: &mut WinAscentCache, font: &parley::FontData, font_size: f32) -> Option<f32> {
+    let ratio = *cache
+        .entry((font.data.id(), font.index))
+        .or_insert_with(|| win_ascent_ratio(font));
+    Some(ratio? * font_size)
+}
+
+/// The unitless `usWinAscent / unitsPerEm` ratio for a font face, or `None` when the font
+/// has no usable head/OS/2 table.
+fn win_ascent_ratio(font: &parley::FontData) -> Option<f32> {
     use skrifa::raw::{FontRef, TableProvider as _};
     let font_ref = FontRef::from_index(font.data.as_ref(), font.index).ok()?;
     let units_per_em = font_ref.head().ok()?.units_per_em();
     let win_ascent = font_ref.os2().ok()?.us_win_ascent();
-    Some(win_ascent as f32 * font_size / units_per_em as f32)
+    Some(win_ascent as f32 / units_per_em as f32)
 }
 
 /// Mirrors Blink's `SelectBestDashGap`: choose the gap length (as close as possible to
@@ -224,6 +239,7 @@ pub(crate) struct DrawTextContext {
     stack: Vec<DecorationStackEntry>,
     path_scratch: Vec<NodeId>,
     deco_boxes: Vec<LineDecoration>,
+    win_ascent_ratios: WinAscentCache,
 }
 
 /// Resolve the CSS `text-decoration-thickness` to a device-pixel size.
@@ -366,6 +382,7 @@ fn flush_line_decorations(
     transform: Affine,
     scale: f64,
     deco_boxes: &[LineDecoration],
+    win_ascent_ratios: &mut WinAscentCache,
 ) {
     // Draw innermost boxes first so ancestors' decorations paint on top, matching the
     // per-run drawing order this replaced (`stack.iter().rev()`).
@@ -457,7 +474,8 @@ fn flush_line_decorations(
                 geom.css_font_size,
                 scale,
             );
-            let ascent = win_ascent(&geom.font, geom.font_size).unwrap_or(geom.ascent);
+            let ascent =
+                win_ascent(win_ascent_ratios, &geom.font, geom.font_size).unwrap_or(geom.ascent);
             let offset = ascent + size;
 
             // A `double` overline extends upward, away from the text.
@@ -489,7 +507,8 @@ fn flush_line_decorations(
             // Chrome (which places it `2/3 * ascent` below the text-top). Parley's
             // `strikethrough_offset` (the font's `yStrikeoutPosition`) sits lower and would
             // draw the line too close to the baseline.
-            let ascent = win_ascent(&geom.font, geom.font_size).unwrap_or(geom.ascent);
+            let ascent =
+                win_ascent(win_ascent_ratios, &geom.font, geom.font_size).unwrap_or(geom.ascent);
             let offset = ascent / 3.0 + size / 2.0;
 
             draw_decoration_line(
@@ -524,6 +543,7 @@ pub(crate) fn stroke_text<'a>(
         stack,
         path_scratch,
         deco_boxes,
+        win_ascent_ratios,
     } = context;
     stack.clear();
     path_scratch.clear();
@@ -662,7 +682,7 @@ pub(crate) fn stroke_text<'a>(
             }
         }
 
-        flush_line_decorations(scene, transform, scale, deco_boxes);
+        flush_line_decorations(scene, transform, scale, deco_boxes, win_ascent_ratios);
     }
 }
 

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -339,8 +339,16 @@ pub(crate) fn stroke_text<'a>(
                     draw_decoration_line(offset, size, &text_decoration_brush, -1.0);
                 }
                 if has_strikethrough {
-                    let offset = metrics.strikethrough_offset;
                     let size = decoration_size(metrics.strikethrough_size);
+
+                    // Centre the line-through a third of the ascent above the baseline, matching
+                    // Chrome (which places it `2/3 * ascent` below the text-top). Parley's
+                    // `strikethrough_offset` (the font's `yStrikeoutPosition`) sits lower and would
+                    // draw the line too close to the baseline. `draw_decoration_line` centres the
+                    // stroke on `baseline - offset + size / 2`, so `offset = ascent / 3 + size / 2`
+                    // puts the centre at `baseline - ascent / 3`.
+                    let ascent = win_ascent(run.font(), run.font_size()).unwrap_or(metrics.ascent);
+                    let offset = ascent / 3.0 + size / 2.0;
 
                     draw_decoration_line(offset, size, &text_decoration_brush, 1.0);
                 }

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -127,7 +127,7 @@ struct ResolvedDecoration {
 /// values resolved from its computed style so descending into the same node across
 /// consecutive runs doesn't re-resolve them.
 struct DecorationStackEntry {
-    node_id: usize,
+    node_id: NodeId,
     /// This node's (inherited) text colour, used for the glyphs of runs whose
     /// innermost node is this one.
     text_color: Color,
@@ -136,7 +136,7 @@ struct DecorationStackEntry {
 }
 
 /// Resolve the cached style values for a single node into a [`DecorationStackEntry`].
-fn resolve_decoration_entry(doc: &BaseDocument, node_id: usize) -> DecorationStackEntry {
+fn resolve_decoration_entry(doc: &BaseDocument, node_id: NodeId) -> DecorationStackEntry {
     let Some(styles) = doc.get_node(node_id).and_then(|node| node.primary_styles()) else {
         return DecorationStackEntry {
             node_id,
@@ -206,7 +206,7 @@ struct DecorationRunGeometry {
 /// extent it covers on the line (`min_x`/`max_x`) and the font geometry to draw with, then
 /// paint a single line spanning the box rather than one segment per run.
 struct LineDecoration {
-    node_id: usize,
+    node_id: NodeId,
     deco: ResolvedDecoration,
     min_x: f64,
     max_x: f64,
@@ -222,7 +222,7 @@ struct LineDecoration {
 #[derive(Default)]
 pub(crate) struct DrawTextContext {
     stack: Vec<DecorationStackEntry>,
-    path_scratch: Vec<usize>,
+    path_scratch: Vec<NodeId>,
     deco_boxes: Vec<LineDecoration>,
 }
 
@@ -517,7 +517,7 @@ pub(crate) fn stroke_text<'a>(
     doc: &BaseDocument,
     transform: Affine,
     scale: f64,
-    inline_root_id: usize,
+    inline_root_id: NodeId,
     context: &mut DrawTextContext,
 ) {
     let DrawTextContext {

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -3,7 +3,8 @@ use blitz_dom::{BaseDocument, NodeId, node::TextBrush, util::ToColorColor};
 use kurbo::{Affine, Rect, Stroke};
 use parley::{Affinity, Cursor, Layout, Line, PositionedLayoutItem, Selection};
 use peniko::Fill;
-use style::values::computed::{Length, TextDecorationLine};
+use style::values::computed::{Length, TextDecorationLength, TextDecorationLine};
+use style::values::generics::text::GenericTextDecorationLength;
 
 use crate::color::{Color, ToColorColor as _};
 use crate::{FONT_EMBOLDEN_ENABLED, SELECTION_COLOR};
@@ -98,6 +99,8 @@ pub(crate) fn stroke_text<'a>(
                     .unwrap_or(text_color);
                 let text_decoration_brush = anyrender::Paint::from(text_decoration_color);
                 let text_decoration_line = text_styles.text_decoration_line;
+                let text_decoration_thickness: TextDecorationLength =
+                    text_styles.text_decoration_thickness.clone();
                 let has_underline = text_decoration_line.contains(TextDecorationLine::UNDERLINE);
                 let has_strikethrough =
                     text_decoration_line.contains(TextDecorationLine::LINE_THROUGH);
@@ -136,8 +139,22 @@ pub(crate) fn stroke_text<'a>(
                         scene.stroke(&Stroke::new(size as f64), transform, brush, None, &line)
                     };
 
+                // Resolve the CSS `text-decoration-thickness` to a device-pixel size. `auto`
+                // and `from-font` keep the font's suggested thickness for the specific
+                // decoration line; a `<length-percentage>` is resolved against the font size
+                // (percentages are relative to 1em) in CSS pixels, then scaled to device pixels.
+                let decoration_size = |metric_size: f32| match &text_decoration_thickness {
+                    GenericTextDecorationLength::LengthPercentage(lp) => {
+                        let css_font_size = font_size as f64 / scale;
+                        lp.resolve(Length::new(css_font_size as f32)).px() as f64 * scale
+                    }
+                    GenericTextDecorationLength::FromFont | GenericTextDecorationLength::Auto => {
+                        metric_size as f64
+                    }
+                } as f32;
+
                 if has_underline {
-                    let size = metrics.underline_size;
+                    let size = decoration_size(metrics.underline_size);
 
                     // Apply the CSS `text-underline-offset`, which moves the underline further
                     // away from the text. `auto` keeps the font's suggested position. The value
@@ -163,7 +180,7 @@ pub(crate) fn stroke_text<'a>(
                 }
                 if has_strikethrough {
                     let offset = metrics.strikethrough_offset;
-                    let size = metrics.strikethrough_size;
+                    let size = decoration_size(metrics.strikethrough_size);
 
                     draw_decoration_line(offset, size, &text_decoration_brush);
                 }

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -1,6 +1,6 @@
 use anyrender::PaintScene;
 use blitz_dom::{BaseDocument, NodeId, node::TextBrush, util::ToColorColor};
-use kurbo::{Affine, Rect, Stroke};
+use kurbo::{Affine, Cap, Rect, Stroke};
 use parley::{Affinity, Cursor, Layout, Line, PositionedLayoutItem, Selection};
 use peniko::Fill;
 use style::values::computed::{Length, TextDecorationLength, TextDecorationLine};
@@ -137,7 +137,8 @@ pub(crate) fn stroke_text<'a>(
                         let w = glyph_run.advance() as f64;
                         let y = (glyph_run.baseline() - offset + size / 2.0) as f64;
                         let line = kurbo::Line::new((x, y), (x + w, y));
-                        scene.stroke(&Stroke::new(size as f64), transform, brush, None, &line)
+                        let stroke = Stroke::new(size as f64).with_caps(Cap::Butt);
+                        scene.stroke(&stroke, transform, brush, None, &line)
                     };
 
                 // Resolve the CSS `text-decoration-thickness` to a device-pixel size. `auto`

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -1,8 +1,9 @@
 use anyrender::PaintScene;
 use blitz_dom::{BaseDocument, NodeId, node::TextBrush, util::ToColorColor};
-use kurbo::{Affine, Cap, Rect, Stroke};
+use kurbo::{Affine, BezPath, Cap, Circle, Rect, Stroke};
 use parley::{Affinity, Cursor, Layout, Line, PositionedLayoutItem, Selection};
 use peniko::Fill;
+use style::properties::generated::longhands::text_decoration_style::computed_value::T as TextDecorationStyle;
 use style::values::computed::{Length, TextDecorationLength, TextDecorationLine};
 use style::values::generics::text::GenericTextDecorationLength;
 
@@ -63,6 +64,27 @@ pub(crate) fn draw_inline_backgrounds<'a>(
     }
 }
 
+/// Mirrors Blink's `SelectBestDashGap`: choose the gap length (as close as possible to
+/// `gap_length`) that fits a whole number of `dash_length` dashes across `stroke_length`,
+/// so dashes are evenly distributed and a dash lands at each end of the line.
+fn select_best_dash_gap(stroke_length: f64, dash_length: f64, gap_length: f64) -> f64 {
+    let available_length = stroke_length + gap_length;
+    let min_num_dashes = (available_length / (dash_length + gap_length)).floor();
+    let max_num_dashes = min_num_dashes + 1.0;
+    let min_num_gaps = min_num_dashes - 1.0;
+    let max_num_gaps = max_num_dashes - 1.0;
+    if min_num_gaps < 1.0 {
+        return gap_length;
+    }
+    let min_gap = (stroke_length - min_num_dashes * dash_length) / min_num_gaps;
+    let max_gap = (stroke_length - max_num_dashes * dash_length) / max_num_gaps;
+    if max_gap <= 0.0 || (min_gap - gap_length).abs() < (max_gap - gap_length).abs() {
+        min_gap
+    } else {
+        max_gap
+    }
+}
+
 pub(crate) fn stroke_text<'a>(
     scene: &mut impl PaintScene,
     lines: impl Iterator<Item = Line<'a, TextBrush>>,
@@ -99,6 +121,7 @@ pub(crate) fn stroke_text<'a>(
                     .unwrap_or(text_color);
                 let text_decoration_brush = anyrender::Paint::from(text_decoration_color);
                 let text_decoration_line = text_styles.text_decoration_line;
+                let text_decoration_style = text_styles.text_decoration_style;
                 let text_decoration_thickness: TextDecorationLength =
                     text_styles.text_decoration_thickness.clone();
                 let has_underline = text_decoration_line.contains(TextDecorationLine::UNDERLINE);
@@ -131,14 +154,99 @@ pub(crate) fn stroke_text<'a>(
                     }),
                 );
 
+                // Draws a single decoration line of the given `text-decoration-style`. `y` is
+                // the centre of the line; `x`/`w` span the glyph run. Geometry is built
+                // explicitly (rather than relying on backend dash support) so it renders
+                // consistently across renderers.
+                //
+                // `double_dir` points away from the text (`+1` = down, `-1` = up) and is used
+                // to place the second line of a `double` decoration.
                 let mut draw_decoration_line =
-                    |offset: f32, size: f32, brush: &anyrender::Paint| {
+                    |offset: f32, size: f32, brush: &anyrender::Paint, double_dir: f64| {
                         let x = glyph_run.offset() as f64;
                         let w = glyph_run.advance() as f64;
                         let y = (glyph_run.baseline() - offset + size / 2.0) as f64;
-                        let line = kurbo::Line::new((x, y), (x + w, y));
-                        let stroke = Stroke::new(size as f64).with_caps(Cap::Butt);
-                        scene.stroke(&stroke, transform, brush, None, &line)
+                        let size = size as f64;
+                        let butt_stroke = Stroke::new(size).with_caps(Cap::Butt);
+
+                        match text_decoration_style {
+                            TextDecorationStyle::MozNone => {
+                                // no line. Equivalent to `text-decoration-line: none`
+                            }
+                            // `solid`
+                            TextDecorationStyle::Solid => {
+                                let line = kurbo::Line::new((x, y), (x + w, y));
+                                scene.stroke(&butt_stroke, transform, brush, None, &line);
+                            }
+                            // Two lines, each `size` thick, separated by a 1px (CSS) gap. This
+                            // matches Chrome, where the second line is offset by `thickness + 1px`
+                            // and sits further from the text (below for underline, above for
+                            // overline).
+                            TextDecorationStyle::Double => {
+                                let one_css_px = scale;
+                                for cy in [y, y + double_dir * (size + one_css_px)] {
+                                    let line = kurbo::Line::new((x, cy), (x + w, cy));
+                                    scene.stroke(&butt_stroke, transform, brush, None, &line);
+                                }
+                            }
+                            // Round dots (diameter = line thickness) spaced one dot apart.
+                            TextDecorationStyle::Dotted => {
+                                let radius = size / 2.0;
+                                let step = 2.0 * size;
+                                let mut cx = x + radius;
+                                while cx <= x + w - radius {
+                                    let dot = Circle::new((cx, y), radius);
+                                    scene.fill(Fill::NonZero, transform, brush, None, &dot);
+                                    cx += step;
+                                }
+                            }
+                            // Dashes as filled rectangles. Dash/gap lengths are relative to the
+                            // thickness (matching Blink): thinner lines use proportionally longer
+                            // dashes and gaps so they don't read as dotted or solid.
+                            TextDecorationStyle::Dashed => {
+                                let (dash_ratio, gap_ratio) =
+                                    if size >= 3.0 { (2.0, 1.0) } else { (3.0, 2.0) };
+                                let dash = size * dash_ratio;
+                                let nominal_gap = size * gap_ratio;
+                                // Nudge the gap so a whole number of dashes fits the run evenly.
+                                let gap = if w > 2.0 * dash {
+                                    select_best_dash_gap(w, dash, nominal_gap)
+                                } else {
+                                    nominal_gap
+                                };
+                                let mut dx = x;
+                                while dx < x + w {
+                                    let end = (dx + dash).min(x + w);
+                                    let rect = Rect::new(dx, y - size / 2.0, end, y + size / 2.0);
+                                    scene.fill(Fill::NonZero, transform, brush, None, &rect);
+                                    dx += dash + gap;
+                                }
+                            }
+                            // A squiggle built from alternating quadratic Béziers.
+                            TextDecorationStyle::Wavy => {
+                                let amplitude = size;
+                                let half_wave = (2.0 * size).max(1.0);
+                                let mut path = BezPath::new();
+                                path.move_to((x, y));
+                                let mut px = x;
+                                let mut up = true;
+                                while px < x + w {
+                                    let nx = (px + half_wave).min(x + w);
+                                    // A quad Bézier reaches half the control-point offset at its
+                                    // midpoint, so use `2 * amplitude` to hit the target peak.
+                                    let ctrl_y = if up {
+                                        y - 2.0 * amplitude
+                                    } else {
+                                        y + 2.0 * amplitude
+                                    };
+                                    path.quad_to(((px + nx) / 2.0, ctrl_y), (nx, y));
+                                    px = nx;
+                                    up = !up;
+                                }
+                                let stroke = Stroke::new(size).with_caps(Cap::Round);
+                                scene.stroke(&stroke, transform, brush, None, &path);
+                            }
+                        }
                     };
 
                 // Resolve the CSS `text-decoration-thickness` to a device-pixel size.
@@ -181,7 +289,8 @@ pub(crate) fn stroke_text<'a>(
                     let offset = metrics.underline_offset - extra_offset as f32;
 
                     // TODO: intercept line when crossing an descending character like "gqy"
-                    draw_decoration_line(offset, size, &text_decoration_brush);
+                    // A `double` underline extends downward, away from the text.
+                    draw_decoration_line(offset, size, &text_decoration_brush, 1.0);
                 }
                 if has_overline {
                     // Fonts don't provide a dedicated overline metric, so reuse the
@@ -190,13 +299,14 @@ pub(crate) fn stroke_text<'a>(
                     let offset = metrics.ascent;
                     let size = decoration_size(metrics.underline_size);
 
-                    draw_decoration_line(offset, size, &text_decoration_brush);
+                    // A `double` overline extends upward, away from the text.
+                    draw_decoration_line(offset, size, &text_decoration_brush, -1.0);
                 }
                 if has_strikethrough {
                     let offset = metrics.strikethrough_offset;
                     let size = decoration_size(metrics.strikethrough_size);
 
-                    draw_decoration_line(offset, size, &text_decoration_brush);
+                    draw_decoration_line(offset, size, &text_decoration_brush, 1.0);
                 }
             }
         }

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -4,7 +4,9 @@ use kurbo::{Affine, BezPath, Cap, Circle, Rect, Stroke};
 use parley::{Affinity, Cursor, Layout, Line, PositionedLayoutItem, Selection};
 use peniko::Fill;
 use style::properties::generated::longhands::text_decoration_style::computed_value::T as TextDecorationStyle;
-use style::values::computed::{Length, TextDecorationLength, TextDecorationLine};
+use style::values::computed::{
+    Length, TextDecorationLength, TextDecorationLine, TextUnderlinePosition,
+};
 use style::values::generics::text::GenericTextDecorationLength;
 
 use crate::color::{Color, ToColorColor as _};
@@ -283,10 +285,23 @@ pub(crate) fn stroke_text<'a>(
                         })
                         .unwrap_or(0.0);
 
+                    // `text-underline-position: under` places the underline below the glyph
+                    // box (below descenders) rather than at the font's suggested position near
+                    // the alphabetic baseline. We anchor the top of the line at the descent so
+                    // it clears descending glyphs like "gqy".
+                    //
                     // `draw_decoration_line` computes `y = baseline - offset + size / 2` and `y`
-                    // grows downward, so subtracting the offset pushes the underline downward,
+                    // grows downward, so a more negative offset pushes the underline downward,
                     // away from the text.
-                    let offset = metrics.underline_offset - extra_offset as f32;
+                    let base_offset = if itext_styles
+                        .text_underline_position
+                        .contains(TextUnderlinePosition::UNDER)
+                    {
+                        -metrics.descent
+                    } else {
+                        metrics.underline_offset
+                    };
+                    let offset = base_offset - extra_offset as f32;
 
                     // TODO: intercept line when crossing an descending character like "gqy"
                     // A `double` underline extends downward, away from the text.

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -66,6 +66,19 @@ pub(crate) fn draw_inline_backgrounds<'a>(
     }
 }
 
+/// The font's OS/2 `usWinAscent`, in the same (device) pixels as `font_size`.
+///
+/// This is the ascent browsers use as the top of the "em box" when positioning overlines. It
+/// is typically taller than the hhea ascent Parley exposes via [`parley::layout::run::RunMetrics`].
+/// Returns `None` when the font has no OS/2 table.
+fn win_ascent(font: &parley::FontData, font_size: f32) -> Option<f32> {
+    use read_fonts::{FontRef, TableProvider as _};
+    let font_ref = FontRef::from_index(font.data.as_ref(), font.index).ok()?;
+    let units_per_em = font_ref.head().ok()?.units_per_em();
+    let win_ascent = font_ref.os2().ok()?.us_win_ascent();
+    Some(win_ascent as f32 * font_size / units_per_em as f32)
+}
+
 /// Mirrors Blink's `SelectBestDashGap`: choose the gap length (as close as possible to
 /// `gap_length`) that fits a whole number of `dash_length` dashes across `stroke_length`,
 /// so dashes are evenly distributed and a dash lands at each end of the line.
@@ -308,11 +321,19 @@ pub(crate) fn stroke_text<'a>(
                     draw_decoration_line(offset, size, &text_decoration_brush, 1.0);
                 }
                 if has_overline {
-                    // Fonts don't provide a dedicated overline metric, so reuse the
-                    // underline thickness and position the line at the top of the text
-                    // (i.e. one ascent above the baseline).
-                    let offset = metrics.ascent;
+                    // Fonts don't provide a dedicated overline metric, so reuse the underline
+                    // thickness. The line sits at the top of the "em box": its lower edge rests
+                    // on the ascent so it clears the glyphs, and it extends upward from there
+                    // (`draw_decoration_line` centres the stroke on `baseline - offset + size / 2`,
+                    // so `offset = ascent + size` puts the bottom edge at `baseline - ascent`).
+                    //
+                    // Browsers use the OS/2 `usWinAscent` for this edge, which is taller than the
+                    // hhea-based ascent Parley reports; using the smaller value would draw the
+                    // overline too low (too close to the glyphs). Fall back to Parley's ascent for
+                    // fonts without a usable OS/2 table.
                     let size = decoration_size(metrics.underline_size);
+                    let ascent = win_ascent(run.font(), run.font_size()).unwrap_or(metrics.ascent);
+                    let offset = ascent + size;
 
                     // A `double` overline extends upward, away from the text.
                     draw_decoration_line(offset, size, &text_decoration_brush, -1.0);

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -168,7 +168,10 @@ fn resolve_decoration_entry(doc: &BaseDocument, node_id: NodeId) -> DecorationSt
         | TextDecorationLine::OVERLINE
         | TextDecorationLine::LINE_THROUGH;
     let line = text.text_decoration_line;
-    let decoration = line.intersects(drawn_lines).then(|| {
+    // Decorations propagate through the box tree, and a `display: contents` element
+    // generates no box, so its decorations have no effect on descendants.
+    let is_contents = styles.clone_display().is_contents();
+    let decoration = (!is_contents && line.intersects(drawn_lines)).then(|| {
         // `text-decoration-color: currentColor` (the initial value) resolves against
         // the decorating box's own colour, not the descendant run's.
         let color = text
@@ -247,6 +250,9 @@ pub(crate) struct DrawTextContext {
 /// - Percentages are resolved against the font size,
 /// - `from-font` uses the metrics from Parley,
 /// - `auto` uses a thickness of `font-size / 10` (minimum: 1px).
+///
+/// The result is floored to a whole number of device pixels (minimum 1), matching
+/// browsers, which snap decoration thickness to whole pixels.
 fn decoration_size(
     thickness: &TextDecorationLength,
     metric_size: f32,
@@ -259,7 +265,9 @@ fn decoration_size(
         }
         GenericTextDecorationLength::FromFont => metric_size as f64,
         GenericTextDecorationLength::Auto => (css_font_size / 10.0).max(1.0) * scale,
-    }) as f32
+    })
+    .floor()
+    .max(1.0) as f32
 }
 
 /// Draws a single decoration line of the given `text-decoration-style` spanning

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -217,6 +217,15 @@ struct LineDecoration {
     first: Option<DecorationRunGeometry>,
 }
 
+/// Reusable scratch storage for drawing text across all inline formatting contexts in a
+/// document. The vectors are cleared between uses without releasing their allocations.
+#[derive(Default)]
+pub(crate) struct DrawTextContext {
+    stack: Vec<DecorationStackEntry>,
+    path_scratch: Vec<usize>,
+    deco_boxes: Vec<LineDecoration>,
+}
+
 /// Resolve the CSS `text-decoration-thickness` to a device-pixel size.
 ///
 /// - Percentages are resolved against the font size,
@@ -509,7 +518,17 @@ pub(crate) fn stroke_text<'a>(
     transform: Affine,
     scale: f64,
     inline_root_id: usize,
+    context: &mut DrawTextContext,
 ) {
+    let DrawTextContext {
+        stack,
+        path_scratch,
+        deco_boxes,
+    } = context;
+    stack.clear();
+    path_scratch.clear();
+    deco_boxes.clear();
+
     // Persistent stack mirroring the ancestor path (inline root -> current run's
     // node) as we walk the runs. The `text-decoration-*` properties are *not*
     // inherited; instead a decoration set on an ancestor is propagated to the
@@ -517,15 +536,12 @@ pub(crate) fn stroke_text<'a>(
     // ancestor chain on every run, we cache each node's resolved values here and,
     // for each run, only resolve styles for the nodes newly descended into (popping
     // as we ascend). `path_scratch` is a reusable buffer for the run's node path.
-    let mut stack: Vec<DecorationStackEntry> = Vec::new();
-    let mut path_scratch: Vec<usize> = Vec::new();
-
     for line in lines {
         // Decorations accumulated for this line, keyed by decorating box, so each box is
         // painted once (spanning all its runs) using its own font — matching Firefox, which
         // draws one decoration per box rather than one stepped segment per differently-sized
-        // run.
-        let mut deco_boxes: Vec<LineDecoration> = Vec::new();
+        // run. Clearing preserves the allocation for the next line and inline context.
+        deco_boxes.clear();
 
         for item in line.items() {
             if let PositionedLayoutItem::GlyphRun(glyph_run) = item {
@@ -646,7 +662,7 @@ pub(crate) fn stroke_text<'a>(
             }
         }
 
-        flush_line_decorations(scene, transform, scale, &deco_boxes);
+        flush_line_decorations(scene, transform, scale, deco_boxes);
     }
 }
 

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -7,7 +7,7 @@ use style::properties::generated::longhands::text_decoration_style::computed_val
 use style::values::computed::{
     Length, TextDecorationLength, TextDecorationLine, TextUnderlinePosition,
 };
-use style::values::generics::text::GenericTextDecorationLength;
+use style::values::generics::text::{GenericTextDecorationInset, GenericTextDecorationLength};
 
 use crate::color::{Color, ToColorColor as _};
 use crate::{FONT_EMBOLDEN_ENABLED, SELECTION_COLOR};
@@ -139,6 +139,23 @@ pub(crate) fn stroke_text<'a>(
                 let text_decoration_style = text_styles.text_decoration_style;
                 let text_decoration_thickness: TextDecorationLength =
                     text_styles.text_decoration_thickness.clone();
+
+                // `text-decoration-inset` shortens (or, when negative, extends) the decoration
+                // line from the inline-start and inline-end edges of the text. Resolve the
+                // start/end lengths to device pixels; percentages are resolved against the
+                // decoration line length (the glyph run's advance). `auto` is treated as no inset.
+                let (inset_start, inset_end) = match &text_styles.text_decoration_inset {
+                    GenericTextDecorationInset::LengthPercentage { start, end } => {
+                        // The advance is already in device pixels; convert to CSS pixels so the
+                        // resolved (device-pixel) result can be scaled back consistently.
+                        let line_length = Length::new(glyph_run.advance() / scale as f32);
+                        (
+                            start.resolve(line_length).px() as f64 * scale,
+                            end.resolve(line_length).px() as f64 * scale,
+                        )
+                    }
+                    GenericTextDecorationInset::Auto => (0.0, 0.0),
+                };
                 let has_underline = text_decoration_line.contains(TextDecorationLine::UNDERLINE);
                 let has_overline = text_decoration_line.contains(TextDecorationLine::OVERLINE);
                 let has_strikethrough =
@@ -178,8 +195,13 @@ pub(crate) fn stroke_text<'a>(
                 // to place the second line of a `double` decoration.
                 let mut draw_decoration_line =
                     |offset: f32, size: f32, brush: &anyrender::Paint, double_dir: f64| {
-                        let x = glyph_run.offset() as f64;
-                        let w = glyph_run.advance() as f64;
+                        // Inset the line from the run's start/end edges (assumes LTR: start is
+                        // the left edge). Negative insets extend the line past the text.
+                        let x = glyph_run.offset() as f64 + inset_start;
+                        let w = glyph_run.advance() as f64 - inset_start - inset_end;
+                        if w <= 0.0 {
+                            return;
+                        }
                         let y = (glyph_run.baseline() - offset + size / 2.0) as f64;
                         let size = size as f64;
                         let butt_stroke = Stroke::new(size).with_caps(Cap::Butt);

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -109,6 +109,7 @@ fn select_best_dash_gap(stroke_length: f64, dash_length: f64, gap_length: f64) -
 /// can be cached on the ancestor stack and reused across every run within the same
 /// decorating box. The `text-decoration-inset` and `text-underline-offset` values
 /// depend on the run's advance/font-size and are resolved lazily when drawing.
+#[derive(Clone)]
 struct ResolvedDecoration {
     line: TextDecorationLine,
     style: TextDecorationStyle,
@@ -181,6 +182,326 @@ fn resolve_decoration_entry(doc: &BaseDocument, node_id: usize) -> DecorationSta
     }
 }
 
+/// The run-dependent geometry used to position and size a decoration, captured from a
+/// single glyph run. Firefox draws a decoration once for the whole decorating box using
+/// the box's own font, so we prefer the values from a run whose innermost node *is* the
+/// decorating box (its own text), falling back to the first run it covers.
+#[derive(Clone)]
+struct DecorationRunGeometry {
+    /// The line's baseline (shared by every run on the line).
+    baseline: f32,
+    ascent: f32,
+    descent: f32,
+    underline_offset: f32,
+    underline_size: f32,
+    strikethrough_size: f32,
+    font: parley::FontData,
+    font_size: f32,
+    css_font_size: f64,
+}
+
+/// A decoration accumulated across the runs of a single line for one decorating box.
+///
+/// The `text-decoration-*` properties describe the whole box, so we gather the horizontal
+/// extent it covers on the line (`min_x`/`max_x`) and the font geometry to draw with, then
+/// paint a single line spanning the box rather than one segment per run.
+struct LineDecoration {
+    node_id: usize,
+    deco: ResolvedDecoration,
+    min_x: f64,
+    max_x: f64,
+    /// Geometry from a run whose innermost node is the decorating box itself.
+    own: Option<DecorationRunGeometry>,
+    /// Geometry from the first run the box covers (fallback when it has no own text on
+    /// this line, e.g. it only wraps differently-sized descendants).
+    first: Option<DecorationRunGeometry>,
+}
+
+/// Resolve the CSS `text-decoration-thickness` to a device-pixel size.
+///
+/// - Percentages are resolved against the font size,
+/// - `from-font` uses the metrics from Parley,
+/// - `auto` uses a thickness of `font-size / 10` (minimum: 1px).
+fn decoration_size(
+    thickness: &TextDecorationLength,
+    metric_size: f32,
+    css_font_size: f64,
+    scale: f64,
+) -> f32 {
+    (match thickness {
+        GenericTextDecorationLength::LengthPercentage(lp) => {
+            lp.resolve(Length::new(css_font_size as f32)).px() as f64 * scale
+        }
+        GenericTextDecorationLength::FromFont => metric_size as f64,
+        GenericTextDecorationLength::Auto => (css_font_size / 10.0).max(1.0) * scale,
+    }) as f32
+}
+
+/// Draws a single decoration line of the given `text-decoration-style` spanning
+/// `[x0, x0 + width]`. `baseline` is the line's baseline and `offset` positions the line
+/// relative to it (`y = baseline - offset + size / 2`, growing downward). Geometry is built
+/// explicitly (rather than relying on backend dash support) so it renders consistently
+/// across renderers.
+///
+/// `double_dir` points away from the text (`+1` = down, `-1` = up) and is used to place the
+/// second line of a `double` decoration.
+#[allow(clippy::too_many_arguments)]
+fn draw_decoration_line(
+    scene: &mut impl PaintScene,
+    transform: Affine,
+    scale: f64,
+    x0: f64,
+    width: f64,
+    baseline: f32,
+    offset: f32,
+    size: f32,
+    brush: &anyrender::Paint,
+    double_dir: f64,
+    deco_style: TextDecorationStyle,
+    inset_start: f64,
+    inset_end: f64,
+) {
+    // Inset the line from the box's start/end edges (assumes LTR: start is the left edge).
+    // Negative insets extend the line past the text.
+    let x = x0 + inset_start;
+    let w = width - inset_start - inset_end;
+    if w <= 0.0 {
+        return;
+    }
+    let y = (baseline - offset + size / 2.0) as f64;
+    let size = size as f64;
+    let butt_stroke = Stroke::new(size).with_caps(Cap::Butt);
+
+    match deco_style {
+        TextDecorationStyle::MozNone => {
+            // no line. Equivalent to `text-decoration-line: none`
+        }
+        // `solid`
+        TextDecorationStyle::Solid => {
+            let line = kurbo::Line::new((x, y), (x + w, y));
+            scene.stroke(&butt_stroke, transform, brush, None, &line);
+        }
+        // Two lines, each `size` thick, separated by a 1px (CSS) gap. This
+        // matches Chrome, where the second line is offset by `thickness + 1px`
+        // and sits further from the text (below for underline, above for
+        // overline).
+        TextDecorationStyle::Double => {
+            let one_css_px = scale;
+            for cy in [y, y + double_dir * (size + one_css_px)] {
+                let line = kurbo::Line::new((x, cy), (x + w, cy));
+                scene.stroke(&butt_stroke, transform, brush, None, &line);
+            }
+        }
+        // Round dots (diameter = line thickness) spaced one dot apart.
+        TextDecorationStyle::Dotted => {
+            let radius = size / 2.0;
+            let step = 2.0 * size;
+            let mut cx = x + radius;
+            while cx <= x + w - radius {
+                let dot = Circle::new((cx, y), radius);
+                scene.fill(Fill::NonZero, transform, brush, None, &dot);
+                cx += step;
+            }
+        }
+        // Dashes as filled rectangles. Dash/gap lengths are relative to the
+        // thickness (matching Blink): thinner lines use proportionally longer
+        // dashes and gaps so they don't read as dotted or solid.
+        TextDecorationStyle::Dashed => {
+            let (dash_ratio, gap_ratio) = if size >= 3.0 { (2.0, 1.0) } else { (3.0, 2.0) };
+            let dash = size * dash_ratio;
+            let nominal_gap = size * gap_ratio;
+            // Nudge the gap so a whole number of dashes fits the run evenly.
+            let gap = if w > 2.0 * dash {
+                select_best_dash_gap(w, dash, nominal_gap)
+            } else {
+                nominal_gap
+            };
+            let mut dx = x;
+            while dx < x + w {
+                let end = (dx + dash).min(x + w);
+                let rect = Rect::new(dx, y - size / 2.0, end, y + size / 2.0);
+                scene.fill(Fill::NonZero, transform, brush, None, &rect);
+                dx += dash + gap;
+            }
+        }
+        // A squiggle built from alternating quadratic Béziers.
+        TextDecorationStyle::Wavy => {
+            let amplitude = size;
+            let half_wave = (2.0 * size).max(1.0);
+            let mut path = BezPath::new();
+            path.move_to((x, y));
+            let mut px = x;
+            let mut up = true;
+            while px < x + w {
+                let nx = (px + half_wave).min(x + w);
+                // A quad Bézier reaches half the control-point offset at its
+                // midpoint, so use `2 * amplitude` to hit the target peak.
+                let ctrl_y = if up {
+                    y - 2.0 * amplitude
+                } else {
+                    y + 2.0 * amplitude
+                };
+                path.quad_to(((px + nx) / 2.0, ctrl_y), (nx, y));
+                px = nx;
+                up = !up;
+            }
+            let stroke = Stroke::new(size).with_caps(Cap::Round);
+            scene.stroke(&stroke, transform, brush, None, &path);
+        }
+    }
+}
+
+/// Paint the decorations accumulated for one line, one line per decorating box.
+fn flush_line_decorations(
+    scene: &mut impl PaintScene,
+    transform: Affine,
+    scale: f64,
+    deco_boxes: &[LineDecoration],
+) {
+    // Draw innermost boxes first so ancestors' decorations paint on top, matching the
+    // per-run drawing order this replaced (`stack.iter().rev()`).
+    for acc in deco_boxes.iter().rev() {
+        let deco = &acc.deco;
+        // Prefer the decorating box's own font; fall back to the first run it covers.
+        let Some(geom) = acc.own.as_ref().or(acc.first.as_ref()) else {
+            continue;
+        };
+        let width = acc.max_x - acc.min_x;
+        if width <= 0.0 {
+            continue;
+        }
+        let brush = anyrender::Paint::from(deco.color);
+
+        // `text-decoration-inset` shortens (or, when negative, extends) the line from the
+        // inline-start/end edges. Percentages resolve against the decoration line length
+        // (the box's total advance on this line); `auto` is no inset.
+        let (inset_start, inset_end) = match &deco.inset {
+            GenericTextDecorationInset::LengthPercentage { start, end } => {
+                // The extent is in device pixels; convert to CSS pixels so the resolved
+                // result can be scaled back.
+                let line_length = Length::new((width / scale) as f32);
+                (
+                    start.resolve(line_length).px() as f64 * scale,
+                    end.resolve(line_length).px() as f64 * scale,
+                )
+            }
+            GenericTextDecorationInset::Auto => (0.0, 0.0),
+        };
+
+        if deco.line.contains(TextDecorationLine::UNDERLINE) {
+            let size = decoration_size(
+                &deco.thickness,
+                geom.underline_size,
+                geom.css_font_size,
+                scale,
+            );
+
+            // `text-underline-offset` moves the underline away from the text. `auto` keeps
+            // the font's suggested position; otherwise it resolves against the font size
+            // (percentages relative to 1em).
+            let extra_underline_offset = deco
+                .underline_offset
+                .as_ref()
+                .map(|lp| lp.resolve(Length::new(geom.css_font_size as f32)).px() as f64 * scale)
+                .unwrap_or(0.0);
+
+            // `text-underline-position: under` places the underline below the glyph box
+            // (below descenders) rather than at the font's suggested position near the
+            // alphabetic baseline. We anchor the top of the line at the descent so it clears
+            // descending glyphs like "gqy".
+            let base_offset = if deco.underline_under {
+                -geom.descent
+            } else {
+                geom.underline_offset
+            };
+            let offset = base_offset - extra_underline_offset as f32;
+
+            // A `double` underline extends downward, away from the text.
+            draw_decoration_line(
+                scene,
+                transform,
+                scale,
+                acc.min_x,
+                width,
+                geom.baseline,
+                offset,
+                size,
+                &brush,
+                1.0,
+                deco.style,
+                inset_start,
+                inset_end,
+            );
+        }
+        if deco.line.contains(TextDecorationLine::OVERLINE) {
+            // Fonts don't provide a dedicated overline metric, so reuse the underline
+            // thickness. The line sits at the top of the "em box": its lower edge rests on
+            // the ascent so it clears the glyphs, and it extends upward from there.
+            //
+            // Browsers use the OS/2 `usWinAscent` for this edge, which is taller than the
+            // hhea-based ascent Parley reports; using the smaller value would draw the
+            // overline too low. Fall back to Parley's ascent for fonts without a usable
+            // OS/2 table.
+            let size = decoration_size(
+                &deco.thickness,
+                geom.underline_size,
+                geom.css_font_size,
+                scale,
+            );
+            let ascent = win_ascent(&geom.font, geom.font_size).unwrap_or(geom.ascent);
+            let offset = ascent + size;
+
+            // A `double` overline extends upward, away from the text.
+            draw_decoration_line(
+                scene,
+                transform,
+                scale,
+                acc.min_x,
+                width,
+                geom.baseline,
+                offset,
+                size,
+                &brush,
+                -1.0,
+                deco.style,
+                inset_start,
+                inset_end,
+            );
+        }
+        if deco.line.contains(TextDecorationLine::LINE_THROUGH) {
+            let size = decoration_size(
+                &deco.thickness,
+                geom.strikethrough_size,
+                geom.css_font_size,
+                scale,
+            );
+
+            // Centre the line-through a third of the ascent above the baseline, matching
+            // Chrome (which places it `2/3 * ascent` below the text-top). Parley's
+            // `strikethrough_offset` (the font's `yStrikeoutPosition`) sits lower and would
+            // draw the line too close to the baseline.
+            let ascent = win_ascent(&geom.font, geom.font_size).unwrap_or(geom.ascent);
+            let offset = ascent / 3.0 + size / 2.0;
+
+            draw_decoration_line(
+                scene,
+                transform,
+                scale,
+                acc.min_x,
+                width,
+                geom.baseline,
+                offset,
+                size,
+                &brush,
+                1.0,
+                deco.style,
+                inset_start,
+                inset_end,
+            );
+        }
+    }
+}
+
 pub(crate) fn stroke_text<'a>(
     scene: &mut impl PaintScene,
     lines: impl Iterator<Item = Line<'a, TextBrush>>,
@@ -200,6 +521,12 @@ pub(crate) fn stroke_text<'a>(
     let mut path_scratch: Vec<usize> = Vec::new();
 
     for line in lines {
+        // Decorations accumulated for this line, keyed by decorating box, so each box is
+        // painted once (spanning all its runs) using its own font — matching Firefox, which
+        // draws one decoration per box rather than one stepped segment per differently-sized
+        // run.
+        let mut deco_boxes: Vec<LineDecoration> = Vec::new();
+
         for item in line.items() {
             if let PositionedLayoutItem::GlyphRun(glyph_run) = item {
                 let run = glyph_run.run();
@@ -267,251 +594,59 @@ pub(crate) fn stroke_text<'a>(
                     }),
                 );
 
-                // Draws a single decoration line of the given `text-decoration-style`. `y` is
-                // the centre of the line; `x`/`w` span the glyph run. Geometry is built
-                // explicitly (rather than relying on backend dash support) so it renders
-                // consistently across renderers.
-                //
-                // `double_dir` points away from the text (`+1` = down, `-1` = up) and is used
-                // to place the second line of a `double` decoration.
-                let mut draw_decoration_line =
-                    |offset: f32,
-                     size: f32,
-                     brush: &anyrender::Paint,
-                     double_dir: f64,
-                     deco_style: TextDecorationStyle,
-                     inset_start: f64,
-                     inset_end: f64| {
-                        // Inset the line from the run's start/end edges (assumes LTR: start is
-                        // the left edge). Negative insets extend the line past the text.
-                        let x = glyph_run.offset() as f64 + inset_start;
-                        let w = glyph_run.advance() as f64 - inset_start - inset_end;
-                        if w <= 0.0 {
-                            return;
-                        }
-                        let y = (glyph_run.baseline() - offset + size / 2.0) as f64;
-                        let size = size as f64;
-                        let butt_stroke = Stroke::new(size).with_caps(Cap::Butt);
+                // Accumulate this run's contribution to each decorating box on its ancestor
+                // path. The decoration is drawn once per box after the whole line has been
+                // walked (see `flush_line_decorations`), so mixed font sizes within a box
+                // produce a single straight line rather than one stepped segment per run.
+                let geometry = DecorationRunGeometry {
+                    baseline: glyph_run.baseline(),
+                    ascent: metrics.ascent,
+                    descent: metrics.descent,
+                    underline_offset: metrics.underline_offset,
+                    underline_size: metrics.underline_size,
+                    strikethrough_size: metrics.strikethrough_size,
+                    font: font.clone(),
+                    font_size,
+                    css_font_size,
+                };
+                let run_node_id = style.brush.id;
+                let run_x0 = glyph_run.offset() as f64;
+                let run_x1 = run_x0 + glyph_run.advance() as f64;
 
-                        match deco_style {
-                            TextDecorationStyle::MozNone => {
-                                // no line. Equivalent to `text-decoration-line: none`
-                            }
-                            // `solid`
-                            TextDecorationStyle::Solid => {
-                                let line = kurbo::Line::new((x, y), (x + w, y));
-                                scene.stroke(&butt_stroke, transform, brush, None, &line);
-                            }
-                            // Two lines, each `size` thick, separated by a 1px (CSS) gap. This
-                            // matches Chrome, where the second line is offset by `thickness + 1px`
-                            // and sits further from the text (below for underline, above for
-                            // overline).
-                            TextDecorationStyle::Double => {
-                                let one_css_px = scale;
-                                for cy in [y, y + double_dir * (size + one_css_px)] {
-                                    let line = kurbo::Line::new((x, cy), (x + w, cy));
-                                    scene.stroke(&butt_stroke, transform, brush, None, &line);
-                                }
-                            }
-                            // Round dots (diameter = line thickness) spaced one dot apart.
-                            TextDecorationStyle::Dotted => {
-                                let radius = size / 2.0;
-                                let step = 2.0 * size;
-                                let mut cx = x + radius;
-                                while cx <= x + w - radius {
-                                    let dot = Circle::new((cx, y), radius);
-                                    scene.fill(Fill::NonZero, transform, brush, None, &dot);
-                                    cx += step;
-                                }
-                            }
-                            // Dashes as filled rectangles. Dash/gap lengths are relative to the
-                            // thickness (matching Blink): thinner lines use proportionally longer
-                            // dashes and gaps so they don't read as dotted or solid.
-                            TextDecorationStyle::Dashed => {
-                                let (dash_ratio, gap_ratio) =
-                                    if size >= 3.0 { (2.0, 1.0) } else { (3.0, 2.0) };
-                                let dash = size * dash_ratio;
-                                let nominal_gap = size * gap_ratio;
-                                // Nudge the gap so a whole number of dashes fits the run evenly.
-                                let gap = if w > 2.0 * dash {
-                                    select_best_dash_gap(w, dash, nominal_gap)
-                                } else {
-                                    nominal_gap
-                                };
-                                let mut dx = x;
-                                while dx < x + w {
-                                    let end = (dx + dash).min(x + w);
-                                    let rect = Rect::new(dx, y - size / 2.0, end, y + size / 2.0);
-                                    scene.fill(Fill::NonZero, transform, brush, None, &rect);
-                                    dx += dash + gap;
-                                }
-                            }
-                            // A squiggle built from alternating quadratic Béziers.
-                            TextDecorationStyle::Wavy => {
-                                let amplitude = size;
-                                let half_wave = (2.0 * size).max(1.0);
-                                let mut path = BezPath::new();
-                                path.move_to((x, y));
-                                let mut px = x;
-                                let mut up = true;
-                                while px < x + w {
-                                    let nx = (px + half_wave).min(x + w);
-                                    // A quad Bézier reaches half the control-point offset at its
-                                    // midpoint, so use `2 * amplitude` to hit the target peak.
-                                    let ctrl_y = if up {
-                                        y - 2.0 * amplitude
-                                    } else {
-                                        y + 2.0 * amplitude
-                                    };
-                                    path.quad_to(((px + nx) / 2.0, ctrl_y), (nx, y));
-                                    px = nx;
-                                    up = !up;
-                                }
-                                let stroke = Stroke::new(size).with_caps(Cap::Round);
-                                scene.stroke(&stroke, transform, brush, None, &path);
-                            }
-                        }
-                    };
-
-                // Resolve the CSS `text-decoration-thickness` to a device-pixel size.
-                //
-                // - Percentages are resolved against the font size,
-                // - `from-font` uses the metrics from Parley
-                // - `auto` uses a thickness of `font-size / 10` (minimum: 1px).
-                let decoration_size =
-                    |thickness: &TextDecorationLength, metric_size: f32| match thickness {
-                        GenericTextDecorationLength::LengthPercentage(lp) => {
-                            lp.resolve(Length::new(css_font_size as f32)).px() as f64 * scale
-                        }
-                        GenericTextDecorationLength::FromFont => metric_size as f64,
-                        GenericTextDecorationLength::Auto => {
-                            (css_font_size / 10.0).max(1.0) * scale
-                        }
-                    }
-                        as f32;
-
-                // Draw each decoration propagated from a decorating box (from the innermost
-                // out to the inline root). Geometry (thickness metrics, ascent/descent) uses
-                // this run's own font.
-                for entry in stack.iter().rev() {
-                    let Some(deco) = &entry.decoration else {
+                for entry in stack.iter() {
+                    if entry.decoration.is_none() {
                         continue;
-                    };
-                    let brush = anyrender::Paint::from(deco.color);
-
-                    // `text-decoration-inset` shortens (or, when negative, extends) the line
-                    // from the inline-start/end edges. Percentages resolve against the
-                    // decoration line length (the glyph run's advance); `auto` is no inset.
-                    // Resolved per run since the advance varies.
-                    let (inset_start, inset_end) = match &deco.inset {
-                        GenericTextDecorationInset::LengthPercentage { start, end } => {
-                            // The advance is already in device pixels; convert to CSS pixels so
-                            // the resolved result can be scaled back.
-                            let line_length = Length::new(glyph_run.advance() / scale as f32);
-                            (
-                                start.resolve(line_length).px() as f64 * scale,
-                                end.resolve(line_length).px() as f64 * scale,
-                            )
+                    }
+                    let idx = match deco_boxes.iter().position(|d| d.node_id == entry.node_id) {
+                        Some(idx) => idx,
+                        None => {
+                            deco_boxes.push(LineDecoration {
+                                node_id: entry.node_id,
+                                deco: entry.decoration.clone().unwrap(),
+                                min_x: f64::INFINITY,
+                                max_x: f64::NEG_INFINITY,
+                                own: None,
+                                first: None,
+                            });
+                            deco_boxes.len() - 1
                         }
-                        GenericTextDecorationInset::Auto => (0.0, 0.0),
                     };
-
-                    if deco.line.contains(TextDecorationLine::UNDERLINE) {
-                        let size = decoration_size(&deco.thickness, metrics.underline_size);
-
-                        // `text-underline-offset` moves the underline away from the text. `auto`
-                        // keeps the font's suggested position; otherwise it resolves against the
-                        // font size (percentages relative to 1em). Resolved per run.
-                        let extra_underline_offset = deco
-                            .underline_offset
-                            .as_ref()
-                            .map(|lp| {
-                                lp.resolve(Length::new(css_font_size as f32)).px() as f64 * scale
-                            })
-                            .unwrap_or(0.0);
-
-                        // `text-underline-position: under` places the underline below the glyph
-                        // box (below descenders) rather than at the font's suggested position near
-                        // the alphabetic baseline. We anchor the top of the line at the descent so
-                        // it clears descending glyphs like "gqy".
-                        //
-                        // `draw_decoration_line` computes `y = baseline - offset + size / 2` and
-                        // `y` grows downward, so a more negative offset pushes the underline
-                        // downward, away from the text.
-                        let base_offset = if deco.underline_under {
-                            -metrics.descent
-                        } else {
-                            metrics.underline_offset
-                        };
-                        let offset = base_offset - extra_underline_offset as f32;
-
-                        // TODO: intercept line when crossing an descending character like "gqy"
-                        // A `double` underline extends downward, away from the text.
-                        draw_decoration_line(
-                            offset,
-                            size,
-                            &brush,
-                            1.0,
-                            deco.style,
-                            inset_start,
-                            inset_end,
-                        );
+                    let acc = &mut deco_boxes[idx];
+                    acc.min_x = acc.min_x.min(run_x0);
+                    acc.max_x = acc.max_x.max(run_x1);
+                    if acc.first.is_none() {
+                        acc.first = Some(geometry.clone());
                     }
-                    if deco.line.contains(TextDecorationLine::OVERLINE) {
-                        // Fonts don't provide a dedicated overline metric, so reuse the underline
-                        // thickness. The line sits at the top of the "em box": its lower edge rests
-                        // on the ascent so it clears the glyphs, and it extends upward from there
-                        // (`draw_decoration_line` centres the stroke on `baseline - offset +
-                        // size / 2`, so `offset = ascent + size` puts the bottom edge at
-                        // `baseline - ascent`).
-                        //
-                        // Browsers use the OS/2 `usWinAscent` for this edge, which is taller than
-                        // the hhea-based ascent Parley reports; using the smaller value would draw
-                        // the overline too low (too close to the glyphs). Fall back to Parley's
-                        // ascent for fonts without a usable OS/2 table.
-                        let size = decoration_size(&deco.thickness, metrics.underline_size);
-                        let ascent =
-                            win_ascent(run.font(), run.font_size()).unwrap_or(metrics.ascent);
-                        let offset = ascent + size;
-
-                        // A `double` overline extends upward, away from the text.
-                        draw_decoration_line(
-                            offset,
-                            size,
-                            &brush,
-                            -1.0,
-                            deco.style,
-                            inset_start,
-                            inset_end,
-                        );
-                    }
-                    if deco.line.contains(TextDecorationLine::LINE_THROUGH) {
-                        let size = decoration_size(&deco.thickness, metrics.strikethrough_size);
-
-                        // Centre the line-through a third of the ascent above the baseline,
-                        // matching Chrome (which places it `2/3 * ascent` below the text-top).
-                        // Parley's `strikethrough_offset` (the font's `yStrikeoutPosition`) sits
-                        // lower and would draw the line too close to the baseline.
-                        // `draw_decoration_line` centres the stroke on `baseline - offset +
-                        // size / 2`, so `offset = ascent / 3 + size / 2` puts the centre at
-                        // `baseline - ascent / 3`.
-                        let ascent =
-                            win_ascent(run.font(), run.font_size()).unwrap_or(metrics.ascent);
-                        let offset = ascent / 3.0 + size / 2.0;
-
-                        draw_decoration_line(
-                            offset,
-                            size,
-                            &brush,
-                            1.0,
-                            deco.style,
-                            inset_start,
-                            inset_end,
-                        );
+                    // A run whose innermost node is the box itself is the box's own text, so
+                    // its font is the one Firefox positions and sizes the decoration with.
+                    if entry.node_id == run_node_id {
+                        acc.own = Some(geometry.clone());
                     }
                 }
             }
         }
+
+        flush_line_decorations(scene, transform, scale, &deco_boxes);
     }
 }
 

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -102,6 +102,7 @@ pub(crate) fn stroke_text<'a>(
                 let text_decoration_thickness: TextDecorationLength =
                     text_styles.text_decoration_thickness.clone();
                 let has_underline = text_decoration_line.contains(TextDecorationLine::UNDERLINE);
+                let has_overline = text_decoration_line.contains(TextDecorationLine::OVERLINE);
                 let has_strikethrough =
                     text_decoration_line.contains(TextDecorationLine::LINE_THROUGH);
 
@@ -176,6 +177,15 @@ pub(crate) fn stroke_text<'a>(
                     let offset = metrics.underline_offset - extra_offset as f32;
 
                     // TODO: intercept line when crossing an descending character like "gqy"
+                    draw_decoration_line(offset, size, &text_decoration_brush);
+                }
+                if has_overline {
+                    // Fonts don't provide a dedicated overline metric, so reuse the
+                    // underline thickness and position the line at the top of the text
+                    // (i.e. one ascent above the baseline).
+                    let offset = metrics.ascent;
+                    let size = decoration_size(metrics.underline_size);
+
                     draw_decoration_line(offset, size, &text_decoration_brush);
                 }
                 if has_strikethrough {

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -3,7 +3,7 @@ use blitz_dom::{BaseDocument, NodeId, node::TextBrush, util::ToColorColor};
 use kurbo::{Affine, Rect, Stroke};
 use parley::{Affinity, Cursor, Layout, Line, PositionedLayoutItem, Selection};
 use peniko::Fill;
-use style::values::computed::TextDecorationLine;
+use style::values::computed::{Length, TextDecorationLine};
 
 use crate::color::{Color, ToColorColor as _};
 use crate::{FONT_EMBOLDEN_ENABLED, SELECTION_COLOR};
@@ -137,8 +137,26 @@ pub(crate) fn stroke_text<'a>(
                     };
 
                 if has_underline {
-                    let offset = metrics.underline_offset;
                     let size = metrics.underline_size;
+
+                    // Apply the CSS `text-underline-offset`, which moves the underline further
+                    // away from the text. `auto` keeps the font's suggested position. The value
+                    // is resolved against the font size (percentages are relative to 1em) in CSS
+                    // pixels, then scaled to device pixels to match the (already scaled) glyph
+                    // metrics.
+                    let extra_offset = itext_styles
+                        .text_underline_offset
+                        .non_auto()
+                        .map(|lp| {
+                            let css_font_size = font_size as f64 / scale;
+                            lp.resolve(Length::new(css_font_size as f32)).px() as f64 * scale
+                        })
+                        .unwrap_or(0.0);
+
+                    // `draw_decoration_line` computes `y = baseline - offset + size / 2` and `y`
+                    // grows downward, so subtracting the offset pushes the underline downward,
+                    // away from the text.
+                    let offset = metrics.underline_offset - extra_offset as f32;
 
                     // TODO: intercept line when crossing an descending character like "gqy"
                     draw_decoration_line(offset, size, &text_decoration_brush);

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -141,17 +141,20 @@ pub(crate) fn stroke_text<'a>(
                         scene.stroke(&stroke, transform, brush, None, &line)
                     };
 
-                // Resolve the CSS `text-decoration-thickness` to a device-pixel size. `auto`
-                // and `from-font` keep the font's suggested thickness for the specific
-                // decoration line; a `<length-percentage>` is resolved against the font size
-                // (percentages are relative to 1em) in CSS pixels, then scaled to device pixels.
+                // Resolve the CSS `text-decoration-thickness` to a device-pixel size.
+                //
+                // - Percentages are resolved against the font size,
+                // - `from-font` uses the metrics from Parley
+                // - `auto` uses a thickness of `font-size / 10` (minimum: 1px).
                 let decoration_size = |metric_size: f32| match &text_decoration_thickness {
                     GenericTextDecorationLength::LengthPercentage(lp) => {
                         let css_font_size = font_size as f64 / scale;
                         lp.resolve(Length::new(css_font_size as f32)).px() as f64 * scale
                     }
-                    GenericTextDecorationLength::FromFont | GenericTextDecorationLength::Auto => {
-                        metric_size as f64
+                    GenericTextDecorationLength::FromFont => metric_size as f64,
+                    GenericTextDecorationLength::Auto => {
+                        let css_font_size = font_size as f64 / scale;
+                        (css_font_size / 10.0).max(1.0) * scale
                     }
                 } as f32;
 

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -5,7 +5,7 @@ use parley::{Affinity, Cursor, Layout, Line, PositionedLayoutItem, Selection};
 use peniko::Fill;
 use style::properties::generated::longhands::text_decoration_style::computed_value::T as TextDecorationStyle;
 use style::values::computed::{
-    Length, TextDecorationLength, TextDecorationLine, TextUnderlinePosition,
+    Length, LengthPercentage, TextDecorationLength, TextDecorationLine, TextUnderlinePosition,
 };
 use style::values::generics::text::{GenericTextDecorationInset, GenericTextDecorationLength};
 
@@ -100,13 +100,105 @@ fn select_best_dash_gap(stroke_length: f64, dash_length: f64, gap_length: f64) -
     }
 }
 
+/// A text decoration resolved from a single "decorating box" (an element that
+/// sets `text-decoration-line`), ready to be drawn over a glyph run. Because the
+/// `text-decoration-*` properties do not inherit, decorations are propagated from
+/// ancestors rather than inherited, so a run may be covered by several of these.
+///
+/// Only the run-independent (style-derived) values are stored here so an instance
+/// can be cached on the ancestor stack and reused across every run within the same
+/// decorating box. The `text-decoration-inset` and `text-underline-offset` values
+/// depend on the run's advance/font-size and are resolved lazily when drawing.
+struct ResolvedDecoration {
+    line: TextDecorationLine,
+    style: TextDecorationStyle,
+    color: Color,
+    thickness: TextDecorationLength,
+    /// `text-underline-offset`; `None` for `auto`. Resolved per run.
+    underline_offset: Option<LengthPercentage>,
+    /// Whether `text-underline-position: under` is in effect.
+    underline_under: bool,
+    /// `text-decoration-inset`. Resolved per run.
+    inset: GenericTextDecorationInset<LengthPercentage>,
+}
+
+/// An element on the current ancestor path (inline root -> run node), caching the
+/// values resolved from its computed style so descending into the same node across
+/// consecutive runs doesn't re-resolve them.
+struct DecorationStackEntry {
+    node_id: usize,
+    /// This node's (inherited) text colour, used for the glyphs of runs whose
+    /// innermost node is this one.
+    text_color: Color,
+    /// The decoration this node introduces as a decorating box, if any.
+    decoration: Option<ResolvedDecoration>,
+}
+
+/// Resolve the cached style values for a single node into a [`DecorationStackEntry`].
+fn resolve_decoration_entry(doc: &BaseDocument, node_id: usize) -> DecorationStackEntry {
+    let Some(styles) = doc.get_node(node_id).and_then(|node| node.primary_styles()) else {
+        return DecorationStackEntry {
+            node_id,
+            text_color: Color::BLACK,
+            decoration: None,
+        };
+    };
+
+    let itext = styles.get_inherited_text();
+    let text = styles.get_text();
+    let text_color = itext.color.as_color_color();
+
+    let drawn_lines = TextDecorationLine::UNDERLINE
+        | TextDecorationLine::OVERLINE
+        | TextDecorationLine::LINE_THROUGH;
+    let line = text.text_decoration_line;
+    let decoration = line.intersects(drawn_lines).then(|| {
+        // `text-decoration-color: currentColor` (the initial value) resolves against
+        // the decorating box's own colour, not the descendant run's.
+        let color = text
+            .text_decoration_color
+            .as_absolute()
+            .map(ToColorColor::as_color_color)
+            .unwrap_or(text_color);
+
+        ResolvedDecoration {
+            line,
+            style: text.text_decoration_style,
+            color,
+            thickness: text.text_decoration_thickness.clone(),
+            underline_offset: itext.text_underline_offset.non_auto(),
+            underline_under: itext
+                .text_underline_position
+                .contains(TextUnderlinePosition::UNDER),
+            inset: text.text_decoration_inset.clone(),
+        }
+    });
+
+    DecorationStackEntry {
+        node_id,
+        text_color,
+        decoration,
+    }
+}
+
 pub(crate) fn stroke_text<'a>(
     scene: &mut impl PaintScene,
     lines: impl Iterator<Item = Line<'a, TextBrush>>,
     doc: &BaseDocument,
     transform: Affine,
     scale: f64,
+    inline_root_id: usize,
 ) {
+    // Persistent stack mirroring the ancestor path (inline root -> current run's
+    // node) as we walk the runs. The `text-decoration-*` properties are *not*
+    // inherited; instead a decoration set on an ancestor is propagated to the
+    // descendant text it wraps. Rather than re-resolving styles for the whole
+    // ancestor chain on every run, we cache each node's resolved values here and,
+    // for each run, only resolve styles for the nodes newly descended into (popping
+    // as we ascend). `path_scratch` is a reusable buffer for the run's node path.
+    let mut stack: Vec<DecorationStackEntry> = Vec::new();
+    let mut path_scratch: Vec<usize> = Vec::new();
+
     for line in lines {
         for item in line.items() {
             if let PositionedLayoutItem::GlyphRun(glyph_run) = item {
@@ -120,46 +212,35 @@ pub(crate) fn stroke_text<'a>(
                     .skew()
                     .map(|angle| Affine::skew(angle.to_radians().tan() as f64, 0.0));
 
-                // Styles
-                let styles = doc
-                    .get_node(style.brush.id)
-                    .unwrap()
-                    .primary_styles()
-                    .unwrap();
-                let itext_styles = styles.get_inherited_text();
-                let text_styles = styles.get_text();
-                let text_color = itext_styles.color.as_color_color();
-                let text_decoration_color = text_styles
-                    .text_decoration_color
-                    .as_absolute()
-                    .map(ToColorColor::as_color_color)
-                    .unwrap_or(text_color);
-                let text_decoration_brush = anyrender::Paint::from(text_decoration_color);
-                let text_decoration_line = text_styles.text_decoration_line;
-                let text_decoration_style = text_styles.text_decoration_style;
-                let text_decoration_thickness: TextDecorationLength =
-                    text_styles.text_decoration_thickness.clone();
+                let css_font_size = font_size as f64 / scale;
 
-                // `text-decoration-inset` shortens (or, when negative, extends) the decoration
-                // line from the inline-start and inline-end edges of the text. Resolve the
-                // start/end lengths to device pixels; percentages are resolved against the
-                // decoration line length (the glyph run's advance). `auto` is treated as no inset.
-                let (inset_start, inset_end) = match &text_styles.text_decoration_inset {
-                    GenericTextDecorationInset::LengthPercentage { start, end } => {
-                        // The advance is already in device pixels; convert to CSS pixels so the
-                        // resolved (device-pixel) result can be scaled back consistently.
-                        let line_length = Length::new(glyph_run.advance() / scale as f32);
-                        (
-                            start.resolve(line_length).px() as f64 * scale,
-                            end.resolve(line_length).px() as f64 * scale,
-                        )
+                // Reconcile the stack with this run's ancestor path. Build the path
+                // (inline root -> run node), keep the shared prefix already on the stack,
+                // pop the rest, and resolve styles only for the newly-descended nodes.
+                path_scratch.clear();
+                let mut walk_id = Some(style.brush.id);
+                while let Some(node_id) = walk_id {
+                    path_scratch.push(node_id);
+                    if node_id == inline_root_id {
+                        break;
                     }
-                    GenericTextDecorationInset::Auto => (0.0, 0.0),
-                };
-                let has_underline = text_decoration_line.contains(TextDecorationLine::UNDERLINE);
-                let has_overline = text_decoration_line.contains(TextDecorationLine::OVERLINE);
-                let has_strikethrough =
-                    text_decoration_line.contains(TextDecorationLine::LINE_THROUGH);
+                    walk_id = doc.get_node(node_id).and_then(|node| node.parent);
+                }
+                path_scratch.reverse();
+
+                let shared = stack
+                    .iter()
+                    .zip(path_scratch.iter())
+                    .take_while(|(entry, node_id)| entry.node_id == **node_id)
+                    .count();
+                stack.truncate(shared);
+                for &node_id in &path_scratch[shared..] {
+                    stack.push(resolve_decoration_entry(doc, node_id));
+                }
+
+                // The glyph colour comes from the run's own node (the stack top): `color`
+                // inherits, so the innermost inline element already carries the right value.
+                let text_color = stack.last().map(|e| e.text_color).unwrap_or(Color::BLACK);
 
                 let embolden = if FONT_EMBOLDEN_ENABLED {
                     let fs = font_size as f64 / scale;
@@ -194,7 +275,13 @@ pub(crate) fn stroke_text<'a>(
                 // `double_dir` points away from the text (`+1` = down, `-1` = up) and is used
                 // to place the second line of a `double` decoration.
                 let mut draw_decoration_line =
-                    |offset: f32, size: f32, brush: &anyrender::Paint, double_dir: f64| {
+                    |offset: f32,
+                     size: f32,
+                     brush: &anyrender::Paint,
+                     double_dir: f64,
+                     deco_style: TextDecorationStyle,
+                     inset_start: f64,
+                     inset_end: f64| {
                         // Inset the line from the run's start/end edges (assumes LTR: start is
                         // the left edge). Negative insets extend the line past the text.
                         let x = glyph_run.offset() as f64 + inset_start;
@@ -206,7 +293,7 @@ pub(crate) fn stroke_text<'a>(
                         let size = size as f64;
                         let butt_stroke = Stroke::new(size).with_caps(Cap::Butt);
 
-                        match text_decoration_style {
+                        match deco_style {
                             TextDecorationStyle::MozNone => {
                                 // no line. Equivalent to `text-decoration-line: none`
                             }
@@ -291,88 +378,137 @@ pub(crate) fn stroke_text<'a>(
                 // - Percentages are resolved against the font size,
                 // - `from-font` uses the metrics from Parley
                 // - `auto` uses a thickness of `font-size / 10` (minimum: 1px).
-                let decoration_size = |metric_size: f32| match &text_decoration_thickness {
-                    GenericTextDecorationLength::LengthPercentage(lp) => {
-                        let css_font_size = font_size as f64 / scale;
-                        lp.resolve(Length::new(css_font_size as f32)).px() as f64 * scale
-                    }
-                    GenericTextDecorationLength::FromFont => metric_size as f64,
-                    GenericTextDecorationLength::Auto => {
-                        let css_font_size = font_size as f64 / scale;
-                        (css_font_size / 10.0).max(1.0) * scale
-                    }
-                } as f32;
-
-                if has_underline {
-                    let size = decoration_size(metrics.underline_size);
-
-                    // Apply the CSS `text-underline-offset`, which moves the underline further
-                    // away from the text. `auto` keeps the font's suggested position. The value
-                    // is resolved against the font size (percentages are relative to 1em) in CSS
-                    // pixels, then scaled to device pixels to match the (already scaled) glyph
-                    // metrics.
-                    let extra_offset = itext_styles
-                        .text_underline_offset
-                        .non_auto()
-                        .map(|lp| {
-                            let css_font_size = font_size as f64 / scale;
+                let decoration_size =
+                    |thickness: &TextDecorationLength, metric_size: f32| match thickness {
+                        GenericTextDecorationLength::LengthPercentage(lp) => {
                             lp.resolve(Length::new(css_font_size as f32)).px() as f64 * scale
-                        })
-                        .unwrap_or(0.0);
+                        }
+                        GenericTextDecorationLength::FromFont => metric_size as f64,
+                        GenericTextDecorationLength::Auto => {
+                            (css_font_size / 10.0).max(1.0) * scale
+                        }
+                    }
+                        as f32;
 
-                    // `text-underline-position: under` places the underline below the glyph
-                    // box (below descenders) rather than at the font's suggested position near
-                    // the alphabetic baseline. We anchor the top of the line at the descent so
-                    // it clears descending glyphs like "gqy".
-                    //
-                    // `draw_decoration_line` computes `y = baseline - offset + size / 2` and `y`
-                    // grows downward, so a more negative offset pushes the underline downward,
-                    // away from the text.
-                    let base_offset = if itext_styles
-                        .text_underline_position
-                        .contains(TextUnderlinePosition::UNDER)
-                    {
-                        -metrics.descent
-                    } else {
-                        metrics.underline_offset
+                // Draw each decoration propagated from a decorating box (from the innermost
+                // out to the inline root). Geometry (thickness metrics, ascent/descent) uses
+                // this run's own font.
+                for entry in stack.iter().rev() {
+                    let Some(deco) = &entry.decoration else {
+                        continue;
                     };
-                    let offset = base_offset - extra_offset as f32;
+                    let brush = anyrender::Paint::from(deco.color);
 
-                    // TODO: intercept line when crossing an descending character like "gqy"
-                    // A `double` underline extends downward, away from the text.
-                    draw_decoration_line(offset, size, &text_decoration_brush, 1.0);
-                }
-                if has_overline {
-                    // Fonts don't provide a dedicated overline metric, so reuse the underline
-                    // thickness. The line sits at the top of the "em box": its lower edge rests
-                    // on the ascent so it clears the glyphs, and it extends upward from there
-                    // (`draw_decoration_line` centres the stroke on `baseline - offset + size / 2`,
-                    // so `offset = ascent + size` puts the bottom edge at `baseline - ascent`).
-                    //
-                    // Browsers use the OS/2 `usWinAscent` for this edge, which is taller than the
-                    // hhea-based ascent Parley reports; using the smaller value would draw the
-                    // overline too low (too close to the glyphs). Fall back to Parley's ascent for
-                    // fonts without a usable OS/2 table.
-                    let size = decoration_size(metrics.underline_size);
-                    let ascent = win_ascent(run.font(), run.font_size()).unwrap_or(metrics.ascent);
-                    let offset = ascent + size;
+                    // `text-decoration-inset` shortens (or, when negative, extends) the line
+                    // from the inline-start/end edges. Percentages resolve against the
+                    // decoration line length (the glyph run's advance); `auto` is no inset.
+                    // Resolved per run since the advance varies.
+                    let (inset_start, inset_end) = match &deco.inset {
+                        GenericTextDecorationInset::LengthPercentage { start, end } => {
+                            // The advance is already in device pixels; convert to CSS pixels so
+                            // the resolved result can be scaled back.
+                            let line_length = Length::new(glyph_run.advance() / scale as f32);
+                            (
+                                start.resolve(line_length).px() as f64 * scale,
+                                end.resolve(line_length).px() as f64 * scale,
+                            )
+                        }
+                        GenericTextDecorationInset::Auto => (0.0, 0.0),
+                    };
 
-                    // A `double` overline extends upward, away from the text.
-                    draw_decoration_line(offset, size, &text_decoration_brush, -1.0);
-                }
-                if has_strikethrough {
-                    let size = decoration_size(metrics.strikethrough_size);
+                    if deco.line.contains(TextDecorationLine::UNDERLINE) {
+                        let size = decoration_size(&deco.thickness, metrics.underline_size);
 
-                    // Centre the line-through a third of the ascent above the baseline, matching
-                    // Chrome (which places it `2/3 * ascent` below the text-top). Parley's
-                    // `strikethrough_offset` (the font's `yStrikeoutPosition`) sits lower and would
-                    // draw the line too close to the baseline. `draw_decoration_line` centres the
-                    // stroke on `baseline - offset + size / 2`, so `offset = ascent / 3 + size / 2`
-                    // puts the centre at `baseline - ascent / 3`.
-                    let ascent = win_ascent(run.font(), run.font_size()).unwrap_or(metrics.ascent);
-                    let offset = ascent / 3.0 + size / 2.0;
+                        // `text-underline-offset` moves the underline away from the text. `auto`
+                        // keeps the font's suggested position; otherwise it resolves against the
+                        // font size (percentages relative to 1em). Resolved per run.
+                        let extra_underline_offset = deco
+                            .underline_offset
+                            .as_ref()
+                            .map(|lp| {
+                                lp.resolve(Length::new(css_font_size as f32)).px() as f64 * scale
+                            })
+                            .unwrap_or(0.0);
 
-                    draw_decoration_line(offset, size, &text_decoration_brush, 1.0);
+                        // `text-underline-position: under` places the underline below the glyph
+                        // box (below descenders) rather than at the font's suggested position near
+                        // the alphabetic baseline. We anchor the top of the line at the descent so
+                        // it clears descending glyphs like "gqy".
+                        //
+                        // `draw_decoration_line` computes `y = baseline - offset + size / 2` and
+                        // `y` grows downward, so a more negative offset pushes the underline
+                        // downward, away from the text.
+                        let base_offset = if deco.underline_under {
+                            -metrics.descent
+                        } else {
+                            metrics.underline_offset
+                        };
+                        let offset = base_offset - extra_underline_offset as f32;
+
+                        // TODO: intercept line when crossing an descending character like "gqy"
+                        // A `double` underline extends downward, away from the text.
+                        draw_decoration_line(
+                            offset,
+                            size,
+                            &brush,
+                            1.0,
+                            deco.style,
+                            inset_start,
+                            inset_end,
+                        );
+                    }
+                    if deco.line.contains(TextDecorationLine::OVERLINE) {
+                        // Fonts don't provide a dedicated overline metric, so reuse the underline
+                        // thickness. The line sits at the top of the "em box": its lower edge rests
+                        // on the ascent so it clears the glyphs, and it extends upward from there
+                        // (`draw_decoration_line` centres the stroke on `baseline - offset +
+                        // size / 2`, so `offset = ascent + size` puts the bottom edge at
+                        // `baseline - ascent`).
+                        //
+                        // Browsers use the OS/2 `usWinAscent` for this edge, which is taller than
+                        // the hhea-based ascent Parley reports; using the smaller value would draw
+                        // the overline too low (too close to the glyphs). Fall back to Parley's
+                        // ascent for fonts without a usable OS/2 table.
+                        let size = decoration_size(&deco.thickness, metrics.underline_size);
+                        let ascent =
+                            win_ascent(run.font(), run.font_size()).unwrap_or(metrics.ascent);
+                        let offset = ascent + size;
+
+                        // A `double` overline extends upward, away from the text.
+                        draw_decoration_line(
+                            offset,
+                            size,
+                            &brush,
+                            -1.0,
+                            deco.style,
+                            inset_start,
+                            inset_end,
+                        );
+                    }
+                    if deco.line.contains(TextDecorationLine::LINE_THROUGH) {
+                        let size = decoration_size(&deco.thickness, metrics.strikethrough_size);
+
+                        // Centre the line-through a third of the ascent above the baseline,
+                        // matching Chrome (which places it `2/3 * ascent` below the text-top).
+                        // Parley's `strikethrough_offset` (the font's `yStrikeoutPosition`) sits
+                        // lower and would draw the line too close to the baseline.
+                        // `draw_decoration_line` centres the stroke on `baseline - offset +
+                        // size / 2`, so `offset = ascent / 3 + size / 2` puts the centre at
+                        // `baseline - ascent / 3`.
+                        let ascent =
+                            win_ascent(run.font(), run.font_size()).unwrap_or(metrics.ascent);
+                        let offset = ascent / 3.0 + size / 2.0;
+
+                        draw_decoration_line(
+                            offset,
+                            size,
+                            &brush,
+                            1.0,
+                            deco.style,
+                            inset_start,
+                            inset_end,
+                        );
+                    }
                 }
             }
         }

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -72,7 +72,7 @@ pub(crate) fn draw_inline_backgrounds<'a>(
 /// is typically taller than the hhea ascent Parley exposes via [`parley::layout::run::RunMetrics`].
 /// Returns `None` when the font has no OS/2 table.
 fn win_ascent(font: &parley::FontData, font_size: f32) -> Option<f32> {
-    use read_fonts::{FontRef, TableProvider as _};
+    use skrifa::raw::{FontRef, TableProvider as _};
     let font_ref = FontRef::from_index(font.data.as_ref(), font.index).ok()?;
     let units_per_em = font_ref.head().ok()?.units_per_em();
     let win_ascent = font_ref.os2().ok()?.us_win_ascent();


### PR DESCRIPTION
## Summary

Rebase of #510 onto latest main (couldn't push to the fork branch, so opening as a new PR).

Implements:

- text-decoration-style (solid / double / dotted / dashed / wavy, with geometry built explicitly for cross-renderer consistency; dashed gap selection mirrors Blink's `SelectBestDashGap`)
- text-decoration-thickness
- text-decoration-inset
- text-underline-offset
- text-underline-position
- overline support

Decorations are now accumulated per "decorating box" across a whole line (`LineDecoration` keyed by node id) and flushed once per line, so mixed font sizes within a box draw a single straight line rather than stepped per-run segments (matching Firefox). Overline/strikethrough placement uses the OS/2 `usWinAscent` (via a new `read-fonts` dependency), matching browser behaviour.

Rebase changes vs #510:
- resolved import conflicts in `packages/blitz-paint/src/text.rs`
- new commit "Adapt text-decoration code to NodeId newtype": node ids in the new decoration code (`DecorationStackEntry`, `LineDecoration`, `path_scratch`, `stroke_text`'s `inline_root_id`) changed from `usize` to the `NodeId` newtype introduced on main

Verified with `cargo check`, clippy, fmt, and by rendering `examples/assets/text-decoration.html` with the screenshot example.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/1e40516b22b34e3d89abb619530f4b45
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**18** newly passing, **11** newly failing (net +7).

<details>
<summary>Full diff (29 changed tests)</summary>

```diff
- Pass => Fail css/CSS2/text/painting-order-underline-001.xht
+ Fail => Pass css/css-text-decor/text-decoration-dotted-002.html
+ Fail => Pass css/css-text-decor/text-decoration-inset-001.html
+ Fail => Pass css/css-text-decor/text-decoration-inset-007.html
- Pass => Fail css/css-text-decor/text-decoration-inset-010.html
+ Fail => Pass css/css-text-decor/text-decoration-inset-015.html
+ Fail => Pass css/css-text-decor/text-decoration-inset-016.html
+ Fail => Pass css/css-text-decor/text-decoration-inset-024.html
- Pass => Fail css/css-text-decor/text-decoration-propagation-dynamic-001.html
+ Fail => Pass css/css-text-decor/text-decoration-propagation-shadow.html
+ Fail => Pass css/css-text-decor/text-decoration-style-multiple.html
- Pass => Fail css/css-text-decor/text-decoration-style-recalc.html
+ Fail => Pass css/css-text-decor/text-decoration-subelements-002.html
- Pass => Fail css/css-text-decor/text-decoration-subelements-004.html
+ Fail => Pass css/css-text-decor/text-decoration-thickness-001.html
+ Fail => Pass css/css-text-decor/text-decoration-thickness-calc.html
+ Fail => Pass css/css-text-decor/text-decoration-thickness-fixed.html
+ Fail => Pass css/css-text-decor/text-decoration-thickness-linethrough-001.html
+ Fail => Pass css/css-text-decor/text-decoration-thickness-scroll-001.html
+ Fail => Pass css/css-text-decor/text-decoration-thickness-single.html
+ Fail => Pass css/css-text-decor/text-underline-offset-001.html
- Pass => Fail css/css-text-decor/text-underline-offset-002.html
+ Fail => Pass css/css-text-decor/text-underline-offset-negative.html
+ Fail => Pass css/css-text-decor/text-underline-offset-scroll-001.html
- Pass => Fail css/css-text-decor/text-underline-offset-variable.html
- Pass => Fail css/css-text-decor/text-underline-offset-vertical-001.html
- Pass => Fail css/css-text-decor/text-underline-offset-vertical-002.html
- Pass => Fail css/css-text-decor/text-underline-offset-vertical-003.html
- Pass => Fail css/selectors/not-links.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32258041860).</sub>
<!-- wpt-results-end -->
