### PR TITLE
Coalesce stylist device changes into a single rebuild per resolve

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1,6 +1,5 @@
 use crate::NodeTree;
 use crate::events::{DragMode, handle_dom_event};
-use crate::font_metrics::BlitzFontMetricsProvider;
 use crate::layout::construct::ConstructionTask;
 use crate::layout::damage::ALL_DAMAGE;
 use crate::mutator::ViewportMut;
@@ -10,6 +9,7 @@ use crate::net::{
 use crate::node::{ImageData, NodeFlags, RasterImageData, SpecialElementData, Status, TextBrush};
 use crate::scrolling::ScrollAnimationState;
 use crate::selection::TextSelection;
+use crate::stylo_device::{DeviceChanges, make_device};
 use crate::stylo_to_cursor_icon::stylo_to_cursor_icon;
 use crate::traversal::TreeTraverser;
 use crate::url::DocumentUrl;
@@ -24,7 +24,7 @@ use blitz_traits::events::{DomEvent, HitResult, UiEvent};
 use blitz_traits::navigation::{DummyNavigationProvider, NavigationProvider};
 use blitz_traits::net::{AbortSignal, DummyNetProvider, NetProvider, Request};
 use blitz_traits::node_id::NodeId;
-use blitz_traits::shell::{ColorScheme, DummyShellProvider, ShellProvider, Viewport};
+use blitz_traits::shell::{DummyShellProvider, ShellProvider, Viewport};
 use cursor_icon::CursorIcon;
 use linebender_resource_handle::Blob;
 use markup5ever::{LocalName, local_name};
@@ -46,12 +46,11 @@ use style::animation::DocumentAnimationSet;
 use style::attr::{AttrIdentifier, AttrValue};
 use style::computed_value_flags::ComputedValueFlags;
 use style::data::{ElementData as StyloElementData, ElementStyles};
+use style::invalidation::element::restyle_hints::RestyleHint;
 use style::media_queries::MediaType;
 use style::properties::ComputedValues;
 use style::properties::style_structs::Font;
-use style::queries::values::PrefersColorScheme;
 use style::selector_parser::ServoElementSnapshot;
-use style::servo::media_features::PointerCapabilities;
 use style::servo_arc::Arc as ServoArc;
 use style::values::GenericAtomIdent;
 use style::values::computed::UserSelect;
@@ -206,6 +205,10 @@ pub struct BaseDocument {
     pub(crate) viewport_scroll: crate::Point<f64>,
     /// CSS media type used to evaluate `@media` rules.
     pub(crate) media_type: MediaType,
+    /// Changes to the stylist [`Device`] that have been requested since the
+    /// last [`resolve`](Self::resolve), to be applied (coalesced into a single
+    /// device rebuild) at the start of the next resolve.
+    pub(crate) pending_device_changes: DeviceChanges,
     /// Strategy for Stylo's style traversal during `resolve`.
     pub(crate) style_threading: StyleThreading,
     /// Whether incremental layout is enabled for this document.
@@ -353,34 +356,6 @@ pub struct BaseDocument {
     pub(crate) abort_signal: Option<AbortSignal>,
 }
 
-pub(crate) fn make_device(
-    viewport: &Viewport,
-    media_type: MediaType,
-    font_ctx: Arc<Mutex<FontContext>>,
-) -> Device {
-    let width = viewport.window_size.0 as f32 / viewport.scale();
-    let height = viewport.window_size.1 as f32 / viewport.scale();
-    let viewport_size = euclid::Size2D::new(width, height);
-    let device_size = euclid::Size2D::new(width, height) * viewport.scale();
-    let device_pixel_ratio = euclid::Scale::new(viewport.scale());
-
-    Device::new(
-        media_type,
-        selectors::matching::QuirksMode::NoQuirks,
-        viewport_size,
-        device_size,
-        device_pixel_ratio,
-        Box::new(BlitzFontMetricsProvider { font_ctx }),
-        ComputedValues::initial_values_with_font_override(Font::initial_values()),
-        match viewport.color_scheme {
-            ColorScheme::Light => PrefersColorScheme::Light,
-            ColorScheme::Dark => PrefersColorScheme::Dark,
-        },
-        PointerCapabilities::default(),
-        PointerCapabilities::default(),
-    )
-}
-
 impl BaseDocument {
     /// Create a new (empty) [`BaseDocument`] with the specified configuration
     pub fn new(config: DocumentConfig) -> Self {
@@ -464,6 +439,7 @@ impl BaseDocument {
             nodes_to_id,
             viewport,
             media_type,
+            pending_device_changes: DeviceChanges::empty(),
             style_threading: config.style_threading,
             incremental_layout: config.incremental.unwrap_or(true),
             subdocument_depth: config.subdocument_depth,
@@ -1943,19 +1919,9 @@ impl BaseDocument {
     }
 
     pub fn set_viewport(&mut self, viewport: Viewport) {
-        let scale_has_changed = viewport.scale_f64() != self.viewport.scale_f64();
+        let changes = DeviceChanges::from_viewports(&self.viewport, &viewport);
         self.viewport = viewport;
-        self.set_stylist_device(make_device(
-            &self.viewport,
-            self.media_type.clone(),
-            self.font_ctx.clone(),
-        ));
-        self.scroll_viewport_by(0.0, 0.0); // Clamp scroll offset
-
-        if scale_has_changed {
-            self.invalidate_inline_contexts();
-            self.shell_provider.request_redraw();
-        }
+        self.queue_device_changes(changes);
     }
 
     /// Returns the current CSS media type used to evaluate `@media` rules.
@@ -1964,17 +1930,13 @@ impl BaseDocument {
     }
 
     /// Sets the CSS media type used to evaluate `@media` rules (e.g. `screen` or `print`)
-    /// and rebuilds the stylist device so updated rules apply on the next restyle.
+    /// and queues a stylist device rebuild so updated rules apply on the next restyle.
     pub fn set_media_type(&mut self, media_type: MediaType) {
         if self.media_type == media_type {
             return;
         }
         self.media_type = media_type;
-        self.set_stylist_device(make_device(
-            &self.viewport,
-            self.media_type.clone(),
-            self.font_ctx.clone(),
-        ));
+        self.queue_device_changes(DeviceChanges::MEDIA_TYPE);
     }
 
     pub fn viewport(&self) -> &Viewport {
@@ -2046,6 +2008,47 @@ impl BaseDocument {
             | self.scrollbars_animating()
     }
 
+    /// Record pending [`DeviceChanges`] and request a redraw so that they are
+    /// flushed (via [`Self::flush_pending_device_changes`]) on the next resolve.
+    pub(crate) fn queue_device_changes(&mut self, changes: DeviceChanges) {
+        if changes.is_empty() {
+            return;
+        }
+        self.pending_device_changes |= changes;
+        self.shell_provider.request_redraw();
+    }
+
+    /// Apply any pending device changes to the stylist, coalescing all changes
+    /// since the last flush into a single device rebuild.
+    pub(crate) fn flush_pending_device_changes(&mut self) {
+        let changes = std::mem::take(&mut self.pending_device_changes);
+        if changes.is_empty() {
+            return;
+        }
+
+        self.set_stylist_device(make_device(
+            &self.viewport,
+            self.media_type.clone(),
+            self.font_ctx.clone(),
+        ));
+        self.scroll_viewport_by(0.0, 0.0); // Clamp scroll offset
+
+        // Text is shaped at a specific scale factor, so cached inline layouts
+        // must be invalidated when the scale changes.
+        if changes.contains(DeviceChanges::SCALE) {
+            self.invalidate_inline_contexts();
+        }
+
+        // Color-scheme changes affect values that are resolved at cascade time
+        // (`light-dark()`, system colors) without necessarily flipping any
+        // media query result, so conservatively recascade the whole tree.
+        if changes.contains(DeviceChanges::COLOR_SCHEME) {
+            if let Some(root_id) = self.try_root_element().map(|el| el.id) {
+                self.nodes[root_id].set_restyle_hint(RestyleHint::recascade_subtree());
+            }
+        }
+    }
+
     /// Update the device and reset the stylist to process the new size
     pub fn set_stylist_device(&mut self, device: Device) {
         // Seed the new device with the root element's current style and font-relative
@@ -2110,6 +2113,7 @@ impl BaseDocument {
     }
 
     pub fn stylist_device(&mut self) -> &Device {
+        self.flush_pending_device_changes();
         self.stylist.device()
     }
 

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -57,6 +57,7 @@ mod scrolling;
 mod selection;
 /// Implementations that interact with servo's style engine
 mod stylo;
+mod stylo_device;
 mod stylo_to_cursor_icon;
 mod stylo_to_kurbo;
 mod stylo_to_parley;

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -3,10 +3,10 @@ use std::collections::HashSet;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 
-use crate::document::make_device;
 use crate::layout::damage::ALL_DAMAGE;
 use crate::net::{ImageHandler, ResourceHandler, StylesheetHandler};
 use crate::node::{CanvasData, NodeFlags, SpecialElementData};
+use crate::stylo_device::DeviceChanges;
 use crate::util::ImageType;
 use crate::{
     Attribute, BaseDocument, Document, ElementData, Node, NodeData, QualName, local_name, qual_name,
@@ -1294,19 +1294,8 @@ impl Drop for ViewportMut<'_> {
             return;
         }
 
-        self.doc.set_stylist_device(make_device(
-            &self.doc.viewport,
-            self.doc.media_type.clone(),
-            self.doc.font_ctx.clone(),
-        ));
-        self.doc.scroll_viewport_by(0.0, 0.0); // Clamp scroll offset
-
-        let scale_has_changed =
-            self.doc.viewport().scale_f64() != self.initial_viewport.scale_f64();
-        if scale_has_changed {
-            self.doc.invalidate_inline_contexts();
-            self.doc.shell_provider.request_redraw();
-        }
+        let changes = DeviceChanges::from_viewports(&self.initial_viewport, &self.doc.viewport);
+        self.doc.queue_device_changes(changes);
     }
 }
 

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -75,6 +75,10 @@ impl BaseDocument {
         let root_node_id = self.root_element().id;
         debug_timer!(timer, feature = "log-phase-times");
 
+        // Apply any device changes (viewport resize, zoom, color-scheme, etc)
+        // accumulated since the last resolve as a single device rebuild.
+        self.flush_pending_device_changes();
+
         // we need to resolve stylist first since it will need to drive our layout bits
         self.resolve_stylist(current_time_for_animations);
         timer.record_time("style");

--- a/packages/blitz-dom/src/stylo_device.rs
+++ b/packages/blitz-dom/src/stylo_device.rs
@@ -46,7 +46,7 @@ impl DeviceChanges {
     /// viewport `new`.
     pub(crate) fn from_viewports(old: &Viewport, new: &Viewport) -> Self {
         let mut changes = Self::empty();
-        if css_viewport_size(old) != css_viewport_size(new) {
+        if old.logical_size() != new.logical_size() {
             changes |= Self::VIEWPORT_SIZE;
         }
         if old.scale_f64() != new.scale_f64() {
@@ -59,22 +59,12 @@ impl DeviceChanges {
     }
 }
 
-/// The viewport size in CSS pixels (physical window size divided by the
-/// total scale factor).
-fn css_viewport_size(viewport: &Viewport) -> (f32, f32) {
-    let scale = viewport.scale();
-    (
-        viewport.window_size.0 as f32 / scale,
-        viewport.window_size.1 as f32 / scale,
-    )
-}
-
 pub(crate) fn make_device(
     viewport: &Viewport,
     media_type: MediaType,
     font_ctx: Arc<Mutex<FontContext>>,
 ) -> Device {
-    let (width, height) = css_viewport_size(viewport);
+    let (width, height) = viewport.logical_size();
     let viewport_size = euclid::Size2D::new(width, height);
     let device_size = euclid::Size2D::new(width, height) * viewport.scale();
     let device_pixel_ratio = euclid::Scale::new(viewport.scale());

--- a/packages/blitz-dom/src/stylo_device.rs
+++ b/packages/blitz-dom/src/stylo_device.rs
@@ -1,0 +1,97 @@
+//! Management of the Stylo [`Device`]: constructing it from shell state and
+//! coalescing changes to it (viewport resizes, zoom, color-scheme and media
+//! type changes) so that the stylist device is rebuilt at most once per
+//! [`resolve`](crate::BaseDocument::resolve), no matter how many changes
+//! occurred since the last resolve.
+
+use std::sync::{Arc, Mutex};
+
+use bitflags::bitflags;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use parley::FontContext;
+use selectors::matching::QuirksMode;
+use style::device::Device;
+use style::media_queries::MediaType;
+use style::properties::ComputedValues;
+use style::properties::style_structs::Font;
+use style::queries::values::PrefersColorScheme;
+use style::servo::media_features::PointerCapabilities;
+
+use crate::font_metrics::BlitzFontMetricsProvider;
+
+bitflags! {
+    /// The set of changes to the [`Device`] that have accumulated since the
+    /// stylist device was last rebuilt. Only the *latest* values matter (they
+    /// live on [`BaseDocument`](crate::BaseDocument)); these flags record
+    /// which kinds of change occurred so that the flush can do the right
+    /// amount of invalidation work.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub(crate) struct DeviceChanges: u8 {
+        /// The CSS pixel viewport size changed (window resize, zoom, or hidpi
+        /// scale change).
+        const VIEWPORT_SIZE = 0b0000_0001;
+        /// The total scale factor (hidpi scale * zoom) changed. Requires
+        /// invalidating cached inline layouts (text is shaped at a specific
+        /// scale) and a redraw.
+        const SCALE = 0b0000_0010;
+        /// The preferred color scheme changed.
+        const COLOR_SCHEME = 0b0000_0100;
+        /// The media type (e.g. screen/print) changed.
+        const MEDIA_TYPE = 0b0000_1000;
+    }
+}
+
+impl DeviceChanges {
+    /// Compute the [`DeviceChanges`] implied by moving from viewport `old` to
+    /// viewport `new`.
+    pub(crate) fn from_viewports(old: &Viewport, new: &Viewport) -> Self {
+        let mut changes = Self::empty();
+        if css_viewport_size(old) != css_viewport_size(new) {
+            changes |= Self::VIEWPORT_SIZE;
+        }
+        if old.scale_f64() != new.scale_f64() {
+            changes |= Self::SCALE;
+        }
+        if old.color_scheme != new.color_scheme {
+            changes |= Self::COLOR_SCHEME;
+        }
+        changes
+    }
+}
+
+/// The viewport size in CSS pixels (physical window size divided by the
+/// total scale factor).
+fn css_viewport_size(viewport: &Viewport) -> (f32, f32) {
+    let scale = viewport.scale();
+    (
+        viewport.window_size.0 as f32 / scale,
+        viewport.window_size.1 as f32 / scale,
+    )
+}
+
+pub(crate) fn make_device(
+    viewport: &Viewport,
+    media_type: MediaType,
+    font_ctx: Arc<Mutex<FontContext>>,
+) -> Device {
+    let (width, height) = css_viewport_size(viewport);
+    let viewport_size = euclid::Size2D::new(width, height);
+    let device_size = euclid::Size2D::new(width, height) * viewport.scale();
+    let device_pixel_ratio = euclid::Scale::new(viewport.scale());
+
+    Device::new(
+        media_type,
+        QuirksMode::NoQuirks,
+        viewport_size,
+        device_size,
+        device_pixel_ratio,
+        Box::new(BlitzFontMetricsProvider { font_ctx }),
+        ComputedValues::initial_values_with_font_override(Font::initial_values()),
+        match viewport.color_scheme {
+            ColorScheme::Light => PrefersColorScheme::Light,
+            ColorScheme::Dark => PrefersColorScheme::Dark,
+        },
+        PointerCapabilities::default(),
+        PointerCapabilities::default(),
+    )
+}

--- a/packages/blitz-traits/src/shell.rs
+++ b/packages/blitz-traits/src/shell.rs
@@ -116,6 +116,16 @@ impl Viewport {
         self.scale() as f64
     }
 
+    /// The viewport size in CSS pixels (physical window size divided by the
+    /// total scale factor)
+    pub fn logical_size(&self) -> (f32, f32) {
+        let scale = self.scale();
+        (
+            self.window_size.0 as f32 / scale,
+            self.window_size.1 as f32 / scale,
+        )
+    }
+
     /// Set hidpi scale factor
     pub fn set_hidpi_scale(&mut self, scale: f32) {
         self.hidpi_scale = scale;

--- a/tests/blitz-tests/tests/device_coalescing.rs
+++ b/tests/blitz-tests/tests/device_coalescing.rs
@@ -1,0 +1,110 @@
+//! Device changes (viewport resizes, zoom, color-scheme, media-type) are
+//! coalesced: they accumulate on the document and are applied to the stylist
+//! as a single device rebuild at the start of the next resolve.
+
+use blitz_dom::DocumentConfig;
+use blitz_html::{HtmlDocument, HtmlProvider};
+use blitz_traits::shell::{ColorScheme, Viewport};
+use std::sync::Arc;
+
+const HTML: &str = r#"<!DOCTYPE html>
+<html><head><style>
+    body { margin: 0; }
+    #static { width: 100px; height: 20px; }
+    #vw { width: 50vw; height: 10vh; }
+    #mq { width: 10px; }
+    @media (min-width: 850px) {
+        #mq { width: 30px; }
+    }
+</style></head>
+<body><div id="static"></div><div id="vw"></div><div id="mq"></div></body></html>
+"#;
+
+fn make_doc(width: u32, height: u32) -> HtmlDocument {
+    HtmlDocument::from_html(
+        HTML,
+        DocumentConfig {
+            viewport: Some(Viewport::new(width, height, 1.0, ColorScheme::Light)),
+            html_parser_provider: Some(Arc::new(HtmlProvider) as _),
+            ..Default::default()
+        },
+    )
+}
+
+fn used_width(doc: &HtmlDocument, selector: &str) -> f32 {
+    let id = doc.query_selector(selector).unwrap().unwrap();
+    doc.get_node(id).unwrap().final_layout().size.width
+}
+
+fn style_ptr(doc: &HtmlDocument, selector: &str) -> *const () {
+    let id = doc.query_selector(selector).unwrap().unwrap();
+    let node = doc.get_node(id).unwrap();
+    let styles = node.primary_styles().unwrap();
+    std::ptr::from_ref(&**styles).cast()
+}
+
+#[test]
+fn multiple_resizes_between_resolves_apply_latest_size() {
+    let mut doc = make_doc(800, 600);
+    doc.resolve(0.0);
+
+    // Several resizes before the next resolve: only the latest matters.
+    doc.viewport_mut().window_size = (900, 600);
+    doc.viewport_mut().window_size = (1000, 700);
+    doc.viewport_mut().window_size = (700, 500);
+    doc.resolve(0.0);
+
+    assert_eq!(used_width(&doc, "#vw"), 350.0);
+    // 700px is below the 850px breakpoint, so #mq must have its narrow width
+    // even though intermediate sizes crossed the breakpoint.
+    assert_eq!(used_width(&doc, "#mq"), 10.0);
+}
+
+#[test]
+fn resize_and_zoom_coalesce() {
+    let mut doc = make_doc(800, 600);
+    doc.resolve(0.0);
+
+    {
+        let mut viewport = doc.viewport_mut();
+        viewport.window_size = (800, 600);
+        *viewport.zoom_mut() = 2.0;
+    }
+    doc.resolve(0.0);
+
+    // CSS viewport is 400x300; 50vw = 200 CSS px.
+    assert_eq!(used_width(&doc, "#vw"), 200.0);
+    assert_eq!(used_width(&doc, "#mq"), 10.0);
+}
+
+#[test]
+fn stylist_device_read_flushes_pending_changes() {
+    let mut doc = make_doc(800, 600);
+    doc.resolve(0.0);
+
+    doc.viewport_mut().window_size = (700, 500);
+
+    // Reading the stylist device before the next resolve must observe the
+    // pending viewport change.
+    let size = doc.stylist_device().au_viewport_size();
+    assert_eq!(size.width.to_f32_px(), 700.0);
+    assert_eq!(size.height.to_f32_px(), 500.0);
+}
+
+#[test]
+fn color_scheme_change_recascades_styles() {
+    let mut doc = make_doc(800, 600);
+    doc.resolve(0.0);
+
+    let static_style = style_ptr(&doc, "#static");
+
+    doc.viewport_mut().color_scheme = ColorScheme::Dark;
+    doc.resolve(0.0);
+
+    // Color-scheme-dependent values (light-dark(), system colors) resolve at
+    // cascade time without necessarily flipping a media query, so a
+    // color-scheme change must recascade even viewport-independent elements.
+    assert_ne!(style_ptr(&doc, "#static"), static_style);
+    // Layout is unaffected.
+    assert_eq!(used_width(&doc, "#static"), 100.0);
+}


### PR DESCRIPTION
## Summary
Follow-up to #782/#784. Device changes (viewport resize, zoom, hidpi scale, color scheme, media type) previously rebuilt the Stylo `Device` (and re-ran the media-query diff) eagerly on every change — e.g. once per winit `Resized` event. They are now coalesced, Gecko-style (`MediaFeatureChange`), into a single device rebuild flushed at the start of the next `resolve()`.

New module `stylo_device.rs` holds:
- `DeviceChanges` — a reason bitmask (`VIEWPORT_SIZE | SCALE | COLOR_SCHEME | MEDIA_TYPE`) with `DeviceChanges::from_viewports(old, new)`. Only the *latest* viewport/media-type values matter (they live on `BaseDocument`); the flags record which kinds of change occurred so the flush does the right invalidation work.
- `make_device` (moved unchanged from `document.rs`).

Flow:
```
set_viewport / set_media_type / ViewportMut::drop
  -> update latest values, queue_device_changes(flags) + request_redraw
resolve()
  -> flush_pending_device_changes():
       one make_device + set_stylist_device (MQ diff + targeted vw/vh invalidation)
       clamp scroll offset
       SCALE        -> invalidate_inline_contexts()
       COLOR_SCHEME -> RestyleHint::recascade_subtree() on the root
```

`stylist_device()` flushes pending changes before returning, so out-of-band device reads between resolves stay consistent.

The `COLOR_SCHEME` recascade is conservatively correct ahead of Stylo wiring up `light-dark()`/system colors in Servo mode (currently `Device::is_dark_color_scheme` hard-returns false): a color-scheme flip must recascade even when no media query result changes. Theme changes are rare, so the full-tree `RECASCADE_SELF` is acceptable.

## Tests
New `tests/blitz-tests/tests/device_coalescing.rs`:
- multiple resizes between resolves apply only the latest size (including a breakpoint crossed by intermediate sizes only)
- resize + zoom in one batch both apply
- `stylist_device()` read between resolves observes pending changes
- color-scheme change recascades viewport-independent elements

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ff356f9bd164441fbeb42f24f9bde7c3
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/ff356f9bd164441fbeb42f24f9bde7c3?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32786315531).</sub>
<!-- wpt-results-end -->
