### PR TITLE
Fix zoom_by/zoom_to skipping inline-context invalidation and redraw

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1985,13 +1985,11 @@ impl BaseDocument {
     }
 
     pub fn zoom_by(&mut self, increment: f32) {
-        *self.viewport.zoom_mut() += increment;
-        self.set_viewport(self.viewport.clone());
+        *self.viewport_mut().zoom_mut() += increment;
     }
 
     pub fn zoom_to(&mut self, zoom: f32) {
-        *self.viewport.zoom_mut() = zoom;
-        self.set_viewport(self.viewport.clone());
+        *self.viewport_mut().zoom_mut() = zoom;
     }
 
     pub fn get_viewport(&self) -> Viewport {
@@ -2701,6 +2699,42 @@ impl AsRef<BaseDocument> for BaseDocument {
 impl AsMut<BaseDocument> for BaseDocument {
     fn as_mut(&mut self) -> &mut BaseDocument {
         self
+    }
+}
+
+#[cfg(test)]
+mod zoom_tests {
+    use super::*;
+    use blitz_traits::shell::ColorScheme;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Default)]
+    struct CountingShellProvider {
+        redraw_count: AtomicUsize,
+    }
+    impl ShellProvider for CountingShellProvider {
+        fn request_redraw(&self) {
+            self.redraw_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn zoom_requests_redraw() {
+        let shell_provider = Arc::new(CountingShellProvider::default());
+        let mut doc = BaseDocument::new(DocumentConfig {
+            viewport: Some(Viewport::new(400, 300, 1.0, ColorScheme::Light)),
+            shell_provider: Some(shell_provider.clone() as _),
+            ..Default::default()
+        });
+        doc.resolve(0.0);
+
+        let base = shell_provider.redraw_count.load(Ordering::SeqCst);
+        doc.zoom_by(0.5);
+        assert!(shell_provider.redraw_count.load(Ordering::SeqCst) > base);
+
+        let base = shell_provider.redraw_count.load(Ordering::SeqCst);
+        doc.zoom_to(1.0);
+        assert!(shell_provider.redraw_count.load(Ordering::SeqCst) > base);
     }
 }
 


### PR DESCRIPTION
## Summary

`BaseDocument::zoom_by`/`zoom_to` mutate `self.viewport.zoom` first and then call `set_viewport(self.viewport.clone())`. Inside `set_viewport`, `scale_has_changed` compares the incoming viewport against `self.viewport` — which was already mutated — so it is always `false` and the `invalidate_inline_contexts()` + `request_redraw()` step is silently skipped for zoom changes made via these two methods.

Fix: route zoom through the existing `ViewportMut` guard, which snapshots the viewport before mutation and correctly detects the scale change on drop:

```diff
 pub fn zoom_by(&mut self, increment: f32) {
-    *self.viewport.zoom_mut() += increment;
-    self.set_viewport(self.viewport.clone());
+    *self.viewport_mut().zoom_mut() += increment;
 }
```

(same for `zoom_to`)

Adds a unit test using a redraw-counting `ShellProvider` asserting `zoom_by`/`zoom_to` request a redraw.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ff356f9bd164441fbeb42f24f9bde7c3
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/ff356f9bd164441fbeb42f24f9bde7c3?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32783842596).</sub>
<!-- wpt-results-end -->
