### PR TITLE
Drive background/mask image flushing from the style traversal

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -330,7 +330,7 @@ pub struct BaseDocument {
     /// Nodes whose `background-image`/`mask-image` layers need flushing to
     /// dedicated storage on the node because their style changed (populated by
     /// the style traversal and by pseudo-element box construction).
-    pub(crate) pending_image_flush_nodes: Vec<NodeId>,
+    pub(crate) pending_style_image_nodes: Vec<NodeId>,
 
     // Tracks in-flight "critical" resources (e.g. stylesheets linked from the `<head>`),
     // keyed by request id
@@ -498,7 +498,7 @@ impl BaseDocument {
             deferred_construction_nodes: Vec::new(),
             image_cache: HashMap::new(),
             pending_images: HashMap::new(),
-            pending_image_flush_nodes: Vec::new(),
+            pending_style_image_nodes: Vec::new(),
             pending_critical_resources: HashSet::new(),
             controls_to_form: HashMap::new(),
             net_provider,

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -327,6 +327,11 @@ pub struct BaseDocument {
     /// Value is a list of (node_id, image_type) pairs waiting for the image.
     pub(crate) pending_images: HashMap<String, Vec<(NodeId, ImageType)>>,
 
+    /// Nodes whose `background-image`/`mask-image` layers need flushing to
+    /// dedicated storage on the node because their style changed (populated by
+    /// the style traversal and by pseudo-element box construction).
+    pub(crate) pending_image_flush_nodes: Vec<NodeId>,
+
     // Tracks in-flight "critical" resources (e.g. stylesheets linked from the `<head>`),
     // keyed by request id
     pub(crate) pending_critical_resources: HashSet<usize>,
@@ -493,6 +498,7 @@ impl BaseDocument {
             deferred_construction_nodes: Vec::new(),
             image_cache: HashMap::new(),
             pending_images: HashMap::new(),
+            pending_image_flush_nodes: Vec::new(),
             pending_critical_resources: HashSet::new(),
             controls_to_form: HashMap::new(),
             net_provider,
@@ -3081,6 +3087,71 @@ mod hover_invalidation_tests {
             text_color(&doc, before),
             initial_color,
             "unhover should restore the ::before color"
+        );
+    }
+
+    /// Background-image layers must be flushed to the node's dedicated image
+    /// storage when its style changes (queued during the style traversal),
+    /// now that image flushing no longer runs on every node in the flush pass.
+    #[test]
+    fn hover_updates_background_image_layers() {
+        let mut doc = BaseDocument::new(DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        });
+        doc.add_user_agent_stylesheet(
+            "div { background-image: url(\"https://example.com/a.png\"); } \
+             div:hover { background-image: url(\"https://example.com/b.png\"); }",
+        );
+        let root_id = doc.root_node().id;
+        let style = |value: &str| Attribute {
+            name: qual_name!("style"),
+            value: value.to_string(),
+        };
+
+        let mut mutator = doc.mutate();
+        let html = mutator.create_element(qual_name!("html"), vec![]);
+        let body = mutator.create_element(qual_name!("body"), vec![style("margin:0")]);
+        let div = mutator.create_element(
+            qual_name!("div"),
+            vec![style("display:block;width:300px;height:100px")],
+        );
+        mutator.append_children(body, &[div]);
+        mutator.append_children(html, &[body]);
+        mutator.append_children(root_id, &[html]);
+        drop(mutator);
+
+        let background_image_url = |doc: &BaseDocument, id: NodeId| -> Option<String> {
+            let elem = doc.nodes[id].data.downcast_element().unwrap();
+            elem.background_images
+                .first()
+                .and_then(|img| img.as_ref())
+                .map(|img| img.url.as_str().to_string())
+        };
+
+        doc.resolve(0.0);
+        assert_eq!(
+            background_image_url(&doc, div).as_deref(),
+            Some("https://example.com/a.png"),
+            "initial resolve should flush the background image"
+        );
+
+        doc.set_hover_to(10.0, 10.0);
+        assert!(doc.nodes[div].is_hovered());
+        doc.resolve(0.0);
+        assert_eq!(
+            background_image_url(&doc, div).as_deref(),
+            Some("https://example.com/b.png"),
+            "hover should flush the changed background image"
+        );
+
+        doc.set_hover_to(10.0, 200.0);
+        assert!(!doc.nodes[div].is_hovered());
+        doc.resolve(0.0);
+        assert_eq!(
+            background_image_url(&doc, div).as_deref(),
+            Some("https://example.com/a.png"),
+            "unhover should flush the restored background image"
         );
     }
 }

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -741,7 +741,7 @@ fn flush_pseudo_elements(doc: &mut BaseDocument, node_id: NodeId) {
             node.set_pe_by_index(idx, Some(new_node_id));
             node.insert_damage(ALL_DAMAGE);
 
-            doc.pending_image_flush_nodes.push(new_node_id);
+            doc.pending_style_image_nodes.push(new_node_id);
         }
 
         // Else: Update psuedo element
@@ -793,7 +793,7 @@ fn flush_pseudo_elements(doc: &mut BaseDocument, node_id: NodeId) {
             if !std::ptr::eq(&**primary_styles.as_ref().unwrap(), &*pe_style) {
                 *primary_styles = Some(pe_style);
                 node_styles.set_restyled();
-                doc.pending_image_flush_nodes.push(pe_node_id);
+                doc.pending_style_image_nodes.push(pe_node_id);
             }
         }
     }

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -740,6 +740,8 @@ fn flush_pseudo_elements(doc: &mut BaseDocument, node_id: NodeId) {
             let node = &mut doc.nodes[node_id];
             node.set_pe_by_index(idx, Some(new_node_id));
             node.insert_damage(ALL_DAMAGE);
+
+            doc.pending_image_flush_nodes.push(new_node_id);
         }
 
         // Else: Update psuedo element
@@ -749,8 +751,8 @@ fn flush_pseudo_elements(doc: &mut BaseDocument, node_id: NodeId) {
             //
             // Note: this deliberately compares the text itself rather than relying on
             // the style-pointer comparison below, as the pseudo-element's style may
-            // already have been updated by `sync_pseudo_element_styles` during damage
-            // propagation without the text having been updated.
+            // already have been updated by `sync_pseudo_element_styles` during the
+            // style traversal without the text having been updated.
             let new_text = pe_content_text(&pe_style).map(str::to_string);
             let existing_text_node_id = doc.nodes[pe_node_id]
                 .children
@@ -791,6 +793,7 @@ fn flush_pseudo_elements(doc: &mut BaseDocument, node_id: NodeId) {
             if !std::ptr::eq(&**primary_styles.as_ref().unwrap(), &*pe_style) {
                 *primary_styles = Some(pe_style);
                 node_styles.set_restyled();
+                doc.pending_image_flush_nodes.push(pe_node_id);
             }
         }
     }

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -422,6 +422,23 @@ impl BaseDocument {
         self.flush_styles_to_layout_impl(node_id, None);
     }
 
+    /// Flush the image layers of nodes whose style changed during the last
+    /// style traversal (or whose pseudo-element boxes were (re)constructed).
+    pub(crate) fn flush_pending_images(&mut self) {
+        let mut pending = std::mem::take(&mut self.pending_image_flush_nodes);
+        pending.sort_unstable();
+        pending.dedup();
+        for node_id in pending {
+            // Anonymous boxes (including pseudo-elements) can be removed from
+            // the slab between queueing and flushing; skip stale IDs.
+            if !self.nodes.contains_key(node_id) {
+                continue;
+            }
+            self.flush_image_layers_from_style(node_id, ImageLayerKind::Background);
+            self.flush_image_layers_from_style(node_id, ImageLayerKind::Mask);
+        }
+    }
+
     /// Flush a CSS image layer list (`background-image` or `mask-image`) from style
     /// to dedicated storage on the node, fetching any images which are not yet loaded.
     fn flush_image_layers_from_style(&mut self, node_id: NodeId, kind: ImageLayerKind) {
@@ -522,10 +539,6 @@ impl BaseDocument {
     ) {
         let mut new_stacking_context: HoistedPaintChildren = HoistedPaintChildren::new();
         let stacking_context = &mut new_stacking_context;
-
-        // Flush background/mask images from style to dedicated storage on the node
-        self.flush_image_layers_from_style(node_id, ImageLayerKind::Background);
-        self.flush_image_layers_from_style(node_id, ImageLayerKind::Mask);
 
         let incremental = self.incremental_layout;
         let display = {

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -479,7 +479,7 @@ impl BaseDocument {
                     let old_image = elem_images[idx].as_ref();
                     let old_image_url = old_image.map(|data| &data.url);
                     if old_image_url.is_some_and(|old_url| **new_url == **old_url) {
-                        break;
+                        continue;
                     }
 
                     // Check cache first

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -424,8 +424,8 @@ impl BaseDocument {
 
     /// Flush the image layers of nodes whose style changed during the last
     /// style traversal (or whose pseudo-element boxes were (re)constructed).
-    pub(crate) fn flush_pending_images(&mut self) {
-        let mut pending = std::mem::take(&mut self.pending_image_flush_nodes);
+    pub(crate) fn flush_pending_style_images(&mut self) {
+        let mut pending = std::mem::take(&mut self.pending_style_image_nodes);
         pending.sort_unstable();
         pending.dedup();
         for node_id in pending {

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -92,6 +92,12 @@ impl BaseDocument {
         self.resolve_deferred_tasks();
         timer.record_time("pconstruct");
 
+        // Flush background/mask images from style to dedicated storage on the
+        // nodes whose style changed (queued by the style traversal and by
+        // pseudo-element box construction), fetching any not-yet-loaded images.
+        self.flush_pending_images();
+        timer.record_time("images");
+
         // Merge stylo into taffy
         self.flush_styles_to_layout(root_node_id);
         timer.record_time("flush");

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -93,7 +93,7 @@ impl BaseDocument {
         // Flush background/mask images from style to dedicated storage on the
         // nodes whose style changed (queued by the style traversal and by
         // pseudo-element box construction), fetching any not-yet-loaded images.
-        self.flush_pending_images();
+        self.flush_pending_style_images();
         timer.record_time("pconstruct");
 
         // Merge stylo into taffy

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -90,13 +90,11 @@ impl BaseDocument {
         timer.record_time("construct");
 
         self.resolve_deferred_tasks();
-        timer.record_time("pconstruct");
-
         // Flush background/mask images from style to dedicated storage on the
         // nodes whose style changed (queued by the style traversal and by
         // pseudo-element box construction), fetching any not-yet-loaded images.
         self.flush_pending_images();
-        timer.record_time("images");
+        timer.record_time("pconstruct");
 
         // Merge stylo into taffy
         self.flush_styles_to_layout(root_node_id);

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -3,6 +3,7 @@
 
 use blitz_traits::node_id::NodeId;
 use std::ptr::NonNull;
+use std::sync::Mutex;
 use std::sync::atomic::Ordering;
 
 use crate::StyleThreading;
@@ -140,15 +141,20 @@ impl crate::document::BaseDocument {
         // dbg!(root);
         let token = RecalcStyle::pre_traverse(root, &context);
 
+        let mut nodes_needing_image_flush = Vec::new();
         if token.should_traverse() {
             // Style the elements, resolving their data
-            let traverser = RecalcStyle::new(context);
+            let mut traverser = RecalcStyle::new(context);
             // `Sequential` bypasses Stylo's global pool. See `StyleThreading`.
             let pool_guard = matches!(self.style_threading, StyleThreading::Parallel)
                 .then(|| STYLE_THREAD_POOL.pool());
             let rayon_pool = pool_guard.as_ref().and_then(|g| g.as_ref());
             style::driver::traverse_dom(&traverser, token, rayon_pool);
+            nodes_needing_image_flush =
+                std::mem::take(traverser.nodes_needing_image_flush.get_mut().unwrap());
         }
+        self.pending_image_flush_nodes
+            .extend(nodes_needing_image_flush);
 
         for opaque in self.snapshots.keys() {
             let id = NodeId::from_u64(opaque.id() as u64);
@@ -1225,11 +1231,18 @@ use style::traversal::recalc_style_at;
 
 pub struct RecalcStyle<'a> {
     context: SharedStyleContext<'a>,
+    /// Nodes whose `background-image`/`mask-image` layers need flushing to
+    /// dedicated storage on the node (see `flush_image_layers_from_style`)
+    /// because their style changed during this traversal.
+    nodes_needing_image_flush: Mutex<Vec<NodeId>>,
 }
 
 impl<'a> RecalcStyle<'a> {
     pub fn new(context: SharedStyleContext<'a>) -> Self {
-        RecalcStyle { context }
+        RecalcStyle {
+            context,
+            nodes_needing_image_flush: Mutex::new(Vec::new()),
+        }
     }
 }
 
@@ -1247,12 +1260,20 @@ impl<'dom> DomTraversal<BlitzNode<'dom>> for RecalcStyle<'_> {
             let mut data = unsafe { el.ensure_data() };
             recalc_style_at(self, traversal_data, context, el, &mut data, note_child);
 
-            sync_pseudo_element_styles(el, &data);
+            sync_pseudo_element_styles(el, &data, &self.nodes_needing_image_flush);
 
-            // Mark the ancestor chain so that the damage propagation pass
-            // visits this element.
             if !data.damage.is_empty() {
+                // Mark the ancestor chain so that the damage propagation pass
+                // visits this element.
                 el.mark_damaged();
+
+                if data
+                    .styles
+                    .get_primary()
+                    .is_some_and(|style| needs_image_flush(el, style))
+                {
+                    self.nodes_needing_image_flush.lock().unwrap().push(el.id);
+                }
             }
 
             // Gets set later on
@@ -1301,7 +1322,11 @@ impl<'dom> DomTraversal<BlitzNode<'dom>> for RecalcStyle<'_> {
 /// not themselves visited by the traversal), so mutating the pseudo node's
 /// stylo data here cannot race with any other traversal thread.
 #[allow(unsafe_code)]
-fn sync_pseudo_element_styles(el: &Node, data: &style::data::ElementData) {
+fn sync_pseudo_element_styles(
+    el: &Node,
+    data: &style::data::ElementData,
+    nodes_needing_image_flush: &Mutex<Vec<NodeId>>,
+) {
     let before_node_id = el.before();
     let after_node_id = el.after();
     if before_node_id.is_none() && after_node_id.is_none() {
@@ -1339,10 +1364,35 @@ fn sync_pseudo_element_styles(el: &Node, data: &style::data::ElementData) {
         if !diff.damage.is_empty() {
             pe_data.damage.insert(diff.damage);
             pe_node.mark_damaged();
+
+            if needs_image_flush(pe_node, &pe_style) {
+                nodes_needing_image_flush.lock().unwrap().push(pe_node_id);
+            }
         }
         pe_data.styles.primary = Some(pe_style);
         pe_data.set_restyled();
     }
+}
+
+/// Whether a node's `background-image`/`mask-image` layers need flushing to
+/// dedicated storage on the node: its new style references image URLs, or the
+/// node has previously-flushed image data (which may need clearing).
+fn needs_image_flush(node: &Node, style: &ComputedValues) -> bool {
+    use style::values::computed::image::Image;
+    fn has_url_image(images: &[Image]) -> bool {
+        images.iter().any(|image| matches!(image, Image::Url(_)))
+    }
+
+    if has_url_image(&style.get_background().background_image.0)
+        || has_url_image(&style.get_svg().mask_image.0)
+    {
+        return true;
+    }
+
+    node.data.downcast_element().is_some_and(|el| {
+        el.background_images.iter().any(Option::is_some)
+            || el.mask_images.iter().any(Option::is_some)
+    })
 }
 
 #[test]

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -141,7 +141,7 @@ impl crate::document::BaseDocument {
         // dbg!(root);
         let token = RecalcStyle::pre_traverse(root, &context);
 
-        let mut nodes_needing_image_flush = Vec::new();
+        let mut nodes_needing_style_image_flush = Vec::new();
         if token.should_traverse() {
             // Style the elements, resolving their data
             let mut traverser = RecalcStyle::new(context);
@@ -150,11 +150,11 @@ impl crate::document::BaseDocument {
                 .then(|| STYLE_THREAD_POOL.pool());
             let rayon_pool = pool_guard.as_ref().and_then(|g| g.as_ref());
             style::driver::traverse_dom(&traverser, token, rayon_pool);
-            nodes_needing_image_flush =
-                std::mem::take(traverser.nodes_needing_image_flush.get_mut().unwrap());
+            nodes_needing_style_image_flush =
+                std::mem::take(traverser.nodes_needing_style_image_flush.get_mut().unwrap());
         }
-        self.pending_image_flush_nodes
-            .extend(nodes_needing_image_flush);
+        self.pending_style_image_nodes
+            .extend(nodes_needing_style_image_flush);
 
         for opaque in self.snapshots.keys() {
             let id = NodeId::from_u64(opaque.id() as u64);
@@ -1234,14 +1234,14 @@ pub struct RecalcStyle<'a> {
     /// Nodes whose `background-image`/`mask-image` layers need flushing to
     /// dedicated storage on the node (see `flush_image_layers_from_style`)
     /// because their style changed during this traversal.
-    nodes_needing_image_flush: Mutex<Vec<NodeId>>,
+    nodes_needing_style_image_flush: Mutex<Vec<NodeId>>,
 }
 
 impl<'a> RecalcStyle<'a> {
     pub fn new(context: SharedStyleContext<'a>) -> Self {
         RecalcStyle {
             context,
-            nodes_needing_image_flush: Mutex::new(Vec::new()),
+            nodes_needing_style_image_flush: Mutex::new(Vec::new()),
         }
     }
 }
@@ -1260,7 +1260,7 @@ impl<'dom> DomTraversal<BlitzNode<'dom>> for RecalcStyle<'_> {
             let mut data = unsafe { el.ensure_data() };
             recalc_style_at(self, traversal_data, context, el, &mut data, note_child);
 
-            sync_pseudo_element_styles(el, &data, &self.nodes_needing_image_flush);
+            sync_pseudo_element_styles(el, &data, &self.nodes_needing_style_image_flush);
 
             if !data.damage.is_empty() {
                 // Mark the ancestor chain so that the damage propagation pass
@@ -1270,9 +1270,12 @@ impl<'dom> DomTraversal<BlitzNode<'dom>> for RecalcStyle<'_> {
                 if data
                     .styles
                     .get_primary()
-                    .is_some_and(|style| needs_image_flush(el, style))
+                    .is_some_and(|style| needs_style_image_flush(el, style))
                 {
-                    self.nodes_needing_image_flush.lock().unwrap().push(el.id);
+                    self.nodes_needing_style_image_flush
+                        .lock()
+                        .unwrap()
+                        .push(el.id);
                 }
             }
 
@@ -1325,7 +1328,7 @@ impl<'dom> DomTraversal<BlitzNode<'dom>> for RecalcStyle<'_> {
 fn sync_pseudo_element_styles(
     el: &Node,
     data: &style::data::ElementData,
-    nodes_needing_image_flush: &Mutex<Vec<NodeId>>,
+    nodes_needing_style_image_flush: &Mutex<Vec<NodeId>>,
 ) {
     let before_node_id = el.before();
     let after_node_id = el.after();
@@ -1365,8 +1368,11 @@ fn sync_pseudo_element_styles(
             pe_data.damage.insert(diff.damage);
             pe_node.mark_damaged();
 
-            if needs_image_flush(pe_node, &pe_style) {
-                nodes_needing_image_flush.lock().unwrap().push(pe_node_id);
+            if needs_style_image_flush(pe_node, &pe_style) {
+                nodes_needing_style_image_flush
+                    .lock()
+                    .unwrap()
+                    .push(pe_node_id);
             }
         }
         pe_data.styles.primary = Some(pe_style);
@@ -1377,7 +1383,7 @@ fn sync_pseudo_element_styles(
 /// Whether a node's `background-image`/`mask-image` layers need flushing to
 /// dedicated storage on the node: its new style references image URLs, or the
 /// node has previously-flushed image data (which may need clearing).
-fn needs_image_flush(node: &Node, style: &ComputedValues) -> bool {
+fn needs_style_image_flush(node: &Node, style: &ComputedValues) -> bool {
     use style::values::computed::image::Image;
     fn has_url_image(images: &[Image]) -> bool {
         images.iter().any(|image| matches!(image, Image::Url(_)))

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -1381,23 +1381,37 @@ fn sync_pseudo_element_styles(
 }
 
 /// Whether a node's `background-image`/`mask-image` layers need flushing to
-/// dedicated storage on the node: its new style references image URLs, or the
-/// node has previously-flushed image data (which may need clearing).
+/// dedicated storage on the node: the URLs referenced by the new style differ
+/// from the image data currently stored on the node.
 fn needs_style_image_flush(node: &Node, style: &ComputedValues) -> bool {
+    use crate::node::ImageResourceData;
+    use style::url::ComputedUrl;
     use style::values::computed::image::Image;
-    fn has_url_image(images: &[Image]) -> bool {
-        images.iter().any(|image| matches!(image, Image::Url(_)))
-    }
 
-    if has_url_image(&style.get_background().background_image.0)
-        || has_url_image(&style.get_svg().mask_image.0)
-    {
-        return true;
+    fn out_of_sync(style_images: &[Image], stored: &[Option<ImageResourceData>]) -> bool {
+        if style_images.len() != stored.len() {
+            // Differing lengths only matter if either side references an image
+            // (a style list of `none` layers and empty storage are in sync).
+            return style_images
+                .iter()
+                .any(|image| matches!(image, Image::Url(_)))
+                || stored.iter().any(Option::is_some);
+        }
+        std::iter::zip(style_images, stored).any(|(style_image, stored)| {
+            match (style_image, stored) {
+                (Image::Url(ComputedUrl::Valid(url)), Some(data)) => **url != *data.url,
+                (Image::Url(ComputedUrl::Valid(_)), None) => true,
+                (_, Some(_)) => true,
+                (_, None) => false,
+            }
+        })
     }
 
     node.data.downcast_element().is_some_and(|el| {
-        el.background_images.iter().any(Option::is_some)
-            || el.mask_images.iter().any(Option::is_some)
+        out_of_sync(
+            &style.get_background().background_image.0,
+            &el.background_images,
+        ) || out_of_sync(&style.get_svg().mask_image.0, &el.mask_images)
     })
 }
 


### PR DESCRIPTION
## Summary

Removes the per-node `flush_image_layers_from_style` calls from the whole-tree `flush_styles_to_layout_impl` walk. Instead, nodes whose image layers may need syncing are queued during the style traversal and drained single-threaded afterwards — only nodes whose style actually changed pay, instead of every node on every resolve.

Because `flush_image_layers_from_style` mutates document-level state (`image_cache`, `pending_images`, `net_provider.fetch`) it can't run inside the (potentially parallel) Stylo traversal itself, hence the queue-and-drain split:

- `RecalcStyle` gains `nodes_needing_image_flush: Mutex<Vec<NodeId>>`. In `process_preorder`, an element with non-empty damage is queued when `needs_image_flush(el, new_primary_style)` — i.e. its new style references a `url()` image in `background-image`/`mask-image`, *or* the node already has flushed image data (covers the removal/clearing case). `sync_pseudo_element_styles` applies the same check when a pseudo-element's style changes.
- After `traverse_dom` returns, `resolve_stylist` moves the queue into `BaseDocument::pending_image_flush_nodes`. Pseudo-element box construction also pushes there when it creates a pseudo node or swaps in a new pseudo style (styles present at creation never go through the traversal path).
- A new `flush_pending_images` phase in `resolve` (after construction, before flush) sorts/dedups the queue, skips ids no longer in the slab, and runs the unchanged `flush_image_layers_from_style` for both layer kinds.

Nodes without URL images and without stored image data are never queued, so hover-style restyles that don't touch images add no work. Anonymous boxes are unaffected: their synthesized styles can't carry background/mask images (non-inherited properties).

Regression test `hover_updates_background_image_layers` covers initial flush, a hover-driven URL change, and the unhover restore.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/89fe3b9a876e43389d2ac10467bfca48
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/89fe3b9a876e43389d2ac10467bfca48?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32662619583).</sub>
<!-- wpt-results-end -->
