### PR TITLE
Upgrade Taffy for measure cache axis fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=bc459bbb9ffb10c9bac85f917649a67a10f1367e#bc459bbb9ffb10c9bac85f917649a67a10f1367e"
+source = "git+https://github.com/DioxusLabs/taffy?rev=2c5715e6c7a12f54dfd839b2ac94f361af1a2ed4#2c5715e6c7a12f54dfd839b2ac94f361af1a2ed4"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=b27f2f78afae108cea537cb890207d193a27c9b8#b27f2f78afae108cea537cb890207d193a27c9b8"
+source = "git+https://github.com/DioxusLabs/taffy?rev=bc459bbb9ffb10c9bac85f917649a67a10f1367e#bc459bbb9ffb10c9bac85f917649a67a10f1367e"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=d680af586250a1472695489630e133a245cb7d01#d680af586250a1472695489630e133a245cb7d01"
+source = "git+https://github.com/DioxusLabs/taffy?rev=b27f2f78afae108cea537cb890207d193a27c9b8#b27f2f78afae108cea537cb890207d193a27c9b8"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d680af586250a1472695489630e133a245cb7d01", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b27f2f78afae108cea537cb890207d193a27c9b8", default-features = false, features = [
     "std",
     "flexbox",
     "grid",
@@ -308,4 +308,3 @@ rustc-hash = { workspace = true }
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "bc459bbb9ffb10c9bac85f917649a67a10f1367e", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "2c5715e6c7a12f54dfd839b2ac94f361af1a2ed4", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "b27f2f78afae108cea537cb890207d193a27c9b8", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "bc459bbb9ffb10c9bac85f917649a67a10f1367e", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,3 +308,4 @@ rustc-hash = { workspace = true }
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
+

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -437,11 +437,11 @@ impl LayoutPartialTree for BaseDocument {
 impl taffy::CacheTree for BaseDocument {
     #[inline]
     fn cache_get(
-        &self,
+        &mut self,
         node_id: NodeId,
         inputs: &taffy::LayoutInput,
     ) -> Option<taffy::LayoutOutput> {
-        self.node_from_id(node_id).cache().get(inputs)
+        self.node_from_id_mut(node_id).cache_mut().get(inputs)
     }
 
     #[inline]


### PR DESCRIPTION
## Summary
Pin Taffy to `b27f2f78`, the tip of `devin/1785483206-fix-measure-cache-axis`, which fixes axis handling in the measure cache. Adapt Blitz's `CacheTree::cache_get` implementation to the new mutable cache lookup API.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/7dfa80b22d3b4a8eaa88cc617fa69e11
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/7dfa80b22d3b4a8eaa88cc617fa69e11?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**23** newly passing, **0** newly failing (net +23).

<details>
<summary>Full diff (23 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/backgrounds/background-position-applies-to-013d.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-111.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b01.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b02.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b03.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b04.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b05.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b06.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b07.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b08.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b09.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b10.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b11.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003b12.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c01.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c02.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c03.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c04.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c05.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c06.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c07.xht
+ Fail => Pass css/CSS2/tables/fixed-table-layout-003c08.xht
+ Fail => Pass css/css-grid/layout-algorithm/grid-find-fr-size-gutters-001.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32750014710).</sub>
<!-- wpt-results-end -->
