### PR TITLE
Pass newtype wrapper of Stylo `ComputedValues` to Taffy directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7288,6 +7288,7 @@ dependencies = [
 name = "stylo_taffy"
 version = "0.3.0-beta.2"
 dependencies = [
+ "bitflags 2.13.1",
  "stylo",
  "stylo_atoms",
  "taffy",

--- a/packages/blitz-dom/assets/default.css
+++ b/packages/blitz-dom/assets/default.css
@@ -53,6 +53,11 @@ input {
     display: inline-block;
 }
 
+/* https://html.spec.whatwg.org/#hidden-elements */
+input[type="hidden" i] {
+    display: none !important;
+}
+
 input[type="checkbox"] {
     width: 14px;
     height: 14px;

--- a/packages/blitz-dom/src/debug.rs
+++ b/packages/blitz-dom/src/debug.rs
@@ -14,7 +14,7 @@ impl BaseDocument {
         #[cfg(feature = "tracing")]
         {
             tracing::info!("Layout: {:?}", node.final_layout());
-            tracing::info!("Style: {:?}", node.style());
+            tracing::info!("Display: {:?}", node.taffy_display());
         }
 
         println!("\nNode {} {}", node.id, node.node_debug_str());

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -426,6 +426,11 @@ fn collect_layout_children_with_wrap(
     out: &mut LayoutChildren,
     wrap: Option<WrapContext>,
 ) {
+    // Record the `display` the box is being constructed with
+    if let Some(display) = doc.nodes[container_node_id].display_style() {
+        *doc.nodes[container_node_id].display_constructed_as_mut() = display;
+    }
+
     // Reset construction flags
     // TODO: make incremental and only remove this if the element is no longer an inline root
     doc.nodes[container_node_id]

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -531,7 +531,7 @@ impl BaseDocument {
         }
     }
 
-    /// Walk the whole tree, converting styles to layout
+    /// Walk the whole tree, rebuilding paint children and hoisting z-indexed boxes
     fn flush_styles_to_layout_impl(
         &mut self,
         node_id: NodeId,
@@ -543,32 +543,10 @@ impl BaseDocument {
         let incremental = self.incremental_layout;
         let display = {
             let node = self.nodes.get_mut(node_id).unwrap();
-            let _damage = node.damage().unwrap_or(ALL_DAMAGE);
 
-            // Compute the owned taffy style and display in an inner scope so the
-            // immutable borrow of `node` (held by the stylo element data guard)
-            // is released before we mutably access `node` below.
-            let (mut taffy_style, display_constructed_as) = {
-                let stylo_element_data = node.stylo_element_data_opt().and_then(|s| s.get());
-                let primary_styles = stylo_element_data
-                    .as_ref()
-                    .and_then(|data| data.styles.get_primary());
-
-                let Some(style) = primary_styles else {
-                    return;
-                };
-
-                (stylo_taffy::to_taffy_style(style), style.clone_display())
+            let Some(display) = node.display_style() else {
+                return;
             };
-            taffy_style.item_is_replaced = node
-                .data
-                .downcast_element()
-                .is_some_and(|el| crate::layout::replaced::is_replaced_element(&el.name.local));
-
-            // if damage.intersects(RestyleDamage::RELAYOUT | CONSTRUCT_BOX) {
-            *node.style_mut() = taffy_style;
-            *node.display_constructed_as_mut() = display_constructed_as;
-            // }
 
             // In non-incremental mode we unconditionally clear the Taffy cache.
             // In incremental mode this is handled as part of damage propagation.
@@ -583,13 +561,14 @@ impl BaseDocument {
                 }
             }
 
-            node.style().display
+            display
         };
 
         // If the node has children, then take those children and...
         let children = self.nodes[node_id].layout_children.borrow_mut().take();
         if let Some(mut children) = children {
-            let is_flex_or_grid = matches!(display, taffy::Display::Flex | taffy::Display::Grid);
+            let is_flex_or_grid =
+                matches!(display.inside(), DisplayInside::Flex | DisplayInside::Grid);
 
             // Recursively call flush_styles_to_layout on each child
             for &child in children.iter() {

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -12,7 +12,7 @@ use taffy::{
 #[cfg(feature = "floats")]
 use parley::YieldData;
 #[cfg(feature = "floats")]
-use taffy::{Clear, Float, prelude::TaffyMaxContent};
+use taffy::{BlockItemStyle as _, Clear, Float, prelude::TaffyMaxContent};
 
 use super::resolve_calc_value;
 use crate::BaseDocument;
@@ -30,11 +30,11 @@ impl BaseDocument {
             run_mode,
             ..
         } = inputs;
-        let style = self.nodes[node_id].style();
+        let style = self.nodes[node_id].layout_style();
 
         // Pull these out earlier to avoid borrowing issues
         let is_scroll_container =
-            style.overflow.x.is_scroll_container() || style.overflow.y.is_scroll_container();
+            style.overflow().x.is_scroll_container() || style.overflow().y.is_scroll_container();
         let padding = style
             .padding()
             .resolve_or_zero(parent_size.width, resolve_calc_value);
@@ -103,6 +103,8 @@ impl BaseDocument {
             }
         }
 
+        drop(style);
+
         // Unwrap the block formatting context if one was passed, or else create a new one
         match block_ctx {
             Some(inherited_bfc) if !is_scroll_container => self.compute_inline_layout_inner(
@@ -151,7 +153,7 @@ impl BaseDocument {
             .take_inline_layout()
             .unwrap();
 
-        let style = self.nodes[node_id].style();
+        let style = self.nodes[node_id].layout_style();
 
         // Note: both horizontal and vertical percentage padding/borders are resolved against the container's inline size (i.e. width).
         // This is not a bug, but is how CSS is specified (see: https://developer.mozilla.org/en-US/docs/Web/CSS/padding#values)
@@ -197,22 +199,6 @@ impl BaseDocument {
         // || !inline_layout.text.is_empty();
         // || !inline_layout.layout.inline_boxes().is_empty();
 
-        // Short circuit if inline context contains no text or inline boxes
-        if !has_styles_preventing_being_collapsed_through
-            && inline_layout.text.is_empty()
-            && inline_layout.layout.inline_boxes().is_empty()
-        {
-            // Put layout back
-            self.nodes[node_id]
-                .data
-                .downcast_element_mut()
-                .unwrap()
-                .inline_layout_data = Some(inline_layout);
-            return LayoutOutput::from_outer_size(
-                Size::ZERO.maybe_max(container_pb.sum_axes().map(Some)),
-            );
-        }
-
         // Resolve node's preferred/min/max sizes (width/heights) against the available space (percentages resolve to pixel values)
         // For ContentSize mode, we pretend that the node has no size styles as these should be ignored.
         let (node_size, node_min_size, node_max_size, aspect_ratio) = match sizing_mode {
@@ -244,6 +230,24 @@ impl BaseDocument {
                 (node_size, style_min_size, style_max_size, aspect_ratio)
             }
         };
+
+        drop(style);
+
+        // Short circuit if inline context contains no text or inline boxes
+        if !has_styles_preventing_being_collapsed_through
+            && inline_layout.text.is_empty()
+            && inline_layout.layout.inline_boxes().is_empty()
+        {
+            // Put layout back
+            self.nodes[node_id]
+                .data
+                .downcast_element_mut()
+                .unwrap()
+                .inline_layout_data = Some(inline_layout);
+            return LayoutOutput::from_outer_size(
+                Size::ZERO.maybe_max(container_pb.sum_axes().map(Some)),
+            );
+        }
 
         // Compute available space
         let available_space = Size {
@@ -290,17 +294,20 @@ impl BaseDocument {
 
         // Update inline boxes
         for ibox in inline_layout.layout.inline_boxes_mut() {
-            let style = self.nodes[NodeId::from_u64(ibox.id)].style();
+            let style = self.nodes[NodeId::from_u64(ibox.id)].layout_style();
             let margin = style
-                .margin
+                .margin()
                 .resolve_or_zero(inputs.parent_size, resolve_calc_value);
 
             #[cfg(feature = "floats")]
-            let is_floated = style.float.is_floated();
+            let is_floated = style.float().is_floated();
             #[cfg(not(feature = "floats"))]
             let is_floated = false;
 
-            if style.position == Position::Absolute || is_floated {
+            let is_absolute = style.position() == Position::Absolute;
+            drop(style);
+
+            if is_absolute || is_floated {
                 ibox.width = 0.0;
                 ibox.height = 0.0;
             } else {
@@ -352,12 +359,17 @@ impl BaseDocument {
                     AvailableSpace::MinContent => {
                         let mut width: f32 = 0.0;
                         for ibox in inline_layout.layout.inline_boxes_mut() {
-                            let style = self.nodes[NodeId::from_u64(ibox.id)].style();
+                            let (is_floated, margin) = {
+                                let style = self.nodes[NodeId::from_u64(ibox.id)].layout_style();
+                                (
+                                    style.float().is_floated(),
+                                    style
+                                        .margin()
+                                        .resolve_or_zero(inputs.parent_size, resolve_calc_value),
+                                )
+                            };
 
-                            if style.float.is_floated() {
-                                let margin = style
-                                    .margin
-                                    .resolve_or_zero(inputs.parent_size, resolve_calc_value);
+                            if is_floated {
                                 let output = self.compute_child_layout(
                                     taffy::NodeId::from(ibox.id),
                                     child_inputs,
@@ -381,20 +393,25 @@ impl BaseDocument {
                         let mut right_band: f32 = 0.0;
                         let mut width: f32 = 0.0;
                         for ibox in inline_layout.layout.inline_boxes_mut() {
-                            let style = self.nodes[NodeId::from_u64(ibox.id)].style();
-                            let float = style.float;
+                            let (float, clear, margin) = {
+                                let style = self.nodes[NodeId::from_u64(ibox.id)].layout_style();
+                                (
+                                    style.float(),
+                                    style.clear(),
+                                    style
+                                        .margin()
+                                        .resolve_or_zero(inputs.parent_size, resolve_calc_value),
+                                )
+                            };
 
                             if float.is_floated() {
-                                if matches!(style.clear, Clear::Left | Clear::Both) {
+                                if matches!(clear, Clear::Left | Clear::Both) {
                                     left_band = 0.0;
                                 }
-                                if matches!(style.clear, Clear::Right | Clear::Both) {
+                                if matches!(clear, Clear::Right | Clear::Both) {
                                     right_band = 0.0;
                                 }
 
-                                let margin = style
-                                    .margin
-                                    .resolve_or_zero(inputs.parent_size, resolve_calc_value);
                                 let output = self.compute_child_layout(
                                     taffy::NodeId::from(ibox.id),
                                     child_inputs,
@@ -535,19 +552,23 @@ impl BaseDocument {
                     YieldData::InlineBoxBreak(box_break_data) => {
                         let state = breaker.state_mut();
                         let node_id = NodeId::from_u64(box_break_data.inline_box_id);
-                        let node = &mut self.nodes[node_id];
 
-                        // We can assume that the box is a float because we only set `break_on_box: true` for floats
-                        let direction = match node.style().float {
-                            Float::Left => taffy::FloatDirection::Left,
-                            Float::Right => taffy::FloatDirection::Right,
-                            Float::None => unreachable!(),
+                        let (direction, clear, margin) = {
+                            let style = self.nodes[node_id].layout_style();
+                            // We can assume that the box is a float because we only set `break_on_box: true` for floats
+                            let direction = match style.float() {
+                                Float::Left => taffy::FloatDirection::Left,
+                                Float::Right => taffy::FloatDirection::Right,
+                                Float::None => unreachable!(),
+                            };
+                            (
+                                direction,
+                                style.clear(),
+                                style
+                                    .margin()
+                                    .resolve_or_zero(inputs.parent_size, resolve_calc_value),
+                            )
                         };
-                        let clear = node.style().clear;
-                        let margin = node
-                            .style()
-                            .margin
-                            .resolve_or_zero(inputs.parent_size, resolve_calc_value);
 
                         let margin_sum = margin.sum_axes();
 
@@ -679,45 +700,61 @@ impl BaseDocument {
         }
         .maybe_max(container_pb.sum_axes().map(Some));
 
-        let container_direction = self.nodes[node_id].style().direction;
+        let container_direction = self.nodes[node_id].layout_style().direction();
 
         // Store sizes and positions of inline boxes
         for line in inline_layout.layout.lines() {
             for item in line.items() {
                 if let parley::layout::PositionedLayoutItem::InlineBox(ibox) = item {
-                    let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
-                    let padding = node
-                        .style()
-                        .padding
+                    let node = &self.nodes[NodeId::from_u64(ibox.id)];
+                    let style = node.layout_style();
+                    let padding = style
+                        .padding()
                         .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
-                    let border = node
-                        .style()
-                        .border
+                    let border = style
+                        .border()
                         .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
-                    let margin = node
-                        .style()
-                        .margin
+                    let margin = style
+                        .margin()
                         .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
 
                     #[cfg(feature = "floats")]
-                    let is_floated = node.style().float != Float::None;
+                    let is_floated = style.float() != Float::None;
                     #[cfg(not(feature = "floats"))]
                     let is_floated = false;
 
-                    if node.style().position == Position::Absolute {
-                        let direction = node.style().direction;
+                    let is_absolute = style.position() == Position::Absolute;
+                    let direction = style.direction();
 
-                        // The static position of an absolutely positioned box depends on the
-                        // display its hypothetical box would have had (the display specified
-                        // before position:absolute blockified it): inline-level boxes sit at
-                        // their position within the line, while block-level boxes start at the
-                        // content-box left edge of their containing block.
-                        let is_inline_level = node
-                            .primary_styles()
-                            .map(|s| {
-                                s.get_box().original_display.outside() == DisplayOutside::Inline
-                            })
-                            .unwrap_or(true);
+                    // The static position of an absolutely positioned box depends on the
+                    // display its hypothetical box would have had (the display specified
+                    // before position:absolute blockified it): inline-level boxes sit at
+                    // their position within the line, while block-level boxes start at the
+                    // content-box left edge of their containing block.
+                    let is_inline_level =
+                        style.style.get_box().original_display.outside() == DisplayOutside::Inline;
+
+                    // Resolve relative inset offsets against the containing block
+                    // (the content box of the inline container).
+                    let container_content_size = final_size - content_box_inset.sum_axes();
+                    let inset_style = style.inset();
+                    let inset = taffy::Rect {
+                        left: inset_style
+                            .left
+                            .maybe_resolve(container_content_size.width, resolve_calc_value),
+                        right: inset_style
+                            .right
+                            .maybe_resolve(container_content_size.width, resolve_calc_value),
+                        top: inset_style
+                            .top
+                            .maybe_resolve(container_content_size.height, resolve_calc_value),
+                        bottom: inset_style
+                            .bottom
+                            .maybe_resolve(container_content_size.height, resolve_calc_value),
+                    };
+                    drop(style);
+
+                    if is_absolute {
                         // Inline-level boxes are placed at the top of the line box they would
                         // have occupied (`ibox.y` is the baseline as out-of-flow boxes are
                         // zero-sized), and block-level boxes below it.
@@ -757,28 +794,6 @@ impl BaseDocument {
                             .size;
                         let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
 
-                        // Resolve relative inset offsets against the containing block
-                        // (the content box of the inline container).
-                        let style = node.style();
-                        let container_content_size = final_size - content_box_inset.sum_axes();
-                        let inset = taffy::Rect {
-                            left: style
-                                .inset
-                                .left
-                                .maybe_resolve(container_content_size.width, resolve_calc_value),
-                            right: style
-                                .inset
-                                .right
-                                .maybe_resolve(container_content_size.width, resolve_calc_value),
-                            top: style
-                                .inset
-                                .top
-                                .maybe_resolve(container_content_size.height, resolve_calc_value),
-                            bottom: style
-                                .inset
-                                .bottom
-                                .maybe_resolve(container_content_size.height, resolve_calc_value),
-                        };
                         let inset_offset = taffy::Point {
                             x: if container_direction == Direction::Rtl {
                                 inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -4,7 +4,7 @@
 //! However, in Blitz, we do a style pass then a layout pass.
 //! This is slower, yes, but happens fast enough that it's not a huge issue.
 
-use crate::node::{ImageData, NodeData, SpecialElementData};
+use crate::node::{ComputedStyleRef, ImageData, NodeData, SpecialElementData};
 use crate::{document::BaseDocument, dom_node_id, node::Node, taffy_node_id};
 use markup5ever::{LocalName, local_name};
 use std::cell::Ref;
@@ -12,9 +12,10 @@ use std::sync::Arc;
 use style::Atom;
 use style::values::computed::CSSPixelLength;
 use style::values::computed::length_percentage::CalcLengthPercentage;
+use stylo_taffy::TaffyStyloStyle;
 use taffy::{
-    BlockContext, FlexDirection, LayoutPartialTree, NodeId, ResolveOrZero, RoundTree, Style,
-    TraversePartialTree, TraverseTree, compute_block_layout, compute_cached_layout,
+    BlockContext, CoreStyle as _, FlexDirection, LayoutPartialTree, NodeId, ResolveOrZero,
+    RoundTree, TraversePartialTree, TraverseTree, compute_block_layout, compute_cached_layout,
     compute_flexbox_layout, compute_grid_layout, compute_leaf_layout, prelude::*,
 };
 
@@ -152,7 +153,7 @@ impl BaseDocument {
 
                     return compute_leaf_layout(
                         inputs,
-                        node.style(),
+                        &node.layout_style(),
                         resolve_calc_value,
                         |_known_size, _available_space| taffy::Size {
                             width: cols
@@ -167,20 +168,20 @@ impl BaseDocument {
                     match element_data.attr(local_name!("type")) {
                         // if the input type is hidden, hide it
                         Some("hidden") => {
-                            node.style_mut().display = Display::None;
                             return taffy::LayoutOutput::HIDDEN;
                         }
                         Some("checkbox") => {
                             return compute_leaf_layout(
                                 inputs,
-                                node.style(),
+                                &node.layout_style(),
                                 resolve_calc_value,
                                 |_known_size, _available_space| {
-                                    let width = node.style().size.width.resolve_or_zero(
+                                    let size = node.layout_style().size();
+                                    let width = size.width.resolve_or_zero(
                                         inputs.parent_size.width,
                                         resolve_calc_value,
                                     );
-                                    let height = node.style().size.height.resolve_or_zero(
+                                    let height = size.height.resolve_or_zero(
                                         inputs.parent_size.height,
                                         resolve_calc_value,
                                     );
@@ -195,7 +196,7 @@ impl BaseDocument {
                         None | Some("text" | "password" | "email" | "tel" | "url" | "search") => {
                             return compute_leaf_layout(
                                 inputs,
-                                node.style(),
+                                &node.layout_style(),
                                 resolve_calc_value,
                                 |_known_size, _available_space| taffy::Size {
                                     width: match inputs.available_space.width {
@@ -315,7 +316,7 @@ impl BaseDocument {
 
                     return compute_replaced_layout(
                         inputs,
-                        node.style(),
+                        &node.layout_style(),
                         resolve_calc_value,
                         &replaced_context,
                     );
@@ -356,7 +357,7 @@ impl BaseDocument {
                 }
 
                 // The default CSS file will set
-                match node.style().display {
+                match node.taffy_display() {
                     Display::Block => compute_block_layout(self, node_id, inputs, block_ctx),
                     Display::FlowRoot => compute_block_layout(self, node_id, inputs, None),
                     Display::Flex => compute_flexbox_layout(self, node_id, inputs),
@@ -404,14 +405,14 @@ impl TraverseTree for BaseDocument {}
 
 impl LayoutPartialTree for BaseDocument {
     type CoreContainerStyle<'a>
-        = &'a taffy::Style<Atom>
+        = TaffyStyloStyle<ComputedStyleRef<'a>>
     where
         Self: 'a;
 
     type CustomIdent = Atom;
 
-    fn get_core_container_style(&self, node_id: NodeId) -> &Style<Atom> {
-        self.node_from_id(node_id).style()
+    fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
+        self.node_from_id(node_id).layout_style()
     }
 
     fn set_unrounded_layout(&mut self, node_id: NodeId, layout: &Layout) {
@@ -464,12 +465,12 @@ impl taffy::CacheTree for BaseDocument {
 
 impl taffy::LayoutBlockContainer for BaseDocument {
     type BlockContainerStyle<'a>
-        = &'a Style<Atom>
+        = TaffyStyloStyle<ComputedStyleRef<'a>>
     where
         Self: 'a;
 
     type BlockItemStyle<'a>
-        = &'a Style<Atom>
+        = TaffyStyloStyle<ComputedStyleRef<'a>>
     where
         Self: 'a;
 
@@ -496,12 +497,12 @@ impl taffy::LayoutBlockContainer for BaseDocument {
 
 impl taffy::LayoutFlexboxContainer for BaseDocument {
     type FlexboxContainerStyle<'a>
-        = &'a Style<Atom>
+        = TaffyStyloStyle<ComputedStyleRef<'a>>
     where
         Self: 'a;
 
     type FlexboxItemStyle<'a>
-        = &'a Style<Atom>
+        = TaffyStyloStyle<ComputedStyleRef<'a>>
     where
         Self: 'a;
 
@@ -516,12 +517,12 @@ impl taffy::LayoutFlexboxContainer for BaseDocument {
 
 impl taffy::LayoutGridContainer for BaseDocument {
     type GridContainerStyle<'a>
-        = &'a Style<Atom>
+        = TaffyStyloStyle<ComputedStyleRef<'a>>
     where
         Self: 'a;
 
     type GridItemStyle<'a>
-        = &'a Style<Atom>
+        = TaffyStyloStyle<ComputedStyleRef<'a>>
     where
         Self: 'a;
 
@@ -566,9 +567,9 @@ impl PrintTree for BaseDocument {
             NodeData::Comment { .. } => "COMMENT",
             NodeData::AnonymousBlock(_) => "ANONYMOUS BLOCK",
             NodeData::Element(_) => {
-                let style = node.style();
-                let display = match style.display {
-                    Display::Flex => match style.flex_direction {
+                let style = node.layout_style();
+                let display = match node.taffy_display() {
+                    Display::Flex => match taffy::FlexboxContainerStyle::flex_direction(&style) {
                         FlexDirection::Row | FlexDirection::RowReverse => "FLEX ROW",
                         FlexDirection::Column | FlexDirection::ColumnReverse => "FLEX COL",
                     },

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -21,10 +21,7 @@ use style::{
 };
 use style_dom::ElementState;
 use style_traits::ParsingMode;
-use taffy::{
-    Cache,
-    prelude::{Layout, Style},
-};
+use taffy::{Cache, prelude::Layout};
 use url::Url;
 
 use super::stylo_data::StyloData;
@@ -112,7 +109,6 @@ pub struct ElementData {
     pub detailed_grid_info: Option<Box<taffy::DetailedGridInfo<Atom>>>,
 
     // Taffy layout data:
-    pub style: Style<Atom>,
     pub display_constructed_as: StyloDisplay,
     pub cache: Cache,
     pub unrounded_layout: Layout,
@@ -141,7 +137,6 @@ pub struct DocumentData {
     pub element_state: ElementState,
     pub has_snapshot: bool,
     pub snapshot_handled: AtomicBool,
-    pub style: Style<Atom>,
     pub display_constructed_as: StyloDisplay,
     pub cache: Cache,
     pub unrounded_layout: Layout,
@@ -163,7 +158,6 @@ impl std::fmt::Debug for DocumentData {
             .field("element_state", &self.element_state)
             .field("has_snapshot", &self.has_snapshot)
             .field("snapshot_handled", &self.snapshot_handled)
-            .field("style", &self.style)
             .field("display_constructed_as", &self.display_constructed_as)
             .field("cache", &self.cache)
             .field("unrounded_layout", &self.unrounded_layout)
@@ -186,7 +180,6 @@ impl DocumentData {
             element_state: ElementState::empty(),
             has_snapshot: false,
             snapshot_handled: AtomicBool::new(false),
-            style: Default::default(),
             display_constructed_as: StyloDisplay::Block,
             cache: Cache::new(),
             unrounded_layout: Layout::new(),
@@ -267,7 +260,6 @@ impl Clone for ElementData {
             before: None,
             after: None,
             detailed_grid_info: None,
-            style: Default::default(),
             display_constructed_as: StyloDisplay::Block,
             cache: Cache::new(),
             unrounded_layout: Layout::new(),
@@ -379,7 +371,6 @@ impl ElementData {
             before: None,
             after: None,
             detailed_grid_info: None,
-            style: Default::default(),
             display_constructed_as: StyloDisplay::Block,
             cache: Cache::new(),
             unrounded_layout: Layout::new(),

--- a/packages/blitz-dom/src/node/mod.rs
+++ b/packages/blitz-dom/src/node/mod.rs
@@ -23,6 +23,7 @@ pub use element::{
 };
 pub use node::*;
 pub use scrollbar::{ScrollbarColor, ScrollbarRef, ScrollbarWidth};
+pub use stylo_data::ComputedStyleRef;
 #[cfg(feature = "svg")]
 pub use svg::{SvgImageData, SvgIntrinsicDimensions};
 pub use text::{GeneratedTextInputEvent, TextBrush, TextInputData, TextLayout};

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -18,7 +18,6 @@ use std::fmt::Write;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use style::Atom;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::properties::ComputedValues;
 use style::properties::generated::longhands::position::computed_value::T as Position;
@@ -31,13 +30,10 @@ use style::values::computed::Display as StyloDisplay;
 use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style_dom::ElementState;
 use style_traits::values::ToCss;
-use taffy::{
-    Cache,
-    prelude::{Layout, Style},
-};
+use taffy::{Cache, prelude::Layout};
 use thin_vec::ThinVec;
 
-use super::stylo_data::StyloData;
+use super::stylo_data::{ComputedStyleRef, StyloData};
 use super::{Attribute, DocumentData, ElementData};
 
 #[derive(Clone, Copy)]
@@ -159,7 +155,6 @@ macro_rules! universal_accessors {
 
 universal_accessors! {
     stylo_element_data / stylo_element_data_mut: StyloData,
-    style / style_mut: Style<Atom>,
     cache / cache_mut: Cache,
     unrounded_layout / unrounded_layout_mut: Layout,
     final_layout / final_layout_mut: Layout,
@@ -1085,6 +1080,35 @@ impl Node {
     pub fn primary_styles(&self) -> Option<impl Deref<Target = ServoArc<ComputedValues>>> {
         self.stylo_element_data_opt()
             .and_then(|stylo| stylo.primary_styles())
+    }
+
+    /// A lazy Taffy style backed by this node's primary stylo style.
+    ///
+    /// Panics if the node has no computed styles: layout always runs after
+    /// styling, and the only unstyled nodes (text, comments, descendants of
+    /// `display: none`) are never queried by Taffy.
+    pub fn layout_style(&self) -> stylo_taffy::TaffyStyloStyle<ComputedStyleRef<'_>> {
+        let styles = self
+            .stylo_element_data_opt()
+            .and_then(|stylo| stylo.computed_styles())
+            .expect("layout_style() called on a node without computed styles");
+
+        let mut flags = stylo_taffy::StyleFlags::empty();
+        if let Some(el) = self.data.downcast_element() {
+            if crate::layout::replaced::is_replaced_element(&el.name.local) {
+                flags |= stylo_taffy::StyleFlags::IS_REPLACED;
+            }
+        }
+
+        stylo_taffy::TaffyStyloStyle::new(styles, flags)
+    }
+
+    /// The node's `display` as a [`taffy::Display`]. Returns [`taffy::Display::Block`]
+    /// for nodes without computed styles (e.g. text nodes).
+    pub fn taffy_display(&self) -> taffy::Display {
+        self.primary_styles()
+            .map(|s| stylo_taffy::convert::display(s.clone_display()))
+            .unwrap_or(taffy::Display::Block)
     }
 
     pub fn text_content(&self) -> String {

--- a/packages/blitz-dom/src/node/stylo_data.rs
+++ b/packages/blitz-dom/src/node/stylo_data.rs
@@ -81,6 +81,11 @@ impl StyloData {
         }
     }
 
+    /// Borrow the primary computed style directly (rather than the `Arc` containing it).
+    pub fn computed_styles(&self) -> Option<ComputedStyleRef<'_>> {
+        self.primary_styles().map(ComputedStyleRef)
+    }
+
     /// Get a mutable reference to the data
     pub unsafe fn unsafe_stylo_only_mut(&self) -> Option<ElementDataMut<'_>> {
         let opt = unsafe { &mut *self.inner.get() };
@@ -120,5 +125,18 @@ impl Deref for StyleDataRef<'_> {
 
     fn deref(&self) -> &Self::Target {
         self.0.styles.get_primary().unwrap()
+    }
+}
+
+/// Borrow of a node's stylo element data that `Deref`s directly to the primary
+/// [`ComputedValues`](style::properties::ComputedValues), suitable for wrapping
+/// in [`stylo_taffy::TaffyStyloStyle`].
+pub struct ComputedStyleRef<'a>(StyleDataRef<'a>);
+
+impl Deref for ComputedStyleRef<'_> {
+    type Target = style::properties::ComputedValues;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.0.styles.get_primary().unwrap()
     }
 }

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -294,7 +294,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         let node = &self.dom.as_ref().tree()[node_id];
 
         // Early return if the element is hidden
-        if matches!(node.style().display, taffy::Display::None) {
+        if matches!(node.taffy_display(), taffy::Display::None) {
             return;
         }
 
@@ -1145,7 +1145,7 @@ impl ElementCx<'_, '_> {
             let shape = &self.frame.border_box;
             let stroke = Stroke::new(self.scale);
 
-            let stroke_color = match self.node.style().display {
+            let stroke_color = match self.node.taffy_display() {
                 taffy::Display::Block | taffy::Display::FlowRoot => {
                     Color::new([1.0, 0.0, 0.0, 1.0])
                 }

--- a/packages/stylo_taffy/Cargo.toml
+++ b/packages/stylo_taffy/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 
 
 [dependencies]
+bitflags = { workspace = true }
 taffy = { workspace = true }
 style = { workspace = true }
 style_atoms = { workspace = true }

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -182,11 +182,7 @@ pub fn inset(val: &stylo::InsetVal) -> taffy::LengthPercentageAuto {
 
 #[inline]
 pub fn is_block(input: stylo::Display) -> bool {
-    matches!(input.outside(), stylo::DisplayOutside::Block)
-        && matches!(
-            input.inside(),
-            stylo::DisplayInside::Flow | stylo::DisplayInside::FlowRoot
-        )
+    self::display(input) == taffy::Display::Block
 }
 
 #[inline]

--- a/packages/stylo_taffy/src/lib.rs
+++ b/packages/stylo_taffy/src/lib.rs
@@ -4,7 +4,7 @@
 //! used standalone, and serves as useful reference for anyone wanting to integrate [`stylo`](::style) with [`taffy`]
 
 mod wrapper;
-pub use wrapper::TaffyStyloStyle;
+pub use wrapper::{StyleFlags, TaffyStyloStyle};
 
 pub mod convert;
 #[doc(inline)]

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -1,4 +1,5 @@
 use crate::convert;
+use bitflags::bitflags;
 use convert::stylo;
 use std::ops::Deref;
 use style::properties::ComputedValues;
@@ -12,21 +13,48 @@ use style::values::{
     specified::position::NamedArea,
 };
 
+bitflags! {
+    /// Flags for style information that Taffy needs but which is not part of the
+    /// stylo [`ComputedValues`]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+    pub struct StyleFlags: u8 {
+        /// Whether the node is a replaced element (e.g. an image or form control)
+        const IS_REPLACED = 1 << 0;
+    }
+}
+
 /// A wrapper struct for anything that `Deref`s to a [`stylo::ComputedValues`](ComputedValues) (can be pointed to by an `&` reference, [`Arc`](std::sync::Arc),
 /// [`Ref`](std::cell::Ref), etc). It implements [`taffy`]'s [layout traits](taffy::traits) and can used with Taffy's [layout algorithms](taffy::compute).
-pub struct TaffyStyloStyle<T: Deref<Target = ComputedValues>>(pub T);
+pub struct TaffyStyloStyle<T: Deref<Target = ComputedValues>> {
+    /// The stylo style
+    pub style: T,
+    /// Extra node-derived flags that are not part of the stylo style
+    pub flags: StyleFlags,
+}
+
+impl<T: Deref<Target = ComputedValues>> TaffyStyloStyle<T> {
+    /// Create a new [`TaffyStyloStyle`] from a stylo style and [`StyleFlags`]
+    pub fn new(style: T, flags: StyleFlags) -> Self {
+        Self { style, flags }
+    }
+}
 
 // Deref<stylo::ComputedValues> impl
 impl<T: Deref<Target = ComputedValues>> From<T> for TaffyStyloStyle<T> {
     fn from(value: T) -> Self {
-        Self(value)
+        Self {
+            style: value,
+            flags: StyleFlags::empty(),
+        }
     }
 }
 
 // Into<taffy::Style> impl
 impl<T: Deref<Target = ComputedValues>> From<TaffyStyloStyle<T>> for taffy::Style<Atom> {
     fn from(value: TaffyStyloStyle<T>) -> Self {
-        convert::to_taffy_style(&value.0)
+        let mut style = convert::to_taffy_style(&value.style);
+        style.item_is_replaced = value.flags.contains(StyleFlags::IS_REPLACED);
+        style
     }
 }
 
@@ -36,27 +64,32 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn box_generation_mode(&self) -> taffy::BoxGenerationMode {
-        convert::box_generation_mode(self.0.get_box().display)
+        convert::box_generation_mode(self.style.get_box().display)
     }
 
     #[inline]
     fn is_block(&self) -> bool {
-        convert::is_block(self.0.get_box().display)
+        convert::is_block(self.style.get_box().display)
+    }
+
+    #[inline]
+    fn is_compressible_replaced(&self) -> bool {
+        self.flags.contains(StyleFlags::IS_REPLACED)
     }
 
     #[inline]
     fn box_sizing(&self) -> taffy::BoxSizing {
-        convert::box_sizing(self.0.get_position().box_sizing)
+        convert::box_sizing(self.style.get_position().box_sizing)
     }
 
     #[inline]
     fn direction(&self) -> taffy::Direction {
-        convert::direction(self.0.get_inherited_box().direction)
+        convert::direction(self.style.get_inherited_box().direction)
     }
 
     #[inline]
     fn overflow(&self) -> taffy::Point<taffy::Overflow> {
-        let box_styles = self.0.get_box();
+        let box_styles = self.style.get_box();
         taffy::Point {
             x: convert::overflow(box_styles.overflow_x),
             y: convert::overflow(box_styles.overflow_y),
@@ -70,18 +103,18 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn contain(&self) -> taffy::Contain {
-        let box_styles = self.0.get_box();
+        let box_styles = self.style.get_box();
         convert::contain(box_styles.contain, box_styles.display)
     }
 
     #[inline]
     fn position(&self) -> taffy::Position {
-        convert::position(self.0.get_box().position)
+        convert::position(self.style.get_box().position)
     }
 
     #[inline]
     fn inset(&self) -> taffy::Rect<taffy::LengthPercentageAuto> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Rect {
             left: convert::inset(&position_styles.left),
             right: convert::inset(&position_styles.right),
@@ -92,7 +125,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn size(&self) -> taffy::Size<taffy::Dimension> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Size {
             width: convert::dimension(&position_styles.width),
             height: convert::dimension(&position_styles.height),
@@ -101,7 +134,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn min_size(&self) -> taffy::Size<taffy::LengthPercentageAuto> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Size {
             width: convert::min_size(&position_styles.min_width),
             height: convert::min_size(&position_styles.min_height),
@@ -110,7 +143,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn max_size(&self) -> taffy::Size<taffy::LengthPercentageAuto> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Size {
             width: convert::max_size(&position_styles.max_width),
             height: convert::max_size(&position_styles.max_height),
@@ -119,12 +152,12 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn aspect_ratio(&self) -> Option<f32> {
-        convert::aspect_ratio(self.0.get_position().aspect_ratio)
+        convert::aspect_ratio(self.style.get_position().aspect_ratio)
     }
 
     #[inline]
     fn margin(&self) -> taffy::Rect<taffy::LengthPercentageAuto> {
-        let margin_styles = self.0.get_margin();
+        let margin_styles = self.style.get_margin();
         taffy::Rect {
             left: convert::margin(&margin_styles.margin_left),
             right: convert::margin(&margin_styles.margin_right),
@@ -135,7 +168,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn padding(&self) -> taffy::Rect<taffy::LengthPercentage> {
-        let padding_styles = self.0.get_padding();
+        let padding_styles = self.style.get_padding();
         taffy::Rect {
             left: convert::length_percentage(&padding_styles.padding_left.0),
             right: convert::length_percentage(&padding_styles.padding_right.0),
@@ -146,7 +179,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn border(&self) -> taffy::Rect<taffy::LengthPercentage> {
-        let border_styles = self.0.get_border();
+        let border_styles = self.style.get_border();
         taffy::Rect {
             left: convert::border(
                 &border_styles.border_left_width,
@@ -173,12 +206,15 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 impl<T: Deref<Target = ComputedValues>> taffy::BlockContainerStyle for TaffyStyloStyle<T> {
     #[inline]
     fn text_align(&self) -> taffy::TextAlign {
-        convert::text_align(self.0.clone_text_align())
+        convert::text_align(self.style.clone_text_align())
     }
 
     #[inline]
     fn align_content(&self) -> Option<taffy::AlignContent> {
-        convert::content_alignment(self.0.get_position().align_content, self.0.clone_display())
+        convert::content_alignment(
+            self.style.get_position().align_content,
+            self.style.clone_display(),
+        )
     }
 }
 
@@ -187,7 +223,19 @@ impl<T: Deref<Target = ComputedValues>> taffy::BlockContainerStyle for TaffyStyl
 impl<T: Deref<Target = ComputedValues>> taffy::BlockItemStyle for TaffyStyloStyle<T> {
     #[inline]
     fn is_table(&self) -> bool {
-        convert::is_table(self.0.clone_display())
+        convert::is_table(self.style.clone_display())
+    }
+
+    #[cfg(feature = "floats")]
+    #[inline]
+    fn float(&self) -> taffy::Float {
+        convert::float(self.style.clone_float())
+    }
+
+    #[cfg(feature = "floats")]
+    #[inline]
+    fn clear(&self) -> taffy::Clear {
+        convert::clear(self.style.clone_clear())
     }
 }
 
@@ -196,17 +244,17 @@ impl<T: Deref<Target = ComputedValues>> taffy::BlockItemStyle for TaffyStyloStyl
 impl<T: Deref<Target = ComputedValues>> taffy::FlexboxContainerStyle for TaffyStyloStyle<T> {
     #[inline]
     fn flex_direction(&self) -> taffy::FlexDirection {
-        convert::flex_direction(self.0.get_position().flex_direction)
+        convert::flex_direction(self.style.get_position().flex_direction)
     }
 
     #[inline]
     fn flex_wrap(&self) -> taffy::FlexWrap {
-        convert::flex_wrap(self.0.get_position().flex_wrap)
+        convert::flex_wrap(self.style.get_position().flex_wrap)
     }
 
     #[inline]
     fn gap(&self) -> taffy::Size<taffy::LengthPercentage> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Size {
             width: convert::gap(&position_styles.column_gap),
             height: convert::gap(&position_styles.row_gap),
@@ -215,19 +263,22 @@ impl<T: Deref<Target = ComputedValues>> taffy::FlexboxContainerStyle for TaffySt
 
     #[inline]
     fn align_content(&self) -> Option<taffy::AlignContent> {
-        convert::content_alignment(self.0.get_position().align_content, self.0.clone_display())
+        convert::content_alignment(
+            self.style.get_position().align_content,
+            self.style.clone_display(),
+        )
     }
 
     #[inline]
     fn align_items(&self) -> Option<taffy::AlignItems> {
-        convert::item_alignment(self.0.get_position().align_items.0, false)
+        convert::item_alignment(self.style.get_position().align_items.0, false)
     }
 
     #[inline]
     fn justify_content(&self) -> Option<taffy::JustifyContent> {
         convert::content_alignment(
-            self.0.get_position().justify_content,
-            self.0.clone_display(),
+            self.style.get_position().justify_content,
+            self.style.clone_display(),
         )
     }
 }
@@ -237,22 +288,22 @@ impl<T: Deref<Target = ComputedValues>> taffy::FlexboxContainerStyle for TaffySt
 impl<T: Deref<Target = ComputedValues>> taffy::FlexboxItemStyle for TaffyStyloStyle<T> {
     #[inline]
     fn flex_basis(&self) -> taffy::Dimension {
-        convert::flex_basis(&self.0.get_position().flex_basis)
+        convert::flex_basis(&self.style.get_position().flex_basis)
     }
 
     #[inline]
     fn flex_grow(&self) -> f32 {
-        self.0.get_position().flex_grow.0
+        self.style.get_position().flex_grow.0
     }
 
     #[inline]
     fn flex_shrink(&self) -> f32 {
-        self.0.get_position().flex_shrink.0
+        self.style.get_position().flex_shrink.0
     }
 
     #[inline]
     fn align_self(&self) -> Option<taffy::AlignSelf> {
-        convert::item_alignment(self.0.get_position().align_self.0, false)
+        convert::item_alignment(self.style.get_position().align_self.0, false)
     }
 }
 
@@ -379,7 +430,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 
     #[inline]
     fn grid_template_rows(&self) -> Option<Self::TemplateTrackList<'_>> {
-        match &self.0.get_position().grid_template_rows {
+        match &self.style.get_position().grid_template_rows {
             stylo::GenericGridTemplateComponent::None => None,
             stylo::GenericGridTemplateComponent::TrackList(list) => {
                 Some(list.values.iter().map(|track| match track {
@@ -400,7 +451,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 
     #[inline]
     fn grid_template_columns(&self) -> Option<Self::TemplateTrackList<'_>> {
-        match &self.0.get_position().grid_template_columns {
+        match &self.style.get_position().grid_template_columns {
             stylo::GenericGridTemplateComponent::None => None,
             stylo::GenericGridTemplateComponent::TrackList(list) => {
                 Some(list.values.iter().map(|track| match track {
@@ -421,7 +472,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 
     #[inline]
     fn grid_auto_rows(&self) -> Self::AutoTrackList<'_> {
-        self.0
+        self.style
             .get_position()
             .grid_auto_rows
             .0
@@ -431,7 +482,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 
     #[inline]
     fn grid_auto_columns(&self) -> Self::AutoTrackList<'_> {
-        self.0
+        self.style
             .get_position()
             .grid_auto_columns
             .0
@@ -440,7 +491,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
     }
 
     fn grid_template_areas(&self) -> Option<Self::GridTemplateAreas<'_>> {
-        match &self.0.get_position().grid_template_areas {
+        match &self.style.get_position().grid_template_areas {
             GridTemplateAreas::Areas(areas) => {
                 Some(areas.0.areas.iter().map(|area| taffy::GridTemplateArea {
                     name: area.name.clone(),
@@ -455,21 +506,21 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
     }
 
     fn grid_template_area_row_count(&self) -> u16 {
-        match &self.0.get_position().grid_template_areas {
+        match &self.style.get_position().grid_template_areas {
             GridTemplateAreas::Areas(areas) => areas.0.strings.len() as u16,
             GridTemplateAreas::None => 0,
         }
     }
 
     fn grid_template_area_column_count(&self) -> u16 {
-        match &self.0.get_position().grid_template_areas {
+        match &self.style.get_position().grid_template_areas {
             GridTemplateAreas::Areas(areas) => areas.0.width as u16,
             GridTemplateAreas::None => 0,
         }
     }
 
     fn grid_template_column_names(&self) -> Option<Self::TemplateLineNames<'_>> {
-        match &self.0.get_position().grid_template_columns {
+        match &self.style.get_position().grid_template_columns {
             stylo::GenericGridTemplateComponent::None => None,
             stylo::GenericGridTemplateComponent::TrackList(list) => {
                 Some(StyloLineNameIter::new(&list.line_names))
@@ -481,7 +532,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
     }
 
     fn grid_template_row_names(&self) -> Option<Self::TemplateLineNames<'_>> {
-        match &self.0.get_position().grid_template_rows {
+        match &self.style.get_position().grid_template_rows {
             stylo::GenericGridTemplateComponent::None => None,
             stylo::GenericGridTemplateComponent::TrackList(list) => {
                 Some(StyloLineNameIter::new(&list.line_names))
@@ -494,12 +545,12 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 
     #[inline]
     fn grid_auto_flow(&self) -> taffy::GridAutoFlow {
-        convert::grid_auto_flow(self.0.get_position().grid_auto_flow)
+        convert::grid_auto_flow(self.style.get_position().grid_auto_flow)
     }
 
     #[inline]
     fn gap(&self) -> taffy::Size<taffy::LengthPercentage> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Size {
             width: convert::gap(&position_styles.column_gap),
             height: convert::gap(&position_styles.row_gap),
@@ -508,27 +559,30 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 
     #[inline]
     fn align_content(&self) -> Option<taffy::AlignContent> {
-        convert::content_alignment(self.0.get_position().align_content, self.0.clone_display())
+        convert::content_alignment(
+            self.style.get_position().align_content,
+            self.style.clone_display(),
+        )
     }
 
     #[inline]
     fn justify_content(&self) -> Option<taffy::JustifyContent> {
         convert::content_alignment(
-            self.0.get_position().justify_content,
-            self.0.clone_display(),
+            self.style.get_position().justify_content,
+            self.style.clone_display(),
         )
     }
 
     #[inline]
     fn align_items(&self) -> Option<taffy::AlignItems> {
-        convert::item_alignment(self.0.get_position().align_items.0, false)
+        convert::item_alignment(self.style.get_position().align_items.0, false)
     }
 
     #[inline]
     fn justify_items(&self) -> Option<taffy::AlignItems> {
         convert::item_alignment(
-            (self.0.get_position().justify_items.computed.0).0,
-            self.0.clone_direction() == stylo::Direction::Rtl,
+            (self.style.get_position().justify_items.computed.0).0,
+            self.style.clone_direction() == stylo::Direction::Rtl,
         )
     }
 }
@@ -538,7 +592,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 impl<T: Deref<Target = ComputedValues>> taffy::GridItemStyle for TaffyStyloStyle<T> {
     #[inline]
     fn grid_row(&self) -> taffy::Line<taffy::GridPlacement<Atom>> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Line {
             start: convert::grid_line(&position_styles.grid_row_start),
             end: convert::grid_line(&position_styles.grid_row_end),
@@ -547,7 +601,7 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridItemStyle for TaffyStyloStyle
 
     #[inline]
     fn grid_column(&self) -> taffy::Line<taffy::GridPlacement<Atom>> {
-        let position_styles = self.0.get_position();
+        let position_styles = self.style.get_position();
         taffy::Line {
             start: convert::grid_line(&position_styles.grid_column_start),
             end: convert::grid_line(&position_styles.grid_column_end),
@@ -556,14 +610,14 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridItemStyle for TaffyStyloStyle
 
     #[inline]
     fn align_self(&self) -> Option<taffy::AlignSelf> {
-        convert::item_alignment(self.0.get_position().align_self.0, false)
+        convert::item_alignment(self.style.get_position().align_self.0, false)
     }
 
     #[inline]
     fn justify_self(&self) -> Option<taffy::AlignSelf> {
         convert::item_alignment(
-            self.0.get_position().justify_self.0,
-            self.0.clone_direction() == stylo::Direction::Rtl,
+            self.style.get_position().justify_self.0,
+            self.style.clone_direction() == stylo::Direction::Rtl,
         )
     }
 }

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -276,8 +276,11 @@ impl<T: Deref<Target = ComputedValues>> taffy::FlexboxContainerStyle for TaffySt
 
     #[inline]
     fn justify_content(&self) -> Option<taffy::JustifyContent> {
-        convert::content_alignment(
-            self.style.get_position().justify_content,
+        let position_styles = self.style.get_position();
+        convert::justify_content(
+            position_styles.justify_content,
+            position_styles.flex_direction,
+            self.style.clone_direction(),
             self.style.clone_display(),
         )
     }
@@ -567,8 +570,11 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStylo
 
     #[inline]
     fn justify_content(&self) -> Option<taffy::JustifyContent> {
-        convert::content_alignment(
-            self.style.get_position().justify_content,
+        let position_styles = self.style.get_position();
+        convert::justify_content(
+            position_styles.justify_content,
+            position_styles.flex_direction,
+            self.style.clone_direction(),
             self.style.clone_display(),
         )
     }


### PR DESCRIPTION
## Summary

Removes the eager Stylo→Taffy style conversion pass entirely: layout now reads styles lazily through the existing `TaffyStyloStyle` wrapper, straight from the node's primary stylo `ComputedValues`.

Key changes:

- **`TaffyStyloStyle` is now a named-field struct with extensible flags**:
  ```rust
  bitflags! { pub struct StyleFlags: u8 { const IS_REPLACED = 1 << 0; } }
  pub struct TaffyStyloStyle<T: Deref<Target = ComputedValues>> { pub style: T, pub flags: StyleFlags }
  ```
  `CoreStyle::is_compressible_replaced()` reads the flag, so the node-derived `item_is_replaced` no longer needs to be stamped into a materialized style.

- **Blitz layout GATs return the lazy wrapper by value**:
  ```rust
  type CoreContainerStyle<'a> = TaffyStyloStyle<ComputedStyleRef<'a>>;
  fn get_core_container_style(&self, node_id: NodeId) -> Self::CoreContainerStyle<'_> {
      self.node_from_id(node_id).layout_style()  // unwraps primary_styles(); no fallback
  }
  ```
  `ComputedStyleRef<'a>` is a mapped `AtomicRef` deref-ing to the primary `ComputedValues`. There is deliberately no default-style fallback: layout only runs post-style, and text/comment nodes and `display:none` descendants are never queried by Taffy.

- **`flush_styles_to_layout` no longer converts styles** — it retains only paint-children rebuilding / z-index hoisting. `display_constructed_as` is now recorded during box construction. The per-node owned `taffy::Style` field is deleted (a per-node memory win: it embedded grid track vectors).

- Direct owned-style readers in `layout/mod.rs`, `inline.rs`, `blitz-paint`, and debug output were ported to the lazy wrapper / stylo reads. Hidden `<input type=hidden>` handling moved from mutating an owned style to a UA rule (`display: none !important`) + `LayoutOutput::HIDDEN`.

- Table layout keeps materializing (`to_taffy_style`) since it mutates grid fields; the existing `From<TaffyStyloStyle> for taffy::Style` covers it.

- Two wrapper conversion mismatches surfaced by baseline WPT comparison were fixed to match materialized semantics: `convert::is_block()` (now `display(input) == Block`, matching `taffy::Style::is_block()`) and the flex `justify_content()` getter (now uses direction/flex-direction-aware `convert::justify_content`).

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets` / `cargo test --workspace` pass.
- WPT parity vs `main` (same machine, same WPT checkout) on `css/css-flexbox`, `css/css-grid`, `css/CSS2`, `css/css-position`, `css/css-sizing`, `css/css-align`, `css/css-display`: **0 regressions, 0 improvements** (identical pass/fail sets).
- Benchmarks (main vs branch, Wikipedia + grid-heavy page) are running in a separate session; results will be posted on this PR when available.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/89fe3b9a876e43389d2ac10467bfca48
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/89fe3b9a876e43389d2ac10467bfca48?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32903380146).</sub>
<!-- wpt-results-end -->
