### PR TITLE
Update Taffy (flexbox `ContentSize` sizing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=2c5715e6c7a12f54dfd839b2ac94f361af1a2ed4#2c5715e6c7a12f54dfd839b2ac94f361af1a2ed4"
+source = "git+https://github.com/DioxusLabs/taffy?rev=7bbf0ddd998df4b678c7ee2ef7c01a7ebaacdda6#7bbf0ddd998df4b678c7ee2ef7c01a7ebaacdda6"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=7bbf0ddd998df4b678c7ee2ef7c01a7ebaacdda6#7bbf0ddd998df4b678c7ee2ef7c01a7ebaacdda6"
+source = "git+https://github.com/DioxusLabs/taffy?rev=520ff53b9bdfbfdcc511a9637b03e34d5bfccfef#520ff53b9bdfbfdcc511a9637b03e34d5bfccfef"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "7bbf0ddd998df4b678c7ee2ef7c01a7ebaacdda6", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "520ff53b9bdfbfdcc511a9637b03e34d5bfccfef", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "2c5715e6c7a12f54dfd839b2ac94f361af1a2ed4", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "7bbf0ddd998df4b678c7ee2ef7c01a7ebaacdda6", default-features = false, features = [
     "std",
     "flexbox",
     "grid",


### PR DESCRIPTION
## Summary

Updates the `taffy` git dependency to current taffy main (`520ff53b`), which includes the now-merged DioxusLabs/taffy#1155 (flexbox applies inherent style sizing on top of `SizingMode::ContentSize` measures, fixing taffy#1149).

Also adapts `BaseDocument`'s `CacheTree` impl to the new `cache_get(&mut self, ...)` signature (`node_from_id` → `node_from_id_mut`, `cache` → `cache_mut`).

WPT results with this revision are identical to the previous pin (default suite: 1584/1687 tests passed/failed, 5112/8804 subtests passed; `css/CSS2/margin-padding-clear`: 648/34; per-test diff shows 0 changes).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d4ac61d19dd44d4a89dae618503bde4f
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/d4ac61d19dd44d4a89dae618503bde4f?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32754299746).</sub>
<!-- wpt-results-end -->
