### PR TITLE
Implement :nth-child(An+B of S)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2523,7 +2523,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2792,7 +2792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4953,7 +4953,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6451,7 +6451,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6577,8 +6577,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeee001a77567bb05e71652718d3ff76d8697c151ac523e68e9513194eb2b75a"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "bitflags 2.13.1",
  "cssparser",
@@ -6719,8 +6718,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7011,7 +7009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7170,8 +7168,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebaeb0b51f5e574bf36606c4dc982430a20d7a17175bdc0deab4d43d2063040b"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7227,8 +7224,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d448de89b7d18169a160ca258d2ee63efe79bd6cb20360654101835e9b80e386"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "string_cache 0.9.0",
  "string_cache_codegen",
@@ -7237,8 +7233,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cfdbf36a2d2db4fc75db0bfc1abd16e90971c360f00773cbd2501a5175dbec7"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -7250,8 +7245,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346fde14a66fdc568ef79a8c81f8b6a35722a0906295bce2997df6c90c7b848f"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "bitflags 2.13.1",
  "stylo_malloc_size_of",
@@ -7260,8 +7254,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1ee5ec323e0207ebaafff2210fec808214575d67cfe25e288d34a12010e2b3"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7278,8 +7271,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e017eb7fd506fa0fb0da653a6bc3793d9fc11edf92d4721c16b350432f8116f"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "toml",
 ]
@@ -7297,8 +7289,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a8d2ca5b29c7f5dd94ec66fbb256b274b76ecaab164417c92ce9a4586c8259"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "app_units",
  "bitflags 2.13.1",
@@ -7466,7 +7457,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7484,7 +7475,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7654,8 +7645,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c81cee0d28327337a94f3f32a1a77c03bbfd926510f3b42956f9d914e7810c"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7668,8 +7658,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba1f5563024b63bb6acb4558452d9ba737518c1d11fcc1861febe98d1e31cf4"
+source = "git+https://github.com/DioxusLabs/stylo?rev=5e8fb1a144bbcd23009b2d19fbcd62490739963b#5e8fb1a144bbcd23009b2d19fbcd62490739963b"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -8028,7 +8017,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8963,7 +8952,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,14 @@ browser-persistence = { path = "./apps/browser/persistence" }
 blitz-test-harness = { path = "./packages/blitz-test-harness" }
 
 # Servo dependencies
-style = { version = "0.20.0", package = "stylo" }
-style_traits = { version = "0.20.0", package = "stylo_traits" }
-style_atoms = { version = "0.20.0", package = "stylo_atoms" }
-style_config = { version = "0.20.0", package = "stylo_static_prefs" }
-style_dom = { version = "0.20.0", package = "stylo_dom" }
-selectors = { version = "0.40.0", package = "selectors" }
+# TODO: revert to crates.io versions once a stylo release ships the
+# "layout.css.nth-child-of.enabled" / "layout.css.has-selector.enabled" prefs.
+style = { git = "https://github.com/DioxusLabs/stylo", rev = "5e8fb1a144bbcd23009b2d19fbcd62490739963b", package = "stylo" }
+style_traits = { git = "https://github.com/DioxusLabs/stylo", rev = "5e8fb1a144bbcd23009b2d19fbcd62490739963b", package = "stylo_traits" }
+style_atoms = { git = "https://github.com/DioxusLabs/stylo", rev = "5e8fb1a144bbcd23009b2d19fbcd62490739963b", package = "stylo_atoms" }
+style_config = { git = "https://github.com/DioxusLabs/stylo", rev = "5e8fb1a144bbcd23009b2d19fbcd62490739963b", package = "stylo_static_prefs" }
+style_dom = { git = "https://github.com/DioxusLabs/stylo", rev = "5e8fb1a144bbcd23009b2d19fbcd62490739963b", package = "stylo_dom" }
+selectors = { git = "https://github.com/DioxusLabs/stylo", rev = "5e8fb1a144bbcd23009b2d19fbcd62490739963b", package = "selectors" }
 cssparser = { version = "0.37.0" }
 
 # HTML5ever dependencies

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1613,6 +1613,80 @@ impl BaseDocument {
         self.nodes[node_id].mark_ancestors_dirty();
     }
 
+    /// Restyle the children of a container after a child insertion or removal,
+    /// based on the container's [`ElementSelectorFlags`] (mirroring Gecko's
+    /// `RestyleManager::RestyleForInsertOrChange` / `RestyleForRemove`):
+    ///
+    /// - `HAS_EMPTY_SELECTOR`: the container itself may match `:empty`, so restyle it.
+    /// - `HAS_SLOW_SELECTOR` (`:nth-last-child` etc): restyle all children.
+    /// - `HAS_SLOW_SELECTOR_LATER_SIBLINGS` (`:nth-child` etc): restyle children
+    ///   at or after the change position.
+    /// - `HAS_EDGE_CHILD_SELECTOR` (`:first-child`/`:last-child`/`:only-child`):
+    ///   restyle the first and last element children.
+    ///
+    /// `change_idx` is the index at which a child was inserted, or the index the
+    /// removed child used to occupy (i.e. the index of the first child whose
+    /// sibling indices may have changed). Must be called *after* the child list
+    /// has been updated.
+    pub(crate) fn restyle_for_child_insert_or_remove(
+        &mut self,
+        parent_id: NodeId,
+        change_idx: usize,
+    ) {
+        let parent = &self.nodes[parent_id];
+        if !parent.flags.is_in_document() {
+            return;
+        }
+        let flags = parent.selector_flags().get();
+
+        let restyle_all = flags.contains(ElementSelectorFlags::HAS_SLOW_SELECTOR);
+        let restyle_later = flags.contains(ElementSelectorFlags::HAS_SLOW_SELECTOR_LATER_SIBLINGS);
+        let restyle_edges = flags.contains(ElementSelectorFlags::HAS_EDGE_CHILD_SELECTOR);
+        let restyle_self = flags.contains(ElementSelectorFlags::HAS_EMPTY_SELECTOR);
+
+        if !(restyle_all || restyle_later || restyle_edges || restyle_self) {
+            return;
+        }
+
+        if restyle_self {
+            if let Some(mut data) = self.nodes[parent_id]
+                .stylo_element_data_opt_mut()
+                .and_then(|s| s.get_mut())
+            {
+                data.hint |= RestyleHint::RESTYLE_SELF;
+            }
+        }
+
+        if restyle_all || restyle_later || restyle_edges {
+            let children = self.nodes[parent_id].children.clone();
+            let is_element = |id: &NodeId| self.nodes[*id].is_element();
+            let first_element = children.iter().copied().find(is_element);
+            let last_element = children.iter().rev().copied().find(is_element);
+            for (idx, child_id) in children.iter().copied().enumerate() {
+                if !self.nodes[child_id].is_element() {
+                    continue;
+                }
+                let is_edge = Some(child_id) == first_element || Some(child_id) == last_element;
+                let affected = restyle_all
+                    || (restyle_later && idx >= change_idx)
+                    || (restyle_edges && is_edge);
+                if !affected {
+                    continue;
+                }
+                if let Some(mut data) = self.nodes[child_id]
+                    .stylo_element_data_opt_mut()
+                    .and_then(|s| s.get_mut())
+                {
+                    data.hint |= RestyleHint::restyle_subtree();
+                }
+            }
+        }
+
+        // Mark ancestors dirty so the style traversal visits the restyled nodes.
+        self.nodes[parent_id].set_dirty_descendants();
+        self.nodes[parent_id].mark_ancestors_dirty();
+    }
+
     // Takes (x, y) co-ordinates (relative to the )
     pub fn hit(&self, x: f32, y: f32) -> Option<HitResult> {
         self.hit_with_scrollbar(x, y).0

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -29,7 +29,10 @@ use cursor_icon::CursorIcon;
 use linebender_resource_handle::Blob;
 use markup5ever::{LocalName, local_name};
 use parley::{FontContext, PlainEditorDriver};
-use selectors::{Element, matching::QuirksMode};
+use selectors::{
+    Element,
+    matching::{ElementSelectorFlags, QuirksMode},
+};
 use smallvec::SmallVec;
 use std::any::Any;
 use std::cell::RefCell;
@@ -394,6 +397,7 @@ impl BaseDocument {
         style_config::set_pref!("layout.unimplemented", true);
         style_config::set_pref!("layout.columns.enabled", true);
         style_config::set_pref!("layout.css.basic-shape-shape.enabled", true);
+        style_config::set_pref!("layout.css.nth-child-of.enabled", true);
         style_config::set_pref!("layout.threads", -1);
 
         let viewport = config.viewport.unwrap_or_default();
@@ -1520,6 +1524,93 @@ impl BaseDocument {
             self.snapshot_node_state_only(node_id);
         }
         cb(&mut self.nodes[node_id]);
+        if self
+            .stylist
+            .iter_origins()
+            .any(|(data, _)| data.has_nth_of_state_dependency(state))
+        {
+            self.restyle_siblings_for_nth_of(node_id);
+        }
+    }
+
+    /// Returns whether changing the attribute `local_name` (with the given old/new
+    /// values) on an element might affect which siblings are matched by the
+    /// selector list of some `:nth-child(An+B of <selector list>)`-family selector.
+    pub(crate) fn attribute_might_affect_nth_of(
+        &self,
+        local_name: &LocalName,
+        old_value: Option<&str>,
+        new_value: Option<&str>,
+    ) -> bool {
+        let name = GenericAtomIdent(local_name.clone());
+        self.stylist.iter_origins().any(|(data, _)| {
+            if data.might_have_nth_of_attribute_dependency(&name) {
+                return true;
+            }
+            if *local_name == local_name!("id") {
+                [old_value, new_value]
+                    .iter()
+                    .flatten()
+                    .any(|id| data.might_have_nth_of_id_dependency(&Atom::from(*id)))
+            } else if *local_name == local_name!("class") {
+                [old_value, new_value]
+                    .iter()
+                    .flatten()
+                    .flat_map(|classes| classes.split_ascii_whitespace())
+                    .any(|class| data.might_have_nth_of_class_dependency(&Atom::from(class)))
+            } else {
+                false
+            }
+        })
+    }
+
+    /// Restyle the siblings of a mutated element that may be matched by an
+    /// `:nth-child(An+B of S)`-family selector (mirroring Gecko's
+    /// `RestyleManager::RestyleSiblingsForNthOf`). The generic snapshot-based
+    /// invalidation only walks downwards from the mutated element, so changes
+    /// affecting `of S` matching of *siblings* must be handled here.
+    ///
+    /// Whether the mutation is relevant to some nth-of selector list must be
+    /// checked by the caller; this method only checks the parent's selector
+    /// flags, then conservatively restyles siblings in the flagged directions.
+    pub(crate) fn restyle_siblings_for_nth_of(&mut self, node_id: NodeId) {
+        let Some(parent_id) = self.nodes[node_id].parent else {
+            return;
+        };
+        let parent_flags = self.nodes[parent_id].selector_flags().get();
+        if !parent_flags.contains(ElementSelectorFlags::HAS_SLOW_SELECTOR_NTH_OF) {
+            return;
+        }
+        // :nth-last-child(.. of S) sets HAS_SLOW_SELECTOR (earlier siblings affected);
+        // :nth-child(.. of S) sets HAS_SLOW_SELECTOR_LATER_SIBLINGS (later siblings affected).
+        let restyle_previous = parent_flags.contains(ElementSelectorFlags::HAS_SLOW_SELECTOR);
+        let restyle_later =
+            parent_flags.contains(ElementSelectorFlags::HAS_SLOW_SELECTOR_LATER_SIBLINGS);
+
+        let children = self.nodes[parent_id].children.clone();
+        let Some(node_idx) = children.iter().position(|id| *id == node_id) else {
+            return;
+        };
+        for (idx, sibling_id) in children.iter().copied().enumerate() {
+            if idx == node_idx
+                || (idx < node_idx && !restyle_previous)
+                || (idx > node_idx && !restyle_later)
+            {
+                continue;
+            }
+            let sibling = &mut self.nodes[sibling_id];
+            if !sibling.is_element() {
+                continue;
+            }
+            if let Some(mut data) = sibling
+                .stylo_element_data_opt_mut()
+                .and_then(|s| s.get_mut())
+            {
+                data.hint |= RestyleHint::restyle_subtree();
+            }
+        }
+        // Mark ancestors dirty so the style traversal visits the restyled siblings.
+        self.nodes[node_id].mark_ancestors_dirty();
     }
 
     // Takes (x, y) co-ordinates (relative to the )

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -245,18 +245,6 @@ impl DocumentMutator<'_> {
             }
             node.mark_damaged();
 
-            // TODO: make this fine grained / conditional based on ElementSelectorFlags
-            let parent = node.parent;
-            if let Some(parent_id) = parent {
-                let parent = &mut self.doc.nodes[parent_id];
-                if let Some(mut data) = parent
-                    .stylo_element_data_opt_mut()
-                    .and_then(|s| s.get_mut())
-                {
-                    data.hint |= RestyleHint::restyle_subtree();
-                }
-            }
-
             // Mark ancestors dirty so the style traversal visits this subtree.
             // Without this, the traversal may skip nodes with pending RestyleHint/damage
             // because it uses dirty_descendants flags to determine which subtrees to visit.
@@ -532,20 +520,14 @@ impl DocumentMutator<'_> {
             self.mutations_occurred |= node_is_in_document;
             let parent = &mut self.doc.nodes[parent_id];
             parent.insert_damage(ALL_DAMAGE);
-
-            // TODO: make this fine grained / conditional based on ElementSelectorFlags
-            if node_is_in_document {
-                if let Some(mut data) = parent
-                    .stylo_element_data_opt_mut()
-                    .and_then(|s| s.get_mut())
-                {
-                    data.hint |= RestyleHint::restyle_subtree();
-                }
-            }
-
             // Mark ancestors dirty so the style traversal visits this subtree.
             parent.mark_ancestors_dirty();
+            let old_idx = parent.index_of_child(node_id);
             parent.children.retain(|id| *id != node_id);
+            if let Some(old_idx) = old_idx {
+                self.doc
+                    .restyle_for_child_insert_or_remove(parent_id, old_idx);
+            }
             self.maybe_record_node(parent_id);
         }
     }
@@ -571,21 +553,14 @@ impl DocumentMutator<'_> {
         if let Some(parent_id) = node.as_ref().and_then(|node| node.parent) {
             let parent = &mut self.doc.nodes[parent_id];
             parent.insert_damage(ALL_DAMAGE);
-            let parent_is_in_doc = parent.flags.is_in_document();
-
-            // TODO: make this fine grained / conditional based on ElementSelectorFlags
-            if parent_is_in_doc {
-                if let Some(mut data) = parent
-                    .stylo_element_data_opt_mut()
-                    .and_then(|s| s.get_mut())
-                {
-                    data.hint |= RestyleHint::restyle_subtree();
-                }
-                // Mark ancestors dirty so the style traversal visits this subtree.
-                parent.mark_ancestors_dirty();
-            }
-
+            // Mark ancestors dirty so the style traversal visits this subtree.
+            parent.mark_ancestors_dirty();
+            let old_idx = parent.index_of_child(node_id);
             parent.children.retain(|id| *id != node_id);
+            if let Some(old_idx) = old_idx {
+                self.doc
+                    .restyle_for_child_insert_or_remove(parent_id, old_idx);
+            }
             self.maybe_record_node(parent_id);
         }
 
@@ -596,17 +571,8 @@ impl DocumentMutator<'_> {
         let parent = &mut self.doc.nodes[node_id];
         let parent_is_in_doc = parent.flags.is_in_document();
 
-        // TODO: make this fine grained / conditional based on ElementSelectorFlags
-        if parent_is_in_doc {
-            if let Some(mut data) = parent
-                .stylo_element_data_opt_mut()
-                .and_then(|s| s.get_mut())
-            {
-                data.hint |= RestyleHint::restyle_subtree();
-            }
-            // Mark ancestors dirty so the style traversal visits this subtree.
-            parent.mark_ancestors_dirty();
-        }
+        // Mark ancestors dirty so the style traversal visits this subtree.
+        parent.mark_ancestors_dirty();
 
         let children = mem::take(&mut parent.children);
         self.mutations_occurred |= parent_is_in_doc && !children.is_empty();
@@ -614,6 +580,7 @@ impl DocumentMutator<'_> {
             self.process_removed_subtree(child_id);
             let _ = self.doc.drop_node_ignoring_parent(child_id);
         }
+        self.doc.restyle_for_child_insert_or_remove(node_id, 0);
         self.maybe_record_node(node_id);
     }
 
@@ -677,39 +644,31 @@ impl DocumentMutator<'_> {
 
             let old_parent = &mut self.doc.nodes[old_parent_id];
             old_parent.insert_damage(ALL_DAMAGE);
-
-            // TODO: make this fine grained / conditional based on ElementSelectorFlags
-            if child_was_in_doc {
-                if let Some(mut data) = old_parent
-                    .stylo_element_data_opt_mut()
-                    .and_then(|s| s.get_mut())
-                {
-                    data.hint |= RestyleHint::restyle_subtree();
-                }
-                // Mark ancestors dirty so the style traversal visits this subtree.
-                old_parent.mark_ancestors_dirty();
-            }
-
+            // Mark ancestors dirty so the style traversal visits this subtree.
+            old_parent.mark_ancestors_dirty();
+            let old_idx = old_parent.index_of_child(child_id);
             old_parent.children.retain(|id| *id != child_id);
+            if let Some(old_idx) = old_idx {
+                self.doc
+                    .restyle_for_child_insert_or_remove(old_parent_id, old_idx);
+            }
             self.maybe_record_node(old_parent_id);
         }
 
         let new_parent = &mut self.doc.nodes[parent_id];
         new_parent.insert_damage(ALL_DAMAGE);
-
-        // TODO: make this fine grained / conditional based on ElementSelectorFlags
-        if new_parent_is_in_document {
-            if let Some(mut data) = new_parent
-                .stylo_element_data_opt_mut()
-                .and_then(|s| s.get_mut())
-            {
-                data.hint |= RestyleHint::restyle_subtree();
-            }
-            // Mark ancestors dirty so the style traversal visits this subtree.
-            new_parent.mark_ancestors_dirty();
-        }
+        // Mark ancestors dirty so the style traversal visits this subtree.
+        new_parent.mark_ancestors_dirty();
 
         insert_children_fn(new_parent, child_ids);
+
+        if let Some(insert_idx) = child_ids
+            .first()
+            .and_then(|id| self.doc.nodes[parent_id].index_of_child(*id))
+        {
+            self.doc
+                .restyle_for_child_insert_or_remove(parent_id, insert_idx);
+        }
 
         for child_id in child_ids.iter().copied() {
             let child = &mut self.doc.nodes[child_id];

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -261,6 +261,17 @@ impl DocumentMutator<'_> {
             // Without this, the traversal may skip nodes with pending RestyleHint/damage
             // because it uses dirty_descendants flags to determine which subtrees to visit.
             self.doc.nodes[node_id].mark_ancestors_dirty();
+
+            let affects_nth_of = {
+                let old_value = self.doc.nodes[node_id]
+                    .element_data()
+                    .and_then(|el| el.attr(name.local.clone()));
+                self.doc
+                    .attribute_might_affect_nth_of(&name.local, old_value, Some(value))
+            };
+            if affects_nth_of {
+                self.doc.restyle_siblings_for_nth_of(node_id);
+            }
         }
 
         if name.local == local_name!("id") && node_is_in_document {
@@ -375,6 +386,17 @@ impl DocumentMutator<'_> {
             // Mark ancestors dirty so the style traversal visits this subtree.
             // Without this, the traversal may skip nodes with pending RestyleHint/damage.
             node.mark_ancestors_dirty();
+
+            let affects_nth_of = {
+                let old_value = self.doc.nodes[node_id]
+                    .element_data()
+                    .and_then(|el| el.attr(name.local.clone()));
+                self.doc
+                    .attribute_might_affect_nth_of(&name.local, old_value, None)
+            };
+            if affects_nth_of {
+                self.doc.restyle_siblings_for_nth_of(node_id);
+            }
         }
 
         if name.local == local_name!("id") && node_is_in_document {
@@ -510,6 +532,17 @@ impl DocumentMutator<'_> {
             self.mutations_occurred |= node_is_in_document;
             let parent = &mut self.doc.nodes[parent_id];
             parent.insert_damage(ALL_DAMAGE);
+
+            // TODO: make this fine grained / conditional based on ElementSelectorFlags
+            if node_is_in_document {
+                if let Some(mut data) = parent
+                    .stylo_element_data_opt_mut()
+                    .and_then(|s| s.get_mut())
+                {
+                    data.hint |= RestyleHint::restyle_subtree();
+                }
+            }
+
             // Mark ancestors dirty so the style traversal visits this subtree.
             parent.mark_ancestors_dirty();
             parent.children.retain(|id| *id != node_id);

--- a/packages/blitz-test-harness/tests/nth_child_of.rs
+++ b/packages/blitz-test-harness/tests/nth_child_of.rs
@@ -1,0 +1,217 @@
+//! Tests for `:nth-child(An+B of S)` matching and invalidation.
+
+use blitz_dom::qual_name;
+use blitz_dom::{BaseDocument, LocalName, QualName, ns};
+use blitz_html::HtmlDocument;
+use blitz_test_harness::Harness;
+use blitz_traits::node_id::NodeId;
+
+const RED: [f32; 3] = [1.0, 0.0, 0.0];
+const BLACK: [f32; 3] = [0.0, 0.0, 0.0];
+
+fn color_of(doc: &BaseDocument, node_id: NodeId) -> [f32; 3] {
+    let styles = doc.get_node(node_id).unwrap().primary_styles().unwrap();
+    let color = styles.clone_color();
+    [color.components.0, color.components.1, color.components.2]
+}
+
+fn colors(harness: &Harness<HtmlDocument>, selector: &str) -> Vec<[f32; 3]> {
+    let doc = harness.base();
+    harness
+        .query_all(selector)
+        .into_iter()
+        .map(|id| color_of(&doc, id))
+        .collect()
+}
+
+#[test]
+fn nth_child_of_matches_statically() {
+    let harness = Harness::from_html(
+        r#"
+        <style>
+            li { color: rgb(0, 0, 0); }
+            li:nth-child(2 of .a) { color: rgb(255, 0, 0); }
+        </style>
+        <ul>
+            <li class="a">one</li>
+            <li>two</li>
+            <li class="a">three</li>
+            <li class="a">four</li>
+        </ul>
+        "#,
+    );
+    assert_eq!(colors(&harness, "li"), [BLACK, BLACK, RED, BLACK]);
+}
+
+#[test]
+fn nth_child_of_invalidates_on_sibling_class_change() {
+    let mut harness = Harness::from_html(
+        r#"
+        <style>
+            li { color: rgb(0, 0, 0); }
+            li:nth-child(2 of .a) { color: rgb(255, 0, 0); }
+        </style>
+        <ul>
+            <li class="a">one</li>
+            <li>two</li>
+            <li class="a">three</li>
+            <li class="a">four</li>
+        </ul>
+        "#,
+    );
+    assert_eq!(colors(&harness, "li"), [BLACK, BLACK, RED, BLACK]);
+
+    // Removing .a from the first sibling makes "four" the second .a element.
+    let first_li = harness.node("li");
+    harness
+        .base_mut()
+        .mutate()
+        .clear_attribute(first_li, qual_name!("class"));
+    harness.pump();
+    assert_eq!(colors(&harness, "li"), [BLACK, BLACK, BLACK, RED]);
+
+    // Adding .a to the second sibling makes "three" the second .a element again.
+    let second_li = harness.query_all("li")[1];
+    harness
+        .base_mut()
+        .mutate()
+        .set_attribute(second_li, qual_name!("class"), "a");
+    harness.pump();
+    assert_eq!(colors(&harness, "li"), [BLACK, BLACK, RED, BLACK]);
+}
+
+#[test]
+fn nth_last_child_of_invalidates_on_sibling_class_change() {
+    let mut harness = Harness::from_html(
+        r#"
+        <style>
+            li { color: rgb(0, 0, 0); }
+            li:nth-last-child(1 of .a) { color: rgb(255, 0, 0); }
+        </style>
+        <ul>
+            <li class="a">one</li>
+            <li class="a">two</li>
+            <li>three</li>
+        </ul>
+        "#,
+    );
+    assert_eq!(colors(&harness, "li"), [BLACK, RED, BLACK]);
+
+    // Removing .a from "two" makes "one" the last .a element: an *earlier*
+    // sibling must be restyled.
+    let second_li = harness.query_all("li")[1];
+    harness
+        .base_mut()
+        .mutate()
+        .clear_attribute(second_li, qual_name!("class"));
+    harness.pump();
+    assert_eq!(colors(&harness, "li"), [RED, BLACK, BLACK]);
+}
+
+#[test]
+fn nth_child_of_invalidates_on_sibling_id_change() {
+    let mut harness = Harness::from_html(
+        r#"
+        <style>
+            li { color: rgb(0, 0, 0); }
+            li:nth-child(1 of #foo) { color: rgb(255, 0, 0); }
+        </style>
+        <ul>
+            <li>one</li>
+            <li id="foo">two</li>
+        </ul>
+        "#,
+    );
+    assert_eq!(colors(&harness, "li"), [BLACK, RED]);
+
+    let first_li = harness.node("li");
+    harness
+        .base_mut()
+        .mutate()
+        .set_attribute(first_li, qual_name!("id"), "foo");
+    harness.pump();
+    assert_eq!(colors(&harness, "li"), [RED, BLACK]);
+}
+
+#[test]
+fn nth_child_of_invalidates_on_sibling_attribute_change() {
+    let mut harness = Harness::from_html(
+        r#"
+        <style>
+            li { color: rgb(0, 0, 0); }
+            li:nth-child(2 of [data-x]) { color: rgb(255, 0, 0); }
+        </style>
+        <ul>
+            <li data-x>one</li>
+            <li>two</li>
+            <li data-x>three</li>
+        </ul>
+        "#,
+    );
+    assert_eq!(colors(&harness, "li"), [BLACK, BLACK, RED]);
+
+    let first_li = harness.node("li");
+    harness.base_mut().mutate().clear_attribute(
+        first_li,
+        QualName::new(None, ns!(), LocalName::from("data-x")),
+    );
+    harness.pump();
+    assert_eq!(colors(&harness, "li"), [BLACK, BLACK, BLACK]);
+}
+
+#[test]
+fn nth_child_of_invalidates_on_sibling_state_change() {
+    let mut harness = Harness::from_html(
+        r#"
+        <style>
+            input { color: rgb(0, 0, 0); }
+            input:nth-child(2 of :checked) { color: rgb(255, 0, 0); }
+        </style>
+        <div>
+            <input type="checkbox" checked>
+            <input type="checkbox">
+            <input type="checkbox" checked>
+        </div>
+        "#,
+    );
+    assert_eq!(colors(&harness, "input"), [BLACK, BLACK, RED]);
+
+    // Checking the second checkbox makes it the second :checked element.
+    harness.click("input:nth-child(2)");
+    harness.pump();
+    assert_eq!(colors(&harness, "input"), [BLACK, RED, BLACK]);
+}
+
+#[test]
+fn nth_child_of_invalidates_on_sibling_insertion_and_removal() {
+    let mut harness = Harness::from_html(
+        r#"
+        <style>
+            li { color: rgb(0, 0, 0); }
+            li:nth-child(2 of .a) { color: rgb(255, 0, 0); }
+        </style>
+        <ul>
+            <li class="a">one</li>
+            <li class="a">two</li>
+        </ul>
+        "#,
+    );
+    assert_eq!(colors(&harness, "li"), [BLACK, RED]);
+
+    let first_li = harness.node("li");
+    {
+        let mut doc = harness.base_mut();
+        let mut mutator = doc.mutate();
+        let new_li = mutator.create_element(qual_name!("li", html), Vec::new());
+        mutator.set_attribute(new_li, qual_name!("class"), "a");
+        mutator.insert_nodes_before(first_li, &[new_li]);
+    }
+    harness.pump();
+    assert_eq!(colors(&harness, "li"), [BLACK, RED, BLACK]);
+
+    // Removing the inserted element restores the original matching.
+    let inserted_li = harness.node("li");
+    harness.base_mut().mutate().remove_node(inserted_li);
+    harness.pump();
+    assert_eq!(colors(&harness, "li"), [BLACK, RED]);
+}


### PR DESCRIPTION
## Summary

Enables `:nth-child(An+B of S)` / `:nth-last-child(An+B of S)` parsing and adds the embedder-side invalidation it requires. Matching is already generic in stylo/selectors; the missing piece is that a mutation on one child can change which *siblings* match (their nth-of index changes), which stylo's downward snapshot invalidation can't reach. This mirrors Gecko's `RestyleManager::RestyleSiblingsForNthOf`.

Depends on (and temporarily rev-pins stylo to) DioxusLabs/stylo#16, which adds a separate `layout.css.nth-child-of.enabled` pref (and a `layout.css.has-selector.enabled` pref for later `:has()` work). Blitz enables only the nth-of pref. TODO comment notes reverting to crates.io once a stylo release ships the prefs.

### Invalidation

New `BaseDocument::restyle_siblings_for_nth_of(node_id)`:
- early-out unless the parent carries `HAS_SLOW_SELECTOR_NTH_OF` (set by stylo via `apply_selector_flags` during matching)
- restyles earlier siblings only if parent has `HAS_SLOW_SELECTOR` (`:nth-last-child(.. of S)`), later siblings only if `HAS_SLOW_SELECTOR_LATER_SIBLINGS` (`:nth-child(.. of S)`), by inserting `RestyleHint::restyle_subtree()` and marking ancestors dirty

Hooked at the two mutation classes that can change `of S` matching:
- `DocumentMutator::{set_attribute, clear_attribute}` — gated by new `attribute_might_affect_nth_of`, which consults the stylist's nth-of dependency maps (`might_have_nth_of_{attribute,id,class}_dependency`) using both old and new id/class values
- `BaseDocument::snapshot_node_and` (element state changes, e.g. `:checked`) — gated by `has_nth_of_state_dependency`

Also fixes `DocumentMutator::remove_node` to insert `restyle_subtree()` on the parent like the other removal paths already do (plain positional `:nth-child` needs this too; found via the new insertion/removal test).

### Tests

`packages/blitz-test-harness/tests/nth_child_of.rs`: static matching plus dynamic invalidation for sibling class add/remove, id change, arbitrary attribute change, `:checked` state change, insertion/removal, and `:nth-last-child(.. of S)`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/65287500bfb04b2589b9fc6a08bc2d14
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/65287500bfb04b2589b9fc6a08bc2d14?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**36** newly passing, **2** newly failing (net +34).

<details>
<summary>Full diff (38 changed tests)</summary>

```diff
+ Fail => Pass css/css-color-adjust/rendering/dark-color-scheme/color-scheme-rule-cache.html
- Pass => Fail css/css-color-adjust/rendering/dark-color-scheme/color-scheme-table-border-currentcolor-responsive.html
- Pass => Fail css/css-images/gradient/color-scheme-dependent-color-stops.html
+ Fail => Pass css/css-properties-values-api/registered-property-computation-color-001.html
+ Fail => Pass css/css-properties-values-api/registered-property-computation-color-002.html
+ Fail => Pass css/css-variables/registered-property-light-dark.html
+ Fail => Pass css/selectors/invalidation/nth-child-of-attr-largedom.html
+ Fail => Pass css/selectors/nth-child-and-nth-last-child.html
+ Fail => Pass css/selectors/nth-child-of-attribute.html
+ Fail => Pass css/selectors/nth-child-of-classname-002.html
+ Fail => Pass css/selectors/nth-child-of-classname.html
+ Fail => Pass css/selectors/nth-child-of-complex-selector-many-children.html
+ Fail => Pass css/selectors/nth-child-of-complex-selector.html
+ Fail => Pass css/selectors/nth-child-of-compound-selector.html
+ Fail => Pass css/selectors/nth-child-of-nesting.html
+ Fail => Pass css/selectors/nth-child-of-no-space-after-of.html
+ Fail => Pass css/selectors/nth-child-of-not.html
+ Fail => Pass css/selectors/nth-child-of-nth-child.html
+ Fail => Pass css/selectors/nth-child-of-pseudo.html
+ Fail => Pass css/selectors/nth-child-of-tagname.html
+ Fail => Pass css/selectors/nth-child-of-universal-selector.html
+ Fail => Pass css/selectors/nth-child-specificity-1.html
+ Fail => Pass css/selectors/nth-child-specificity-2.html
+ Fail => Pass css/selectors/nth-child-specificity-3.html
+ Fail => Pass css/selectors/nth-child-specificity-4.html
+ Fail => Pass css/selectors/nth-last-child-of-classname.html
+ Fail => Pass css/selectors/nth-last-child-of-complex-selector.html
+ Fail => Pass css/selectors/nth-last-child-of-compound-selector.html
+ Fail => Pass css/selectors/nth-last-child-of-nesting.html
+ Fail => Pass css/selectors/nth-last-child-of-no-space-after-of.html
+ Fail => Pass css/selectors/nth-last-child-of-style-sharing-1.html
+ Fail => Pass css/selectors/nth-last-child-of-style-sharing-2.html
+ Fail => Pass css/selectors/nth-last-child-of-tagname.html
+ Fail => Pass css/selectors/nth-last-child-specificity-1.html
+ Fail => Pass css/selectors/nth-last-child-specificity-2.html
+ Fail => Pass css/selectors/nth-last-child-specificity-3.html
+ Fail => Pass css/selectors/nth-last-child-specificity-4.html
+ Fail => Pass css/selectors/nth-of-selector-before.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32918036105).</sub>
<!-- wpt-results-end -->
