### PR TITLE
Use ThinVec for element attrs, background_images and mask_images

### DIFF
--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -470,7 +470,7 @@ impl BaseDocument {
         };
 
         let len = style_images.len();
-        elem_images.resize_with(len, || None);
+        elem_images.resize(len, None);
 
         for idx in 0..len {
             let style_image = &style_images[idx];

--- a/packages/blitz-dom/src/node/attributes.rs
+++ b/packages/blitz-dom/src/node/attributes.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use markup5ever::QualName;
+use thin_vec::ThinVec;
 
 /// A tag attribute, e.g. `class="test"` in `<div class="test" ...>`.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
@@ -13,12 +14,14 @@ pub struct Attribute {
 
 #[derive(Clone, Debug)]
 pub struct Attributes {
-    inner: Vec<Attribute>,
+    inner: ThinVec<Attribute>,
 }
 
 impl Attributes {
     pub fn new(inner: Vec<Attribute>) -> Self {
-        Self { inner }
+        Self {
+            inner: inner.into_iter().collect(),
+        }
     }
 
     pub fn get(&mut self, name: &QualName) -> Option<&Attribute> {
@@ -45,7 +48,7 @@ impl Attributes {
 }
 
 impl Deref for Attributes {
-    type Target = Vec<Attribute>;
+    type Target = ThinVec<Attribute>;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -25,6 +25,7 @@ use taffy::{
     Cache,
     prelude::{Layout, Style},
 };
+use thin_vec::ThinVec;
 use url::Url;
 
 use super::stylo_data::StyloData;
@@ -67,9 +68,9 @@ pub struct ElementData {
     ///   - The text editor for input/textarea elements
     pub special_data: SpecialElementData,
 
-    pub background_images: Vec<Option<ImageResourceData>>,
+    pub background_images: ThinVec<Option<ImageResourceData>>,
 
-    pub mask_images: Vec<Option<ImageResourceData>>,
+    pub mask_images: ThinVec<Option<ImageResourceData>>,
 
     /// Parley text layout (elements with inline inner display mode only)
     pub inline_layout_data: Option<Box<TextLayout>>,
@@ -365,8 +366,8 @@ impl ElementData {
             list_item_data: None,
             special_data: SpecialElementData::None,
             template_contents: None,
-            background_images: Vec::new(),
-            mask_images: Vec::new(),
+            background_images: ThinVec::new(),
+            mask_images: ThinVec::new(),
 
             stylo_element_data: Default::default(),
             selector_flags: Cell::new(ElementSelectorFlags::empty()),


### PR DESCRIPTION
## Summary

Converts the three remaining `Vec`-family fields on `ElementData` to `ThinVec` (24 → 8 bytes each inline, empty vecs allocate nothing):

```rust
// Attributes
inner: Vec<Attribute>  ->  inner: ThinVec<Attribute>   // Deref target follows

// ElementData
background_images / mask_images: Vec<Option<ImageResourceData>> -> ThinVec<...>
```

`Attributes::new(Vec<Attribute>)` keeps its signature (collects into a `ThinVec`) so the html parser call sites are unchanged; the only other call-site change is `resize_with(len, || None)` → `resize(len, None)` in `damage.rs` since `ThinVec` has no `resize_with`.

`size_of::<ElementData>()`: 1472 → 1424. On the Barack Obama Wikipedia page, bg/mask vecs are empty on 88% of the 24,721 elements and 25% have no attributes; the win is small standalone (same malloc size class today) but compounds with #794/#796/#797 — after those land, the −48B drops `ElementData` across another macOS malloc class boundary (384 → 320), ~64B/element real saving. Non-empty vecs pay a 16B `ThinVec` header.

Verified with `cargo test -p blitz-dom` (all passing) and workspace clippy/fmt clean.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9cffd370ef03474e88a93f5335b19b65
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/9cffd370ef03474e88a93f5335b19b65?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32897838344).</sub>
<!-- wpt-results-end -->
