### PR TITLE
Apply scale and transform in fast path of `resolve_transforms`

### DIFF
--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -176,7 +176,7 @@ impl BaseDocument {
 
             let mut transform = Affine::translate((location.x, location.y));
             if let Some(t) = node.transform() {
-                transform = transform * *t
+                transform *= *t
             }
 
             let overflow = *node.scrollable_overflow();

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -164,15 +164,24 @@ impl BaseDocument {
             return Rect::ZERO;
         }
 
+        let scale = self.viewport.scale_f64();
+
         if !self.nodes[node_id]
             .damage()
             .map(|d| d.contains(style::selector_parser::RestyleDamage::RECALCULATE_OVERFLOW))
             .unwrap_or(false)
         {
-            return *self.nodes[node_id].scrollable_overflow();
-        }
+            let node = &self.nodes[node_id];
+            let location = node.final_layout().location.map(|v| v as f64 * scale);
 
-        let scale = self.viewport.scale_f64();
+            let mut transform = Affine::translate((location.x, location.y));
+            if let Some(t) = node.transform() {
+                transform = transform * *t
+            }
+
+            let overflow = *node.scrollable_overflow();
+            return transform.transform_rect_bbox(overflow);
+        }
 
         let transform = self.nodes[node_id].set_transform(scale as f32);
 


### PR DESCRIPTION
## Summary

Fixes the table with id `mwEQ` on https://en.wikipedia.org/wiki/HTML disappearing while still partially visible during scrolling.

Root cause: in `resolve_transforms`, the early return for nodes without `RECALCULATE_OVERFLOW` damage returned the cached `scrollable_overflow` **in the node's own coordinate space**, while callers union the return value into the parent's overflow expecting **parent-space** coordinates (the full path returns `Affine::translate(location) * transform` applied to the overflow rect).

So whenever a damaged ancestor (e.g. hover restyle during scrolling) recomputed its overflow while its children were undamaged, each child's overflow lost its position offset:

```rust
// before: undamaged child
return *node.scrollable_overflow();          // node-space, e.g. 0..798

// full path (damaged child)
full.transform_rect_bbox(overflow)           // parent-space, e.g. 887..1685
```

The Wikipedia section containing the floated table thus had its `scrollable_overflow` collapse from `y1=1685` to its own height `y1=1384`, and `render_element`'s viewport cull dropped the whole section (and the table) once the section's border box scrolled off — at ~62% ("roughly half") of the table's height.

The fix applies the same location translation + CSS transform to the cached overflow in the early-return path.

Verified with a Wikipedia repro harness (incremental resolve after hover+scroll now preserves the section overflow) and interactively in the `rdme` app — the table now stays rendered until fully scrolled off-screen.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/4034e037ce0148888022a8fb7e251cf9
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/4034e037ce0148888022a8fb7e251cf9?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32853342644).</sub>
<!-- wpt-results-end -->
