### PR TITLE
Upgrade to anyrender_vello_cpu 0.17 (bounded image cache)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,8 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "anyrender"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e00e1af5c6ac9b1e8ed8e431529a1024b7386d5385dce2a83494da3d39a6bab5"
 dependencies = [
  "kurbo",
  "peniko",
@@ -328,7 +329,8 @@ dependencies = [
 [[package]]
 name = "anyrender_serialize"
 version = "0.7.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa3ca49ef372eb4477a70623b77f95d71eb5bdc40d71433459dc2dd9e00add82"
 dependencies = [
  "anyrender",
  "image",
@@ -346,7 +348,8 @@ dependencies = [
 [[package]]
 name = "anyrender_skia"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fd22e1d5b834ec2da56a85f9f27c578e00335f5b135a753ae8963828f0d460"
 dependencies = [
  "anyrender",
  "ash",
@@ -373,7 +376,8 @@ dependencies = [
 [[package]]
 name = "anyrender_svg"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a06a9cab20563ae5b392239db09d42222820fd3706fe483db7d3cb25546c24"
 dependencies = [
  "anyrender",
  "image",
@@ -385,7 +389,8 @@ dependencies = [
 [[package]]
 name = "anyrender_vello"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1301d68b8d7a9333c242225bb026dc08f70a5b0ab096087866c06ceab227de5"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -402,8 +407,9 @@ dependencies = [
 
 [[package]]
 name = "anyrender_vello_cpu"
-version = "0.16.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb392bf738b1e50c50fc82824ff3f875f15632717ba732fe68e2fe6e1011e6c"
 dependencies = [
  "anyrender",
  "bytemuck",
@@ -421,7 +427,8 @@ dependencies = [
 [[package]]
 name = "anyrender_vello_hybrid"
 version = "0.10.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acface501bfa9d5b2abf9413ee5728ded41bd7f9c63b24162b9ea54f431d7e4f"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5725,7 +5732,8 @@ dependencies = [
 [[package]]
 name = "pixels_window_renderer"
 version = "0.8.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320b195ebb5b4513d7c538fc7686ebd4ee3fa1f945e5995c70338f6d78fb07de"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7031,7 +7039,8 @@ dependencies = [
 [[package]]
 name = "softbuffer_window_renderer"
 version = "0.8.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce2a1c61716161a23530df2c507a7dd3f132a149789c5700f24f2893a3a877"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8870,7 +8879,8 @@ dependencies = [
 [[package]]
 name = "wgpu_context"
 version = "0.9.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6c2553d5b114dfd941fa3372c7df1e1cde7bd81800e89aa13b7e3af2e4be9b"
 dependencies = [
  "futures-intrusive",
  "wgpu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -316,7 +316,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "anyrender"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "kurbo",
  "peniko",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "anyrender_serialize"
 version = "0.7.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "anyrender",
  "image",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "anyrender_skia"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "anyrender",
  "ash",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "anyrender_svg"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "anyrender",
  "image",
@@ -385,7 +385,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello_cpu"
 version = "0.16.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "anyrender",
  "bytemuck",
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello_hybrid"
 version = "0.10.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1530,7 +1530,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2516,7 +2516,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2785,7 +2785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4935,7 +4935,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5725,7 +5725,7 @@ dependencies = [
 [[package]]
 name = "pixels_window_renderer"
 version = "0.8.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6433,7 +6433,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6993,7 +6993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7031,7 +7031,7 @@ dependencies = [
 [[package]]
 name = "softbuffer_window_renderer"
 version = "0.8.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7434,7 +7434,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7453,7 +7453,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8007,7 +8007,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "wgpu_context"
 version = "0.9.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9ae41e88c547aeae9d840c2d614579db4b24de07#9ae41e88c547aeae9d840c2d614579db4b24de07"
 dependencies = [
  "futures-intrusive",
  "wgpu",
@@ -8941,7 +8941,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,8 +316,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "anyrender"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00e1af5c6ac9b1e8ed8e431529a1024b7386d5385dce2a83494da3d39a6bab5"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "kurbo",
  "peniko",
@@ -329,8 +328,7 @@ dependencies = [
 [[package]]
 name = "anyrender_serialize"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3ca49ef372eb4477a70623b77f95d71eb5bdc40d71433459dc2dd9e00add82"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "anyrender",
  "image",
@@ -348,8 +346,7 @@ dependencies = [
 [[package]]
 name = "anyrender_skia"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fd22e1d5b834ec2da56a85f9f27c578e00335f5b135a753ae8963828f0d460"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "anyrender",
  "ash",
@@ -376,8 +373,7 @@ dependencies = [
 [[package]]
 name = "anyrender_svg"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06a9cab20563ae5b392239db09d42222820fd3706fe483db7d3cb25546c24"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "anyrender",
  "image",
@@ -389,8 +385,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1301d68b8d7a9333c242225bb026dc08f70a5b0ab096087866c06ceab227de5"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,10 +403,11 @@ dependencies = [
 [[package]]
 name = "anyrender_vello_cpu"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcae178cb9738b1e74d21db66c0e269f6d9c146d6e45bde66674cb1b8dcd062"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "anyrender",
+ "bytemuck",
+ "color",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "glifo",
  "kurbo",
@@ -425,8 +421,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello_hybrid"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acface501bfa9d5b2abf9413ee5728ded41bd7f9c63b24162b9ea54f431d7e4f"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5730,8 +5725,7 @@ dependencies = [
 [[package]]
 name = "pixels_window_renderer"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320b195ebb5b4513d7c538fc7686ebd4ee3fa1f945e5995c70338f6d78fb07de"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7037,8 +7031,7 @@ dependencies = [
 [[package]]
 name = "softbuffer_window_renderer"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce2a1c61716161a23530df2c507a7dd3f132a149789c5700f24f2893a3a877"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8877,8 +8870,7 @@ dependencies = [
 [[package]]
 name = "wgpu_context"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6c2553d5b114dfd941fa3372c7df1e1cde7bd81800e89aa13b7e3af2e4be9b"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
 dependencies = [
  "futures-intrusive",
  "wgpu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -316,7 +316,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "anyrender"
 version = "0.13.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "kurbo",
  "peniko",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "anyrender_serialize"
 version = "0.7.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "anyrender",
  "image",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "anyrender_skia"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "anyrender",
  "ash",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "anyrender_svg"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "anyrender",
  "image",
@@ -385,7 +385,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello_cpu"
 version = "0.16.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "anyrender",
  "bytemuck",
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "anyrender_vello_hybrid"
 version = "0.10.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1530,7 +1530,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2516,7 +2516,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2785,7 +2785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4935,7 +4935,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5725,7 +5725,7 @@ dependencies = [
 [[package]]
 name = "pixels_window_renderer"
 version = "0.8.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6433,7 +6433,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6993,7 +6993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7031,7 +7031,7 @@ dependencies = [
 [[package]]
 name = "softbuffer_window_renderer"
 version = "0.8.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "anyrender",
  "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7434,7 +7434,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7453,7 +7453,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8007,7 +8007,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "wgpu_context"
 version = "0.9.0"
-source = "git+https://github.com/DioxusLabs/anyrender?rev=5759af1c2f47bdb1452b932e7ec7f16e13167c7a#5759af1c2f47bdb1452b932e7ec7f16e13167c7a"
+source = "git+https://github.com/DioxusLabs/anyrender?rev=9e0bb767f47c05104758d76ee1f64e0a50a0879f#9e0bb767f47c05104758d76ee1f64e0a50a0879f"
 dependencies = [
  "futures-intrusive",
  "wgpu",
@@ -8941,7 +8941,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,14 +111,14 @@ skrifa = { version = "0.44", default-features = false, features = [
 ] } # Should match parley and vello versions
 
 # AnyRender
-anyrender = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
-anyrender_serialize = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
-anyrender_skia = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
-anyrender_vello = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
-anyrender_vello_cpu = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
-anyrender_vello_hybrid = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
-anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
-wgpu_context = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
+anyrender = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
+anyrender_serialize = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
+anyrender_skia = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
+anyrender_vello = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
+anyrender_vello_cpu = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
+anyrender_vello_hybrid = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
+anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
+wgpu_context = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
 
 # Linebender + Fontations + WGPU + SVG
 color = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,14 +111,14 @@ skrifa = { version = "0.44", default-features = false, features = [
 ] } # Should match parley and vello versions
 
 # AnyRender
-anyrender = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
-anyrender_serialize = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
-anyrender_skia = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
-anyrender_vello = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
-anyrender_vello_cpu = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
-anyrender_vello_hybrid = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
-anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
-wgpu_context = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
+anyrender = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
+anyrender_serialize = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
+anyrender_skia = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
+anyrender_vello = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
+anyrender_vello_cpu = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
+anyrender_vello_hybrid = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
+anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
+wgpu_context = { git = "https://github.com/DioxusLabs/anyrender", rev = "9e0bb767f47c05104758d76ee1f64e0a50a0879f" }
 
 # Linebender + Fontations + WGPU + SVG
 color = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,14 +111,14 @@ skrifa = { version = "0.44", default-features = false, features = [
 ] } # Should match parley and vello versions
 
 # AnyRender
-anyrender = { version = "0.13.0" }
-anyrender_serialize = { version = "0.7.0" }
-anyrender_skia = { version = "0.11.0" }
-anyrender_vello = { version = "0.14.0" }
-anyrender_vello_cpu = { version = "0.16.0" }
-anyrender_vello_hybrid = { version = "0.10.0" }
-anyrender_svg = { version = "0.14.0" }
-wgpu_context = { version = "0.9.0" }
+anyrender = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
+anyrender_serialize = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
+anyrender_skia = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
+anyrender_vello = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
+anyrender_vello_cpu = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
+anyrender_vello_hybrid = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
+anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
+wgpu_context = { git = "https://github.com/DioxusLabs/anyrender", rev = "5759af1c2f47bdb1452b932e7ec7f16e13167c7a" }
 
 # Linebender + Fontations + WGPU + SVG
 color = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,14 +111,14 @@ skrifa = { version = "0.44", default-features = false, features = [
 ] } # Should match parley and vello versions
 
 # AnyRender
-anyrender = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
-anyrender_serialize = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
-anyrender_skia = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
-anyrender_vello = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
-anyrender_vello_cpu = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
-anyrender_vello_hybrid = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
-anyrender_svg = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
-wgpu_context = { git = "https://github.com/DioxusLabs/anyrender", rev = "9ae41e88c547aeae9d840c2d614579db4b24de07" }
+anyrender = { version = "0.13.0" }
+anyrender_serialize = { version = "0.7.0" }
+anyrender_skia = { version = "0.11.0" }
+anyrender_vello = { version = "0.14.0" }
+anyrender_vello_cpu = { version = "0.17.0" }
+anyrender_vello_hybrid = { version = "0.10.0" }
+anyrender_svg = { version = "0.14.0" }
+wgpu_context = { version = "0.9.0" }
 
 # Linebender + Fontations + WGPU + SVG
 color = "0.3"

--- a/examples/paint_bench.rs
+++ b/examples/paint_bench.rs
@@ -6,9 +6,10 @@
 //! Usage: paint_bench <url> [width] [height] [scale] [iters] [backend]
 //!   backend: vello (default) | cpu | hybrid
 
+use anyrender::ImageRenderer as _;
 use anyrender::PaintScene as _;
 use anyrender_vello::VelloScenePainter;
-use anyrender_vello_cpu::VelloCpuScenePainter;
+use anyrender_vello_cpu::VelloCpuImageRenderer;
 use anyrender_vello_hybrid::{ImageManager, VelloHybridScenePainter};
 use blitz_dom::DocumentConfig;
 use blitz_html::HtmlDocument;
@@ -179,40 +180,30 @@ async fn main() {
             });
         }
         "cpu" | "vello_cpu" => {
-            let mut painter = VelloCpuScenePainter {
-                render_ctx: vello_cpu::RenderContext::new(
-                    render_width as u16,
-                    render_height as u16,
-                ),
-                resources: vello_cpu::Resources::new(),
-            };
+            let mut renderer = VelloCpuImageRenderer::new(render_width, render_height);
             let mut buffer = vec![0u8; render_width as usize * render_height as usize * 4];
             bench(iters, || {
-                let encode_start = Instant::now();
-                painter.reset();
-                paint_scene(
-                    &mut painter,
-                    document.as_mut(),
-                    scale,
-                    render_width,
-                    render_height,
-                    0,
-                    0,
+                let total_start = Instant::now();
+                let mut encode = 0u128;
+                renderer.render(
+                    |painter| {
+                        let encode_start = Instant::now();
+                        painter.reset();
+                        paint_scene(
+                            painter,
+                            document.as_mut(),
+                            scale,
+                            render_width,
+                            render_height,
+                            0,
+                            0,
+                        );
+                        encode = encode_start.elapsed().as_micros();
+                    },
+                    &mut buffer,
                 );
-                let encode = encode_start.elapsed().as_micros();
-
-                let raster_start = Instant::now();
-                painter.render_ctx.flush();
-                painter.render_ctx.render(
-                    vello_cpu::PixmapMut::new(
-                        render_width as u16,
-                        render_height as u16,
-                        &mut buffer,
-                    )
-                    .unwrap(),
-                    &mut painter.resources,
-                );
-                (encode, raster_start.elapsed().as_micros())
+                let total = total_start.elapsed().as_micros();
+                (encode, total - encode)
             });
         }
         "hybrid" | "vello_hybrid" => {


### PR DESCRIPTION
## Summary

Upgrades `anyrender_vello_cpu` to the published 0.17.0 release, which replaces the `experimental_image_cache` feature with a built-in bounded per-renderer image cache (DioxusLabs/anyrender#91). Other anyrender crates are unchanged (no new releases).

- `examples/paint_bench.rs` adapted to the new API: `VelloCpuScenePainter`'s fields are now private, so the cpu path uses `VelloCpuImageRenderer::new(w, h)` + `renderer.render(|painter| ..., &mut buffer)` (which also runs the cache's per-frame `maintain()`); rasterize time is measured as total − encode.

On image-heavy pages (e.g. servo.org) this drops steady-state cpu-backend paint encode time by ~28× versus uncached conversion, with the cache bounded by age (64 frames) and byte budget (64 MiB) and auto-evicting when source image data is dropped.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/8e954fa711924513bbbcf2ee117f2f98
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/8e954fa711924513bbbcf2ee117f2f98?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32772481617).</sub>
<!-- wpt-results-end -->
