### PR TITLE
Box the per-node transform to shrink ElementData

### DIFF
--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -113,7 +113,7 @@ pub struct ElementData {
     pub display_constructed_as: StyloDisplay,
     /// Layout output state (`None` until layout first writes to this node).
     pub layout_data: Option<Box<LayoutData>>,
-    pub transform: Option<Affine>,
+    pub transform: Option<Box<Affine>>,
 }
 
 /// Taffy layout output state (cache, layouts, scroll offset and overflow).
@@ -206,7 +206,7 @@ pub struct DocumentData {
     pub display_constructed_as: StyloDisplay,
     /// Layout output state (`None` until layout first writes to this node).
     pub layout_data: Option<Box<LayoutData>>,
-    pub transform: Option<Affine>,
+    pub transform: Option<Box<Affine>>,
 }
 
 // Hand-written like `ElementData`'s, because `ElementSelectorFlags` does not

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -155,7 +155,7 @@ macro_rules! universal_accessors {
 
 universal_accessors! {
     stylo_element_data / stylo_element_data_mut: StyloData,
-    transform / transform_mut: Option<Affine>,
+    transform / transform_mut: Option<Box<Affine>>,
     display_constructed_as / display_constructed_as_mut: StyloDisplay,
     // The document node is styled/snapshotted like an element, so it also
     // carries these:
@@ -413,7 +413,7 @@ impl Node {
             })
         });
 
-        *self.transform_mut() = transform;
+        *self.transform_mut() = transform.map(Box::new);
         transform
     }
 
@@ -1329,7 +1329,7 @@ impl Node {
         let mut x = x - self.final_layout().location.x + self.scroll_offset().x as f32;
         let mut y = y - self.final_layout().location.y + self.scroll_offset().y as f32;
 
-        if let Some(t) = *self.transform() {
+        if let Some(t) = self.transform().as_deref() {
             let p = t.inverse() * kurbo::Point::new(x as f64 * scale, y as f64 * scale);
             x = (p.x / scale) as f32;
             y = (p.y / scale) as f32;

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -413,7 +413,12 @@ impl Node {
             })
         });
 
-        *self.transform_mut() = transform.map(Box::new);
+        let slot = self.transform_mut();
+        match (slot.as_deref_mut(), transform) {
+            (Some(existing), Some(new)) => *existing = new,
+            (None, Some(new)) => *slot = Some(Box::new(new)),
+            (_, None) => *slot = None,
+        }
         transform
     }
 

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -175,7 +175,7 @@ impl BaseDocument {
             let location = node.final_layout().location.map(|v| v as f64 * scale);
 
             let mut transform = Affine::translate((location.x, location.y));
-            if let Some(t) = node.transform() {
+            if let Some(t) = node.transform().as_deref() {
                 transform *= *t
             }
 

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -382,7 +382,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         let overflow = *node.scrollable_overflow();
         let transform = parent_style_transform
             * Affine::translate(box_position)
-            * node.transform().unwrap_or_default();
+            * node.transform().as_deref().copied().unwrap_or_default();
 
         let screen_transform = Affine::translate(Vec2 {
             x: -self.initial_x,

--- a/tests/blitz-tests/tests/transform_2d_subset.rs
+++ b/tests/blitz-tests/tests/transform_2d_subset.rs
@@ -18,6 +18,7 @@ fn transform_coeffs(harness: &Harness, selector: &str) -> Option<[f64; 6]> {
         .get_node(node_id)
         .unwrap()
         .transform()
+        .as_deref()
         .map(|affine| affine.as_coeffs())
 }
 

--- a/tests/blitz-tests/tests/transform_viewport_scale.rs
+++ b/tests/blitz-tests/tests/transform_viewport_scale.rs
@@ -33,6 +33,7 @@ fn box_transform_coeffs(doc: &HtmlDocument) -> [f64; 6] {
     doc.get_node(box_id)
         .unwrap()
         .transform()
+        .as_deref()
         .expect("box should have a transform")
         .as_coeffs()
 }


### PR DESCRIPTION
## Summary

`ElementData`/`DocumentData::transform` becomes `Option<Box<Affine>>` instead of `Option<Affine>`. `Affine` is `[f64; 6]` (48 bytes) with no niche, so the inline `Option<Affine>` cost 56 bytes on every element even though the vast majority of elements have no CSS transform; boxed it costs 8 bytes (pointer niche), with a heap allocation only for the rare transformed nodes.

Measured with a size_of probe: `ElementData` drops 1472 → 1424 bytes on `main` (heap profiling of the Barack Obama Wikipedia page showed ~22.8k elements at the 1536-byte malloc size class dominating the Document heap). Note the standalone win is struct-size only — 1424 still rounds to the same 1536-byte malloc class; it compounds with #794 (which removes the 488-byte owned `taffy::Style`) and any future `Cache` shrinking.

Callers adjusted for the extra indirection:
```rust
// resolve.rs / node.rs hit-testing
if let Some(t) = node.transform().as_deref() { transform *= *t }
// blitz-paint render.rs
node.transform().as_deref().copied().unwrap_or_default()
```
`Node::set_transform` still computes and returns `Option<Affine>` by value; only the stored field is boxed (`transform.map(Box::new)`).

## Testing

`cargo clippy --workspace --all-targets` and `cargo fmt --all --check` pass (one pre-existing `clone_on_copy` warning in `examples/custom_widget.rs` unrelated to this change).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9cffd370ef03474e88a93f5335b19b65
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/9cffd370ef03474e88a93f5335b19b65?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32917901489).</sub>
<!-- wpt-results-end -->
