### PR TITLE
Support the `role` attribute when setting the role in an `AccessKitNode`

### DIFF
--- a/packages/blitz-dom/src/accessibility.rs
+++ b/packages/blitz-dom/src/accessibility.rs
@@ -1,4 +1,4 @@
-use crate::{BaseDocument, Node as BlitzDomNode, local_name};
+use crate::{BaseDocument, ElementData, Node as BlitzDomNode, local_name};
 use accesskit::{Node as AccessKitNode, NodeId, Role, Tree, TreeId, TreeUpdate};
 
 impl BaseDocument {
@@ -44,96 +44,14 @@ impl BaseDocument {
             builder.set_role(Role::Window)
         } else if let Some(element_data) = node.element_data() {
             let name = element_data.name.local.to_string();
+            let role_attr = element_data.attr(local_name!("role"));
 
-            // <https://www.w3.org/TR/html-aam-1.0/>
-            let role = match &*name {
-                // Document structure
-                "article" => Role::Article,
-                "aside" => Role::Complementary,
-                "footer" => Role::Footer,
-                "header" => Role::Header,
-                "main" => Role::Main,
-                "nav" => Role::Navigation,
-                "search" => Role::Search,
-                "section" => Role::Section,
-                "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => Role::Heading,
-                "p" => Role::Paragraph,
-                "blockquote" => Role::Blockquote,
-                "figure" => Role::Figure,
-                "figcaption" | "caption" => Role::Caption,
-                "hr" => Role::Splitter,
-
-                // Grouping
-                "ul" | "ol" | "menu" => Role::List,
-                "li" => Role::ListItem,
-                "dl" => Role::DescriptionList,
-                "dt" => Role::Term,
-                "dd" => Role::Definition,
-                "dialog" => Role::Dialog,
-                "fieldset" => Role::Group,
-                "form" => Role::Form,
-                "div" => Role::GenericContainer,
-
-                // Tables
-                "table" => Role::Table,
-                "thead" | "tbody" | "tfoot" => Role::RowGroup,
-                "tr" => Role::Row,
-                "td" => Role::Cell,
-                "th" => match element_data.attr(local_name!("scope")) {
-                    Some("row") | Some("rowgroup") => Role::RowHeader,
-                    _ => Role::ColumnHeader,
-                },
-
-                // Interactive
-                // An <a> is only a link when it has an href.
-                "a" => match element_data.attr(local_name!("href")) {
-                    Some(_) => Role::Link,
-                    None => Role::GenericContainer,
-                },
-                "button" => Role::Button,
-                "label" => Role::Label,
-                "legend" => Role::Label,
-                "select" => match element_data.attr(local_name!("multiple")) {
-                    Some(_) => Role::ListBox,
-                    None => Role::ComboBox,
-                },
-                "option" => Role::ListBoxOption,
-                "textarea" => Role::MultilineTextInput,
-                "progress" => Role::ProgressIndicator,
-                "meter" => Role::Meter,
-                "output" => Role::Status,
-                "summary" => Role::DisclosureTriangle,
-
-                // Inline semantics
-                "code" => Role::Code,
-                "em" => Role::Emphasis,
-                "strong" => Role::Strong,
-                "mark" => Role::Mark,
-                "time" => Role::Time,
-                "img" => Role::Image,
-                "iframe" => Role::Iframe,
-
-                "input" => {
-                    let ty = element_data.attr(local_name!("type")).unwrap_or("text");
-                    match ty {
-                        "button" | "submit" | "reset" => Role::Button,
-                        "checkbox" => Role::CheckBox,
-                        "color" => Role::ColorWell,
-                        "date" => Role::DateInput,
-                        "datetime-local" => Role::DateTimeInput,
-                        "email" => Role::EmailInput,
-                        "number" => Role::NumberInput,
-                        "password" => Role::PasswordInput,
-                        "radio" => Role::RadioButton,
-                        "range" => Role::Slider,
-                        "search" => Role::SearchInput,
-                        "tel" => Role::PhoneNumberInput,
-                        "time" => Role::TimeInput,
-                        _ => Role::TextInput,
-                    }
-                }
-                _ => Role::Unknown,
-            };
+            // TODO: The roles of elements with strong native semantics cannot be overridden; see
+            // https://www.w3.org/TR/wai-aria-1.2/#host_general_conflict.
+            let role = role_attr
+                .and_then(role_from_name)
+                .or_else(|| role_from_element_data(element_data))
+                .unwrap_or(Role::Unknown);
 
             builder.set_role(role);
             builder.set_html_tag(name);
@@ -146,5 +64,161 @@ impl BaseDocument {
         parent.push_child(id);
 
         (id, builder)
+    }
+}
+
+fn role_from_name(name: &str) -> Option<Role> {
+    match name {
+        "alert" => Some(Role::Alert),
+        "alertdialog" => Some(Role::AlertDialog),
+        "button" => Some(Role::Button),
+        "checkbox" => Some(Role::CheckBox),
+        "dialog" => Some(Role::Dialog),
+        "gridcell" => Some(Role::GridCell),
+        "link" => Some(Role::Link),
+        "log" => Some(Role::Log),
+        "marquee" => Some(Role::Marquee),
+        "menuitem" => Some(Role::MenuItem),
+        "menuitemcheckbox" => Some(Role::MenuItemCheckBox),
+        "menuitemradio" => Some(Role::MenuItemRadio),
+        "option" => Some(Role::ListBoxOption),
+        "progressbar" => Some(Role::ProgressIndicator),
+        "radio" => Some(Role::RadioButton),
+        "scrollbar" => Some(Role::ScrollBar),
+        "slider" => Some(Role::Slider),
+        "spinbutton" => Some(Role::SpinButton),
+        "status" => Some(Role::Status),
+        "tab" => Some(Role::Tab),
+        "tabpanel" => Some(Role::TabPanel),
+        "textbox" => Some(Role::TextInput),
+        "timer" => Some(Role::Timer),
+        "tooltip" => Some(Role::Tooltip),
+        "treeitem" => Some(Role::TreeItem),
+        "combobox" => Some(Role::ComboBox),
+        "grid" => Some(Role::Grid),
+        "listbox" => Some(Role::ListBox),
+        "menu" => Some(Role::Menu),
+        "menubar" => Some(Role::MenuBar),
+        "radiogroup" => Some(Role::RadioGroup),
+        "tablist" => Some(Role::TabList),
+        "tree" => Some(Role::Tree),
+        "treegrid" => Some(Role::TreeGrid),
+        "article" => Some(Role::Article),
+        "columnheader" => Some(Role::ColumnHeader),
+        "definition" => Some(Role::Definition),
+        "document" => Some(Role::Document),
+        "group" => Some(Role::Group),
+        "heading" => Some(Role::Heading),
+        "img" => Some(Role::Image),
+        "list" => Some(Role::List),
+        "listitem" => Some(Role::ListItem),
+        "math" => Some(Role::Math),
+        "note" => Some(Role::Note),
+        "region" => Some(Role::Region),
+        "row" => Some(Role::Row),
+        "rowgroup" => Some(Role::RowGroup),
+        "rowheader" => Some(Role::RowHeader),
+        "toolbar" => Some(Role::Toolbar),
+        "application" => Some(Role::Application),
+        "banner" => Some(Role::Banner),
+        "complementary" => Some(Role::Complementary),
+        "contentinfo" => Some(Role::ContentInfo),
+        "form" => Some(Role::Form),
+        "main" => Some(Role::Main),
+        "navigation" => Some(Role::Navigation),
+        "search" => Some(Role::Search),
+        _ => None,
+    }
+}
+
+fn role_from_element_data(element_data: &ElementData) -> Option<Role> {
+    // <https://www.w3.org/TR/html-aam-1.0/>
+    match &*element_data.name.local {
+        // Document structure
+        "article" => Some(Role::Article),
+        "aside" => Some(Role::Complementary),
+        "footer" => Some(Role::Footer),
+        "header" => Some(Role::Header),
+        "main" => Some(Role::Main),
+        "nav" => Some(Role::Navigation),
+        "search" => Some(Role::Search),
+        "section" => Some(Role::Section),
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => Some(Role::Heading),
+        "p" => Some(Role::Paragraph),
+        "blockquote" => Some(Role::Blockquote),
+        "figure" => Some(Role::Figure),
+        "figcaption" | "caption" => Some(Role::Caption),
+        "hr" => Some(Role::Splitter),
+
+        // Grouping
+        "ul" | "ol" | "menu" => Some(Role::List),
+        "li" => Some(Role::ListItem),
+        "dl" => Some(Role::DescriptionList),
+        "dt" => Some(Role::Term),
+        "dd" => Some(Role::Definition),
+        "dialog" => Some(Role::Dialog),
+        "fieldset" => Some(Role::Group),
+        "form" => Some(Role::Form),
+        "div" => Some(Role::GenericContainer),
+
+        // Tables
+        "table" => Some(Role::Table),
+        "thead" | "tbody" | "tfoot" => Some(Role::RowGroup),
+        "tr" => Some(Role::Row),
+        "td" => Some(Role::Cell),
+        "th" => match element_data.attr(local_name!("scope")) {
+            Some("row") | Some("rowgroup") => Some(Role::RowHeader),
+            _ => Some(Role::ColumnHeader),
+        },
+
+        // Interactive
+        // An <a> is only a link when it has an href.
+        "a" => match element_data.attr(local_name!("href")) {
+            Some(_) => Some(Role::Link),
+            None => Some(Role::GenericContainer),
+        },
+        "button" => Some(Role::Button),
+        "label" => Some(Role::Label),
+        "legend" => Some(Role::Label),
+        "select" => match element_data.attr(local_name!("multiple")) {
+            Some(_) => Some(Role::ListBox),
+            None => Some(Role::ComboBox),
+        },
+        "option" => Some(Role::ListBoxOption),
+        "textarea" => Some(Role::MultilineTextInput),
+        "progress" => Some(Role::ProgressIndicator),
+        "meter" => Some(Role::Meter),
+        "output" => Some(Role::Status),
+        "summary" => Some(Role::DisclosureTriangle),
+
+        // Inline semantics
+        "code" => Some(Role::Code),
+        "em" => Some(Role::Emphasis),
+        "strong" => Some(Role::Strong),
+        "mark" => Some(Role::Mark),
+        "time" => Some(Role::Time),
+        "img" => Some(Role::Image),
+        "iframe" => Some(Role::Iframe),
+
+        "input" => {
+            let ty = element_data.attr(local_name!("type")).unwrap_or("text");
+            match ty {
+                "button" | "submit" | "reset" => Some(Role::Button),
+                "checkbox" => Some(Role::CheckBox),
+                "color" => Some(Role::ColorWell),
+                "date" => Some(Role::DateInput),
+                "datetime-local" => Some(Role::DateTimeInput),
+                "email" => Some(Role::EmailInput),
+                "number" => Some(Role::NumberInput),
+                "password" => Some(Role::PasswordInput),
+                "radio" => Some(Role::RadioButton),
+                "range" => Some(Role::Slider),
+                "search" => Some(Role::SearchInput),
+                "tel" => Some(Role::PhoneNumberInput),
+                "time" => Some(Role::TimeInput),
+                _ => Some(Role::TextInput),
+            }
+        }
+        _ => None,
     }
 }


### PR DESCRIPTION
Previously, the ARIA role of a node was determined only from the HTML element name. Normally the role attribute overrides the implicit role given by the element name; see https://www.w3.org/TR/html-aria/#rules-wd. Exceptions for "strong native semantics" are not treated by this PR.

This does not touch the existing mapping of element names to implicit ARIA roles -- that still needs to be completed.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32467606614).</sub>
<!-- wpt-results-end -->
