### PR TITLE
Don't paint collapsed table borders across spanning cells

### DIFF
--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -77,6 +77,15 @@ impl<'a> PhysicalTracks<'a> {
         }
     }
 
+    /// The logical (grid line order) index of a physically ordered track
+    pub(crate) fn logical(self, index: usize) -> usize {
+        if self.reversed {
+            self.positions.len() - 1 - index
+        } else {
+            index
+        }
+    }
+
     /// Iterate track positions in physical order
     pub(crate) fn iter(self) -> impl ExactSizeIterator<Item = taffy::Line<f32>> + 'a {
         (0..self.positions.len()).map(move |index| self.get(index))

--- a/packages/blitz-paint/src/render/border.rs
+++ b/packages/blitz-paint/src/render/border.rs
@@ -553,17 +553,33 @@ impl ElementCx<'_, '_> {
 
         let border_width = border_style.border_top_width.0.to_f64_px();
 
-        // Draw horizontal inner borders (the gutters between adjacent row tracks)
+        // Draw horizontal inner borders (the gutters between adjacent row tracks),
+        // skipping the columns where a cell spans the gutter
         let row_origin = rows.origin();
-        for (prev, next) in rows.iter().zip(rows.iter().skip(1)) {
-            let shape = Rect::new(
-                0.0,
-                (prev.end - row_origin) as f64,
-                inner_width,
-                (next.start - row_origin) as f64,
-            )
-            .scale_from_origin(self.scale);
-            scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
+        let col_origin = cols.origin();
+        let items = &grid_info.items;
+        for (index, (prev, next)) in rows.iter().zip(rows.iter().skip(1)).enumerate() {
+            let line = rows.logical(index).min(rows.logical(index + 1)) as u16 + 2;
+            for (col_index, col) in cols.iter().enumerate() {
+                let col_line = cols.logical(col_index) as u16 + 1;
+                let spanned = items.iter().any(|item| {
+                    item.row_start < line
+                        && item.row_end > line
+                        && item.column_start <= col_line
+                        && item.column_end > col_line
+                });
+                if spanned {
+                    continue;
+                }
+                let shape = Rect::new(
+                    (col.start - col_origin) as f64,
+                    (prev.end - row_origin) as f64,
+                    (col.end - col_origin) as f64,
+                    (next.start - row_origin) as f64,
+                )
+                .scale_from_origin(self.scale);
+                scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
+            }
         }
 
         // Draw horizontal outer borders
@@ -580,17 +596,30 @@ impl ElementCx<'_, '_> {
             scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
         }
 
-        // Draw vertical inner borders (the gutters between adjacent column tracks)
-        let col_origin = cols.origin();
-        for (prev, next) in cols.iter().zip(cols.iter().skip(1)) {
-            let shape = Rect::new(
-                (prev.end - col_origin) as f64,
-                0.0,
-                (next.start - col_origin) as f64,
-                inner_height,
-            )
-            .scale_from_origin(self.scale);
-            scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
+        // Draw vertical inner borders (the gutters between adjacent column tracks),
+        // skipping the rows where a cell spans the gutter
+        for (index, (prev, next)) in cols.iter().zip(cols.iter().skip(1)).enumerate() {
+            let line = cols.logical(index).min(cols.logical(index + 1)) as u16 + 2;
+            for (row_index, row) in rows.iter().enumerate() {
+                let row_line = rows.logical(row_index) as u16 + 1;
+                let spanned = items.iter().any(|item| {
+                    item.column_start < line
+                        && item.column_end > line
+                        && item.row_start <= row_line
+                        && item.row_end > row_line
+                });
+                if spanned {
+                    continue;
+                }
+                let shape = Rect::new(
+                    (prev.end - col_origin) as f64,
+                    (row.start - row_origin) as f64,
+                    (next.start - col_origin) as f64,
+                    (row.end - row_origin) as f64,
+                )
+                .scale_from_origin(self.scale);
+                scene.fill(Fill::NonZero, self.transform, border_color, None, &shape);
+            }
         }
 
         // Draw vertical outer borders


### PR DESCRIPTION
Internal gutters were drawn full-width and full-height, ignoring colspan and rowspan. Amended to skip the tracks covered in spanning cells.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32884759818).</sub>
<!-- wpt-results-end -->
