### PR TITLE
Update Taffy for negative-margin flex sizing fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=ce7eb101590369aa789808b5ffd6aa8ece2b717c#ce7eb101590369aa789808b5ffd6aa8ece2b717c"
+source = "git+https://github.com/DioxusLabs/taffy?rev=d680af586250a1472695489630e133a245cb7d01#d680af586250a1472695489630e133a245cb7d01"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=88125cecb1c0a35516b5c45efa07e96bae07b4b3#88125cecb1c0a35516b5c45efa07e96bae07b4b3"
+source = "git+https://github.com/DioxusLabs/taffy?rev=ce7eb101590369aa789808b5ffd6aa8ece2b717c#ce7eb101590369aa789808b5ffd6aa8ece2b717c"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "ce7eb101590369aa789808b5ffd6aa8ece2b717c", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d680af586250a1472695489630e133a245cb7d01", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "88125cecb1c0a35516b5c45efa07e96bae07b4b3", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "ce7eb101590369aa789808b5ffd6aa8ece2b717c", default-features = false, features = [
     "std",
     "flexbox",
     "grid",
@@ -308,4 +308,3 @@ rustc-hash = { workspace = true }
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,3 +308,4 @@ rustc-hash = { workspace = true }
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
+


### PR DESCRIPTION
## Summary

Pin Taffy to [`ce7eb101`](https://github.com/DioxusLabs/taffy/commit/ce7eb101590369aa789808b5ffd6aa8ece2b717c), the head of [Taffy PR #1152](https://github.com/DioxusLabs/taffy/pull/1152).

This brings in the intrinsic flex-sizing fix for negative main-axis margins on non-shrinking items and refreshes the lockfile to the same revision.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/1c82fa79d1824e7f83b83bebcdfb778a
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/1c82fa79d1824e7f83b83bebcdfb778a?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32678633356).</sub>
<!-- wpt-results-end -->
