### PR TITLE
Generate anonymous table cells for non-table-internal children of tables

### DIFF
--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -259,22 +259,40 @@ pub(crate) fn collect_table_cells(
             }
             doc.nodes[node_id].children = children;
         }
-        DisplayInside::TableCell => {
+        // Table-cell children, plus non-table-internal children which, per the
+        // CSS tables spec, generate an anonymous table cell around them.
+        DisplayInside::TableCell
+        | DisplayInside::Flow
+        | DisplayInside::FlowRoot
+        | DisplayInside::Flex
+        | DisplayInside::Grid => {
             // node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
+            let is_cell = display.inside() == DisplayInside::TableCell;
             let stylo_style = &node.primary_styles().unwrap();
-            let colspan: u16 = node
-                .attr(local_name!("colspan"))
-                .and_then(|val| val.parse().ok())
-                .unwrap_or(1);
-            let rowspan: u16 = node
-                .attr(local_name!("rowspan"))
-                .and_then(|val| val.parse::<u16>().ok())
-                .map(|v| v.clamp(1, 65534))
-                .unwrap_or(1);
+            let colspan: u16 = if is_cell {
+                node.attr(local_name!("colspan"))
+                    .and_then(|val| val.parse().ok())
+                    .unwrap_or(1)
+            } else {
+                1
+            };
+            let rowspan: u16 = if is_cell {
+                node.attr(local_name!("rowspan"))
+                    .and_then(|val| val.parse::<u16>().ok())
+                    .map(|v| v.clamp(1, 65534))
+                    .unwrap_or(1)
+            } else {
+                1
+            };
             let mut style = stylo_taffy::to_taffy_style(stylo_style);
 
-            if first_cell_border.is_none() {
+            if is_cell && first_cell_border.is_none() {
                 *first_cell_border = Some(stylo_style.clone_border());
+            }
+
+            // Cells occurring before any row are placed in an anonymous row
+            if *row == 0 {
+                *row = 1;
             }
 
             if *row == 1 {
@@ -308,12 +326,14 @@ pub(crate) fn collect_table_cells(
 
             // Zero-out cell borders is BorderCollapse is Collapse
             // Borders are handled at the table level in this mode
-            if border_collapse == BorderCollapse::Collapse {
+            if is_cell && border_collapse == BorderCollapse::Collapse {
                 style.border = taffy::Rect::ZERO.map(style_helpers::length);
             }
 
             // The margin properties do not apply to table-internal elements
-            style.margin = taffy::Rect::ZERO.map(style_helpers::length);
+            if is_cell {
+                style.margin = taffy::Rect::ZERO.map(style_helpers::length);
+            }
 
             // Let Taffy auto-place the column. Combined with
             // `grid_auto_flow: RowDense` set on the table root, each cell
@@ -332,17 +352,6 @@ pub(crate) fn collect_table_cells(
             cells.push(TableCell { node_id, style });
 
             *col += colspan;
-        }
-        DisplayInside::Flow
-        | DisplayInside::FlowRoot
-        | DisplayInside::Flex
-        | DisplayInside::Grid => {
-            node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
-            // Probably a table caption: ignore
-            // println!(
-            //     "Warning: ignoring non-table typed descendent of table ({:?})",
-            //     display.inside()
-            // );
         }
         DisplayInside::TableColumnGroup | DisplayInside::TableColumn | DisplayInside::Table => {
             node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);

--- a/tests/blitz-tests/tests/table_anonymous_cell.rs
+++ b/tests/blitz-tests/tests/table_anonymous_cell.rs
@@ -1,0 +1,72 @@
+//! Non-table-internal children of a `display: table` element generate an
+//! anonymous table cell (CSS 2.2 §17.2.1), so they must be laid out and
+//! hit-testable. Regression test for the gov.uk search box, whose input
+//! sits inside plain block `<div>`s that are direct children of a
+//! `display: table` wrapper.
+
+use blitz_test_harness::{Harness, HarnessOptions};
+
+fn harness(html: &str) -> Harness {
+    Harness::from_html_with(
+        html,
+        HarnessOptions {
+            width: 400,
+            height: 200,
+            ..Default::default()
+        },
+    )
+}
+
+#[test]
+fn block_children_of_table_are_laid_out_as_anonymous_cells() {
+    let harness = harness(
+        r#"<html><body style="margin:0">
+        <div style="display:table; width:400px;">
+            <div id="input-wrapper" style="width:100%;">
+                <input id="search" type="search" style="width:100%; height:40px; margin:0; box-sizing:border-box;">
+            </div>
+            <div id="button-wrapper" style="width:40px;">
+                <button style="width:40px; height:40px;">Go</button>
+            </div>
+        </div>
+    </body></html>"#,
+    );
+
+    let wrapper_rect = harness.layout_rect("#input-wrapper");
+    assert!(
+        wrapper_rect.width > 0.0 && wrapper_rect.height > 0.0,
+        "block child of table should be laid out, got {wrapper_rect:?}"
+    );
+
+    let input_rect = harness.layout_rect("#search");
+    assert!(
+        input_rect.width > 0.0 && input_rect.height > 0.0,
+        "input inside table's block child should be laid out, got {input_rect:?}"
+    );
+
+    let input = harness.node("#search");
+    let (cx, cy) = harness.center_of("#search");
+    assert_eq!(
+        harness.hit_node(cx, cy),
+        input,
+        "input inside table's block child should be hit-testable"
+    );
+}
+
+#[test]
+fn clicking_input_inside_table_block_child_focuses_it() {
+    let mut harness = harness(
+        r#"<html><body style="margin:0">
+        <div style="display:table; width:400px;">
+            <div style="width:100%;">
+                <input id="search" type="search" style="width:100%; height:40px; margin:0; box-sizing:border-box;">
+            </div>
+        </div>
+    </body></html>"#,
+    );
+
+    let input = harness.node("#search");
+    let (cx, cy) = harness.center_of("#search");
+    harness.click_at(cx, cy);
+    assert_eq!(harness.focused(), Some(input));
+}


### PR DESCRIPTION
## Summary

Fixes the gov.uk homepage search box being unclickable.

**Root cause:** gov.uk's search component wraps the `<input>` in plain block `<div>`s that are direct children of a `display: table` element. In `collect_table_cells`, children with `DisplayInside::Flow`/`FlowRoot`/`Flex`/`Grid` were silently ignored ("probably a table caption"), so they were never added as layout children of the table grid. The input's wrapper (and the input) therefore got no layout at all — `final_layout()` stayed `0x0` — and `Node::hit_inner` rejects zero-sized nodes, making the search box impossible to click.

**Fix:** per CSS 2.2 §17.2.1, non-table-internal children of a table generate an anonymous table cell around them. `collect_table_cells` now treats such children like table cells (as their own anonymous single-span cell in the current row, bumping `*row` from 0 to 1 when they occur before any row), while skipping cell-only handling (`colspan`/`rowspan` attributes, border-collapse border zeroing, margin zeroing, first-cell-border capture) for non-cell children.

Verified against https://www.gov.uk: the search input now lays out at its rendered size and hit-testing at its center returns the input node; the rendered screenshot is unchanged/correct.

Regression tests added in `tests/blitz-tests/tests/table_anonymous_cell.rs` (layout + hit-test, and click-to-focus for an input inside a table's block child).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e0b69caedcd34e829ff73fb7ff216a75
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/e0b69caedcd34e829ff73fb7ff216a75?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**71** newly passing, **19** newly failing (net +52).

<details>
<summary>Full diff (90 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/backgrounds/background-applies-to-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-attachment-applies-to-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-color-applies-to-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-applies-to-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-applies-to-015.xht
- Pass => Fail css/CSS2/bidi-text/bidi-008a.xht
- Pass => Fail css/CSS2/bidi-text/bidi-008b.xht
+ Fail => Pass css/CSS2/borders/border-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-bottom-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-bottom-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-left-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-left-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-left-width-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-right-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-right-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-right-width-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-top-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-top-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-top-width-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-width-applies-to-015.xht
+ Fail => Pass css/CSS2/colors/color-applies-to-015.xht
- Pass => Fail css/CSS2/css21-errata/s-11-1-1b-001.html
- Pass => Fail css/CSS2/css21-errata/s-11-1-1b-008.html
- Pass => Fail css/CSS2/css21-errata/s-11-1-1b-009.html
+ Fail => Pass css/CSS2/fonts/font-applies-to-015.xht
+ Fail => Pass css/CSS2/fonts/font-variant-applies-to-015.xht
+ Fail => Pass css/CSS2/fonts/font-weight-applies-to-015.xht
+ Fail => Pass css/CSS2/linebox/vertical-align-applies-to-015.xht
+ Fail => Pass css/CSS2/lists/list-style-applies-to-015.xht
+ Fail => Pass css/CSS2/lists/list-style-image-applies-to-015.xht
+ Fail => Pass css/CSS2/lists/list-style-type-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-top-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-bottom-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-left-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-top-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/height-applies-to-015.xht
- Pass => Fail css/CSS2/normal-flow/inline-table-002a.xht
- Pass => Fail css/CSS2/normal-flow/inline-table-width-002b.xht
+ Fail => Pass css/CSS2/normal-flow/inline-table-zorder-002.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/min-width-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/width-applies-to-015.xht
+ Fail => Pass css/CSS2/tables/anonymous-table-box-width-001.xht
+ Fail => Pass css/CSS2/text/letter-spacing-applies-to-015.xht
+ Fail => Pass css/CSS2/text/text-decoration-applies-to-015.xht
+ Fail => Pass css/CSS2/text/text-indent-applies-to-015.xht
+ Fail => Pass css/CSS2/text/white-space-applies-to-015.xht
+ Fail => Pass css/CSS2/text/word-spacing-applies-to-015.xht
- Pass => Fail css/CSS2/ui/outline-applies-to-016.xht
- Pass => Fail css/CSS2/ui/outline-applies-to-017.xht
- Pass => Fail css/css-break/table/break-before-second-row.html
- Pass => Fail css/css-break/table/caption-margin-002.html
- Pass => Fail css/css-break/table/caption-margin-005.html
+ Fail => Pass css/css-break/table/inside-flex-001.html
+ Fail => Pass css/css-break/table/monolithic-overflow-002.tentative.html
+ Fail => Pass css/css-break/table/monolithic-overflow-004.tentative.html
+ Fail => Pass css/css-break/table/repeated-section/image.tentative.html
+ Fail => Pass css/css-contain/contain-inline-size-table.html
- Pass => Fail css/css-contain/contain-size-056.html
- Pass => Fail css/css-contain/contain-size-table-caption-001.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-094.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-095.html
+ Fail => Pass css/css-flexbox/flexbox_flex-formatting-interop.html
+ Fail => Pass css/css-flexbox/flexbox_stf-table-singleline-2.html
+ Fail => Pass css/css-flexbox/flexbox_stf-table-singleline.html
- Pass => Fail css/css-flexbox/table-as-item-flex-cross-size.html
+ Fail => Pass css/css-flexbox/table-as-item-narrow-content.html
- Pass => Fail css/css-flexbox/table-as-item-stretch-cross-size-2.html
- Pass => Fail css/css-flexbox/table-as-item-stretch-cross-size.html
+ Fail => Pass css/css-flexbox/table-with-float-paint.html
+ Fail => Pass css/css-grid/grid-items/explicitly-sized-grid-item-as-table.html
+ Fail => Pass css/css-page/monolithic-overflow-009-print.html
+ Fail => Pass css/css-page/monolithic-overflow-010-print.html
+ Fail => Pass css/css-page/monolithic-overflow-011-print.html
+ Fail => Pass css/css-page/monolithic-overflow-017-print.html
+ Fail => Pass css/css-sizing/calc-margins-table-caption.html
+ Fail => Pass css/css-sizing/table-child-percentage-height-with-border-box.html
+ Fail => Pass css/css-sizing/table-percentage-max-width-beside-float.html
+ Fail => Pass css/css-tables/html-display-table.html
+ Fail => Pass css/css-tables/percent-height-overflow-auto-in-restricted-block-size-cell.html
+ Fail => Pass css/css-tables/percent-height-overflow-auto-in-unrestricted-block-size-cell.tentative.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32786891050).</sub>
<!-- wpt-results-end -->
