### PR TITLE
Keep transforms in the 2d subset instead of dropping all 3d functions

### DIFF
--- a/packages/blitz-dom/src/stylo_to_kurbo.rs
+++ b/packages/blitz-dom/src/stylo_to_kurbo.rs
@@ -56,8 +56,17 @@ pub fn resolve_2d_transform(
             .transform
             .to_transform_3d_matrix(Some(&reference_box))
             .ok()
-            .filter(|(_t, has_3d)| !has_3d)
-            .map(|(t, _has_3d)| {
+            // The `has_3d` flag means a 3d function appeared in the list, not that the
+            // matrix needs 3d: `translate3d(x, y, 0)` sets it while resolving to a
+            // plain 2d translation.
+            //
+            // TODO: support 3D transforms. Outside a 3d rendering context the spec
+            // still applies the transform as a painting effect -- its own example
+            // paints `rotateY(50deg)` narrower -- so dropping one is wrong. `is_2d()`
+            // is closer than the flag, not the rule.
+            // See: https://drafts.csswg.org/css-transforms-2/#3d-transform-rendering
+            .filter(|(t, _has_3d)| t.is_2d())
+            .map(|(t, _)| {
                 // See: https://drafts.csswg.org/css-transforms-2/#two-dimensional-subset
                 // And https://docs.rs/kurbo/latest/kurbo/struct.Affine.html#method.new
                 Affine::new([t.m11, t.m12, t.m21, t.m22, t.m41, t.m42].map(|v| v as f64))

--- a/tests/blitz-tests/tests/transform_2d_subset.rs
+++ b/tests/blitz-tests/tests/transform_2d_subset.rs
@@ -1,0 +1,66 @@
+//! A `transform` list that mentions a 3d function but resolves to a matrix in
+//! the two-dimensional subset must still be applied.
+//!
+//! <https://drafts.csswg.org/css-transforms-2/#two-dimensional-subset>
+//!
+//! `to_transform_3d_matrix` reports `has_3d` when a 3d transform *function*
+//! appeared in the list, which is not the same question as whether the
+//! resulting matrix needs 3d. Filtering on the flag dropped the whole
+//! transform for `translate3d(x, y, 0)` -- the common vertical-centring idiom
+//! -- and painted the element untransformed.
+
+use blitz_test_harness::Harness;
+
+fn transform_coeffs(harness: &Harness, selector: &str) -> Option<[f64; 6]> {
+    let node_id = harness.node(selector);
+    harness
+        .base()
+        .get_node(node_id)
+        .unwrap()
+        .transform()
+        .map(|affine| affine.as_coeffs())
+}
+
+#[test]
+fn translate3d_with_zero_z_resolves_to_a_2d_translation() {
+    let harness = Harness::from_html(
+        r#"<html><body style="margin:0">
+            <div id="box" style="width:100px; height:50px;
+                                 transform: translate3d(60px, 20px, 0);"></div>
+        </body></html>"#,
+    );
+
+    assert_eq!(
+        transform_coeffs(&harness, "#box"),
+        Some([1.0, 0.0, 0.0, 1.0, 60.0, 20.0]),
+        "translate3d with a zero z is a 2d translation and must be applied"
+    );
+}
+
+#[test]
+fn translated_box_hit_tests_at_its_translated_position() {
+    // The transform has to reach consumers, not just be resolved: hit testing
+    // inverts it, so the box must stop answering at its untransformed position.
+    let harness = Harness::from_html(
+        r#"<html><body style="margin:0">
+            <div id="box" style="width:100px; height:50px;
+                                 transform: translate3d(120px, 0, 0);"></div>
+        </body></html>"#,
+    );
+
+    let box_id = harness.node("#box");
+
+    // x=150 is inside the translated box (120..220) and outside the original.
+    assert_eq!(
+        harness.hit_node(150.0, 25.0),
+        box_id,
+        "expected the box at its translated position"
+    );
+
+    // x=50 is inside the original box (0..100) and outside the translated one.
+    assert_ne!(
+        harness.hit_node(50.0, 25.0),
+        box_id,
+        "expected nothing at the box's untransformed position"
+    );
+}


### PR DESCRIPTION
`has_3d` tells you a 3d function appeared in the transform list, not that the resulting matrix needs 3d. The filter treats it as the latter, so `translate3d(x, y, 0)` gets dropped and the element paints with no transform. That one hurts, it's the standard centring trick.

`t.is_2d()` is the actual question, and it's the two-dimensional subset that the spec link on the next line down already points at. rotateX and perspective still get dropped, so the `TODO: support 3D transforms` above still stands.

Tests in `tests/blitz-tests/tests/transform_2d_subset.rs`. The two translate3d ones fail without the fix. The rotateX one passes either way, it's there so nobody later "fixes" 3d by flattening it.

No existing test caught this, by the way. `subpixel-transform-changes-004.html` in css-transforms looks like it should, but it uses translate3d on the reference side too, so dropping them all leaves both sides matching. Can send a reftest to WPT if you want one.

<!-- wpt-results-start -->
## WPT results

**5** newly passing, **2** newly failing (net +3).

<details>
<summary>Full diff (7 changed tests)</summary>

```diff
+ Fail => Pass css/css-transforms/css-transform-3d-rotate3d-Z-negative.html
+ Fail => Pass css/css-transforms/css-transform-3d-rotate3d-Z-positive.html
+ Fail => Pass css/css-transforms/css-transform-3d-rotateZ-negative.html
+ Fail => Pass css/css-transforms/css-transform-3d-rotateZ-positive.html
- Pass => Fail css/css-transforms/subpixel-transform-changes-004.html
+ Fail => Pass css/css-transforms/transform3d-matrix3d-001.html
- Pass => Fail css/css-viewport/zoom/transform-matrix-3d.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32628672299).</sub>
<!-- wpt-results-end -->
