### PR TITLE
Generalize anonymous box creation to table box kinds

### DIFF
--- a/packages/blitz-dom/assets/default.css
+++ b/packages/blitz-dom/assets/default.css
@@ -352,6 +352,19 @@ plaintext {
 
 /* tables */
 
+/* Anonymous table boxes generated during box-tree fixup (CSS 2.2 §17.2.1) */
+*|*::-servo-anonymous-table {
+    display: table;
+}
+
+*|*::-servo-anonymous-table-row {
+    display: table-row;
+}
+
+*|*::-servo-anonymous-table-cell {
+    display: table-cell;
+}
+
 table {
     display: table;
     border-spacing: 2px;

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -2,7 +2,7 @@ use blitz_traits::node_id::NodeId;
 use core::str;
 use std::sync::Arc;
 
-use markup5ever::{QualName, local_name, ns};
+use markup5ever::{QualName, local_name};
 use parley::{
     FontContext, InlineBox, InlineBoxKind, LayoutContext, StyleProperty, TreeBuilder,
     WhiteSpaceCollapse,
@@ -37,6 +37,75 @@ use super::{
 };
 
 const DUMMY_NAME: QualName = qual_name!("div", html);
+
+/// The kind of anonymous box to generate, determining which precomputed
+/// pseudo-element supplies its style (and hence its `display`).
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[allow(dead_code, reason = "table variants are used by upcoming table fixups")]
+pub(crate) enum AnonKind {
+    Block,
+    Table,
+    TableRow,
+    TableCell,
+}
+
+/// Create an anonymous box node of the given kind, styled via the
+/// corresponding precomputed pseudo-element (inheriting from the container's
+/// style). The node is parented to the container but NOT pushed into any
+/// child list: callers are responsible for registering it both as a layout
+/// child and for deallocation (e.g. via `LayoutChildren::anonymous_blocks`).
+pub(crate) fn create_anonymous_node(
+    doc: &mut BaseDocument,
+    container_node_id: NodeId,
+    kind: AnonKind,
+) -> NodeId {
+    use style::selector_parser::PseudoElement;
+
+    let pseudo = match kind {
+        AnonKind::Block => PseudoElement::ServoAnonymousBox,
+        AnonKind::Table => PseudoElement::ServoAnonymousTable,
+        AnonKind::TableRow => PseudoElement::ServoAnonymousTableRow,
+        AnonKind::TableCell => PseudoElement::ServoAnonymousTableCell,
+    };
+
+    let node_id = doc.create_node(NodeData::AnonymousBlock(Box::new(ElementData::new(
+        DUMMY_NAME,
+        Vec::new(),
+    ))));
+
+    // Set style data
+    let parent_style = doc.nodes[container_node_id].primary_styles().unwrap();
+    let read_guard = doc.guard.read();
+    let guards = StylesheetGuards::same(&read_guard);
+    let style = doc
+        .stylist
+        .style_for_anonymous::<&Node>(&guards, &pseudo, &parent_style);
+    let mut stylo_element_data = StyloElementData {
+        damage: ALL_DAMAGE,
+        ..Default::default()
+    };
+    drop(parent_style);
+
+    stylo_element_data.styles.primary = Some(style);
+    stylo_element_data.set_restyled();
+
+    *doc.nodes[node_id]
+        .stylo_element_data_mut()
+        .ensure_init_mut() = stylo_element_data;
+
+    if doc.nodes[container_node_id]
+        .flags
+        .contains(NodeFlags::IS_IN_DOCUMENT)
+    {
+        doc.nodes[node_id].flags.insert(NodeFlags::IS_IN_DOCUMENT);
+    }
+    doc.nodes[node_id].parent = Some(container_node_id);
+    doc.nodes[node_id]
+        .layout_parent
+        .set(Some(container_node_id));
+
+    node_id
+}
 
 #[derive(Clone)]
 pub(crate) struct ConstructionTask {
@@ -130,51 +199,7 @@ impl LayoutChildren {
     }
 
     fn create_anonymous_block(&mut self, container_node_id: NodeId, doc: &mut BaseDocument) {
-        use style::selector_parser::PseudoElement;
-
-        const NAME: QualName = QualName {
-            prefix: None,
-            ns: ns!(html),
-            local: local_name!("div"),
-        };
-        let node_id = doc.create_node(NodeData::AnonymousBlock(Box::new(ElementData::new(
-            NAME,
-            Vec::new(),
-        ))));
-
-        // Set style data
-        let parent_style = doc.nodes[container_node_id].primary_styles().unwrap();
-        let read_guard = doc.guard.read();
-        let guards = StylesheetGuards::same(&read_guard);
-        let style = doc.stylist.style_for_anonymous::<&Node>(
-            &guards,
-            &PseudoElement::ServoAnonymousBox,
-            &parent_style,
-        );
-        let mut stylo_element_data = StyloElementData {
-            damage: ALL_DAMAGE,
-            ..Default::default()
-        };
-        drop(parent_style);
-
-        stylo_element_data.styles.primary = Some(style);
-        stylo_element_data.set_restyled();
-
-        *doc.nodes[node_id]
-            .stylo_element_data_mut()
-            .ensure_init_mut() = stylo_element_data;
-
-        if doc.nodes[container_node_id]
-            .flags
-            .contains(NodeFlags::IS_IN_DOCUMENT)
-        {
-            doc.nodes[node_id].flags.insert(NodeFlags::IS_IN_DOCUMENT);
-        }
-        doc.nodes[node_id].parent = Some(container_node_id);
-        doc.nodes[node_id]
-            .layout_parent
-            .set(Some(container_node_id));
-
+        let node_id = create_anonymous_node(doc, container_node_id, AnonKind::Block);
         self.children.push(node_id);
         self.anonymous_block_id = Some(node_id);
         self.anonymous_blocks.push(node_id);


### PR DESCRIPTION
## Summary

Step 0 of the anonymous table box fixup work (split out from #783; based on #781's branch): generalizes anonymous node creation without changing behavior.

`LayoutChildren::create_anonymous_block`'s body is extracted into a free function parameterized by kind:

```rust
pub(crate) enum AnonKind { Block, Table, TableRow, TableCell }

pub(crate) fn create_anonymous_node(doc, container_node_id, kind: AnonKind) -> NodeId
// kind selects the precomputed pseudo: ServoAnonymousBox / ServoAnonymousTable /
// ServoAnonymousTableRow / ServoAnonymousTableCell
```

Since precomputed pseudos take their declarations from UA stylesheet rules, `default.css` gains

```css
*|*::-servo-anonymous-table { display: table; }
*|*::-servo-anonymous-table-row { display: table-row; }
*|*::-servo-anonymous-table-cell { display: table-cell; }
```

so the table-kind anonymous boxes (used by #783 on top of this) carry honest computed displays. The `Block` path is a pure refactor; the table variants are unused here (`#[allow(dead_code)]` until #783 lands on top).

`cargo fmt` / `clippy` clean; existing table/anonymous-cell tests pass.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e0b69caedcd34e829ff73fb7ff216a75
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/e0b69caedcd34e829ff73fb7ff216a75?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**71** newly passing, **19** newly failing (net +52).

<details>
<summary>Full diff (90 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/backgrounds/background-applies-to-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-attachment-applies-to-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-color-applies-to-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-image-applies-to-015.xht
+ Fail => Pass css/CSS2/backgrounds/background-repeat-applies-to-015.xht
- Pass => Fail css/CSS2/bidi-text/bidi-008a.xht
- Pass => Fail css/CSS2/bidi-text/bidi-008b.xht
+ Fail => Pass css/CSS2/borders/border-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-bottom-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-bottom-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-bottom-width-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-left-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-left-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-left-width-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-right-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-right-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-right-width-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-top-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-top-color-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-top-width-applies-to-015.xht
+ Fail => Pass css/CSS2/borders/border-width-applies-to-015.xht
+ Fail => Pass css/CSS2/colors/color-applies-to-015.xht
- Pass => Fail css/CSS2/css21-errata/s-11-1-1b-001.html
- Pass => Fail css/CSS2/css21-errata/s-11-1-1b-008.html
- Pass => Fail css/CSS2/css21-errata/s-11-1-1b-009.html
+ Fail => Pass css/CSS2/fonts/font-applies-to-015.xht
+ Fail => Pass css/CSS2/fonts/font-variant-applies-to-015.xht
+ Fail => Pass css/CSS2/fonts/font-weight-applies-to-015.xht
+ Fail => Pass css/CSS2/linebox/vertical-align-applies-to-015.xht
+ Fail => Pass css/CSS2/lists/list-style-applies-to-015.xht
+ Fail => Pass css/CSS2/lists/list-style-image-applies-to-015.xht
+ Fail => Pass css/CSS2/lists/list-style-type-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-left-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-right-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/margin-top-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-bottom-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-left-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-right-applies-to-015.xht
+ Fail => Pass css/CSS2/margin-padding-clear/padding-top-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/height-applies-to-015.xht
- Pass => Fail css/CSS2/normal-flow/inline-table-002a.xht
- Pass => Fail css/CSS2/normal-flow/inline-table-width-002b.xht
+ Fail => Pass css/CSS2/normal-flow/inline-table-zorder-002.xht
+ Fail => Pass css/CSS2/normal-flow/max-height-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/max-width-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/min-height-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/min-width-applies-to-015.xht
+ Fail => Pass css/CSS2/normal-flow/width-applies-to-015.xht
+ Fail => Pass css/CSS2/tables/anonymous-table-box-width-001.xht
+ Fail => Pass css/CSS2/text/letter-spacing-applies-to-015.xht
+ Fail => Pass css/CSS2/text/text-decoration-applies-to-015.xht
+ Fail => Pass css/CSS2/text/text-indent-applies-to-015.xht
+ Fail => Pass css/CSS2/text/white-space-applies-to-015.xht
+ Fail => Pass css/CSS2/text/word-spacing-applies-to-015.xht
- Pass => Fail css/CSS2/ui/outline-applies-to-016.xht
- Pass => Fail css/CSS2/ui/outline-applies-to-017.xht
- Pass => Fail css/css-break/table/break-before-second-row.html
- Pass => Fail css/css-break/table/caption-margin-002.html
- Pass => Fail css/css-break/table/caption-margin-005.html
+ Fail => Pass css/css-break/table/inside-flex-001.html
+ Fail => Pass css/css-break/table/monolithic-overflow-002.tentative.html
+ Fail => Pass css/css-break/table/monolithic-overflow-004.tentative.html
+ Fail => Pass css/css-break/table/repeated-section/image.tentative.html
+ Fail => Pass css/css-contain/contain-inline-size-table.html
- Pass => Fail css/css-contain/contain-size-056.html
- Pass => Fail css/css-contain/contain-size-table-caption-001.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-094.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-095.html
+ Fail => Pass css/css-flexbox/flexbox_flex-formatting-interop.html
+ Fail => Pass css/css-flexbox/flexbox_stf-table-singleline-2.html
+ Fail => Pass css/css-flexbox/flexbox_stf-table-singleline.html
- Pass => Fail css/css-flexbox/table-as-item-flex-cross-size.html
+ Fail => Pass css/css-flexbox/table-as-item-narrow-content.html
- Pass => Fail css/css-flexbox/table-as-item-stretch-cross-size-2.html
- Pass => Fail css/css-flexbox/table-as-item-stretch-cross-size.html
+ Fail => Pass css/css-flexbox/table-with-float-paint.html
+ Fail => Pass css/css-grid/grid-items/explicitly-sized-grid-item-as-table.html
+ Fail => Pass css/css-page/monolithic-overflow-009-print.html
+ Fail => Pass css/css-page/monolithic-overflow-010-print.html
+ Fail => Pass css/css-page/monolithic-overflow-011-print.html
+ Fail => Pass css/css-page/monolithic-overflow-017-print.html
+ Fail => Pass css/css-sizing/calc-margins-table-caption.html
+ Fail => Pass css/css-sizing/table-child-percentage-height-with-border-box.html
+ Fail => Pass css/css-sizing/table-percentage-max-width-beside-float.html
+ Fail => Pass css/css-tables/html-display-table.html
+ Fail => Pass css/css-tables/percent-height-overflow-auto-in-restricted-block-size-cell.html
+ Fail => Pass css/css-tables/percent-height-overflow-auto-in-unrestricted-block-size-cell.tentative.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32787653510).</sub>
<!-- wpt-results-end -->
