### PR TITLE
Tables: ignore `none`/`hidden` cell borders in border-collapse mode

### DIFF
--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -54,6 +54,17 @@ pub struct TableRow {
     pub height: f32,
 }
 
+/// The used width of one border side: border widths are not adjusted for
+/// border-style in computed styles, so a border with `none`/`hidden` style
+/// must be treated as zero-width.
+fn side_width(width: app_units::Au, style: BorderStyle) -> f32 {
+    if style.none_or_hidden() {
+        0.0
+    } else {
+        width.to_f32_px()
+    }
+}
+
 pub(crate) fn build_table_context(
     doc: &mut BaseDocument,
     table_root_node_id: NodeId,
@@ -134,15 +145,6 @@ pub(crate) fn build_table_context(
         BorderCollapse::Collapse => first_cell_border
             .as_ref()
             .map(|border| {
-                // Border widths are not adjusted for border-style in computed styles,
-                // so a border with `none`/`hidden` style must be treated as zero-width.
-                let side_width = |width: app_units::Au, style: BorderStyle| -> f32 {
-                    if style.none_or_hidden() {
-                        0.0
-                    } else {
-                        width.to_f32_px()
-                    }
-                };
                 let x = side_width(border.border_left_width.0, border.border_left_style).max(
                     side_width(border.border_right_width.0, border.border_right_style),
                 );

--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -8,7 +8,7 @@ use style::servo_arc::Arc as ServoArc;
 use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style::{
     Atom, computed_values::border_collapse::T as BorderCollapse,
-    computed_values::table_layout::T as TableLayout,
+    computed_values::table_layout::T as TableLayout, values::computed::BorderStyle,
 };
 use taffy::{
     DetailedGridInfo, LayoutPartialTree as _, ResolveOrZero, TrackSizingFunction, style_helpers,
@@ -134,16 +134,21 @@ pub(crate) fn build_table_context(
         BorderCollapse::Collapse => first_cell_border
             .as_ref()
             .map(|border| {
-                let x = border
-                    .border_left_width
-                    .0
-                    .max(border.border_right_width.0)
-                    .to_f32_px();
-                let y = border
-                    .border_top_width
-                    .0
-                    .max(border.border_bottom_width.0)
-                    .to_f32_px();
+                // Border widths are not adjusted for border-style in computed styles,
+                // so a border with `none`/`hidden` style must be treated as zero-width.
+                let side_width = |width: app_units::Au, style: BorderStyle| -> f32 {
+                    if style.none_or_hidden() {
+                        0.0
+                    } else {
+                        width.to_f32_px()
+                    }
+                };
+                let x = side_width(border.border_left_width.0, border.border_left_style).max(
+                    side_width(border.border_right_width.0, border.border_right_style),
+                );
+                let y = side_width(border.border_top_width.0, border.border_top_style).max(
+                    side_width(border.border_bottom_width.0, border.border_bottom_style),
+                );
                 taffy::Size {
                     width: style_helpers::length(x),
                     height: style_helpers::length(y),

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -545,6 +545,12 @@ impl ElementCx<'_, '_> {
             return;
         }
 
+        // Border widths are not adjusted for border-style in computed styles,
+        // so a border with `none`/`hidden` style must be treated as zero-width.
+        if border_style.border_top_style.none_or_hidden() {
+            return;
+        }
+
         let border_width = border_style.border_top_width.0.to_f64_px();
 
         // Draw horizontal inner borders (the gutters between adjacent row tracks)


### PR DESCRIPTION
## Summary

Fixes the thick black borders drawn around/inside the `.sidebar` table (`id=mwEQ`) on https://en.wikipedia.org/wiki/HTML.

In our stylo build, computed border widths are NOT zeroed when `border-style` is `none`/`hidden` — consumers must check the style themselves (as `stylo_taffy::convert::border` already does). The collapsed-borders table code didn't:

- `build_table_context` derived the table gap/border from the first cell's raw `border_*_width` (default `medium` = 3px, even with `border-style: none`)
- `draw_table_borders` then painted all gutters and outer edges 3px wide in the cell's `border-color` (`currentColor` → black)

Wikipedia's sidebar has `border-collapse: collapse` with borderless cells, so it got 3px black borders everywhere; the infobox (`mwCw`) uses separate borders and was unaffected.

Fix: treat a side's width as 0 when its style is `none`/`hidden` in the collapse gap computation, and skip painting collapsed borders entirely when the first cell's border style is none/hidden.

Before / after (sidebar extracted from the Wikipedia page):

![before](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvNTM4NTdiMWEtMTliYy00OWM4LWFiZTAtNTUyNGZkM2JmZTgyIiwiaWF0IjoxNzg3NjYzMzUwLCJleHAiOjE3ODgyNjgxNTAsImZpbGVuYW1lIjoiYmVmb3JlX3NpZGViYXIucG5nIn0.0dWUhtHbilsvoYE0zSbid5RycXs9YPhL1SCozsChIzQ)
![after](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvNzgxNTFlY2ItNzMyNy00NmJlLWI4ODctZTIxMWUzZThkM2M5IiwiaWF0IjoxNzg3NjYzMzUwLCJleHAiOjE3ODgyNjgxNTAsImZpbGVuYW1lIjoiYWZ0ZXJfc2lkZWJhci5wbmcifQ.FKXJPFPNfq3ivk41XYg0znfdkoxPOCnXUfI9x1-nWNc)

Regression check: a table with `border-collapse: collapse` and real cell borders still renders its borders.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/dacb3bd81a814000a9a5dab05e213528
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/dacb3bd81a814000a9a5dab05e213528?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**26** newly passing, **0** newly failing (net +26).

<details>
<summary>Full diff (26 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/borders/border-style-applies-to-016.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-017.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-018.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-019.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-020.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-021.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-022.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-023.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-024.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-025.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-026.xht
+ Fail => Pass css/CSS2/borders/border-style-applies-to-027.xht
+ Fail => Pass css/CSS2/normal-flow/margin-collapse-through-percentage-height-block-inside-table-cell.html
+ Fail => Pass css/CSS2/tables/table-visual-layout-017.xht
+ Fail => Pass css/CSS2/visufx/overflow-applies-to-001.xht
+ Fail => Pass css/css-backgrounds/background-multiple-layers-table-cell.html
+ Fail => Pass css/css-position/sticky/position-sticky-table-td-top.html
+ Fail => Pass css/css-tables/auto-layout-calc-width-001.html
+ Fail => Pass css/css-tables/fixed-layout-calc-width-001.html
+ Fail => Pass css/css-tables/height-distribution/extra-height-given-to-all-row-groups-001.html
+ Fail => Pass css/css-tables/height-distribution/extra-height-given-to-all-row-groups-002.html
+ Fail => Pass css/css-tables/height-distribution/extra-height-given-to-all-row-groups-005.html
+ Fail => Pass css/css-tables/internal-containing-block-001.html
+ Fail => Pass css/css-tables/rules-groups.html
+ Fail => Pass css/css-text/overflow-wrap/overflow-wrap-min-content-size-001.html
+ Fail => Pass css/css-text/overflow-wrap/overflow-wrap-min-content-size-004.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32851463176).</sub>
<!-- wpt-results-end -->
