### PR TITLE
Fix Android FPS overlay safe-area positioning

### DIFF
--- a/apps/browser/assets/browser.css
+++ b/apps/browser/assets/browser.css
@@ -262,10 +262,10 @@ body,
 
 .fps-overlay {
   position: fixed;
-  top: 80px;
+  top: calc(80px + var(--safe-area-top));
   right: 8px;
   background: rgba(0, 0, 0, 0.7);
-  color: #0f0;
+  color: rgb(0, 255, 0);
   font-family: monospace;
   font-size: 12px;
   padding: 4px 8px;

--- a/apps/browser/src/main.rs
+++ b/apps/browser/src/main.rs
@@ -149,12 +149,12 @@ fn app() -> Element {
     const TOP_PAD: &str = if cfg!(target_os = "android") {
         "30px"
     } else {
-        ""
+        "0px"
     };
     const BOTTOM_PAD: &str = if cfg!(target_os = "android") {
         "44px"
     } else {
-        ""
+        "0px"
     };
 
     let show_fps: Signal<bool> = use_signal(|| false);
@@ -168,8 +168,7 @@ fn app() -> Element {
     rsx!(
         div {
             id: "frame",
-            padding_top: TOP_PAD,
-            padding_bottom: BOTTOM_PAD,
+            style: "--safe-area-top: {TOP_PAD}; padding-top: {TOP_PAD}; padding-bottom: {BOTTOM_PAD};",
             class: if IS_MOBILE { "mobile" } else { "" },
             title { "{window_title}" }
             document::Link { rel: "stylesheet", href: BROWSER_UI_STYLES }


### PR DESCRIPTION
## Summary
Expose the browser frame's hardcoded Android top safe-area padding as `--safe-area-top`, then include it in the fixed FPS overlay offset so the meter stays below the URL bar. Use an explicit `rgb(0, 255, 0)` text color for consistent Android rendering.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/80bd61577e9f490c809cd1aa3461a613
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/80bd61577e9f490c809cd1aa3461a613?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32789245447).</sub>
<!-- wpt-results-end -->
