### PR TITLE
Upgrade Taffy to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=0e33e961c4ecd36a38d5103f57f305fbe37d749f#0e33e961c4ecd36a38d5103f57f305fbe37d749f"
+source = "git+https://github.com/DioxusLabs/taffy?rev=8d13fdc88468c83f01b13b36fadc0349950c6f51#8d13fdc88468c83f01b13b36fadc0349950c6f51"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "0e33e961c4ecd36a38d5103f57f305fbe37d749f", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "8d13fdc88468c83f01b13b36fadc0349950c6f51", default-features = false, features = [
     "std",
     "flexbox",
     "grid",
@@ -301,5 +301,4 @@ tracing-subscriber = "0.3"
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
-
 


### PR DESCRIPTION
## Summary
Pin Taffy to `8d13fdc88468c83f01b13b36fadc0349950c6f51`, the latest `main` revision, and refresh the lockfile. This brings in the latest grid sizing fixes and resolved-value expansion APIs while keeping the dependency reproducibly commit-pinned.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/35dbc6bc5d0e497fa16f158f91fae76e
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/35dbc6bc5d0e497fa16f158f91fae76e?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**2** newly passing, **0** newly failing (net +2).

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
+ Fail => Pass css/css-grid/alignment/grid-align-baseline-005.html
+ Fail => Pass css/css-grid/alignment/grid-baseline-align-cycles-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32576946010).</sub>
<!-- wpt-results-end -->
