### PR TITLE
Sync pseudo-element styles during the style traversal

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -3027,6 +3027,62 @@ mod hover_invalidation_tests {
             "unchecking should restore the sibling label color"
         );
     }
+
+    /// A repaint-only style change to an existing `::before` pseudo-element
+    /// (no box construction damage) must be flushed to the pseudo-element's
+    /// anonymous node during the style traversal.
+    #[test]
+    fn hover_updates_existing_pseudo_element_style() {
+        let mut doc = BaseDocument::new(DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        });
+        doc.add_user_agent_stylesheet(
+            "div::before { content: \"x\"; color: rgb(1, 2, 3); } \
+             div:hover::before { color: rgb(0, 0, 255); }",
+        );
+        let root_id = doc.root_node().id;
+        let style = |value: &str| Attribute {
+            name: qual_name!("style"),
+            value: value.to_string(),
+        };
+
+        let mut mutator = doc.mutate();
+        let html = mutator.create_element(qual_name!("html"), vec![]);
+        let body = mutator.create_element(qual_name!("body"), vec![style("margin:0")]);
+        let div = mutator.create_element(
+            qual_name!("div"),
+            vec![style("display:block;width:300px;height:100px")],
+        );
+        let text = mutator.create_text_node("some text");
+        mutator.append_children(div, &[text]);
+        mutator.append_children(body, &[div]);
+        mutator.append_children(html, &[body]);
+        mutator.append_children(root_id, &[html]);
+        drop(mutator);
+
+        doc.resolve(0.0);
+        let before = doc.nodes[div].before().expect("::before node should exist");
+        let initial_color = text_color(&doc, before);
+
+        doc.set_hover_to(10.0, 10.0);
+        assert!(doc.nodes[div].is_hovered());
+        doc.resolve(0.0);
+        assert_ne!(
+            text_color(&doc, before),
+            initial_color,
+            "hover should change the ::before color"
+        );
+
+        doc.set_hover_to(10.0, 200.0);
+        assert!(!doc.nodes[div].is_hovered());
+        doc.resolve(0.0);
+        assert_eq!(
+            text_color(&doc, before),
+            initial_color,
+            "unhover should restore the ::before color"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -59,12 +59,6 @@ impl BaseDocument {
             }
         }
 
-        // Flush updated pseudo-element styles to their anonymous nodes so that
-        // style changes which don't trigger box construction still take effect.
-        //
-        // TODO: see if this can be made more efficient (/run less often)
-        self.sync_pseudo_element_styles(node_id);
-
         let damage_for_children = RestyleDamage::empty();
         let children = std::mem::take(&mut self.nodes[node_id].children);
         let layout_children = std::mem::take(self.nodes[node_id].layout_children.get_mut());
@@ -172,63 +166,6 @@ impl BaseDocument {
         node.clear_damage_mut();
         node.unset_damaged_descendants();
         node.unset_dirty_descendants();
-    }
-
-    /// Flush updated pseudo-element (`::before`/`::after`) styles from the owning
-    /// element's stylo data to the pseudo-element's anonymous node.
-    ///
-    /// Pseudo-element styles are normally flushed to the pseudo-element's node
-    /// during box construction (see `flush_pseudo_elements`), but in incremental
-    /// mode box construction only runs for nodes with construction damage.
-    /// Pseudo-element style changes which don't require reconstruction (e.g.
-    /// animations/transitions of repaint- or relayout-only properties) must still
-    /// be flushed to the pseudo-element's node - along with the damage they imply -
-    /// so that layout and paint see the new style.
-    fn sync_pseudo_element_styles(&mut self, node_id: NodeId) {
-        let node = &self.nodes[node_id];
-
-        let before_node_id = node.before();
-        let after_node_id = node.after();
-        if before_node_id.is_none() && after_node_id.is_none() {
-            return;
-        }
-
-        let (before_style, after_style) = {
-            let style_data = node.stylo_element_data_opt().and_then(|s| s.get());
-            let Some(style_data) = style_data.as_ref() else {
-                return;
-            };
-            // Note: yes these are kinda backwards (see `flush_pseudo_elements`)
-            let pseudos = style_data.styles.pseudos.as_array();
-            (pseudos[1].clone(), pseudos[0].clone())
-        };
-
-        // Creation and removal of pseudo-elements is handled during box construction
-        // (Stylo generates construction damage for those cases), so only the case
-        // where the pseudo-element both was and remains present is handled here.
-        for (pe_node_id, pe_style) in [(before_node_id, before_style), (after_node_id, after_style)]
-        {
-            let (Some(pe_node_id), Some(pe_style)) = (pe_node_id, pe_style) else {
-                continue;
-            };
-            let mut pe_data = self.nodes[pe_node_id]
-                .stylo_element_data_opt_mut()
-                .and_then(|s| s.get_mut());
-            let Some(pe_data) = pe_data.as_mut() else {
-                continue;
-            };
-            let Some(old_style) = pe_data.styles.primary.clone() else {
-                continue;
-            };
-            if std::ptr::eq(&*old_style, &*pe_style) {
-                continue;
-            }
-
-            let diff = RestyleDamage::compute_style_difference::<&Node>(&old_style, &pe_style);
-            pe_data.damage.insert(diff.damage);
-            pe_data.styles.primary = Some(pe_style);
-            pe_data.set_restyled();
-        }
     }
 }
 

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -1247,10 +1247,11 @@ impl<'dom> DomTraversal<BlitzNode<'dom>> for RecalcStyle<'_> {
             let mut data = unsafe { el.ensure_data() };
             recalc_style_at(self, traversal_data, context, el, &mut data, note_child);
 
+            sync_pseudo_element_styles(el, &data);
+
             // Mark the ancestor chain so that the damage propagation pass
-            // visits this element (both for the damage itself and to sync
-            // any updated pseudo-element styles to their anonymous nodes).
-            if !data.damage.is_empty() || el.before().is_some() || el.after().is_some() {
+            // visits this element.
+            if !data.damage.is_empty() {
                 el.mark_damaged();
             }
 
@@ -1275,6 +1276,72 @@ impl<'dom> DomTraversal<BlitzNode<'dom>> for RecalcStyle<'_> {
     #[inline]
     fn shared_context(&self) -> &SharedStyleContext<'_> {
         &self.context
+    }
+}
+
+/// Flush updated pseudo-element (`::before`/`::after`) styles from the owning
+/// element's freshly-computed stylo data to the pseudo-element's anonymous node.
+///
+/// Pseudo-element styles are normally flushed to the pseudo-element's node
+/// during box construction (see `flush_pseudo_elements`), but in incremental
+/// mode box construction only runs for nodes with construction damage.
+/// Pseudo-element style changes which don't require reconstruction (e.g.
+/// animations/transitions of repaint- or relayout-only properties) must still
+/// be flushed to the pseudo-element's node - along with the damage they imply -
+/// so that layout and paint see the new style.
+///
+/// This runs during the style traversal, immediately after the owning element
+/// has been restyled, because that is where the old and new pseudo styles can
+/// be diffed precisely (the pseudo node's stored primary style is the "old"
+/// style; the owner's just-computed pseudo styles are the "new" ones).
+///
+/// SAFETY: the style traversal has exclusive access to the tree, and each
+/// pseudo-element node is only ever accessed from its owning element's
+/// `process_preorder` (pseudo nodes are not part of the DOM child list and are
+/// not themselves visited by the traversal), so mutating the pseudo node's
+/// stylo data here cannot race with any other traversal thread.
+#[allow(unsafe_code)]
+fn sync_pseudo_element_styles(el: &Node, data: &style::data::ElementData) {
+    let before_node_id = el.before();
+    let after_node_id = el.after();
+    if before_node_id.is_none() && after_node_id.is_none() {
+        return;
+    }
+
+    // Note: yes these are kinda backwards (see `flush_pseudo_elements`)
+    let pseudos = data.styles.pseudos.as_array();
+    let before_style = pseudos[1].clone();
+    let after_style = pseudos[0].clone();
+
+    // Creation and removal of pseudo-elements is handled during box construction
+    // (Stylo generates construction damage for those cases), so only the case
+    // where the pseudo-element both was and remains present is handled here.
+    for (pe_node_id, pe_style) in [(before_node_id, before_style), (after_node_id, after_style)] {
+        let (Some(pe_node_id), Some(pe_style)) = (pe_node_id, pe_style) else {
+            continue;
+        };
+        let pe_node = el.with(pe_node_id);
+        let Some(stylo_data) = pe_node.stylo_element_data_opt() else {
+            continue;
+        };
+        let mut pe_data = match unsafe { stylo_data.unsafe_stylo_only_mut() } {
+            Some(data) => data,
+            None => continue,
+        };
+        let Some(old_style) = pe_data.styles.primary.clone() else {
+            continue;
+        };
+        if std::ptr::eq(&*old_style, &*pe_style) {
+            continue;
+        }
+
+        let diff = RestyleDamage::compute_style_difference::<&Node>(&old_style, &pe_style);
+        if !diff.damage.is_empty() {
+            pe_data.damage.insert(diff.damage);
+            pe_node.mark_damaged();
+        }
+        pe_data.styles.primary = Some(pe_style);
+        pe_data.set_restyled();
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #766 (stacked on it), removing its one conservative marking case: previously every restyle-visited element owning `::before`/`::after` nodes had to be flagged `damaged_descendants` — even with empty damage — so the damage pass would reach it and run `sync_pseudo_element_styles`.

The sync now runs during the style traversal instead, in `RecalcStyle::process_preorder` immediately after `recalc_style_at`. The key observation is that the precise old-vs-new pseudo style diff is available there: the pseudo node's stored `styles.primary` is the "old" style and the owner's just-computed `data.styles.pseudos` are the "new" ones (identical ptr-compare + `compute_style_difference` logic to the old damage-phase sync, which is deleted from `propagate_damage_flags`). Damage-marking becomes exact:

```rust
// process_preorder
recalc_style_at(...);
sync_pseudo_element_styles(el, &data);   // writes style + damage to pe node,
                                         // pe_node.mark_damaged() only if diff non-empty
if !data.damage.is_empty() {             // no more `|| el.before().is_some() || ...`
    el.mark_damaged();
}
```

Thread-safety: pseudo nodes are not in the DOM child list and are never visited by the (potentially parallel) style traversal themselves; each is only touched from its owner's `process_preorder`, so mutating its stylo data via `unsafe_stylo_only_mut()` cannot race. Pseudo creation/removal stays with box construction, which is driven by construction damage as before.

## Testing

- New regression test `hover_updates_existing_pseudo_element_style`: a repaint-only `div:hover::before { color }` change on an existing pseudo-element applies and reverts across incremental resolves.
- `cargo fmt` / `clippy` / `test --workspace` pass.
- WPT `css/css-pseudo` (83/185) and `css/selectors/invalidation` (6/57) pass/fail counts identical to `main`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/89fe3b9a876e43389d2ac10467bfca48
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/89fe3b9a876e43389d2ac10467bfca48?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32659030916).</sub>
<!-- wpt-results-end -->
