### PR TITLE
Rename `_opt` accessor methods to use `try_` prefix

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -689,7 +689,7 @@ fn flush_pseudo_elements(doc: &mut BaseDocument, node_id: NodeId) {
         let after_node_id = node.after();
 
         // Note: yes these are kinda backwards
-        let style_data = node.stylo_element_data_opt().and_then(|s| s.get());
+        let style_data = node.try_stylo_element_data().and_then(|s| s.get());
         let before_style = style_data
             .as_ref()
             .and_then(|d| d.styles.pseudos.as_array()[1].clone());
@@ -789,7 +789,7 @@ fn flush_pseudo_elements(doc: &mut BaseDocument, node_id: NodeId) {
             }
 
             let mut node_styles = doc.nodes[pe_node_id]
-                .stylo_element_data_opt_mut()
+                .try_stylo_element_data_mut()
                 .and_then(|s| s.get_mut());
             let node_styles = &mut node_styles.as_mut().unwrap();
             node_styles.damage.insert(ALL_DAMAGE);

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -39,7 +39,7 @@ impl BaseDocument {
         damage_from_parent: RestyleDamage,
     ) -> RestyleDamage {
         let mut damage = if let Some(data) = self.nodes[node_id]
-            .stylo_element_data_opt_mut()
+            .try_stylo_element_data_mut()
             .and_then(|s| s.get_mut())
         {
             data.damage
@@ -448,7 +448,7 @@ impl BaseDocument {
         // borrow of `node` (held by the stylo element data guard) is released
         // before we take a mutable borrow of `node.data` below.
         let style = {
-            let stylo_element_data = node.stylo_element_data_opt().and_then(|s| s.get());
+            let stylo_element_data = node.try_stylo_element_data().and_then(|s| s.get());
             let primary_styles = stylo_element_data
                 .as_ref()
                 .and_then(|data| data.styles.get_primary());

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -443,7 +443,7 @@ impl taffy::CacheTree for BaseDocument {
         inputs: &taffy::LayoutInput,
     ) -> Option<taffy::LayoutOutput> {
         self.node_from_id_mut(node_id)
-            .layout_data_opt_mut()?
+            .try_layout_data_mut()?
             .cache
             .get(inputs)
     }

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -239,7 +239,7 @@ impl DocumentMutator<'_> {
             self.doc.snapshot_node(node_id);
 
             let node = &mut self.doc.nodes[node_id];
-            if let Some(mut data) = node.stylo_element_data_opt_mut().and_then(|s| s.get_mut()) {
+            if let Some(mut data) = node.try_stylo_element_data_mut().and_then(|s| s.get_mut()) {
                 data.hint |= RestyleHint::restyle_subtree();
                 data.damage.insert(ALL_DAMAGE);
             }
@@ -250,7 +250,7 @@ impl DocumentMutator<'_> {
             if let Some(parent_id) = parent {
                 let parent = &mut self.doc.nodes[parent_id];
                 if let Some(mut data) = parent
-                    .stylo_element_data_opt_mut()
+                    .try_stylo_element_data_mut()
                     .and_then(|s| s.get_mut())
                 {
                     data.hint |= RestyleHint::restyle_subtree();
@@ -366,7 +366,7 @@ impl DocumentMutator<'_> {
 
             let node = &mut self.doc.nodes[node_id];
 
-            if let Some(mut data) = node.stylo_element_data_opt_mut().and_then(|s| s.get_mut()) {
+            if let Some(mut data) = node.try_stylo_element_data_mut().and_then(|s| s.get_mut()) {
                 data.hint |= RestyleHint::restyle_subtree();
                 data.damage.insert(ALL_DAMAGE);
             }
@@ -543,7 +543,7 @@ impl DocumentMutator<'_> {
             // TODO: make this fine grained / conditional based on ElementSelectorFlags
             if parent_is_in_doc {
                 if let Some(mut data) = parent
-                    .stylo_element_data_opt_mut()
+                    .try_stylo_element_data_mut()
                     .and_then(|s| s.get_mut())
                 {
                     data.hint |= RestyleHint::restyle_subtree();
@@ -566,7 +566,7 @@ impl DocumentMutator<'_> {
         // TODO: make this fine grained / conditional based on ElementSelectorFlags
         if parent_is_in_doc {
             if let Some(mut data) = parent
-                .stylo_element_data_opt_mut()
+                .try_stylo_element_data_mut()
                 .and_then(|s| s.get_mut())
             {
                 data.hint |= RestyleHint::restyle_subtree();
@@ -648,7 +648,7 @@ impl DocumentMutator<'_> {
             // TODO: make this fine grained / conditional based on ElementSelectorFlags
             if child_was_in_doc {
                 if let Some(mut data) = old_parent
-                    .stylo_element_data_opt_mut()
+                    .try_stylo_element_data_mut()
                     .and_then(|s| s.get_mut())
                 {
                     data.hint |= RestyleHint::restyle_subtree();
@@ -667,7 +667,7 @@ impl DocumentMutator<'_> {
         // TODO: make this fine grained / conditional based on ElementSelectorFlags
         if new_parent_is_in_document {
             if let Some(mut data) = new_parent
-                .stylo_element_data_opt_mut()
+                .try_stylo_element_data_mut()
                 .and_then(|s| s.get_mut())
             {
                 data.hint |= RestyleHint::restyle_subtree();

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -200,7 +200,7 @@ impl Node {
     /// allocated. Never allocates. Returns `None` for node kinds which do not
     /// participate in layout.
     #[inline]
-    pub fn layout_data_opt_mut(&mut self) -> Option<&mut LayoutData> {
+    pub fn try_layout_data_mut(&mut self) -> Option<&mut LayoutData> {
         match &mut self.data {
             NodeData::Element(data) | NodeData::AnonymousBlock(data) => {
                 data.layout_data.as_deref_mut()
@@ -214,7 +214,7 @@ impl Node {
     /// for nodes that have never been laid out.
     #[inline]
     pub fn clear_layout_cache(&mut self) {
-        if let Some(layout_data) = self.layout_data_opt_mut() {
+        if let Some(layout_data) = self.try_layout_data_mut() {
             layout_data.cache.clear();
         }
     }
@@ -272,7 +272,7 @@ impl Node {
     /// Style data from stylo, if this node kind carries it (element or document
     /// nodes). Returns `None` for text/comment nodes.
     #[inline]
-    pub fn stylo_element_data_opt(&self) -> Option<&StyloData> {
+    pub fn try_stylo_element_data(&self) -> Option<&StyloData> {
         match &self.data {
             NodeData::Element(data) | NodeData::AnonymousBlock(data) => {
                 Some(&data.stylo_element_data)
@@ -283,7 +283,7 @@ impl Node {
     }
 
     #[inline]
-    pub fn stylo_element_data_opt_mut(&mut self) -> Option<&mut StyloData> {
+    pub fn try_stylo_element_data_mut(&mut self) -> Option<&mut StyloData> {
         match &mut self.data {
             NodeData::Element(data) | NodeData::AnonymousBlock(data) => {
                 Some(&mut data.stylo_element_data)
@@ -497,7 +497,7 @@ impl Node {
     }
 
     pub fn set_restyle_hint(&mut self, hint: RestyleHint) {
-        if let Some(stylo_element_data) = self.stylo_element_data_opt_mut() {
+        if let Some(stylo_element_data) = self.try_stylo_element_data_mut() {
             if let Some(mut element_data) = stylo_element_data.get_mut() {
                 element_data.hint.insert(hint);
             }
@@ -529,7 +529,7 @@ impl Node {
 
     /// Set appropriate damage for Stylo when an element's style attribute is updated
     pub(crate) fn mark_style_attr_updated(&mut self) {
-        if let Some(stylo_element_data) = self.stylo_element_data_opt_mut() {
+        if let Some(stylo_element_data) = self.try_stylo_element_data_mut() {
             if let Some(mut data) = stylo_element_data.get_mut() {
                 data.hint |= RestyleHint::RESTYLE_STYLE_ATTRIBUTE;
             }
@@ -602,12 +602,12 @@ impl Node {
     // }
 
     pub fn damage(&self) -> Option<RestyleDamage> {
-        self.stylo_element_data_opt()
+        self.try_stylo_element_data()
             .and_then(|stylo| stylo.get().map(|data| data.damage))
     }
 
     pub fn set_damage(&mut self, damage: RestyleDamage) {
-        if let Some(stylo) = self.stylo_element_data_opt_mut() {
+        if let Some(stylo) = self.try_stylo_element_data_mut() {
             if let Some(mut data) = stylo.get_mut() {
                 data.damage = damage;
             }
@@ -615,7 +615,7 @@ impl Node {
     }
 
     pub fn insert_damage(&mut self, damage: RestyleDamage) {
-        if let Some(stylo) = self.stylo_element_data_opt_mut() {
+        if let Some(stylo) = self.try_stylo_element_data_mut() {
             if let Some(mut data) = stylo.get_mut() {
                 data.damage |= damage;
             }
@@ -626,7 +626,7 @@ impl Node {
     }
 
     pub fn remove_damage(&mut self, damage: RestyleDamage) {
-        if let Some(stylo) = self.stylo_element_data_opt_mut() {
+        if let Some(stylo) = self.try_stylo_element_data_mut() {
             if let Some(mut data) = stylo.get_mut() {
                 data.damage.remove(damage);
             }
@@ -634,7 +634,7 @@ impl Node {
     }
 
     pub fn clear_damage_mut(&mut self) {
-        if let Some(stylo) = self.stylo_element_data_opt_mut() {
+        if let Some(stylo) = self.try_stylo_element_data_mut() {
             if let Some(mut data) = stylo.get_mut() {
                 data.damage = RestyleDamage::empty();
             }
@@ -1174,7 +1174,7 @@ impl Node {
     }
 
     pub fn primary_styles(&self) -> Option<impl Deref<Target = ServoArc<ComputedValues>>> {
-        self.stylo_element_data_opt()
+        self.try_stylo_element_data()
             .and_then(|stylo| stylo.primary_styles())
     }
 
@@ -1185,7 +1185,7 @@ impl Node {
     /// `display: none`) are never queried by Taffy.
     pub fn layout_style(&self) -> stylo_taffy::TaffyStyloStyle<ComputedStyleRef<'_>> {
         let styles = self
-            .stylo_element_data_opt()
+            .try_stylo_element_data()
             .and_then(|stylo| stylo.computed_styles())
             .expect("layout_style() called on a node without computed styles");
 
@@ -1692,7 +1692,7 @@ impl std::fmt::Debug for Node {
             .field("layout_children", &self.layout_children.borrow())
             // .field("style", &self.style)
             .field("node", &self.data)
-            .field("stylo_element_data", &self.stylo_element_data_opt())
+            .field("stylo_element_data", &self.try_stylo_element_data())
             // .field("unrounded_layout", &self.unrounded_layout)
             // .field("final_layout", &self.final_layout)
             .finish()

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -257,7 +257,7 @@ impl BaseDocument {
                     resolve_layout_children_recursive(doc, child_id);
                     doc.nodes[child_id].layout_parent.set(Some(node_id));
                     if let Some(mut data) = doc.nodes[child_id]
-                        .stylo_element_data_opt_mut()
+                        .try_stylo_element_data_mut()
                         .and_then(|s| s.get_mut())
                     {
                         data.damage

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -459,7 +459,7 @@ impl selectors::Element for BlitzNode<'_> {
         pe: &PseudoElement,
         _context: &mut MatchingContext<Self::Impl>,
     ) -> bool {
-        let pseudo = match self.stylo_element_data_opt().and_then(|s| s.get()) {
+        let pseudo = match self.try_stylo_element_data().and_then(|s| s.get()) {
             Some(el) => el
                 .styles
                 .get_primary()
@@ -705,11 +705,11 @@ impl<'a> TElement for BlitzNode<'a> {
     }
 
     fn has_data(&self) -> bool {
-        self.stylo_element_data_opt().is_some_and(|s| s.has_data())
+        self.try_stylo_element_data().is_some_and(|s| s.has_data())
     }
 
     fn borrow_data(&self) -> Option<ElementDataRef<'_>> {
-        self.stylo_element_data_opt().and_then(|s| s.get())
+        self.try_stylo_element_data().and_then(|s| s.get())
     }
 
     fn mutate_data(&self) -> Option<ElementDataMut<'_>> {
@@ -1354,7 +1354,7 @@ fn sync_pseudo_element_styles(
             continue;
         };
         let pe_node = el.with(pe_node_id);
-        let Some(stylo_data) = pe_node.stylo_element_data_opt() else {
+        let Some(stylo_data) = pe_node.try_stylo_element_data() else {
             continue;
         };
         let mut pe_data = match unsafe { stylo_data.unsafe_stylo_only_mut() } {


### PR DESCRIPTION
## Summary
Mechanical rename of the Option-returning node accessors from `_opt` suffixes to `try_` prefixes (Rust convention):

- `Node::layout_data_opt_mut` -> `Node::try_layout_data_mut`
- `Node::stylo_element_data_opt` -> `Node::try_stylo_element_data`
- `Node::stylo_element_data_opt_mut` -> `Node::try_stylo_element_data_mut`

No behavior change; all call sites updated.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9cffd370ef03474e88a93f5335b19b65
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/9cffd370ef03474e88a93f5335b19b65?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32917453831).</sub>
<!-- wpt-results-end -->
