### PR TITLE
Track taffy replaced-element fixes stack (taffy#1156–#1158)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=520ff53b9bdfbfdcc511a9637b03e34d5bfccfef#520ff53b9bdfbfdcc511a9637b03e34d5bfccfef"
+source = "git+https://github.com/DioxusLabs/taffy?rev=d66b6e6cf8188e349427e9a0059a7f527a7524a2#d66b6e6cf8188e349427e9a0059a7f527a7524a2"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "520ff53b9bdfbfdcc511a9637b03e34d5bfccfef", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d66b6e6cf8188e349427e9a0059a7f527a7524a2", default-features = false, features = [
     "std",
     "flexbox",
     "grid",


### PR DESCRIPTION
## Summary

Bumps the `taffy` git dependency `rev` to `d66b6e6c`, the HEAD of the taffy replaced-element PR stack:

1. DioxusLabs/taffy#1156 — image (replaced element) support in the test generator
2. DioxusLabs/taffy#1157 — replaced leaf transferred-size fix (intrinsic aspect ratio applied when only one dimension is specified)
3. DioxusLabs/taffy#1158 — replaced grid items default to `start` alignment per css-align-3 (fixes stretch and auto-track sizing of images in grid)

Draft while the stack is in review; I'll bump the `rev` as the stack updates and retarget to a taffy release once it lands.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e168cf7cbcd34c939e1cc5d4e000836b
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/e168cf7cbcd34c939e1cc5d4e000836b?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32756152544).</sub>
<!-- wpt-results-end -->
