### PR TITLE
Avoid cloning decoded image in `ImageHandler::parse`

### DIFF
--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -538,11 +538,13 @@ impl ImageHandler {
             .decode()
         {
             Ok(image) => {
-                let raw_rgba8_data = image.clone().into_rgba8().into_raw();
+                let width = image.width();
+                let height = image.height();
+                let raw_rgba8_data = image.into_rgba8().into_raw();
                 return Ok(Resource::Image(
                     self.kind,
-                    image.width(),
-                    image.height(),
+                    width,
+                    height,
                     Arc::new(raw_rgba8_data),
                 ));
             }


### PR DESCRIPTION
## Summary

`ImageHandler::parse` did `image.clone().into_rgba8()` purely so `image.width()`/`height()` could be called afterwards. For a 3276×2072 image that's an extra transient 27MB allocation (2× peak decode memory per image, and macOS's allocator keeps the freed large region dirty, so it also inflates steady-state footprint).

```diff
- let raw_rgba8_data = image.clone().into_rgba8().into_raw();
+ let width = image.width();
+ let height = image.height();
+ let raw_rgba8_data = image.into_rgba8().into_raw();
```

`into_rgba8()` on an owned `DynamicImage` is also a no-op (no copy) when the decoded image is already RGBA8.

Found while profiling Blitz memory usage (see session analysis for the wider findings: 4096×4096 vello_hybrid image atlas, retained CPU-side pixel copies, etc.).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9cffd370ef03474e88a93f5335b19b65
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/9cffd370ef03474e88a93f5335b19b65?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32887496797).</sub>
<!-- wpt-results-end -->
