### PR TITLE
Skip background image layer clips when the layer paints nothing

### DIFF
--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -146,6 +146,9 @@ impl ElementCx<'_, '_> {
 
         for idx in (0..layer_count).rev() {
             let layer = ImageLayerStyles::from_background(bg_styles, image_data, idx);
+            if layer_paints_nothing(&layer) {
+                continue;
+            }
             let background_clip_path = self.box_path(layer.clip);
 
             self.context.layer_manager.maybe_with_layer(
@@ -864,6 +867,16 @@ fn compute_space_count_and_stride(bg_size: f64, size: f64) -> (u32, f64) {
     } + size;
 
     (count, stride)
+}
+
+/// Whether drawing the layer is guaranteed to paint nothing, making its clip
+/// layer unnecessary
+fn layer_paints_nothing(layer: &ImageLayerStyles) -> bool {
+    match layer.stylo_image {
+        GenericImage::None => true,
+        GenericImage::Url(_) => layer.image_data.is_none(),
+        _ => false,
+    }
 }
 
 #[inline]


### PR DESCRIPTION
## Summary

Second of two PRs skipping clip layers that provably have no effect (companion to #773, which handles `<img>` overflow clips; this one is the much larger win).

Profiling `paint_scene` at 1366x768 @ 2x on servo.org and the Wikipedia Barack Obama article showed clip layers are a major cost for the sparse-strips renderers (which process clips eagerly during encoding). `draw_background` pushed a clip layer unconditionally for *every* `background-image` layer — and since Stylo's computed `background-image` list is never empty, nearly every element pays for a clip layer for its default `background-image: none` entry. New `layer_paints_nothing` skips the layer when the computed image is `GenericImage::None`, or is a `url()` whose image resource hasn't loaded (in both cases `draw_image_layer` draws nothing). Unsupported image kinds (cross-fade, paint-worklet, image-set, …) keep their clip.

## Clip layers removed

Clip layers pushed per frame (hybrid backend, 1366x768 @ 2x, this PR alone): servo.org **276 → 18**, Wikipedia/Barack_Obama **1362 → 108** — ~93% of all clip layers on both pages.

## Benchmarks

`paint_bench` (from #772), 200 iterations at 1366x768 @ 2.0 scale, median of 3 runs (median µs), this PR alone vs main:

| Page | Backend | paint_scene before → after | rasterize before → after |
|---|---|---|---|
| servo.org | vello | 98 → 94 (−4%) | 4606 → 4806 (+4%) |
| servo.org | cpu | 8636 → 8602 (±0%) | 2365 → 2130 (−10%) |
| servo.org | hybrid | 1276 → 1325 (+4%)* | 3998 → 4103 (+3%) |
| Barack_Obama | vello | 530 → 472 (−11%) | 6442 → 5343 (−17%) |
| Barack_Obama | cpu | 1663 → 1618 (−3%) | 829 → 774 (−7%) |
| Barack_Obama | hybrid | 3169 → 2835 (−11%) | 4453 → 4501 (+1%) |

\* servo.org hybrid is very noisy run-to-run (same-binary medians ranged 649–1846µs across repeats); an earlier 3-run set measured 1801 → 1295 (−28%) for the combined change, of which this PR is ~98% of the clip reduction.

## Correctness

Screenshot comparison (`cargo run --example screenshot`) before/after (with both PRs applied):
- Local test page exercising `border-radius`+`overflow:hidden`, `object-fit: fill/contain/cover/none`, and overflowing content: byte-identical PNG.
- https://en.wikipedia.org/wiki/Barack_Obama: byte-identical PNG.
- https://servo.org: pixel-identical (0 differing pixels).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ed6e81208e334301aff4900bd1af28e4
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/ed6e81208e334301aff4900bd1af28e4?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32669787297).</sub>
<!-- wpt-results-end -->
