### PR TITLE
Lazily allocate taffy layout output state in a boxed LayoutData

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1370,7 +1370,7 @@ impl BaseDocument {
                         SpecialElementData::Image(Box::new(image.clone()));
 
                     // Clear layout cache
-                    node.cache_mut().clear();
+                    node.clear_layout_cache();
                     node.insert_damage(ALL_DAMAGE);
                 }
                 ImageType::Background(idx) | ImageType::Mask(idx) => {

--- a/packages/blitz-dom/src/events/pointer.rs
+++ b/packages/blitz-dom/src/events/pointer.rs
@@ -332,18 +332,19 @@ pub(crate) fn handle_pointermove<F: FnMut(DomEvent)>(
         return changed;
     }
 
+    let final_layout = el.layout_data().final_layout;
     if let SpecialElementData::TextInput(ref mut text_input_data) = el.special_data {
         if buttons == MouseEventButtons::None {
             return changed;
         }
 
         let mut content_box_offset = taffy::Point {
-            x: el.final_layout.padding.left + el.final_layout.border.left,
-            y: el.final_layout.padding.top + el.final_layout.border.top,
+            x: final_layout.padding.left + final_layout.border.left,
+            y: final_layout.padding.top + final_layout.border.top,
         };
         if !text_input_data.is_multiline {
             let layout = text_input_data.editor.try_layout().unwrap();
-            let content_box_height = el.final_layout.content_box_height();
+            let content_box_height = final_layout.content_box_height();
             let input_height = layout.height() / layout.scale();
             let y_offset = ((content_box_height - input_height) / 2.0).max(0.0);
 

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -96,7 +96,7 @@ impl BaseDocument {
         // If the node or any of it's children have been mutated or their layout styles
         // have changed, then we should clear it's layout cache.
         if damage.intersects(ONLY_RELAYOUT | CONSTRUCT_BOX) {
-            node.cache_mut().clear();
+            node.clear_layout_cache();
             if let Some(inline_layout) = node
                 .data
                 .downcast_element_mut()
@@ -551,7 +551,7 @@ impl BaseDocument {
             // In non-incremental mode we unconditionally clear the Taffy cache.
             // In incremental mode this is handled as part of damage propagation.
             if !incremental {
-                node.cache_mut().clear();
+                node.clear_layout_cache();
                 if let Some(inline_layout) = node
                     .data
                     .downcast_element_mut()

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -442,7 +442,10 @@ impl taffy::CacheTree for BaseDocument {
         node_id: NodeId,
         inputs: &taffy::LayoutInput,
     ) -> Option<taffy::LayoutOutput> {
-        self.node_from_id_mut(node_id).cache_mut().get(inputs)
+        self.node_from_id_mut(node_id)
+            .layout_data_opt_mut()?
+            .cache
+            .get(inputs)
     }
 
     #[inline]
@@ -459,7 +462,7 @@ impl taffy::CacheTree for BaseDocument {
 
     #[inline]
     fn cache_clear(&mut self, node_id: NodeId) {
-        self.node_from_id_mut(node_id).cache_mut().clear();
+        self.node_from_id_mut(node_id).clear_layout_cache();
     }
 }
 

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -1113,7 +1113,7 @@ impl<'doc> DocumentMutator<'doc> {
                     let node = &mut self.doc.nodes[target_id];
                     node.element_data_mut().unwrap().special_data =
                         SpecialElementData::Image(Box::new(cached_image.clone()));
-                    node.cache_mut().clear();
+                    node.clear_layout_cache();
                     node.insert_damage(ALL_DAMAGE);
                     return;
                 }

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -111,12 +111,77 @@ pub struct ElementData {
 
     // Taffy layout data:
     pub display_constructed_as: StyloDisplay,
+    /// Layout output state (`None` until layout first writes to this node).
+    pub layout_data: Option<Box<LayoutData>>,
+    pub transform: Option<Affine>,
+}
+
+/// Taffy layout output state (cache, layouts, scroll offset and overflow).
+///
+/// Lazily boxed on [`ElementData`] / [`DocumentData`]: inline-level elements
+/// are positioned by the inline (parley) layout rather than by taffy, so most
+/// nodes on text-heavy pages never allocate one.
+#[derive(Debug, Clone)]
+pub struct LayoutData {
     pub cache: Cache,
     pub unrounded_layout: Layout,
     pub final_layout: Layout,
     pub scroll_offset: crate::Point<f64>,
     pub scrollable_overflow: KurboRect,
-    pub transform: Option<Affine>,
+}
+
+impl LayoutData {
+    pub const fn new() -> Self {
+        Self {
+            cache: Cache::new(),
+            unrounded_layout: Layout::new(),
+            final_layout: Layout::new(),
+            scroll_offset: crate::Point::ZERO,
+            scrollable_overflow: KurboRect::ZERO,
+        }
+    }
+}
+
+impl Default for LayoutData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Shared read-only default returned by accessors for nodes whose
+/// [`LayoutData`] has never been allocated.
+pub(crate) static DEFAULT_LAYOUT_DATA: LayoutData = LayoutData::new();
+
+impl ElementData {
+    /// This element's layout output state, or a shared default if layout has
+    /// never written to this element.
+    #[inline]
+    pub fn layout_data(&self) -> &LayoutData {
+        self.layout_data.as_deref().unwrap_or(&DEFAULT_LAYOUT_DATA)
+    }
+
+    /// Mutable access to this element's layout output state, allocating it if
+    /// it does not yet exist.
+    #[inline]
+    pub fn layout_data_mut(&mut self) -> &mut LayoutData {
+        self.layout_data.get_or_insert_default()
+    }
+}
+
+impl DocumentData {
+    /// The document node's layout output state, or a shared default if layout
+    /// has never written to it.
+    #[inline]
+    pub fn layout_data(&self) -> &LayoutData {
+        self.layout_data.as_deref().unwrap_or(&DEFAULT_LAYOUT_DATA)
+    }
+
+    /// Mutable access to the document node's layout output state, allocating
+    /// it if it does not yet exist.
+    #[inline]
+    pub fn layout_data_mut(&mut self) -> &mut LayoutData {
+        self.layout_data.get_or_insert_default()
+    }
 }
 
 /// Data specific to the [`Document`](super::super::Document) root node.
@@ -139,11 +204,8 @@ pub struct DocumentData {
     pub has_snapshot: bool,
     pub snapshot_handled: AtomicBool,
     pub display_constructed_as: StyloDisplay,
-    pub cache: Cache,
-    pub unrounded_layout: Layout,
-    pub final_layout: Layout,
-    pub scroll_offset: crate::Point<f64>,
-    pub scrollable_overflow: KurboRect,
+    /// Layout output state (`None` until layout first writes to this node).
+    pub layout_data: Option<Box<LayoutData>>,
     pub transform: Option<Affine>,
 }
 
@@ -160,11 +222,7 @@ impl std::fmt::Debug for DocumentData {
             .field("has_snapshot", &self.has_snapshot)
             .field("snapshot_handled", &self.snapshot_handled)
             .field("display_constructed_as", &self.display_constructed_as)
-            .field("cache", &self.cache)
-            .field("unrounded_layout", &self.unrounded_layout)
-            .field("final_layout", &self.final_layout)
-            .field("scroll_offset", &self.scroll_offset)
-            .field("scrollable_overflow", &self.scrollable_overflow)
+            .field("layout_data", &self.layout_data)
             .field("transform", &self.transform)
             .finish_non_exhaustive()
     }
@@ -182,11 +240,7 @@ impl DocumentData {
             has_snapshot: false,
             snapshot_handled: AtomicBool::new(false),
             display_constructed_as: StyloDisplay::Block,
-            cache: Cache::new(),
-            unrounded_layout: Layout::new(),
-            final_layout: Layout::new(),
-            scroll_offset: crate::Point::ZERO,
-            scrollable_overflow: KurboRect::ZERO,
+            layout_data: None,
             transform: None,
         }
     }
@@ -262,11 +316,7 @@ impl Clone for ElementData {
             after: None,
             detailed_grid_info: None,
             display_constructed_as: StyloDisplay::Block,
-            cache: Cache::new(),
-            unrounded_layout: Layout::new(),
-            final_layout: Layout::new(),
-            scroll_offset: crate::Point::ZERO,
-            scrollable_overflow: KurboRect::ZERO,
+            layout_data: None,
             transform: None,
         }
     }
@@ -373,11 +423,7 @@ impl ElementData {
             after: None,
             detailed_grid_info: None,
             display_constructed_as: StyloDisplay::Block,
-            cache: Cache::new(),
-            unrounded_layout: Layout::new(),
-            final_layout: Layout::new(),
-            scroll_offset: crate::Point::ZERO,
-            scrollable_overflow: KurboRect::ZERO,
+            layout_data: None,
             transform: None,
         };
         data.flush_is_focussable();

--- a/packages/blitz-dom/src/node/mod.rs
+++ b/packages/blitz-dom/src/node/mod.rs
@@ -17,9 +17,9 @@ pub use custom_widget::{
     ComputedStyles, CustomWidgetData, CustomWidgetStatus, ProxyRenderContext, Widget,
 };
 pub use element::{
-    CanvasData, DocumentData, ElementData, ImageData, ImageResourceData, ListItemLayout,
-    ListItemLayoutPosition, Marker, RasterImageData, SpecialElementData, SpecialElementType,
-    Status,
+    CanvasData, DocumentData, ElementData, ImageData, ImageResourceData, LayoutData,
+    ListItemLayout, ListItemLayoutPosition, Marker, RasterImageData, SpecialElementData,
+    SpecialElementType, Status,
 };
 pub use node::*;
 pub use scrollbar::{ScrollbarColor, ScrollbarRef, ScrollbarWidth};

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -34,7 +34,7 @@ use taffy::{Cache, prelude::Layout};
 use thin_vec::ThinVec;
 
 use super::stylo_data::{ComputedStyleRef, StyloData};
-use super::{Attribute, DocumentData, ElementData};
+use super::{Attribute, DocumentData, ElementData, LayoutData};
 
 #[derive(Clone, Copy)]
 enum OutputStyle {
@@ -155,11 +155,6 @@ macro_rules! universal_accessors {
 
 universal_accessors! {
     stylo_element_data / stylo_element_data_mut: StyloData,
-    cache / cache_mut: Cache,
-    unrounded_layout / unrounded_layout_mut: Layout,
-    final_layout / final_layout_mut: Layout,
-    scroll_offset / scroll_offset_mut: crate::Point<f64>,
-    scrollable_overflow / scrollable_overflow_mut: KurboRect,
     transform / transform_mut: Option<Affine>,
     display_constructed_as / display_constructed_as_mut: StyloDisplay,
     // The document node is styled/snapshotted like an element, so it also
@@ -173,6 +168,107 @@ universal_accessors! {
 }
 
 impl Node {
+    /// This node's layout output state, or a shared default if layout has
+    /// never written to this node.
+    ///
+    /// Panics for node kinds which do not participate in layout (text and
+    /// comment nodes).
+    #[inline]
+    pub fn layout_data(&self) -> &LayoutData {
+        match &self.data {
+            NodeData::Element(data) | NodeData::AnonymousBlock(data) => data.layout_data(),
+            NodeData::Document(data) => data.layout_data(),
+            _ => panic!("`layout_data` is not available on this node kind"),
+        }
+    }
+
+    /// Mutable access to this node's layout output state, allocating it if it
+    /// does not yet exist.
+    ///
+    /// Panics for node kinds which do not participate in layout (text and
+    /// comment nodes).
+    #[inline]
+    pub fn layout_data_mut(&mut self) -> &mut LayoutData {
+        match &mut self.data {
+            NodeData::Element(data) | NodeData::AnonymousBlock(data) => data.layout_data_mut(),
+            NodeData::Document(data) => data.layout_data_mut(),
+            _ => panic!("`layout_data` is not available on this node kind"),
+        }
+    }
+
+    /// Mutable access to this node's layout output state, if it has been
+    /// allocated. Never allocates. Returns `None` for node kinds which do not
+    /// participate in layout.
+    #[inline]
+    pub fn layout_data_opt_mut(&mut self) -> Option<&mut LayoutData> {
+        match &mut self.data {
+            NodeData::Element(data) | NodeData::AnonymousBlock(data) => {
+                data.layout_data.as_deref_mut()
+            }
+            NodeData::Document(data) => data.layout_data.as_deref_mut(),
+            _ => None,
+        }
+    }
+
+    /// Clear this node's taffy layout cache without allocating `LayoutData`
+    /// for nodes that have never been laid out.
+    #[inline]
+    pub fn clear_layout_cache(&mut self) {
+        if let Some(layout_data) = self.layout_data_opt_mut() {
+            layout_data.cache.clear();
+        }
+    }
+
+    #[inline]
+    pub fn cache(&self) -> &Cache {
+        &self.layout_data().cache
+    }
+
+    #[inline]
+    pub fn cache_mut(&mut self) -> &mut Cache {
+        &mut self.layout_data_mut().cache
+    }
+
+    #[inline]
+    pub fn unrounded_layout(&self) -> &Layout {
+        &self.layout_data().unrounded_layout
+    }
+
+    #[inline]
+    pub fn unrounded_layout_mut(&mut self) -> &mut Layout {
+        &mut self.layout_data_mut().unrounded_layout
+    }
+
+    #[inline]
+    pub fn final_layout(&self) -> &Layout {
+        &self.layout_data().final_layout
+    }
+
+    #[inline]
+    pub fn final_layout_mut(&mut self) -> &mut Layout {
+        &mut self.layout_data_mut().final_layout
+    }
+
+    #[inline]
+    pub fn scroll_offset(&self) -> &crate::Point<f64> {
+        &self.layout_data().scroll_offset
+    }
+
+    #[inline]
+    pub fn scroll_offset_mut(&mut self) -> &mut crate::Point<f64> {
+        &mut self.layout_data_mut().scroll_offset
+    }
+
+    #[inline]
+    pub fn scrollable_overflow(&self) -> &KurboRect {
+        &self.layout_data().scrollable_overflow
+    }
+
+    #[inline]
+    pub fn scrollable_overflow_mut(&mut self) -> &mut KurboRect {
+        &mut self.layout_data_mut().scrollable_overflow
+    }
+
     /// Style data from stylo, if this node kind carries it (element or document
     /// nodes). Returns `None` for text/comment nodes.
     #[inline]

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -362,7 +362,7 @@ impl BaseDocument {
         for result in results {
             match result.data {
                 ConstructionTaskResultData::InlineLayout(layout) => {
-                    self.nodes[result.node_id].cache_mut().clear();
+                    self.nodes[result.node_id].clear_layout_cache();
                     self.nodes[result.node_id]
                         .element_data_mut()
                         .unwrap()


### PR DESCRIPTION
## Summary

Groups the taffy layout *output* fields on `ElementData`/`DocumentData` into a lazily-allocated box, since ~85% of elements on text-heavy pages (measured on the Barack Obama Wikipedia article) never have any of them written — inline-level elements are positioned by parley inside their inline root, not by taffy:

```rust
pub struct LayoutData {
    pub cache: Cache,                       // 384
    pub unrounded_layout: Layout,           // 92
    pub final_layout: Layout,               // 92
    pub scroll_offset: Point<f64>,          // 16
    pub scrollable_overflow: Rect,          // 32
}

// ElementData / DocumentData
pub layout_data: Option<Box<LayoutData>>,   // 616 -> 8 bytes inline
```

`size_of::<ElementData>()`: **1472 → 864** bytes (macOS malloc class 1536 → 896, i.e. 640B/element real saving for never-laid-out elements). On the Obama page (22,813 element allocations) this is ~12MB net.

Access semantics:
- Immutable accessors (`final_layout()`, `cache()`, `scroll_offset()`, `scrollable_overflow()`, …) return a reference into a shared `static DEFAULT_LAYOUT_DATA` when the box is absent — behavior-identical to the previous always-zeroed inline fields for readers like hit-testing, painting, `debug_overlay`, and bounding-box helpers.
- `*_mut()` accessors allocate the box on first use, so `set_unrounded_layout`/`set_final_layout` and the atomic-inline/float/abspos writes in `layout/inline.rs` allocate exactly for the nodes taffy actually lays out.
- Read-only mutation paths that must not allocate use new non-allocating helpers: `taffy::CacheTree::cache_get` goes through `layout_data_opt_mut()` (returns `None` for never-laid-out nodes), and all `cache_mut().clear()` sites now use `clear_layout_cache()`, which is a no-op when the box is absent.

Follow-up to #794 (removes the owned `taffy::Style`) and #796 (boxes the transform); the three combine to shrink `ElementData` from 1472B to ~330B.

Verified with `cargo test --workspace` (all passing) and clippy/fmt clean.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9cffd370ef03474e88a93f5335b19b65
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/9cffd370ef03474e88a93f5335b19b65?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32907192293).</sub>
<!-- wpt-results-end -->
