### PR TITLE
Upgrade taffy to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=4ae4219b34e0ad22fd907cb1a7fa9a68c1ea1621#4ae4219b34e0ad22fd907cb1a7fa9a68c1ea1621"
+source = "git+https://github.com/DioxusLabs/taffy?rev=e17e0cf226566db376e1c07454ab87754b56e3b8#e17e0cf226566db376e1c07454ab87754b56e3b8"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=61de129199a2db3b9c6fef380d06007f0f8e2baf#61de129199a2db3b9c6fef380d06007f0f8e2baf"
+source = "git+https://github.com/DioxusLabs/taffy?rev=a29bbc9a09d6fa5b01976f774d31f9bbf21a697d#a29bbc9a09d6fa5b01976f774d31f9bbf21a697d"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=0541bead1e3cd341a11c04570d1215b44b473d74#0541bead1e3cd341a11c04570d1215b44b473d74"
+source = "git+https://github.com/DioxusLabs/taffy?rev=61de129199a2db3b9c6fef380d06007f0f8e2baf#61de129199a2db3b9c6fef380d06007f0f8e2baf"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=e17e0cf226566db376e1c07454ab87754b56e3b8#e17e0cf226566db376e1c07454ab87754b56e3b8"
+source = "git+https://github.com/DioxusLabs/taffy?rev=0541bead1e3cd341a11c04570d1215b44b473d74#0541bead1e3cd341a11c04570d1215b44b473d74"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=3716e04627619708bd72c3768150aa5c5ebf6f83#3716e04627619708bd72c3768150aa5c5ebf6f83"
+source = "git+https://github.com/DioxusLabs/taffy?rev=6741557fded1c418f5536ba6c6181b89eec654d5#6741557fded1c418f5536ba6c6181b89eec654d5"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=6741557fded1c418f5536ba6c6181b89eec654d5#6741557fded1c418f5536ba6c6181b89eec654d5"
+source = "git+https://github.com/DioxusLabs/taffy?rev=0e33e961c4ecd36a38d5103f57f305fbe37d749f#0e33e961c4ecd36a38d5103f57f305fbe37d749f"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=5b6fe5384b8050304deca955116eb655fa1b7c1a#5b6fe5384b8050304deca955116eb655fa1b7c1a"
+source = "git+https://github.com/DioxusLabs/taffy?rev=3716e04627619708bd72c3768150aa5c5ebf6f83#3716e04627619708bd72c3768150aa5c5ebf6f83"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=a29bbc9a09d6fa5b01976f774d31f9bbf21a697d#a29bbc9a09d6fa5b01976f774d31f9bbf21a697d"
+source = "git+https://github.com/DioxusLabs/taffy?rev=5b6fe5384b8050304deca955116eb655fa1b7c1a#5b6fe5384b8050304deca955116eb655fa1b7c1a"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "0541bead1e3cd341a11c04570d1215b44b473d74", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "61de129199a2db3b9c6fef380d06007f0f8e2baf", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "e17e0cf226566db376e1c07454ab87754b56e3b8", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "0541bead1e3cd341a11c04570d1215b44b473d74", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "61de129199a2db3b9c6fef380d06007f0f8e2baf", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a29bbc9a09d6fa5b01976f774d31f9bbf21a697d", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "3716e04627619708bd72c3768150aa5c5ebf6f83", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "6741557fded1c418f5536ba6c6181b89eec654d5", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "a29bbc9a09d6fa5b01976f774d31f9bbf21a697d", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "5b6fe5384b8050304deca955116eb655fa1b7c1a", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "5b6fe5384b8050304deca955116eb655fa1b7c1a", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "3716e04627619708bd72c3768150aa5c5ebf6f83", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "4ae4219b34e0ad22fd907cb1a7fa9a68c1ea1621", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "e17e0cf226566db376e1c07454ab87754b56e3b8", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "6741557fded1c418f5536ba6c6181b89eec654d5", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "0e33e961c4ecd36a38d5103f57f305fbe37d749f", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -536,7 +536,7 @@ impl taffy::LayoutGridContainer for BaseDocument {
     fn set_detailed_grid_info(
         &mut self,
         node_id: NodeId,
-        detailed_grid_info: taffy::DetailedGridInfo,
+        detailed_grid_info: taffy::DetailedGridInfo<Atom>,
     ) {
         let node = self.node_from_id_mut(node_id);
         if let Some(element) = node.element_data_mut() {

--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -29,7 +29,7 @@ pub struct TableContext {
     pub style: taffy::Style<Atom>,
     pub cells: Vec<TableCell>,
     pub rows: Vec<TableRow>,
-    pub computed_grid_info: AtomicRefCell<Option<DetailedGridInfo>>,
+    pub computed_grid_info: AtomicRefCell<Option<DetailedGridInfo<Atom>>>,
     pub border_style: Option<ServoArc<Border>>,
     pub border_collapse: BorderCollapse,
 }
@@ -442,7 +442,7 @@ impl taffy::LayoutGridContainer for TableTreeWrapper<'_> {
     fn set_detailed_grid_info(
         &mut self,
         _node_id: taffy::NodeId,
-        detailed_grid_info: DetailedGridInfo,
+        detailed_grid_info: DetailedGridInfo<Atom>,
     ) {
         *self.ctx.computed_grid_info.borrow_mut() = Some(detailed_grid_info);
     }

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -106,7 +106,7 @@ pub struct ElementData {
 
     /// Detailed grid track sizing information from the most recent layout
     /// (grid containers only). Used by devtools grid inspection.
-    pub detailed_grid_info: Option<Box<taffy::DetailedGridInfo>>,
+    pub detailed_grid_info: Option<Box<taffy::DetailedGridInfo<Atom>>>,
 
     // Taffy layout data:
     pub style: Style<Atom>,

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -45,25 +45,58 @@ use peniko::{self, Fill, ImageData, ImageSampler};
 use style::values::generics::color::GenericColor;
 use taffy::Layout;
 
-/// Derive per-track sizes and gutter sizes (in physical left-to-right / top-to-bottom order)
-/// from the track positions reported by taffy. Taffy reports tracks in logical order, so for
-/// RTL grids the positions are sorted into physical order first. The returned gutters vector
-/// has one more entry than the sizes vector (a leading and trailing gutter of zero size).
-pub(crate) fn track_sizes_and_gutters(
-    tracks: &taffy::DetailedGridTracksInfo,
-) -> (Vec<f32>, Vec<f32>) {
-    let mut positions = tracks.positions.clone();
-    positions.sort_by(|a, b| a.start.total_cmp(&b.start));
-    let sizes: Vec<f32> = positions.iter().map(|line| line.end - line.start).collect();
-    let mut gutters = Vec::with_capacity(positions.len() + 1);
-    gutters.push(0.0);
-    for pair in positions.windows(2) {
-        gutters.push(pair[1].start - pair[0].end);
+/// A view of the track positions reported by taffy in physical (left-to-right /
+/// top-to-bottom) order. Taffy reports tracks in logical order, which for RTL grid
+/// containers is physically reversed.
+#[derive(Clone, Copy)]
+pub(crate) struct PhysicalTracks<'a> {
+    positions: &'a [taffy::Line<f32>],
+    reversed: bool,
+}
+
+impl<'a> PhysicalTracks<'a> {
+    pub(crate) fn from_tracks(tracks: &'a taffy::DetailedGridTracksInfo) -> Self {
+        let positions = tracks.positions.as_slice();
+        let reversed = positions
+            .first()
+            .zip(positions.last())
+            .is_some_and(|(first, last)| first.start > last.start);
+        Self {
+            positions,
+            reversed,
+        }
     }
-    if !positions.is_empty() {
-        gutters.push(0.0);
+
+    fn get(self, index: usize) -> taffy::Line<f32> {
+        if self.reversed {
+            self.positions[self.positions.len() - 1 - index]
+        } else {
+            self.positions[index]
+        }
     }
-    (sizes, gutters)
+
+    /// Iterate track positions in physical order
+    pub(crate) fn iter(self) -> impl ExactSizeIterator<Item = taffy::Line<f32>> + 'a {
+        (0..self.positions.len()).map(move |index| self.get(index))
+    }
+
+    /// The physical start position of the first track
+    pub(crate) fn origin(self) -> f32 {
+        if self.positions.is_empty() {
+            0.0
+        } else {
+            self.get(0).start
+        }
+    }
+
+    /// Total distance from the start of the first track to the end of the last track
+    pub(crate) fn span(self) -> f32 {
+        if self.positions.is_empty() {
+            0.0
+        } else {
+            self.get(self.positions.len() - 1).end - self.get(0).start
+        }
+    }
 }
 
 /// A short-lived struct which holds a bunch of parameters for rendering a scene so

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -55,7 +55,9 @@ pub(crate) struct PhysicalTracks<'a> {
 }
 
 impl<'a> PhysicalTracks<'a> {
-    pub(crate) fn from_tracks(tracks: &'a taffy::DetailedGridTracksInfo) -> Self {
+    pub(crate) fn from_tracks<S: taffy::CheapCloneStr>(
+        tracks: &'a taffy::DetailedGridTracksInfo<S>,
+    ) -> Self {
         let positions = tracks.positions.as_slice();
         let reversed = positions
             .first()

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -45,6 +45,27 @@ use peniko::{self, Fill, ImageData, ImageSampler};
 use style::values::generics::color::GenericColor;
 use taffy::Layout;
 
+/// Derive per-track sizes and gutter sizes (in physical left-to-right / top-to-bottom order)
+/// from the track positions reported by taffy. Taffy reports tracks in logical order, so for
+/// RTL grids the positions are sorted into physical order first. The returned gutters vector
+/// has one more entry than the sizes vector (a leading and trailing gutter of zero size).
+pub(crate) fn track_sizes_and_gutters(
+    tracks: &taffy::DetailedGridTracksInfo,
+) -> (Vec<f32>, Vec<f32>) {
+    let mut positions = tracks.positions.clone();
+    positions.sort_by(|a, b| a.start.total_cmp(&b.start));
+    let sizes: Vec<f32> = positions.iter().map(|line| line.end - line.start).collect();
+    let mut gutters = Vec::with_capacity(positions.len() + 1);
+    gutters.push(0.0);
+    for pair in positions.windows(2) {
+        gutters.push(pair[1].start - pair[0].end);
+    }
+    if !positions.is_empty() {
+        gutters.push(0.0);
+    }
+    (sizes, gutters)
+}
+
 /// A short-lived struct which holds a bunch of parameters for rendering a scene so
 /// that we don't have to pass them down as parameters
 pub struct BlitzDomPainter<'dom, 'a> {

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -1,4 +1,4 @@
-use super::{ElementCx, to_image_quality, to_peniko_image, track_sizes_and_gutters};
+use super::{ElementCx, PhysicalTracks, to_image_quality, to_peniko_image};
 use crate::color::{Color, ToColorColor};
 use crate::gradient::to_peniko_gradient;
 use anyrender::PaintScene;
@@ -224,24 +224,20 @@ impl ElementCx<'_, '_> {
             return;
         };
 
-        let (col_sizes, col_gutters) = track_sizes_and_gutters(&grid_info.columns);
-        let inner_width = (col_sizes.iter().sum::<f32>() + col_gutters.iter().sum::<f32>()) as f64;
+        let cols = PhysicalTracks::from_tracks(&grid_info.columns);
+        let inner_width = cols.span() as f64;
 
-        let (row_sizes, row_gutters) = track_sizes_and_gutters(&grid_info.rows);
-        let mut y = row_gutters.first().copied().unwrap_or_default() as f64;
-        for ((row, &height), &gutter) in table
-            .rows
-            .iter()
-            .zip(row_sizes.iter())
-            .zip(row_gutters.iter().skip(1))
-        {
+        let rows = PhysicalTracks::from_tracks(&grid_info.rows);
+        let row_origin = rows.origin();
+        for (row, row_position) in table.rows.iter().zip(rows.iter()) {
             let row_node = &self.context.dom.get_node(row.node_id).unwrap();
             let Some(style) = row_node.primary_styles() else {
                 continue;
             };
 
-            let shape =
-                Rect::new(0.0, y, inner_width, y + height as f64).scale_from_origin(self.scale);
+            let y = (row_position.start - row_origin) as f64;
+            let height = (row_position.end - row_position.start) as f64;
+            let shape = Rect::new(0.0, y, inner_width, y + height).scale_from_origin(self.scale);
 
             let current_color = style.clone_color();
             let background_color = &style.get_background().background_color;
@@ -253,8 +249,6 @@ impl ElementCx<'_, '_> {
                 // Fill the color
                 scene.fill(Fill::NonZero, self.transform, bg_color, None, &shape);
             }
-
-            y += (height + gutter) as f64;
         }
     }
 

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -1,4 +1,4 @@
-use super::{ElementCx, to_image_quality, to_peniko_image};
+use super::{ElementCx, to_image_quality, to_peniko_image, track_sizes_and_gutters};
 use crate::color::{Color, ToColorColor};
 use crate::gradient::to_peniko_gradient;
 use anyrender::PaintScene;
@@ -224,17 +224,16 @@ impl ElementCx<'_, '_> {
             return;
         };
 
-        let cols = &grid_info.columns;
-        let inner_width =
-            (cols.sizes.iter().sum::<f32>() + cols.gutters.iter().sum::<f32>()) as f64;
+        let (col_sizes, col_gutters) = track_sizes_and_gutters(&grid_info.columns);
+        let inner_width = (col_sizes.iter().sum::<f32>() + col_gutters.iter().sum::<f32>()) as f64;
 
-        let rows = &grid_info.rows;
-        let mut y = rows.gutters.first().copied().unwrap_or_default() as f64;
+        let (row_sizes, row_gutters) = track_sizes_and_gutters(&grid_info.rows);
+        let mut y = row_gutters.first().copied().unwrap_or_default() as f64;
         for ((row, &height), &gutter) in table
             .rows
             .iter()
-            .zip(rows.sizes.iter())
-            .zip(rows.gutters.iter().skip(1))
+            .zip(row_sizes.iter())
+            .zip(row_gutters.iter().skip(1))
         {
             let row_node = &self.context.dom.get_node(row.node_id).unwrap();
             let Some(style) = row_node.primary_styles() else {

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -11,7 +11,7 @@ use style::{
 use crate::{
     color::{ToColorColor as _, contrast_ratio},
     kurbo_css::Edge,
-    render::{ElementCx, track_sizes_and_gutters},
+    render::{ElementCx, PhysicalTracks},
 };
 
 /// A darker version of a colour (mirrors WebKit/Blink's `Color::Dark`): the
@@ -527,11 +527,11 @@ impl ElementCx<'_, '_> {
 
         let outer_border_style = self.style.get_border();
 
-        let (col_sizes, col_gutters) = track_sizes_and_gutters(&grid_info.columns);
-        let (row_sizes, row_gutters) = track_sizes_and_gutters(&grid_info.rows);
+        let cols = PhysicalTracks::from_tracks(&grid_info.columns);
+        let rows = PhysicalTracks::from_tracks(&grid_info.rows);
 
-        let inner_width = (col_sizes.iter().sum::<f32>() + col_gutters.iter().sum::<f32>()) as f64;
-        let inner_height = (row_sizes.iter().sum::<f32>() + row_gutters.iter().sum::<f32>()) as f64;
+        let inner_width = cols.span() as f64;
+        let inner_height = rows.span() as f64;
 
         // TODO: support different colors for different borders
         let current_color = self.style.clone_color();
@@ -547,14 +547,17 @@ impl ElementCx<'_, '_> {
 
         let border_width = border_style.border_top_width.0.to_f64_px();
 
-        // Draw horizontal inner borders
-        let mut y = 0.0;
-        for (&height, &gutter) in row_sizes.iter().zip(row_gutters.iter()) {
-            let shape =
-                Rect::new(0.0, y, inner_width, y + gutter as f64).scale_from_origin(self.scale);
+        // Draw horizontal inner borders (the gutters between adjacent row tracks)
+        let row_origin = rows.origin();
+        for (prev, next) in rows.iter().zip(rows.iter().skip(1)) {
+            let shape = Rect::new(
+                0.0,
+                (prev.end - row_origin) as f64,
+                inner_width,
+                (next.start - row_origin) as f64,
+            )
+            .scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
-
-            y += (height + gutter) as f64;
         }
 
         // Draw horizontal outer borders
@@ -571,14 +574,17 @@ impl ElementCx<'_, '_> {
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
         }
 
-        // Draw vertical inner borders
-        let mut x = 0.0;
-        for (&width, &gutter) in col_sizes.iter().zip(col_gutters.iter()) {
-            let shape =
-                Rect::new(x, 0.0, x + gutter as f64, inner_height).scale_from_origin(self.scale);
+        // Draw vertical inner borders (the gutters between adjacent column tracks)
+        let col_origin = cols.origin();
+        for (prev, next) in cols.iter().zip(cols.iter().skip(1)) {
+            let shape = Rect::new(
+                (prev.end - col_origin) as f64,
+                0.0,
+                (next.start - col_origin) as f64,
+                inner_height,
+            )
+            .scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
-
-            x += (width + gutter) as f64;
         }
 
         // Draw vertical outer borders

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -11,7 +11,7 @@ use style::{
 use crate::{
     color::{ToColorColor as _, contrast_ratio},
     kurbo_css::Edge,
-    render::ElementCx,
+    render::{ElementCx, track_sizes_and_gutters},
 };
 
 /// A darker version of a colour (mirrors WebKit/Blink's `Color::Dark`): the
@@ -527,13 +527,11 @@ impl ElementCx<'_, '_> {
 
         let outer_border_style = self.style.get_border();
 
-        let cols = &grid_info.columns;
-        let rows = &grid_info.rows;
+        let (col_sizes, col_gutters) = track_sizes_and_gutters(&grid_info.columns);
+        let (row_sizes, row_gutters) = track_sizes_and_gutters(&grid_info.rows);
 
-        let inner_width =
-            (cols.sizes.iter().sum::<f32>() + cols.gutters.iter().sum::<f32>()) as f64;
-        let inner_height =
-            (rows.sizes.iter().sum::<f32>() + rows.gutters.iter().sum::<f32>()) as f64;
+        let inner_width = (col_sizes.iter().sum::<f32>() + col_gutters.iter().sum::<f32>()) as f64;
+        let inner_height = (row_sizes.iter().sum::<f32>() + row_gutters.iter().sum::<f32>()) as f64;
 
         // TODO: support different colors for different borders
         let current_color = self.style.clone_color();
@@ -551,7 +549,7 @@ impl ElementCx<'_, '_> {
 
         // Draw horizontal inner borders
         let mut y = 0.0;
-        for (&height, &gutter) in rows.sizes.iter().zip(rows.gutters.iter()) {
+        for (&height, &gutter) in row_sizes.iter().zip(row_gutters.iter()) {
             let shape =
                 Rect::new(0.0, y, inner_width, y + gutter as f64).scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
@@ -575,7 +573,7 @@ impl ElementCx<'_, '_> {
 
         // Draw vertical inner borders
         let mut x = 0.0;
-        for (&width, &gutter) in cols.sizes.iter().zip(cols.gutters.iter()) {
+        for (&width, &gutter) in col_sizes.iter().zip(col_gutters.iter()) {
             let shape =
                 Rect::new(x, 0.0, x + gutter as f64, inner_height).scale_from_origin(self.scale);
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);


### PR DESCRIPTION
## Summary

General upgrade of the pinned `taffy` git dependency to the latest `main` (`0e33e961`), picking up the recent detailed-grid-info work (per-track `positions` replacing `sizes`/`gutters` in taffy#1131, logical-order RTL representation in taffy#1135, generic `DetailedGridInfo<CustomIdent>` with line names/serialization in taffy#1136, and grid-area resolution in taffy#1137) along with everything else on main.

Blitz-side adaptations:

- `DetailedGridInfo` is now generic over the style's `CustomIdent` string type — Blitz's impls/fields use `DetailedGridInfo<Atom>`.
- `DetailedGridTracksInfo` no longer exposes `sizes`/`gutters`, only per-track `positions: Vec<Line<f32>>` in logical track order (physically right-to-left for RTL grids). Table painting adapts via an allocation-free view:

```rust
// blitz-paint/src/render.rs
struct PhysicalTracks<'a> { positions: &'a [Line<f32>], reversed: bool }
// from_tracks() detects RTL (first.start > last.start) and iterates in reverse;
// iter() yields track positions in physical order, origin()/span() give the extent
```

`draw_table_borders` draws gutters directly from adjacent track positions (`prev.end..next.start`), and `draw_table_row_backgrounds` positions each row at `row_position.start - origin` instead of accumulating sizes/gutters.

Verified no rendering change: WPT `css/css-tables` and `css/css-grid` results are byte-identical to `main`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/253040f0c41742e9b31de7b98509e1f6
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/253040f0c41742e9b31de7b98509e1f6?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32476565449).</sub>
<!-- wpt-results-end -->
