### PR TITLE
Upgrade Taffy to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=8d13fdc88468c83f01b13b36fadc0349950c6f51#8d13fdc88468c83f01b13b36fadc0349950c6f51"
+source = "git+https://github.com/DioxusLabs/taffy?rev=88125cecb1c0a35516b5c45efa07e96bae07b4b3#88125cecb1c0a35516b5c45efa07e96bae07b4b3"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "8d13fdc88468c83f01b13b36fadc0349950c6f51", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "88125cecb1c0a35516b5c45efa07e96bae07b4b3", default-features = false, features = [
     "std",
     "flexbox",
     "grid",


### PR DESCRIPTION
## Summary

Bumps the taffy git rev `8d13fdc8` → `88125cec` (latest main), picking up DioxusLabs/taffy#1150: floats with `clear` no longer inflate their container's intrinsic (shrink-to-fit) width. This fixes squeezed body text next to the right-floated infobox stack on Wikipedia article pages.

Verified with the `screenshot` example on https://en.wikipedia.org/wiki/Barack_Obama — the intro paragraph now fills the full column width beside the infobox:

![Obama page after taffy bump](examples/output/enwikipediao.png)


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/93f5f27500934387ae3e7ca3bbfc9f43
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/93f5f27500934387ae3e7ca3bbfc9f43?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32656879785).</sub>
<!-- wpt-results-end -->
