### PR TITLE
Avoid full restyle on viewport resize

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -44,6 +44,7 @@ use std::task::{Context as TaskContext, Waker};
 use style::Atom;
 use style::animation::DocumentAnimationSet;
 use style::attr::{AttrIdentifier, AttrValue};
+use style::computed_value_flags::ComputedValueFlags;
 use style::data::{ElementData as StyloElementData, ElementStyles};
 use style::media_queries::MediaType;
 use style::properties::ComputedValues;
@@ -2071,6 +2072,10 @@ impl BaseDocument {
         }
         drop(root_styles);
 
+        let old_device = self.stylist.device();
+        let viewport_size_changed = old_device.au_viewport_size() != device.au_viewport_size();
+        let styles_use_viewport_units = old_device.used_viewport_size();
+
         let origins = {
             let guard = &self.guard;
             let guards = StylesheetGuards {
@@ -2079,7 +2084,31 @@ impl BaseDocument {
             };
             self.stylist.set_device(device, &guards)
         };
-        self.stylist.force_stylesheet_origins_dirty(origins);
+
+        // Only fully invalidate element styles when the media query results of
+        // some origin actually changed. `force_stylesheet_origins_dirty` fully
+        // invalidates styles even when `origins` is empty, which would force a
+        // full restyle on every viewport resize.
+        if !origins.is_empty() {
+            self.stylist.force_stylesheet_origins_dirty(origins);
+        }
+
+        // Styles that resolve viewport units (vw/vh/etc) still need recomputing
+        // when the viewport size changes, even if no media query results
+        // changed. Invalidate just the elements whose styles use viewport
+        // units (tracked via per-element computed value flags).
+        if viewport_size_changed && styles_use_viewport_units {
+            if self
+                .stylist
+                .get_custom_property_initial_values_flags()
+                .intersects(ComputedValueFlags::USES_VIEWPORT_UNITS)
+            {
+                self.stylist.rebuild_initial_values_for_custom_properties();
+            }
+            if let Some(root) = self.try_root_element() {
+                style::invalidation::viewport_units::invalidate(root);
+            }
+        }
     }
 
     pub fn stylist_device(&mut self) -> &Device {

--- a/tests/blitz-tests/tests/resize_restyle.rs
+++ b/tests/blitz-tests/tests/resize_restyle.rs
@@ -1,0 +1,94 @@
+//! A viewport resize should not restyle the whole document: styles are only
+//! invalidated for origins whose media query results changed and for elements
+//! whose styles use viewport units (vw/vh/etc).
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+const HTML: &str = r#"<!DOCTYPE html>
+<html><head><style>
+    body { margin: 0; }
+    #static { width: 100px; height: 20px; }
+    #vw { width: 50vw; height: 10vh; }
+    #mq { width: 10px; }
+    @media (min-width: 850px) {
+        #mq { width: 30px; }
+    }
+</style></head>
+<body><div id="static"></div><div id="vw"></div><div id="mq"></div></body></html>
+"#;
+
+fn make_doc(width: u32, height: u32) -> HtmlDocument {
+    HtmlDocument::from_html(
+        HTML,
+        DocumentConfig {
+            viewport: Some(Viewport::new(width, height, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    )
+}
+
+fn used_width(doc: &HtmlDocument, selector: &str) -> f32 {
+    let id = doc.query_selector(selector).unwrap().unwrap();
+    doc.get_node(id).unwrap().final_layout().size.width
+}
+
+fn style_ptr(doc: &HtmlDocument, selector: &str) -> *const () {
+    let id = doc.query_selector(selector).unwrap().unwrap();
+    let node = doc.get_node(id).unwrap();
+    let styles = node.primary_styles().unwrap();
+    std::ptr::from_ref(&**styles).cast()
+}
+
+#[test]
+fn viewport_units_update_after_resize() {
+    let mut doc = make_doc(800, 600);
+    doc.resolve(0.0);
+
+    assert_eq!(used_width(&doc, "#vw"), 400.0);
+
+    doc.viewport_mut().window_size = (700, 600);
+    doc.resolve(0.0);
+
+    assert_eq!(used_width(&doc, "#vw"), 350.0);
+}
+
+#[test]
+fn media_query_flip_updates_styles_after_resize() {
+    let mut doc = make_doc(800, 600);
+    doc.resolve(0.0);
+
+    assert_eq!(used_width(&doc, "#mq"), 10.0);
+
+    doc.viewport_mut().window_size = (900, 600);
+    doc.resolve(0.0);
+
+    assert_eq!(used_width(&doc, "#mq"), 30.0);
+
+    doc.viewport_mut().window_size = (800, 600);
+    doc.resolve(0.0);
+
+    assert_eq!(used_width(&doc, "#mq"), 10.0);
+}
+
+#[test]
+fn resize_does_not_restyle_viewport_independent_elements() {
+    let mut doc = make_doc(800, 600);
+    doc.resolve(0.0);
+
+    let static_style = style_ptr(&doc, "#static");
+    let vw_style = style_ptr(&doc, "#vw");
+
+    // Resize without crossing the media query breakpoint.
+    doc.viewport_mut().window_size = (820, 600);
+    doc.resolve(0.0);
+
+    // The viewport-unit-using element was restyled...
+    assert_eq!(used_width(&doc, "#vw"), 410.0);
+    assert_ne!(style_ptr(&doc, "#vw"), vw_style);
+    // ...but the viewport-independent element kept its computed style.
+    assert_eq!(style_ptr(&doc, "#static"), static_style);
+}


### PR DESCRIPTION
## Summary

Resizing the window currently forces a full document restyle: `set_stylist_device` calls `stylist.force_stylesheet_origins_dirty(origins)` unconditionally after `set_device`, and stylo's `DocumentStylesheetSet::force_dirty` calls `invalidations.invalidate_fully()` *even when the `OriginSet` is empty*, which inserts `restyle_subtree()` on the root at the next `flush().process_style()`.

This adopts Gecko's strategy (`Servo_StyleSet_MediumFeaturesChanged` / `Servo_InvalidateForViewportUnits`):

```rust
// set_stylist_device
let origins = self.stylist.set_device(device, &guards); // origins whose MQ results changed
if !origins.is_empty() {
    self.stylist.force_stylesheet_origins_dirty(origins); // full invalidation only on MQ flip
}
if viewport_size_changed && old_device.used_viewport_size() {
    // rebuild registered custom-property initial values if they use viewport units
    style::invalidation::viewport_units::invalidate(root); // per-element USES_VIEWPORT_UNITS flags:
                                                           // RECASCADE_SELF / RESTYLE_SELF only
}
```

So a resize that doesn't cross any media-query breakpoint restyles only elements whose styles actually use viewport units (`vw`/`vh`/...) — usually zero — instead of the whole tree. `device.used_viewport_size()` is set lazily by stylo when style computation reads the viewport size, so pages with no viewport units skip the invalidation walk entirely.

New tests in `tests/blitz-tests/tests/resize_restyle.rs` verify vw elements update on resize, media-query flips still apply, and viewport-independent elements keep their computed style (pointer identity) across a resize — the last one fails without this change.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ff356f9bd164441fbeb42f24f9bde7c3
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/ff356f9bd164441fbeb42f24f9bde7c3?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32782982078).</sub>
<!-- wpt-results-end -->
