### PR TITLE
Upgrade Taffy to v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7405,8 +7405,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=520ff53b9bdfbfdcc511a9637b03e34d5bfccfef#520ff53b9bdfbfdcc511a9637b03e34d5bfccfef"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "639627c87f43b9181c811f40a6296409e093a17bc761214cba3c15df74f86b99"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "520ff53b9bdfbfdcc511a9637b03e34d5bfccfef", default-features = false, features = [
+taffy = { version = "0.14.0", default-features = false, features = [
     "std",
     "flexbox",
     "grid",
@@ -308,4 +308,3 @@ rustc-hash = { workspace = true }
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,3 +308,4 @@ rustc-hash = { workspace = true }
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
+


### PR DESCRIPTION
## Summary

Replace the temporary Taffy git revision with the published `taffy = "0.14.0"` release, retaining the existing feature set.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f5071de0242e4941bc1eb3c6a190aa59
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/f5071de0242e4941bc1eb3c6a190aa59?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32767857438).</sub>
<!-- wpt-results-end -->
