### PR TITLE
Stylo: use snapshot-driven fine-grained invalidation

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -65,6 +65,7 @@ use style::{
     stylesheets::{AllowImportRules, DocumentStyleSheet, Origin, Stylesheet},
     stylist::Stylist,
 };
+use style_dom::ElementState;
 use thin_vec::ThinVec;
 use url::Url;
 use web_time::Instant;
@@ -1397,7 +1398,21 @@ impl BaseDocument {
         }
     }
 
+    /// Snapshot the node's pre-mutation state (element state and attributes) ahead of
+    /// an attribute mutation, so that the next style traversal can diff selector matches
+    /// then-vs-now and invalidate the affected elements.
     pub fn snapshot_node(&mut self, node_id: NodeId) {
+        self.snapshot_node_impl(node_id, true)
+    }
+
+    /// Snapshot only the node's pre-change [`ElementState`] ahead of a state change
+    /// (hover/focus/active/etc). Cheaper than [`Self::snapshot_node`] as it does not
+    /// copy attributes or trigger attribute/class/id invalidation work.
+    pub fn snapshot_node_state_only(&mut self, node_id: NodeId) {
+        self.snapshot_node_impl(node_id, false)
+    }
+
+    fn snapshot_node_impl(&mut self, node_id: NodeId, capture_attrs: bool) {
         let node = &mut self.nodes[node_id];
 
         // Do not snapshot nodes that have never been styled. A snapshot records an element's
@@ -1414,11 +1429,19 @@ impl BaseDocument {
         node.snapshot_handled()
             .store(false, std::sync::atomic::Ordering::SeqCst);
 
-        // TODO: handle invalidations other than hover
-        if let Some(_existing_snapshot) = self.snapshots.get_mut(&opaque_node_id) {
-            // Do nothing
-            // TODO: update snapshot
-        } else {
+        // A snapshot records the element's state/attributes as they were *before the first
+        // mutation* since the last style flush (matching Gecko's ServoElementSnapshot
+        // semantics): state is captured at most once, and attributes are captured at most
+        // once, but a state-only snapshot is upgraded to also capture attributes if an
+        // attribute mutation follows.
+        let needs_attrs = capture_attrs
+            && self
+                .snapshots
+                .get_mut(&opaque_node_id)
+                .is_none_or(|snapshot| snapshot.attrs.is_none());
+
+        let (attrs, changed_attrs) = if needs_attrs {
+            let node = &self.nodes[node_id];
             let attrs: Option<Vec<_>> = node.attrs().map(|attrs| {
                 attrs
                     .iter()
@@ -1448,27 +1471,61 @@ impl BaseDocument {
                     .collect()
             });
 
-            let changed_attrs = attrs
+            let changed_attrs: Vec<_> = attrs
                 .as_ref()
                 .map(|attrs| attrs.iter().map(|attr| attr.0.name.clone()).collect())
                 .unwrap_or_default();
 
+            (attrs, changed_attrs)
+        } else {
+            (None, Vec::new())
+        };
+
+        if let Some(snapshot) = self.snapshots.get_mut(&opaque_node_id) {
+            // The existing snapshot's state is preserved: it records the state before
+            // the *first* change since the last style flush.
+            if needs_attrs {
+                snapshot.attrs = attrs;
+                snapshot.changed_attrs = changed_attrs;
+                snapshot.class_changed = true;
+                snapshot.id_changed = true;
+                snapshot.other_attributes_changed = true;
+            }
+        } else {
             self.snapshots.insert(
                 opaque_node_id,
                 ServoElementSnapshot {
-                    state: Some(*node.element_state()),
+                    state: Some(*self.nodes[node_id].element_state()),
                     attrs,
                     changed_attrs,
-                    class_changed: true,
-                    id_changed: true,
-                    other_attributes_changed: true,
+                    class_changed: needs_attrs,
+                    id_changed: needs_attrs,
+                    other_attributes_changed: needs_attrs,
                 },
             );
         }
     }
 
-    pub fn snapshot_node_and(&mut self, node_id: NodeId, cb: impl FnOnce(&mut Node)) {
-        self.snapshot_node(node_id);
+    /// Returns whether any style rule depends on any of the given [`ElementState`] bits.
+    /// If not, changing those bits cannot affect styling and snapshotting can be skipped.
+    pub fn style_depends_on_state(&self, state: ElementState) -> bool {
+        self.stylist.iter_origins().any(|(data, _)| {
+            data.has_state_dependency(state) || data.has_nth_of_state_dependency(state)
+        })
+    }
+
+    /// Apply a state change (hover/focus/active/etc affecting the given [`ElementState`]
+    /// bits) to a node, taking a state-only snapshot beforehand if any style rule
+    /// depends on those bits.
+    pub fn snapshot_node_and(
+        &mut self,
+        node_id: NodeId,
+        state: ElementState,
+        cb: impl FnOnce(&mut Node),
+    ) {
+        if self.style_depends_on_state(state) {
+            self.snapshot_node_state_only(node_id);
+        }
         cb(&mut self.nodes[node_id]);
     }
 
@@ -1583,7 +1640,9 @@ impl BaseDocument {
     pub fn clear_focus(&mut self) {
         if let Some(id) = self.focus_node_id {
             let shell_provider = self.shell_provider.clone();
-            self.snapshot_node_and(id, |node| node.blur(shell_provider));
+            self.snapshot_node_and(id, ElementState::FOCUS | ElementState::FOCUSRING, |node| {
+                node.blur(shell_provider)
+            });
             self.focus_node_id = None;
         }
     }
@@ -1606,11 +1665,17 @@ impl BaseDocument {
 
         // Remove focus from the old node
         if let Some(id) = self.focus_node_id {
-            self.snapshot_node_and(id, |node| node.blur(shell_provider.clone()));
+            self.snapshot_node_and(id, ElementState::FOCUS | ElementState::FOCUSRING, |node| {
+                node.blur(shell_provider.clone())
+            });
         }
 
         // Focus the new node
-        self.snapshot_node_and(focus_node_id, |node| node.focus(shell_provider));
+        self.snapshot_node_and(
+            focus_node_id,
+            ElementState::FOCUS | ElementState::FOCUSRING,
+            |node| node.focus(shell_provider),
+        );
 
         self.focus_node_id = Some(focus_node_id);
 
@@ -1639,7 +1704,7 @@ impl BaseDocument {
 
         let node_path = self.maybe_node_layout_ancestors(active_node_id);
         for &id in node_path.iter() {
-            self.snapshot_node_and(id, |node| node.active());
+            self.snapshot_node_and(id, ElementState::ACTIVE, |node| node.active());
         }
 
         self.active_node_id = active_node_id;
@@ -1654,7 +1719,7 @@ impl BaseDocument {
 
         let node_path = self.maybe_node_layout_ancestors(Some(active_node_id));
         for &id in node_path.iter() {
-            self.snapshot_node_and(id, |node| node.unactive());
+            self.snapshot_node_and(id, ElementState::ACTIVE, |node| node.unactive());
         }
 
         true
@@ -1794,10 +1859,10 @@ impl BaseDocument {
             .take_while(|(o, n)| o == n)
             .count();
         for &id in old_node_path.iter().skip(same_count) {
-            self.snapshot_node_and(id, |node| node.unhover());
+            self.snapshot_node_and(id, ElementState::HOVER, |node| node.unhover());
         }
         for &id in new_node_path.iter().skip(same_count) {
-            self.snapshot_node_and(id, |node| node.hover());
+            self.snapshot_node_and(id, ElementState::HOVER, |node| node.hover());
         }
 
         self.hover_node_id = hover_node_id;
@@ -1823,7 +1888,7 @@ impl BaseDocument {
 
         let old_node_path = self.maybe_node_layout_ancestors(Some(hover_node_id));
         for &id in old_node_path.iter() {
-            self.snapshot_node_and(id, |node| node.unhover());
+            self.snapshot_node_and(id, ElementState::HOVER, |node| node.unhover());
         }
 
         self.hover_node_id = None;

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -674,25 +674,35 @@ impl BaseDocument {
     }
 
     pub fn toggle_checkbox(el: &mut ElementData) -> bool {
-        let Some(is_checked) = el.checkbox_input_checked_mut() else {
+        let Some(is_checked) = el.checkbox_input_checked() else {
             return false;
         };
-        *is_checked = !*is_checked;
+        let checked = !is_checked;
+        el.set_checkbox_input_checked(checked);
 
-        *is_checked
+        checked
     }
 
     pub fn toggle_radio(&mut self, radio_set_name: String, target_radio_id: NodeId) {
-        for (i, node) in self.nodes.iter_mut() {
-            if let Some(node_data) = node.data.downcast_element_mut() {
-                if node_data.attr(local_name!("name")) == Some(&radio_set_name) {
-                    let was_clicked = i == target_radio_id;
-                    let Some(is_checked) = node_data.checkbox_input_checked_mut() else {
-                        continue;
-                    };
-                    *is_checked = was_clicked;
+        let radio_ids: Vec<NodeId> = self
+            .nodes
+            .iter()
+            .filter_map(|(i, node)| {
+                let el = node.data.downcast_element()?;
+                (el.attr(local_name!("name")) == Some(&radio_set_name)
+                    && el.checkbox_input_checked().is_some())
+                .then_some(i)
+            })
+            .collect();
+
+        for i in radio_ids {
+            let checked = i == target_radio_id;
+            self.snapshot_node_and(i, ElementState::CHECKED, |node| {
+                if let Some(el) = node.element_data_mut() {
+                    el.set_checkbox_input_checked(checked);
                 }
-            }
+                node.mark_ancestors_dirty();
+            });
         }
     }
 
@@ -2938,6 +2948,83 @@ mod hover_invalidation_tests {
             text_color(&doc, span),
             initial_color,
             "unhovering the anchor should restore the headline color"
+        );
+    }
+
+    /// Toggling a checkbox must invalidate `:checked`-dependent styles.
+    #[test]
+    fn checkbox_toggle_updates_checked_styles() {
+        let mut doc = BaseDocument::new(DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        });
+        doc.add_user_agent_stylesheet(
+            "input:checked { color: rgb(184, 0, 0); } input:checked + label { color: rgb(0, 184, 0); }",
+        );
+        let root_id = doc.root_node().id;
+        let attr = |name: QualName, value: &str| Attribute {
+            name,
+            value: value.to_string(),
+        };
+
+        let mut mutator = doc.mutate();
+        let html = mutator.create_element(qual_name!("html"), vec![]);
+        let body = mutator.create_element(
+            qual_name!("body"),
+            vec![attr(qual_name!("style"), "margin:0")],
+        );
+        let input = mutator.create_element(
+            qual_name!("input"),
+            vec![attr(qual_name!("type"), "checkbox")],
+        );
+        let label = mutator.create_element(qual_name!("label"), vec![]);
+        let text = mutator.create_text_node("label text");
+        mutator.append_children(label, &[text]);
+        mutator.append_children(body, &[input, label]);
+        mutator.append_children(html, &[body]);
+        mutator.append_children(root_id, &[html]);
+        drop(mutator);
+
+        doc.resolve(0.0);
+        let initial_input_color = text_color(&doc, input);
+        let initial_label_color = text_color(&doc, label);
+
+        // Toggle the checkbox on (as the click handler does)
+        doc.snapshot_node_and(input, ElementState::CHECKED, |node| {
+            if let Some(el) = node.element_data_mut() {
+                BaseDocument::toggle_checkbox(el);
+            }
+            node.mark_ancestors_dirty();
+        });
+        doc.resolve(0.0);
+        assert_ne!(
+            text_color(&doc, input),
+            initial_input_color,
+            "checking should change the input color"
+        );
+        assert_ne!(
+            text_color(&doc, label),
+            initial_label_color,
+            "checking should change the sibling label color"
+        );
+
+        // Toggle the checkbox back off
+        doc.snapshot_node_and(input, ElementState::CHECKED, |node| {
+            if let Some(el) = node.element_data_mut() {
+                BaseDocument::toggle_checkbox(el);
+            }
+            node.mark_ancestors_dirty();
+        });
+        doc.resolve(0.0);
+        assert_eq!(
+            text_color(&doc, input),
+            initial_input_color,
+            "unchecking should restore the input color"
+        );
+        assert_eq!(
+            text_color(&doc, label),
+            initial_label_color,
+            "unchecking should restore the sibling label color"
         );
     }
 }

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -2780,6 +2780,169 @@ mod hover_state_tests {
 }
 
 #[cfg(test)]
+mod hover_invalidation_tests {
+    use super::*;
+    use crate::{Attribute, QualName, qual_name};
+    use blitz_traits::shell::ColorScheme;
+
+    /// Build `<html><body style="margin:0"><div style="width:300px;height:100px">
+    /// <span>text</span></div></body></html>` with a `div:hover` rule.
+    fn make_doc() -> (BaseDocument, NodeId, NodeId) {
+        let mut doc = BaseDocument::new(DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        });
+        doc.add_user_agent_stylesheet(
+            "div:hover { background-color: rgb(255, 0, 0); } div:hover span { color: rgb(0, 255, 0); }",
+        );
+        let root_id = doc.root_node().id;
+        let style = |value: &str| Attribute {
+            name: qual_name!("style"),
+            value: value.to_string(),
+        };
+
+        let mut mutator = doc.mutate();
+        let html = mutator.create_element(qual_name!("html"), vec![]);
+        let body = mutator.create_element(qual_name!("body"), vec![style("margin:0")]);
+        let div =
+            mutator.create_element(qual_name!("div"), vec![style("width:300px;height:100px")]);
+        let span = mutator.create_element(qual_name!("span"), vec![]);
+        let text = mutator.create_text_node("some text");
+        mutator.append_children(span, &[text]);
+        mutator.append_children(div, &[span]);
+        mutator.append_children(body, &[div]);
+        mutator.append_children(html, &[body]);
+        mutator.append_children(root_id, &[html]);
+        drop(mutator);
+
+        doc.resolve(0.0);
+        (doc, div, span)
+    }
+
+    fn bg_color(doc: &BaseDocument, id: NodeId) -> String {
+        format!(
+            "{:?}",
+            doc.nodes[id]
+                .primary_styles()
+                .unwrap()
+                .get_background()
+                .background_color
+        )
+    }
+
+    fn text_color(doc: &BaseDocument, id: NodeId) -> String {
+        format!(
+            "{:?}",
+            doc.nodes[id].primary_styles().unwrap().clone_color()
+        )
+    }
+
+    #[test]
+    fn hover_styles_apply_and_clear() {
+        let (mut doc, div, span) = make_doc();
+        let initial_bg = bg_color(&doc, div);
+        let initial_color = text_color(&doc, span);
+
+        // Hover the div
+        doc.set_hover_to(10.0, 10.0);
+        assert!(doc.nodes[div].is_hovered());
+        doc.resolve(0.0);
+        let hovered_bg = bg_color(&doc, div);
+        let hovered_color = text_color(&doc, span);
+        assert_ne!(initial_bg, hovered_bg, "hover should change div background");
+        assert_ne!(
+            initial_color, hovered_color,
+            "hover should change span color"
+        );
+
+        // Move the pointer off the div (below it, over the body)
+        doc.set_hover_to(10.0, 200.0);
+        assert!(!doc.nodes[div].is_hovered());
+        doc.resolve(0.0);
+        assert_eq!(
+            bg_color(&doc, div),
+            initial_bg,
+            "unhover should restore div background"
+        );
+        assert_eq!(
+            text_color(&doc, span),
+            initial_color,
+            "unhover should restore span color"
+        );
+    }
+
+    /// Mimics BBC's headline hover pattern: `a:link:hover .headline` with the
+    /// headline several levels below the anchor.
+    #[test]
+    fn ancestor_hover_with_link_state_updates_descendant() {
+        let mut doc = BaseDocument::new(DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        });
+        doc.add_user_agent_stylesheet(
+            ".promo:link:hover .headline, .promo:visited:hover .headline { color: rgb(184, 0, 0); text-decoration-line: underline; }",
+        );
+        let root_id = doc.root_node().id;
+        let attr = |name: QualName, value: &str| Attribute {
+            name,
+            value: value.to_string(),
+        };
+
+        let mut mutator = doc.mutate();
+        let html = mutator.create_element(qual_name!("html"), vec![]);
+        let body = mutator.create_element(
+            qual_name!("body"),
+            vec![attr(qual_name!("style"), "margin:0")],
+        );
+        let a = mutator.create_element(
+            qual_name!("a"),
+            vec![
+                attr(qual_name!("href"), "https://example.com"),
+                attr(qual_name!("class"), "promo"),
+                attr(
+                    qual_name!("style"),
+                    "display:block;width:300px;height:100px",
+                ),
+            ],
+        );
+        let p = mutator.create_element(qual_name!("p"), vec![]);
+        let span = mutator.create_element(
+            qual_name!("span"),
+            vec![attr(qual_name!("class"), "headline")],
+        );
+        let text = mutator.create_text_node("Headline text");
+        mutator.append_children(span, &[text]);
+        mutator.append_children(p, &[span]);
+        mutator.append_children(a, &[p]);
+        mutator.append_children(body, &[a]);
+        mutator.append_children(html, &[body]);
+        mutator.append_children(root_id, &[html]);
+        drop(mutator);
+
+        doc.resolve(0.0);
+        let initial_color = text_color(&doc, span);
+
+        doc.set_hover_to(10.0, 10.0);
+        assert!(doc.nodes[a].is_hovered());
+        doc.resolve(0.0);
+        let hovered_color = text_color(&doc, span);
+        assert_ne!(
+            initial_color, hovered_color,
+            "hovering the anchor should change the headline color"
+        );
+
+        doc.set_hover_to(10.0, 200.0);
+        assert!(!doc.nodes[a].is_hovered());
+        doc.resolve(0.0);
+        assert_eq!(
+            text_color(&doc, span),
+            initial_color,
+            "unhovering the anchor should restore the headline color"
+        );
+    }
+}
+
+#[cfg(test)]
 mod font_face_override_tests {
     use super::*;
     use crate::net::{FontFaceOverrides, Resource, ResourceLoadResponse};

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -13,6 +13,7 @@ use blitz_traits::{
 use keyboard_types::Modifiers;
 use markup5ever::local_name;
 use style::values::computed::{Overflow, TouchAction, UserSelect};
+use style_dom::ElementState;
 use taffy::AbsoluteAxis;
 
 use crate::{
@@ -641,7 +642,13 @@ pub(crate) fn handle_click(
 
             match el.name.local {
                 local_name!("input") if el.attr(local_name!("type")) == Some("checkbox") => {
-                    let is_checked = BaseDocument::toggle_checkbox(el);
+                    let mut is_checked = false;
+                    doc.snapshot_node_and(node_id, ElementState::CHECKED, |node| {
+                        if let Some(el) = node.element_data_mut() {
+                            is_checked = BaseDocument::toggle_checkbox(el);
+                        }
+                        node.mark_ancestors_dirty();
+                    });
                     let value = is_checked.to_string();
                     dispatch_event(DomEvent::new(
                         node_id,
@@ -659,8 +666,13 @@ pub(crate) fn handle_click(
                 local_name!("input") if el.attr(local_name!("type")) == Some("radio") => {
                     if let Some(radio_set) = el.attr(local_name!("name")).map(str::to_string) {
                         BaseDocument::toggle_radio(doc, radio_set, node_id);
-                    } else if let Some(is_checked) = el.checkbox_input_checked_mut() {
-                        *is_checked = true;
+                    } else if el.checkbox_input_checked().is_some() {
+                        doc.snapshot_node_and(node_id, ElementState::CHECKED, |node| {
+                            if let Some(el) = node.element_data_mut() {
+                                el.set_checkbox_input_checked(true);
+                            }
+                            node.mark_ancestors_dirty();
+                        });
                     }
 
                     // TODO: make input event conditional on value actually changing

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -893,6 +893,7 @@ fn create_checkbox_input(doc: &mut BaseDocument, input_element_id: NodeId) {
     if !matches!(element.special_data, SpecialElementData::CheckboxInput(_)) {
         let checked = element.has_attr(local_name!("checked"));
         element.special_data = SpecialElementData::CheckboxInput(checked);
+        element.set_checkbox_input_checked(checked);
     }
 }
 

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -303,6 +303,10 @@ impl DocumentMutator<'_> {
             element.flush_is_focussable();
         }
 
+        if name.local == local_name!("href") {
+            element.flush_link_state();
+        }
+
         let tag = &element.name.local;
         let attr = &name.local;
 
@@ -413,6 +417,10 @@ impl DocumentMutator<'_> {
             || name.local == local_name!("disabled")
         {
             element.flush_is_focussable();
+        }
+
+        if name.local == local_name!("href") {
+            element.flush_link_state();
         }
 
         // Update text input value

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -1246,7 +1246,7 @@ fn set_input_checked_state(element: &mut ElementData, value: String) {
         return;
     };
     match element.special_data {
-        SpecialElementData::CheckboxInput(ref mut checked_mut) => *checked_mut = checked,
+        SpecialElementData::CheckboxInput(_) => element.set_checkbox_input_checked(checked),
         // If we have just constructed the element, set the node attribute,
         // and NodeSpecificData will be created from that later
         // this simulates the checked attribute being set in html,

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -383,6 +383,18 @@ impl ElementData {
         data.flush_is_focussable();
         data.flush_link_state();
 
+        // Mirror the `checked` attribute into the element state so that `:checked`
+        // selectors can be matched (and invalidated) from `ElementState`.
+        if data.name.local == local_name!("input")
+            && matches!(
+                data.attr(local_name!("type")),
+                Some("checkbox") | Some("radio")
+            )
+            && data.has_attr(local_name!("checked"))
+        {
+            data.element_state.insert(ElementState::CHECKED);
+        }
+
         // The element state needs to be modified if the element can be disabled.
         if data.can_be_disabled() {
             data.element_state
@@ -538,6 +550,16 @@ impl ElementData {
             SpecialElementData::CheckboxInput(ref mut checked) => Some(checked),
             _ => None,
         }
+    }
+
+    /// Set the checked state of a checkbox/radio input, keeping the
+    /// `ElementState::CHECKED` bit (used for `:checked` selector matching and
+    /// invalidation) in sync with the special data.
+    pub fn set_checkbox_input_checked(&mut self, checked: bool) {
+        if let Some(is_checked) = self.checkbox_input_checked_mut() {
+            *is_checked = checked;
+        }
+        self.element_state.set(ElementState::CHECKED, checked);
     }
 
     #[cfg(feature = "file-input")]

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -381,6 +381,7 @@ impl ElementData {
             transform: None,
         };
         data.flush_is_focussable();
+        data.flush_link_state();
 
         // The element state needs to be modified if the element can be disabled.
         if data.can_be_disabled() {
@@ -415,6 +416,27 @@ impl ElementData {
 
     pub fn can_be_disabled(&self) -> bool {
         local_names!("button", "input", "select", "textarea").contains(&self.name.local)
+    }
+
+    /// Whether this element is a link (an `<a>` or `<area>` element with an `href` attribute)
+    pub fn is_link(&self) -> bool {
+        (self.name.local == local_name!("a") || self.name.local == local_name!("area"))
+            && self.has_attr(local_name!("href"))
+    }
+
+    /// Sync the visitedness bits of `element_state` with the element's link-ness.
+    /// Blitz does not track browsing history, so all links are unvisited.
+    ///
+    /// Stylo's snapshot invalidation (`ElementWrapper::is_link`) determines link-ness
+    /// from these state bits, so they must be kept accurate for `:link`/`:any-link`
+    /// selectors to be correctly invalidated. Must be called whenever the `href`
+    /// attribute is added or removed.
+    pub fn flush_link_state(&mut self) {
+        self.element_state
+            .remove(ElementState::VISITED_OR_UNVISITED);
+        if self.is_link() {
+            self.element_state.insert(ElementState::UNVISITED);
+        }
     }
 
     pub fn image_data(&self) -> Option<&ImageData> {

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -495,18 +495,23 @@ impl Node {
         }
     }
 
+    // State changes (hover/focus/active/disabled) do not set a restyle hint.
+    // Invalidation is driven by element snapshots: the style traversal diffs the
+    // snapshotted (pre-change) state against the current state and invalidates
+    // only the elements matched by selectors that depend on the changed state
+    // bits. Ancestors are marked dirty so the traversal reaches this node.
     pub fn hover(&mut self) {
         if let Some(data) = self.element_data_mut() {
             data.element_state.insert(ElementState::HOVER);
         }
-        self.set_restyle_hint(RestyleHint::restyle_subtree());
+        self.mark_ancestors_dirty();
     }
 
     pub fn unhover(&mut self) {
         if let Some(data) = self.element_data_mut() {
             data.element_state.remove(ElementState::HOVER);
         }
-        self.set_restyle_hint(RestyleHint::restyle_subtree());
+        self.mark_ancestors_dirty();
     }
 
     pub fn is_hovered(&self) -> bool {
@@ -519,7 +524,7 @@ impl Node {
             data.element_state
                 .insert(ElementState::FOCUS | ElementState::FOCUSRING);
         }
-        self.set_restyle_hint(RestyleHint::restyle_subtree());
+        self.mark_ancestors_dirty();
 
         // If focussing a text input, enable IME and set IME area
         if self
@@ -542,7 +547,7 @@ impl Node {
             data.element_state
                 .remove(ElementState::FOCUS | ElementState::FOCUSRING);
         }
-        self.set_restyle_hint(RestyleHint::restyle_subtree());
+        self.mark_ancestors_dirty();
 
         // If blurring a text input, disable IME
         if self
@@ -563,14 +568,14 @@ impl Node {
         if let Some(data) = self.element_data_mut() {
             data.element_state.insert(ElementState::ACTIVE);
         }
-        self.set_restyle_hint(RestyleHint::restyle_subtree());
+        self.mark_ancestors_dirty();
     }
 
     pub fn unactive(&mut self) {
         if let Some(data) = self.element_data_mut() {
             data.element_state.remove(ElementState::ACTIVE);
         }
-        self.set_restyle_hint(RestyleHint::restyle_subtree());
+        self.mark_ancestors_dirty();
     }
 
     pub fn is_active(&self) -> bool {
@@ -587,7 +592,7 @@ impl Node {
                 data.element_state.remove(ElementState::ENABLED);
             }
         }
-        self.set_restyle_hint(RestyleHint::restyle_subtree());
+        self.mark_ancestors_dirty();
     }
 
     // Marks the node as enabled if it can be.
@@ -599,7 +604,7 @@ impl Node {
                 data.element_state.remove(ElementState::DISABLED);
             }
         }
-        self.set_restyle_hint(RestyleHint::restyle_subtree());
+        self.mark_ancestors_dirty();
     }
 
     pub fn subdoc(&self) -> Option<&dyn Document> {

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -407,18 +407,9 @@ impl selectors::Element for BlitzNode<'_> {
         match *pseudo_class {
             NonTSPseudoClass::Active => self.element_state().contains(ElementState::ACTIVE),
             NonTSPseudoClass::AnyLink => self
-                .data
-                .downcast_element()
-                .map(|elem| {
-                    (elem.name.local == local_name!("a") || elem.name.local == local_name!("area"))
-                        && elem.attr(local_name!("href")).is_some()
-                })
-                .unwrap_or(false),
-            NonTSPseudoClass::Checked => self
-                .data
-                .downcast_element()
-                .and_then(|elem| elem.checkbox_input_checked())
-                .unwrap_or(false),
+                .element_state()
+                .intersects(ElementState::VISITED_OR_UNVISITED),
+            NonTSPseudoClass::Checked => self.element_state().contains(ElementState::CHECKED),
             NonTSPseudoClass::Valid => false,
             NonTSPseudoClass::Invalid => false,
             NonTSPseudoClass::Defined => false,
@@ -432,14 +423,7 @@ impl selectors::Element for BlitzNode<'_> {
             NonTSPseudoClass::Indeterminate => false,
             NonTSPseudoClass::Lang(_) => false,
             NonTSPseudoClass::CustomState(_) => false,
-            NonTSPseudoClass::Link => self
-                .data
-                .downcast_element()
-                .map(|elem| {
-                    (elem.name.local == local_name!("a") || elem.name.local == local_name!("area"))
-                        && elem.attr(local_name!("href")).is_some()
-                })
-                .unwrap_or(false),
+            NonTSPseudoClass::Link => self.element_state().contains(ElementState::UNVISITED),
             NonTSPseudoClass::PlaceholderShown => false,
             NonTSPseudoClass::ReadWrite => false,
             NonTSPseudoClass::ReadOnly => false,


### PR DESCRIPTION
## Summary

Hover (and focus/active/disabled) currently forces `RestyleHint::restyle_subtree()` on every element along the ancestor path, restyling large portions of the DOM. Gecko/Servo instead rely purely on element snapshots: Stylo's traversal diffs the snapshotted pre-change `ElementState` against the current state and invalidates only elements matched by selectors that actually depend on the changed state bits. Blitz already feeds its `SnapshotMap` into the `SharedStyleContext`, so this PR switches state changes over to that path:

- `Node::{hover,unhover,focus,blur,active,unactive,disable,enable}`: `set_restyle_hint(restyle_subtree())` → `mark_ancestors_dirty()` (the dirty-descendants flags are still needed so the traversal reaches the snapshotted node; `invalidate_style_if_needed` then does the targeted work).
- New `BaseDocument::snapshot_node_state_only`: captures only the pre-change `ElementState`, skipping the pessimistic full-attribute copy (+ `class_changed`/`id_changed`/`other_attributes_changed = true`) that `snapshot_node` does — those flags trigger unnecessary class/id/attribute invalidation lookups for pure state changes.
- Snapshots now follow Gecko's `ServoElementSnapshot` merge semantics: state and attributes are each captured at most once per style flush (first mutation wins), and a state-only snapshot is upgraded in place to also capture attributes if an attribute mutation follows before the next flush.
- Gecko-style early-out: `snapshot_node_and` now takes the changed `ElementState` bits and skips snapshotting entirely when no style rule depends on them (`BaseDocument::style_depends_on_state`, checking the stylist's `state_dependencies`/`nth_of_state_dependencies` per origin). E.g. pages with no `:hover` rules now do zero invalidation work on pointer moves.

Attribute mutations in `mutator.rs` intentionally keep their existing broad `restyle_subtree()` behavior; only state changes are narrowed here.

## Testing

`cargo fmt`, `cargo clippy --workspace`, `cargo check --workspace`, and `cargo test --workspace` all pass.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/89fe3b9a876e43389d2ac10467bfca48
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/89fe3b9a876e43389d2ac10467bfca48?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**0** newly passing, **1** newly failing (net -1).

<details>
<summary>Full diff (1 changed tests)</summary>

```diff
- Pass => Fail css/css-text-decor/invalidation/text-decoration-thickness.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32654257466).</sub>
<!-- wpt-results-end -->
