### PR TITLE
Make the damage propagation and clearing passes incremental

### DIFF
--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -48,6 +48,17 @@ impl BaseDocument {
         };
         damage |= damage_from_parent;
 
+        // Skip subtrees which contain no damage. Anonymous nodes are never
+        // skipped themselves because damage marking walks the DOM parent
+        // chain, which bypasses anonymous boxes: a damaged node's flagged
+        // ancestors may reach it only through an unflagged anonymous wrapper.
+        {
+            let node = &self.nodes[node_id];
+            if damage.is_empty() && !node.has_damaged_descendants() && !node.is_anonymous() {
+                return RestyleDamage::empty();
+            }
+        }
+
         // Flush updated pseudo-element styles to their anonymous nodes so that
         // style changes which don't trigger box construction still take effect.
         //
@@ -124,6 +135,43 @@ impl BaseDocument {
 
         // Propagate damage to parent
         damage_for_parent
+    }
+
+    /// Clear damage and the `damaged_descendants`/`dirty_descendants` flags
+    /// on all nodes which may carry them, using the `damaged_descendants`
+    /// flags to skip clean subtrees (mirroring `propagate_damage_flags`).
+    pub(crate) fn clear_damage_and_dirty_flags(&mut self, node_id: NodeId) {
+        {
+            let node = &self.nodes[node_id];
+            let has_damage = node.damage().is_some_and(|d| !d.is_empty());
+            if !has_damage && !node.has_damaged_descendants() && !node.is_anonymous() {
+                return;
+            }
+        }
+
+        let children = std::mem::take(&mut self.nodes[node_id].children);
+        let layout_children = std::mem::take(self.nodes[node_id].layout_children.get_mut());
+        for child in children.iter() {
+            self.clear_damage_and_dirty_flags(*child);
+        }
+        if let Some(layout_children) = layout_children.as_ref() {
+            for child in layout_children.iter() {
+                self.clear_damage_and_dirty_flags(*child);
+            }
+        }
+        if let Some(before_id) = self.nodes[node_id].before() {
+            self.clear_damage_and_dirty_flags(before_id);
+        }
+        if let Some(after_id) = self.nodes[node_id].after() {
+            self.clear_damage_and_dirty_flags(after_id);
+        }
+
+        let node = &mut self.nodes[node_id];
+        node.children = children;
+        *node.layout_children.get_mut() = layout_children;
+        node.clear_damage_mut();
+        node.unset_damaged_descendants();
+        node.unset_dirty_descendants();
     }
 
     /// Flush updated pseudo-element (`::before`/`::after`) styles from the owning

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -243,6 +243,7 @@ impl DocumentMutator<'_> {
                 data.hint |= RestyleHint::restyle_subtree();
                 data.damage.insert(ALL_DAMAGE);
             }
+            node.mark_damaged();
 
             // TODO: make this fine grained / conditional based on ElementSelectorFlags
             let parent = node.parent;
@@ -369,6 +370,7 @@ impl DocumentMutator<'_> {
                 data.hint |= RestyleHint::restyle_subtree();
                 data.damage.insert(ALL_DAMAGE);
             }
+            node.mark_damaged();
 
             // Mark ancestors dirty so the style traversal visits this subtree.
             // Without this, the traversal may skip nodes with pending RestyleHint/damage.

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -99,6 +99,9 @@ pub struct ElementData {
     /// Whether any descendant of this node needs restyling.
     /// Used by Stylo's incremental style traversal to skip unchanged subtrees.
     pub dirty_descendants: AtomicBool,
+    /// Whether this node or any of its descendants may carry `RestyleDamage`.
+    /// Used by the damage propagation pass to skip unchanged subtrees.
+    pub damaged_descendants: AtomicBool,
 
     // Pseudo element nodes
     pub before: Option<NodeId>,
@@ -134,6 +137,7 @@ pub struct DocumentData {
     /// [`Node`](super::Node) is constructed.
     pub guard: Option<SharedRwLock>,
     pub dirty_descendants: AtomicBool,
+    pub damaged_descendants: AtomicBool,
     pub element_state: ElementState,
     pub has_snapshot: bool,
     pub snapshot_handled: AtomicBool,
@@ -155,6 +159,7 @@ impl std::fmt::Debug for DocumentData {
             .field("stylo_element_data", &self.stylo_element_data)
             .field("guard", &self.guard)
             .field("dirty_descendants", &self.dirty_descendants)
+            .field("damaged_descendants", &self.damaged_descendants)
             .field("element_state", &self.element_state)
             .field("has_snapshot", &self.has_snapshot)
             .field("snapshot_handled", &self.snapshot_handled)
@@ -177,6 +182,7 @@ impl DocumentData {
             selector_flags: Cell::new(ElementSelectorFlags::empty()),
             guard: None,
             dirty_descendants: AtomicBool::new(true),
+            damaged_descendants: AtomicBool::new(true),
             element_state: ElementState::empty(),
             has_snapshot: false,
             snapshot_handled: AtomicBool::new(false),
@@ -257,6 +263,7 @@ impl Clone for ElementData {
             has_snapshot: false,
             snapshot_handled: AtomicBool::new(false),
             dirty_descendants: AtomicBool::new(true),
+            damaged_descendants: AtomicBool::new(true),
             before: None,
             after: None,
             detailed_grid_info: None,
@@ -368,6 +375,7 @@ impl ElementData {
             has_snapshot: false,
             snapshot_handled: AtomicBool::new(false),
             dirty_descendants: AtomicBool::new(true),
+            damaged_descendants: AtomicBool::new(true),
             before: None,
             after: None,
             detailed_grid_info: None,

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -215,6 +215,19 @@ impl Node {
         }
     }
 
+    /// The `damaged_descendants` flag, if this node kind carries it (element or
+    /// document nodes). Returns `None` for text/comment nodes.
+    #[inline]
+    fn damaged_descendants_flag(&self) -> Option<&AtomicBool> {
+        match &self.data {
+            NodeData::Element(data) | NodeData::AnonymousBlock(data) => {
+                Some(&data.damaged_descendants)
+            }
+            NodeData::Document(data) => Some(&data.damaged_descendants),
+            _ => None,
+        }
+    }
+
     /// The document's shared style lock. Only available on element and
     /// document nodes.
     #[inline]
@@ -452,6 +465,45 @@ impl Node {
         }
     }
 
+    /// Returns whether this node or any of its descendants may carry damage.
+    pub fn has_damaged_descendants(&self) -> bool {
+        self.damaged_descendants_flag()
+            .is_some_and(|flag| flag.load(Ordering::Relaxed))
+    }
+
+    /// Clears the damaged_descendants flag on this node.
+    pub fn unset_damaged_descendants(&self) {
+        if let Some(flag) = self.damaged_descendants_flag() {
+            flag.store(false, Ordering::Relaxed);
+        }
+    }
+
+    /// Marks this node and all of its ancestors as (potentially) carrying
+    /// damage, so that the damage propagation pass visits this node's subtree.
+    ///
+    /// The invariant is: if a node carries damage (or needs damage-phase
+    /// processing such as pseudo-element style syncing), then it and all of
+    /// its ancestors have `damaged_descendants` set.
+    pub fn mark_damaged(&self) {
+        if let Some(flag) = self.damaged_descendants_flag() {
+            if flag.swap(true, Ordering::Relaxed) {
+                return;
+            }
+        }
+        let mut current_id = self.parent;
+        while let Some(parent_id) = current_id {
+            let parent = &self.tree()[parent_id];
+            // If this ancestor already has damaged_descendants set, we can stop
+            // because all further ancestors must also have it set
+            if let Some(flag) = parent.damaged_descendants_flag() {
+                if flag.swap(true, Ordering::Relaxed) {
+                    break;
+                }
+            }
+            current_id = parent.parent;
+        }
+    }
+
     // pub fn damage_mut(&mut self) -> Option<&mut RestyleDamage> {
     //     self.stylo_element_data
     //         .get_mut()
@@ -476,6 +528,9 @@ impl Node {
             if let Some(mut data) = stylo.get_mut() {
                 data.damage |= damage;
             }
+        }
+        if !damage.is_empty() {
+            self.mark_damaged();
         }
     }
 

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -104,12 +104,11 @@ impl BaseDocument {
         self.resolve_transforms(root_node_id);
         timer.record_time("transform");
 
-        // Clear all damage and dirty flags
+        // Clear all damage and dirty flags, walking only subtrees which are
+        // marked as (potentially) containing damage.
         if self.incremental_layout {
-            for (_, node) in self.nodes.iter_mut() {
-                node.clear_damage_mut();
-                node.unset_dirty_descendants();
-            }
+            let doc_node_id = self.root_node().id;
+            self.clear_damage_and_dirty_flags(doc_node_id);
             timer.record_time("c_damage");
         }
 

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -1234,15 +1234,12 @@ impl<'a> RecalcStyle<'a> {
 }
 
 #[allow(unsafe_code)]
-impl<E> DomTraversal<E> for RecalcStyle<'_>
-where
-    E: TElement,
-{
-    fn process_preorder<F: FnMut(E::ConcreteNode)>(
+impl<'dom> DomTraversal<BlitzNode<'dom>> for RecalcStyle<'_> {
+    fn process_preorder<F: FnMut(BlitzNode<'dom>)>(
         &self,
         traversal_data: &PerLevelTraversalData,
-        context: &mut StyleContext<E>,
-        node: E::ConcreteNode,
+        context: &mut StyleContext<BlitzNode<'dom>>,
+        node: BlitzNode<'dom>,
         note_child: F,
     ) {
         if let Some(el) = node.as_element() {
@@ -1250,8 +1247,15 @@ where
             let mut data = unsafe { el.ensure_data() };
             recalc_style_at(self, traversal_data, context, el, &mut data, note_child);
 
+            // Mark the ancestor chain so that the damage propagation pass
+            // visits this element (both for the damage itself and to sync
+            // any updated pseudo-element styles to their anonymous nodes).
+            if !data.damage.is_empty() || el.before().is_some() || el.after().is_some() {
+                el.mark_damaged();
+            }
+
             // Gets set later on
-            unsafe { el.unset_dirty_descendants() }
+            el.unset_dirty_descendants();
         }
     }
 
@@ -1260,7 +1264,11 @@ where
         false
     }
 
-    fn process_postorder(&self, _style_context: &mut StyleContext<E>, _node: E::ConcreteNode) {
+    fn process_postorder(
+        &self,
+        _style_context: &mut StyleContext<BlitzNode<'dom>>,
+        _node: BlitzNode<'dom>,
+    ) {
         panic!("this should never be called")
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #765: the `damage` and `c_damage` phases of `BaseDocument::resolve` were O(tree size) even for tiny incremental updates (e.g. hover on a Wikipedia-sized page). This makes both O(changed + depth) by adding a `damaged_descendants` bit — an exact twin of `dirty_descendants`, but tracking where `RestyleDamage` landed rather than where restyles are needed. The flush phase is intentionally left untouched (deferred as a follow-up).

The bit means "this node or a descendant may carry damage / need damage-phase processing", and is set on the node plus its ancestor chain (with an early-out when an already-set ancestor is reached, so marking is O(1) amortized):

- `Node::insert_damage` now calls `mark_damaged()` whenever non-empty damage is inserted, covering all blitz-side mutation/construction damage sites (plus two `set_attribute`/`clear_attribute` sites in `mutator.rs` that wrote `data.damage` directly).
- `RecalcStyle::process_preorder` marks each visited element whose stylo-computed `data.damage` is non-empty — or which has `::before`/`::after` nodes, so `sync_pseudo_element_styles` still runs for pseudo-style-only changes. (The `DomTraversal` impl is now concrete over `BlitzNode` instead of generic over `E: TElement` to allow calling the marking method.)

Consumers:

```rust
// propagate_damage_flags: early-out for clean subtrees
if damage.is_empty() && !node.has_damaged_descendants() && !node.is_anonymous() {
    return RestyleDamage::empty();
}
```

The end-of-resolve clear loop (`for (_, node) in self.nodes.iter_mut()`) is replaced by `clear_damage_and_dirty_flags(root)`, a recursive walk gated the same way, which clears damage plus both descendant flags along damaged paths only.

Anonymous boxes are never skipped themselves: damage marking walks the DOM parent chain, which bypasses anonymous wrappers, so a damaged node inside an anonymous box is only reachable through an unflagged anonymous ancestor. The flags default to `true` on node creation so the initial (and any post-mutation-new-subtree) resolve cannot skip anything.

## Testing

- `cargo fmt` / `clippy` / `check` / `test --workspace` all pass.
- WPT `css/selectors/invalidation`, `css/css-pseudo`, and `css/css-transitions` produce identical pass/fail counts on this branch vs `main` (6/57, 83/185, 4/4 respectively).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/89fe3b9a876e43389d2ac10467bfca48
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/89fe3b9a876e43389d2ac10467bfca48?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32659030865).</sub>
<!-- wpt-results-end -->
