### PR TITLE
Make paint-placement maintenance incremental (O(damage), not O(tree))

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=e86f2de4a786f078497c0644f4dd993e4e622deb#e86f2de4a786f078497c0644f4dd993e4e622deb"
+source = "git+https://github.com/DioxusLabs/taffy?rev=5e71ce150954c2b23d081bed239e9930287f6ad6#5e71ce150954c2b23d081bed239e9930287f6ad6"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=4da301158398d53ab898eb90f97b30bbaace6b67#4da301158398d53ab898eb90f97b30bbaace6b67"
+source = "git+https://github.com/DioxusLabs/taffy?rev=98643141270a9d15e8a7c74cea3f0bd6339b9f44#98643141270a9d15e8a7c74cea3f0bd6339b9f44"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=98643141270a9d15e8a7c74cea3f0bd6339b9f44#98643141270a9d15e8a7c74cea3f0bd6339b9f44"
+source = "git+https://github.com/DioxusLabs/taffy?rev=e86f2de4a786f078497c0644f4dd993e4e622deb#e86f2de4a786f078497c0644f4dd993e4e622deb"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,8 +7917,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639627c87f43b9181c811f40a6296409e093a17bc761214cba3c15df74f86b99"
+source = "git+https://github.com/DioxusLabs/taffy?rev=4da301158398d53ab898eb90f97b30bbaace6b67#4da301158398d53ab898eb90f97b30bbaace6b67"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=5e71ce150954c2b23d081bed239e9930287f6ad6#5e71ce150954c2b23d081bed239e9930287f6ad6"
+source = "git+https://github.com/DioxusLabs/taffy?rev=76a2869514ddbedb75e76e07f03afa18aa8fbaba#76a2869514ddbedb75e76e07f03afa18aa8fbaba"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "98643141270a9d15e8a7c74cea3f0bd6339b9f44", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "e86f2de4a786f078497c0644f4dd993e4e622deb", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { version = "0.14.0", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "4da301158398d53ab898eb90f97b30bbaace6b67", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "e86f2de4a786f078497c0644f4dd993e4e622deb", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "5e71ce150954c2b23d081bed239e9930287f6ad6", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "5e71ce150954c2b23d081bed239e9930287f6ad6", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "76a2869514ddbedb75e76e07f03afa18aa8fbaba", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "4da301158398d53ab898eb90f97b30bbaace6b67", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "98643141270a9d15e8a7c74cea3f0bd6339b9f44", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -312,6 +312,12 @@ pub struct BaseDocument {
     pub(crate) iframe_loads: HashMap<NodeId, crate::iframe::IframeLoad>,
     /// Set of changed nodes for updating the accessibility tree
     pub(crate) changed_nodes: HashSet<NodeId>,
+    /// Nodes that are the containing block of at least one out-of-flow
+    /// (hoisted) box, as reported by Taffy's out-of-flow positioning pass.
+    /// Maintained by `set_hoisted_children`/`add_hoisted_children` so that
+    /// `attach_hoisted_children` can visit only these nodes rather than
+    /// scanning the whole node slab.
+    pub(crate) oof_containing_blocks: HashSet<NodeId>,
     /// Set of changed nodes for updating the accessibility tree
     pub(crate) deferred_construction_nodes: Vec<ConstructionTask>,
 
@@ -472,6 +478,7 @@ impl BaseDocument {
             pending_resource_deallocations: Vec::new(),
 
             changed_nodes: HashSet::new(),
+            oof_containing_blocks: HashSet::new(),
             deferred_construction_nodes: Vec::new(),
             image_cache: HashMap::new(),
             pending_images: HashMap::new(),

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1785,9 +1785,16 @@ impl BaseDocument {
             return (None, None);
         }
         let mut scrollbar = None;
-        let hit = self
-            .root_element()
-            .hit_inner(x, y, self.viewport().scale_f64(), &mut scrollbar);
+        let hit = self.root_element().hit_inner(
+            x,
+            y,
+            self.viewport().scale_f64(),
+            &mut scrollbar,
+            taffy::Point {
+                x: self.viewport_scroll.x as f32,
+                y: self.viewport_scroll.y as f32,
+            },
+        );
         (hit, scrollbar)
     }
 

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -713,7 +713,7 @@ fn float_to_order(pos: Float) -> i32 {
 /// Appendix E step 8); within a level the stable sort preserves
 /// (order-modified) document order.
 #[inline(always)]
-fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> (i32, i32) {
+pub(crate) fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> (i32, i32) {
     let Some(style) = node.primary_styles() else {
         return (0, 0);
     };

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -542,10 +542,33 @@ impl BaseDocument {
         node_id: NodeId,
         parent_stacking_context: Option<&mut HoistedPaintChildren>,
     ) {
+        let incremental = self.incremental_layout;
+
+        // Skip clean subtrees: their taffy styles, layout/paint child lists and
+        // stacking contexts are unchanged, and the entries the subtree
+        // contributed to an ancestor stacking context are replayed from the
+        // cache captured on the last flush that visited it. Damage propagation
+        // bubbles descendant damage into each ancestor's stored damage, so an
+        // empty damage value covers the whole subtree. Anonymous boxes are
+        // never skipped (damage marking walks the DOM parent chain, which
+        // bypasses them).
+        if incremental {
+            let node = &self.nodes[node_id];
+            let clean = node.damage().is_some_and(|d| d.is_empty())
+                && !node.has_damaged_descendants()
+                && !node.is_anonymous();
+            if clean {
+                if let Some(parent_stacking_context) = parent_stacking_context {
+                    parent_stacking_context
+                        .children
+                        .extend(node.sc_contribution_cache.borrow().iter().cloned());
+                }
+                return;
+            }
+        }
+
         let mut new_stacking_context: HoistedPaintChildren = HoistedPaintChildren::new();
         let stacking_context = &mut new_stacking_context;
-
-        let incremental = self.incremental_layout;
         let display = {
             let node = self.nodes.get_mut(node_id).unwrap();
 
@@ -670,6 +693,12 @@ impl BaseDocument {
         }
 
         if let Some(parent_stacking_context) = parent_stacking_context {
+            if incremental {
+                let node = &self.nodes[node_id];
+                let mut cache = node.sc_contribution_cache.borrow_mut();
+                cache.clear();
+                cache.extend(stacking_context.children.iter().cloned());
+            }
             parent_stacking_context
                 .children
                 .extend(stacking_context.children.iter().cloned());

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -292,12 +292,16 @@ pub(crate) fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) 
     }
 }
 
-/// A child with a z_index that is hoisted up to it's containing Stacking Context for paint purposes
+/// A child with a z_index that is hoisted up to it's containing Stacking Context for paint purposes.
+///
+/// The child's position relative to the stacking context root is not stored:
+/// it is derived at use-time from the `layout_parent` chain (see
+/// `Node::hoisted_child_position`), so it never goes stale when layout or
+/// scroll offsets change elsewhere in the tree.
 #[derive(Debug, Clone)]
 pub struct HoistedPaintChild {
     pub node_id: NodeId,
     pub z_index: i32,
-    pub position: taffy::Point<f32>,
 }
 
 #[derive(Debug)]
@@ -323,11 +327,12 @@ impl HoistedPaintChildren {
         self.negative_z_count = 0;
     }
 
-    pub fn compute_content_size(&mut self, doc: &BaseDocument) {
-        fn child_pos(child: &HoistedPaintChild, doc: &BaseDocument) -> Rect<f32> {
+    pub fn compute_content_size(&mut self, doc: &BaseDocument, owner_id: NodeId) {
+        fn child_pos(child: &HoistedPaintChild, doc: &BaseDocument, owner_id: NodeId) -> Rect<f32> {
             let node = &doc.nodes[child.node_id];
-            let left = child.position.x + node.final_layout().location.x;
-            let top = child.position.y + node.final_layout().location.y;
+            let position = doc.nodes[owner_id].hoisted_child_position(child.node_id);
+            let left = position.x + node.final_layout().location.x;
+            let top = position.y + node.final_layout().location.y;
             let right = left + node.final_layout().size.width;
             let bottom = top + node.final_layout().size.height;
 
@@ -342,9 +347,9 @@ impl HoistedPaintChildren {
         if self.children.is_empty() {
             self.content_area = taffy::Rect::ZERO;
         } else {
-            self.content_area = child_pos(&self.children[0], doc);
+            self.content_area = child_pos(&self.children[0], doc, owner_id);
             for child in self.children[1..].iter() {
-                let pos = child_pos(child, doc);
+                let pos = child_pos(child, doc, owner_id);
                 self.content_area.left = self.content_area.left.min(pos.left);
                 self.content_area.top = self.content_area.top.min(pos.top);
                 self.content_area.right = self.content_area.right.max(pos.right);
@@ -646,7 +651,6 @@ impl BaseDocument {
                     stacking_context.children.push(HoistedPaintChild {
                         node_id: child_id,
                         z_index,
-                        position: taffy::Point::ZERO,
                     })
                 } else {
                     paint_children.push(child_id);
@@ -666,18 +670,12 @@ impl BaseDocument {
         }
 
         if let Some(parent_stacking_context) = parent_stacking_context {
-            let position = self.nodes[node_id].final_layout().location;
-            let scroll_offset = *self.nodes[node_id].scroll_offset();
-            for hoisted in stacking_context.children.iter_mut() {
-                hoisted.position.x += position.x - scroll_offset.x as f32;
-                hoisted.position.y += position.y - scroll_offset.y as f32;
-            }
             parent_stacking_context
                 .children
                 .extend(stacking_context.children.iter().cloned());
         } else {
             stacking_context.sort();
-            stacking_context.compute_content_size(self);
+            stacking_context.compute_content_size(self, node_id);
             self.nodes[node_id].stacking_context = Some(Box::new(new_stacking_context));
         }
     }

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -613,11 +613,37 @@ impl BaseDocument {
 
                 // Out-of-flow boxes are hoisted to their containing block by Taffy's
                 // out-of-flow positioning pass and their layout location is relative to
-                // the containing block's border box. They are painted (and hit-tested)
-                // via the containing block's `hoisted_children` list (see
-                // `attach_hoisted_children`), not via their DOM parent.
+                // the containing block's border box. When this node is the child's
+                // containing block (it claims the child's position type), the child
+                // stays in this node's paint list, preserving tree order among
+                // positioned siblings. Otherwise it is painted (and hit-tested) via
+                // the containing block's `hoisted_children` list (see
+                // `attach_hoisted_children`), not via its DOM parent.
                 if matches!(position, Position::Absolute | Position::Fixed) {
-                    continue;
+                    let parent = &self.nodes[node_id];
+                    // The root element is the initial containing block: it claims
+                    // every candidate not claimed by a closer containing block.
+                    let is_root = self.try_root_element().is_some_and(|el| el.id == node_id);
+                    let parent_claims = is_root
+                        || match position {
+                            Position::Fixed => parent.establishes_fixed_containing_block(),
+                            _ => {
+                                parent
+                                    .primary_styles()
+                                    .is_some_and(|s| s.clone_position() != Position::Static)
+                                    || parent.establishes_fixed_containing_block()
+                                    || parent.establishes_absolute_containing_block()
+                            }
+                        };
+                    if !parent_claims {
+                        continue;
+                    }
+                    // Z-indexed out-of-flow boxes are routed to their stacking
+                    // context by `attach_hoisted_children` after layout, when
+                    // their containing-block-relative location is known.
+                    if z_index != 0 {
+                        continue;
+                    }
                 }
 
                 // TODO: more complete hoisting detection

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -611,6 +611,15 @@ impl BaseDocument {
                 let position = style.clone_position();
                 let z_index = style.clone_z_index().integer_or(0);
 
+                // Out-of-flow boxes are hoisted to their containing block by Taffy's
+                // out-of-flow positioning pass and their layout location is relative to
+                // the containing block's border box. They are painted (and hit-tested)
+                // via the containing block's `hoisted_children` list (see
+                // `attach_hoisted_children`), not via their DOM parent.
+                if matches!(position, Position::Absolute | Position::Fixed) {
+                    continue;
+                }
+
                 // TODO: more complete hoisting detection
                 // z-index applies to static flex/grid items too
                 // (css-flexbox-1 §painting, css-grid-1 §z-order).

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -625,16 +625,9 @@ impl BaseDocument {
                     // every candidate not claimed by a closer containing block.
                     let is_root = self.try_root_element().is_some_and(|el| el.id == node_id);
                     let parent_claims = is_root
-                        || match position {
-                            Position::Fixed => parent.establishes_fixed_containing_block(),
-                            _ => {
-                                parent
-                                    .primary_styles()
-                                    .is_some_and(|s| s.clone_position() != Position::Static)
-                                    || parent.establishes_fixed_containing_block()
-                                    || parent.establishes_absolute_containing_block()
-                            }
-                        };
+                        || parent
+                            .containing_block_claims()
+                            .for_position(stylo_taffy::convert::position(position));
                     if !parent_claims {
                         continue;
                     }

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -815,13 +815,18 @@ impl BaseDocument {
                         let size = output.size;
                         let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
 
-                        let inset_offset = taffy::Point {
-                            x: if container_direction == Direction::Rtl {
-                                inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)
-                            } else {
-                                inset.left.or(inset.right.map(|x| -x)).unwrap_or(0.0)
-                            },
-                            y: inset.top.or(inset.bottom.map(|x| -x)).unwrap_or(0.0),
+                        let is_relative = position == taffy::Position::Relative;
+                        let inset_offset = if is_relative {
+                            taffy::Point {
+                                x: if container_direction == Direction::Rtl {
+                                    inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)
+                                } else {
+                                    inset.left.or(inset.right.map(|x| -x)).unwrap_or(0.0)
+                                },
+                                y: inset.top.or(inset.bottom.map(|x| -x)).unwrap_or(0.0),
+                            }
+                        } else {
+                            taffy::Point::ZERO
                         };
 
                         let layout = node.unrounded_layout_mut();

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -275,6 +275,14 @@ impl BaseDocument {
                 }),
         };
 
+        let perform_layout = inputs.run_mode == taffy::RunMode::PerformLayout;
+
+        // Measure passes must not leave measure-time state (inline box sizes, line breaks)
+        // in the persistent inline layout: painting uses that state, and a cache hit on a
+        // later full layout pass would not recompute it. Snapshot it here and restore it
+        // before returning.
+        let saved_layout = (!perform_layout).then(|| inline_layout.layout.clone());
+
         // Compute size of inline boxes
         let child_inputs = taffy::tree::LayoutInput {
             known_dimensions: Size::NONE,
@@ -474,7 +482,10 @@ impl BaseDocument {
         if inputs.run_mode == taffy::RunMode::ComputeSize
             && inputs.axis == RequestedAxis::Horizontal
         {
-            // Put layout back
+            // Restore the pre-measure inline layout state and put the layout back
+            if let Some(saved) = saved_layout {
+                inline_layout.layout = saved;
+            }
             self.nodes[node_id]
                 .data
                 .downcast_element_mut()
@@ -600,15 +611,20 @@ impl BaseDocument {
                         state.set_line_x(next_slot.x * scale);
                         state.set_line_y((next_slot.y * scale) as f64);
 
-                        let layout = self.nodes[node_id].unrounded_layout_mut();
-                        layout.size = output.size;
-                        layout.location.x = pos.x + margin.left + container_pb.left;
-                        layout.location.y = pos.y + margin.top + container_pb.top;
+                        let location = taffy::Point {
+                            x: pos.x + margin.left + container_pb.left,
+                            y: pos.y + margin.top + container_pb.top,
+                        };
+                        if perform_layout {
+                            let layout = self.nodes[node_id].unrounded_layout_mut();
+                            layout.size = output.size;
+                            layout.location = location;
+                        }
 
                         // Translate anchors from item-relative to container-relative
                         // coordinates and collect candidates bubbled from the float's subtree
                         if !output.oof_candidates.is_empty() {
-                            output.oof_candidates.translate(layout.location);
+                            output.oof_candidates.translate(location);
                             oof_candidates.append(&mut output.oof_candidates);
                         }
 
@@ -715,140 +731,147 @@ impl BaseDocument {
 
         // Store sizes and positions of inline boxes
         let mut ibox_order: u32 = 0;
-        for line in inline_layout.layout.lines() {
-            for item in line.items() {
-                if let parley::layout::PositionedLayoutItem::InlineBox(ibox) = item {
-                    let order = ibox_order;
-                    ibox_order += 1;
-                    let node = &self.nodes[NodeId::from_u64(ibox.id)];
-                    let style = node.layout_style();
-                    let padding = style
-                        .padding()
-                        .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
-                    let border = style
-                        .border()
-                        .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
-                    let margin = style
-                        .margin()
-                        .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
+        if perform_layout {
+            for line in inline_layout.layout.lines() {
+                for item in line.items() {
+                    if let parley::layout::PositionedLayoutItem::InlineBox(ibox) = item {
+                        let order = ibox_order;
+                        ibox_order += 1;
+                        let node = &self.nodes[NodeId::from_u64(ibox.id)];
+                        let style = node.layout_style();
+                        let padding = style
+                            .padding()
+                            .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
+                        let border = style
+                            .border()
+                            .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
+                        let margin = style
+                            .margin()
+                            .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
 
-                    #[cfg(feature = "floats")]
-                    let is_floated = style.float() != Float::None;
-                    #[cfg(not(feature = "floats"))]
-                    let is_floated = false;
+                        #[cfg(feature = "floats")]
+                        let is_floated = style.float() != Float::None;
+                        #[cfg(not(feature = "floats"))]
+                        let is_floated = false;
 
-                    let position = style.position();
-                    let is_absolute = position.is_out_of_flow();
+                        let position = style.position();
+                        let is_absolute = position.is_out_of_flow();
 
-                    // The static position of an absolutely positioned box depends on the
-                    // display its hypothetical box would have had (the display specified
-                    // before position:absolute blockified it): inline-level boxes sit at
-                    // their position within the line, while block-level boxes start at the
-                    // content-box left edge of their containing block.
-                    let is_inline_level =
-                        style.style.get_box().original_display.outside() == DisplayOutside::Inline;
+                        // The static position of an absolutely positioned box depends on the
+                        // display its hypothetical box would have had (the display specified
+                        // before position:absolute blockified it): inline-level boxes sit at
+                        // their position within the line, while block-level boxes start at the
+                        // content-box left edge of their containing block.
+                        let is_inline_level = style.style.get_box().original_display.outside()
+                            == DisplayOutside::Inline;
 
-                    // Resolve relative inset offsets against the containing block
-                    // (the content box of the inline container).
-                    let container_content_size = final_size - content_box_inset.sum_axes();
-                    let inset_style = style.inset();
-                    let inset = taffy::Rect {
-                        left: inset_style
-                            .left
-                            .maybe_resolve(container_content_size.width, resolve_calc_value),
-                        right: inset_style
-                            .right
-                            .maybe_resolve(container_content_size.width, resolve_calc_value),
-                        top: inset_style
-                            .top
-                            .maybe_resolve(container_content_size.height, resolve_calc_value),
-                        bottom: inset_style
-                            .bottom
-                            .maybe_resolve(container_content_size.height, resolve_calc_value),
-                    };
-                    drop(style);
-
-                    if is_absolute {
-                        // Inline-level boxes are placed at the top of the line box they would
-                        // have occupied (`ibox.y` is the baseline as out-of-flow boxes are
-                        // zero-sized), and block-level boxes below it.
-                        let line_metrics = line.metrics();
-                        let static_position = taffy::Point {
-                            x: if is_inline_level {
-                                (ibox.x / scale) + container_pb.left
-                            } else {
-                                container_pb.left
-                            },
-                            y: if is_inline_level {
-                                (line_metrics.block_min_coord / scale) + container_pb.top
-                            } else {
-                                (line_metrics.block_max_coord / scale) + container_pb.top
-                            },
+                        // Resolve relative inset offsets against the containing block
+                        // (the content box of the inline container).
+                        let container_content_size = final_size - content_box_inset.sum_axes();
+                        let inset_style = style.inset();
+                        let inset = taffy::Rect {
+                            left: inset_style
+                                .left
+                                .maybe_resolve(container_content_size.width, resolve_calc_value),
+                            right: inset_style
+                                .right
+                                .maybe_resolve(container_content_size.width, resolve_calc_value),
+                            top: inset_style
+                                .top
+                                .maybe_resolve(container_content_size.height, resolve_calc_value),
+                            bottom: inset_style
+                                .bottom
+                                .maybe_resolve(container_content_size.height, resolve_calc_value),
                         };
+                        drop(style);
 
-                        oof_candidates.push(OofCandidate {
-                            node: taffy::NodeId::from(ibox.id),
-                            order,
-                            position,
-                            static_position: taffy::Point {
-                                x: StaticPosition::from_edge(
-                                    static_position.x,
-                                    if container_direction == Direction::Rtl && is_inline_level {
-                                        StaticEdge::End
-                                    } else {
-                                        StaticEdge::Start
-                                    },
-                                ),
-                                y: StaticPosition::from_edge(static_position.y, StaticEdge::Start),
-                            },
-                        });
-                    } else if is_floated {
-                        let layout = self.nodes[NodeId::from_u64(ibox.id)].unrounded_layout_mut();
-                        layout.padding = padding; //.map(|p| p / scale);
-                        layout.border = border; //.map(|p| p / scale);
-                    } else {
-                        // Re-measure the box to get its border-box size (this hits the layout
-                        // cache). The size cannot be recovered from `ibox` dimensions as the
-                        // space reserved in the line is clamped to be non-negative.
-                        let mut output =
-                            self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
-                        let size = output.size;
-                        let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
-
-                        let is_relative = position == taffy::Position::Relative;
-                        let inset_offset = if is_relative {
-                            taffy::Point {
-                                x: if container_direction == Direction::Rtl {
-                                    inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)
+                        if is_absolute {
+                            // Inline-level boxes are placed at the top of the line box they would
+                            // have occupied (`ibox.y` is the baseline as out-of-flow boxes are
+                            // zero-sized), and block-level boxes below it.
+                            let line_metrics = line.metrics();
+                            let static_position = taffy::Point {
+                                x: if is_inline_level {
+                                    (ibox.x / scale) + container_pb.left
                                 } else {
-                                    inset.left.or(inset.right.map(|x| -x)).unwrap_or(0.0)
+                                    container_pb.left
                                 },
-                                y: inset.top.or(inset.bottom.map(|x| -x)).unwrap_or(0.0),
-                            }
+                                y: if is_inline_level {
+                                    (line_metrics.block_min_coord / scale) + container_pb.top
+                                } else {
+                                    (line_metrics.block_max_coord / scale) + container_pb.top
+                                },
+                            };
+
+                            oof_candidates.push(OofCandidate {
+                                node: taffy::NodeId::from(ibox.id),
+                                order,
+                                position,
+                                static_position: taffy::Point {
+                                    x: StaticPosition::from_edge(
+                                        static_position.x,
+                                        if container_direction == Direction::Rtl && is_inline_level
+                                        {
+                                            StaticEdge::End
+                                        } else {
+                                            StaticEdge::Start
+                                        },
+                                    ),
+                                    y: StaticPosition::from_edge(
+                                        static_position.y,
+                                        StaticEdge::Start,
+                                    ),
+                                },
+                            });
+                        } else if is_floated {
+                            let layout =
+                                self.nodes[NodeId::from_u64(ibox.id)].unrounded_layout_mut();
+                            layout.padding = padding; //.map(|p| p / scale);
+                            layout.border = border; //.map(|p| p / scale);
                         } else {
-                            taffy::Point::ZERO
-                        };
+                            // Re-measure the box to get its border-box size (this hits the layout
+                            // cache). The size cannot be recovered from `ibox` dimensions as the
+                            // space reserved in the line is clamped to be non-negative.
+                            let mut output = self
+                                .compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
+                            let size = output.size;
+                            let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
 
-                        let layout = node.unrounded_layout_mut();
-                        layout.size = size;
-                        layout.location.x =
-                            (ibox.x / scale) + margin.left + container_pb.left + inset_offset.x;
-                        // A negative `margin-top` shrinks the space the box reserves in the
-                        // line but does not move the box itself, which stays anchored to the
-                        // bottom of the reserved space.
-                        layout.location.y = (ibox.y / scale)
-                            + margin.top.max(0.0)
-                            + container_pb.top
-                            + inset_offset.y;
-                        layout.padding = padding; //.map(|p| p / scale);
-                        layout.border = border; //.map(|p| p / scale);
+                            let is_relative = position == taffy::Position::Relative;
+                            let inset_offset = if is_relative {
+                                taffy::Point {
+                                    x: if container_direction == Direction::Rtl {
+                                        inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)
+                                    } else {
+                                        inset.left.or(inset.right.map(|x| -x)).unwrap_or(0.0)
+                                    },
+                                    y: inset.top.or(inset.bottom.map(|x| -x)).unwrap_or(0.0),
+                                }
+                            } else {
+                                taffy::Point::ZERO
+                            };
 
-                        // Translate anchors from item-relative to container-relative
-                        // coordinates and collect candidates bubbled from the box's subtree
-                        if !output.oof_candidates.is_empty() {
-                            let location = layout.location;
-                            output.oof_candidates.translate(location);
-                            oof_candidates.append(&mut output.oof_candidates);
+                            let layout = node.unrounded_layout_mut();
+                            layout.size = size;
+                            layout.location.x =
+                                (ibox.x / scale) + margin.left + container_pb.left + inset_offset.x;
+                            // A negative `margin-top` shrinks the space the box reserves in the
+                            // line but does not move the box itself, which stays anchored to the
+                            // bottom of the reserved space.
+                            layout.location.y = (ibox.y / scale)
+                                + margin.top.max(0.0)
+                                + container_pb.top
+                                + inset_offset.y;
+                            layout.padding = padding; //.map(|p| p / scale);
+                            layout.border = border; //.map(|p| p / scale);
+
+                            // Translate anchors from item-relative to container-relative
+                            // coordinates and collect candidates bubbled from the box's subtree
+                            if !output.oof_candidates.is_empty() {
+                                let location = layout.location;
+                                output.oof_candidates.translate(location);
+                                oof_candidates.append(&mut output.oof_candidates);
+                            }
                         }
                     }
                 }
@@ -867,7 +890,10 @@ impl BaseDocument {
             .next()
             .map(|line| (line.metrics().baseline / scale) + container_pb.top);
 
-        // Put layout back
+        // Restore the pre-measure inline layout state and put the layout back
+        if let Some(saved) = saved_layout {
+            inline_layout.layout = saved;
+        }
         self.nodes[node_id]
             .data
             .downcast_element_mut()

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -5,8 +5,8 @@ use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent}
 use taffy::{
     AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
     CoreStyle as _, Direction, LayoutInput, LayoutOutput, LayoutPartialTree as _, MaybeMath as _,
-    MaybeResolve as _, Overflow, Point, Position, RequestedAxis, ResolveOrZero as _, RunMode, Size,
-    SizingMode,
+    MaybeResolve as _, OofCandidate, OofCandidates, OofPositioningArea, Overflow, Point,
+    RequestedAxis, ResolveOrZero as _, RunMode, Size, SizingMode, StaticEdge, StaticPosition,
 };
 
 #[cfg(feature = "floats")]
@@ -189,7 +189,7 @@ impl BaseDocument {
         let has_styles_preventing_being_collapsed_through = !style.is_block()
             || style.overflow().x.is_scroll_container()
             || style.overflow().y.is_scroll_container()
-            || style.position() == Position::Absolute
+            || style.position().is_out_of_flow()
             || padding.top > 0.0
             || padding.bottom > 0.0
             || border.top > 0.0
@@ -304,10 +304,10 @@ impl BaseDocument {
             #[cfg(not(feature = "floats"))]
             let is_floated = false;
 
-            let is_absolute = style.position() == Position::Absolute;
+            let is_out_of_flow = style.position().is_out_of_flow();
             drop(style);
 
-            if is_absolute || is_floated {
+            if is_out_of_flow || is_floated {
                 ibox.width = 0.0;
                 ibox.height = 0.0;
             } else {
@@ -502,6 +502,10 @@ impl BaseDocument {
             inline_layout.layout.break_all_lines(Some(width));
         }
 
+        // Out-of-flow candidates bubbled up from this container and its in-flow subtree.
+        // These are laid out by the out-of-flow positioning pass (`compute_oof_layout`).
+        let mut oof_candidates = OofCandidates::new();
+
         // Perform inline layout
         #[cfg(feature = "floats")]
         {
@@ -572,7 +576,7 @@ impl BaseDocument {
 
                         let margin_sum = margin.sum_axes();
 
-                        let output = self.compute_child_layout(
+                        let mut output = self.compute_child_layout(
                             crate::taffy_node_id(node_id),
                             float_child_inputs,
                         );
@@ -600,6 +604,13 @@ impl BaseDocument {
                         layout.size = output.size;
                         layout.location.x = pos.x + margin.left + container_pb.left;
                         layout.location.y = pos.y + margin.top + container_pb.top;
+
+                        // Translate anchors from item-relative to container-relative
+                        // coordinates and collect candidates bubbled from the float's subtree
+                        if !output.oof_candidates.is_empty() {
+                            output.oof_candidates.translate(layout.location);
+                            oof_candidates.append(&mut output.oof_candidates);
+                        }
 
                         // dbg!(&layout.size);
                         // dbg!(&layout.location);
@@ -703,9 +714,12 @@ impl BaseDocument {
         let container_direction = self.nodes[node_id].layout_style().direction();
 
         // Store sizes and positions of inline boxes
+        let mut ibox_order: u32 = 0;
         for line in inline_layout.layout.lines() {
             for item in line.items() {
                 if let parley::layout::PositionedLayoutItem::InlineBox(ibox) = item {
+                    let order = ibox_order;
+                    ibox_order += 1;
                     let node = &self.nodes[NodeId::from_u64(ibox.id)];
                     let style = node.layout_style();
                     let padding = style
@@ -723,8 +737,8 @@ impl BaseDocument {
                     #[cfg(not(feature = "floats"))]
                     let is_floated = false;
 
-                    let is_absolute = style.position() == Position::Absolute;
-                    let direction = style.direction();
+                    let position = style.position();
+                    let is_absolute = position.is_out_of_flow();
 
                     // The static position of an absolutely positioned box depends on the
                     // display its hypothetical box would have had (the display specified
@@ -772,15 +786,22 @@ impl BaseDocument {
                             },
                         };
 
-                        layout_abspos_child(
-                            self,
-                            ibox.id,
-                            static_position,
-                            is_inline_level,
-                            final_size,
-                            taffy::Point::ZERO,
-                            direction,
-                        );
+                        oof_candidates.push(OofCandidate {
+                            node: taffy::NodeId::from(ibox.id),
+                            order,
+                            position,
+                            static_position: taffy::Point {
+                                x: StaticPosition::from_edge(
+                                    static_position.x,
+                                    if container_direction == Direction::Rtl && is_inline_level {
+                                        StaticEdge::End
+                                    } else {
+                                        StaticEdge::Start
+                                    },
+                                ),
+                                y: StaticPosition::from_edge(static_position.y, StaticEdge::Start),
+                            },
+                        });
                     } else if is_floated {
                         let layout = self.nodes[NodeId::from_u64(ibox.id)].unrounded_layout_mut();
                         layout.padding = padding; //.map(|p| p / scale);
@@ -789,9 +810,9 @@ impl BaseDocument {
                         // Re-measure the box to get its border-box size (this hits the layout
                         // cache). The size cannot be recovered from `ibox` dimensions as the
                         // space reserved in the line is clamped to be non-negative.
-                        let size = self
-                            .compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs)
-                            .size;
+                        let mut output =
+                            self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
+                        let size = output.size;
                         let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
 
                         let inset_offset = taffy::Point {
@@ -816,6 +837,14 @@ impl BaseDocument {
                             + inset_offset.y;
                         layout.padding = padding; //.map(|p| p / scale);
                         layout.border = border; //.map(|p| p / scale);
+
+                        // Translate anchors from item-relative to container-relative
+                        // coordinates and collect candidates bubbled from the box's subtree
+                        if !output.oof_candidates.is_empty() {
+                            let location = layout.location;
+                            output.oof_candidates.translate(location);
+                            oof_candidates.append(&mut output.oof_candidates);
+                        }
                     }
                 }
             }
@@ -840,6 +869,13 @@ impl BaseDocument {
             .unwrap()
             .inline_layout_data = Some(inline_layout);
 
+        let oof_position_inset = taffy::Rect {
+            left: border.left,
+            right: border.right + scrollbar_gutter.x,
+            top: border.top,
+            bottom: border.bottom + scrollbar_gutter.y,
+        };
+
         LayoutOutput {
             size: final_size,
             scrollable_overflow_rect: {
@@ -860,6 +896,14 @@ impl BaseDocument {
             margins_can_collapse_through: !has_styles_preventing_being_collapsed_through
                 && final_size.height == 0.0
                 && measured_size.height == 0.0,
+            oof_candidates,
+            oof_positioning_area: Some(OofPositioningArea {
+                size: final_size - oof_position_inset.sum_axes(),
+                offset: Point {
+                    x: oof_position_inset.left,
+                    y: oof_position_inset.top,
+                },
+            }),
         }
     }
 }
@@ -867,323 +911,4 @@ impl BaseDocument {
 #[inline(always)]
 fn f32_max(a: f32, b: f32) -> f32 {
     a.max(b)
-}
-
-/// Perform absolute layout on all absolutely positioned children.
-#[inline]
-fn layout_abspos_child(
-    tree: &mut impl taffy::LayoutBlockContainer,
-    item_id: u64,
-    static_position: Point<f32>,
-    is_inline_level: bool,
-    area_size: Size<f32>,
-    area_offset: Point<f32>,
-    direction: taffy::Direction,
-) {
-    let area_width = area_size.width;
-    let area_height = area_size.height;
-
-    let node_id = taffy::NodeId::from(item_id);
-    let child_style = tree.get_block_child_style(node_id);
-
-    // Skip items that are display:none or are not position:absolute
-    if child_style.box_generation_mode() == taffy::BoxGenerationMode::None
-        || child_style.position() != taffy::Position::Absolute
-    {
-        return;
-    }
-
-    let aspect_ratio = child_style.aspect_ratio();
-    let overflow = child_style.overflow();
-    let scrollbar_width = child_style.scrollbar_width();
-    let margin = child_style
-        .margin()
-        .map(|margin| margin.resolve_to_option(area_width, resolve_calc_value));
-    let padding = child_style
-        .padding()
-        .resolve_or_zero(Some(area_width), resolve_calc_value);
-    let border = child_style
-        .border()
-        .resolve_or_zero(Some(area_width), resolve_calc_value);
-    let padding_border_sum = (padding + border).sum_axes();
-    let box_sizing_adjustment = if child_style.box_sizing() == taffy::BoxSizing::ContentBox {
-        padding_border_sum
-    } else {
-        Size::ZERO
-    };
-
-    // Resolve inset
-    let left = child_style
-        .inset()
-        .left
-        .maybe_resolve(area_width, resolve_calc_value);
-    let right = child_style
-        .inset()
-        .right
-        .maybe_resolve(area_width, resolve_calc_value);
-    let top = child_style
-        .inset()
-        .top
-        .maybe_resolve(area_height, resolve_calc_value);
-    let bottom = child_style
-        .inset()
-        .bottom
-        .maybe_resolve(area_height, resolve_calc_value);
-
-    // Compute known dimensions from min/max/inherent size styles
-    let style_size = child_style
-        .size()
-        .maybe_resolve(area_size, resolve_calc_value)
-        .maybe_apply_aspect_ratio(aspect_ratio)
-        .maybe_add(box_sizing_adjustment);
-    let min_size = child_style
-        .min_size()
-        .maybe_resolve(area_size, resolve_calc_value)
-        .maybe_apply_aspect_ratio(aspect_ratio)
-        .maybe_add(box_sizing_adjustment)
-        .or(padding_border_sum.map(Some))
-        .maybe_max(padding_border_sum);
-    let max_size = child_style
-        .max_size()
-        .maybe_resolve(area_size, resolve_calc_value)
-        .maybe_apply_aspect_ratio(aspect_ratio)
-        .maybe_add(box_sizing_adjustment);
-    let mut known_dimensions = style_size.maybe_clamp(min_size, max_size);
-
-    drop(child_style);
-
-    // Fill in width from left/right and reapply aspect ratio if:
-    //   - Width is not already known
-    //   - Item has both left and right inset properties set
-    if let (None, Some(left), Some(right)) = (known_dimensions.width, left, right) {
-        let new_width_raw =
-            area_width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
-        known_dimensions.width = Some(f32_max(new_width_raw, 0.0));
-        known_dimensions = known_dimensions
-            .maybe_apply_aspect_ratio(aspect_ratio)
-            .maybe_clamp(min_size, max_size);
-    }
-
-    // Fill in height from top/bottom and reapply aspect ratio if:
-    //   - Height is not already known
-    //   - Item has both top and bottom inset properties set
-    if let (None, Some(top), Some(bottom)) = (known_dimensions.height, top, bottom) {
-        let new_height_raw =
-            area_height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
-        known_dimensions.height = Some(f32_max(new_height_raw, 0.0));
-        known_dimensions = known_dimensions
-            .maybe_apply_aspect_ratio(aspect_ratio)
-            .maybe_clamp(min_size, max_size);
-    }
-
-    let measured_size = tree
-        .compute_child_layout(
-            node_id,
-            taffy::LayoutInput {
-                known_dimensions,
-                known_dimensions_are_definite: taffy::Size {
-                    width: true,
-                    height: true,
-                },
-                parent_size: area_size.map(Some),
-                available_space: Size {
-                    width: AvailableSpace::Definite(
-                        area_width.maybe_clamp(min_size.width, max_size.width),
-                    ),
-                    height: AvailableSpace::Definite(
-                        area_height.maybe_clamp(min_size.height, max_size.height),
-                    ),
-                },
-                sizing_mode: SizingMode::ContentSize,
-                run_mode: RunMode::ComputeSize,
-                axis: taffy::RequestedAxis::Both,
-                vertical_margins_are_collapsible: taffy::Line::FALSE,
-            },
-        )
-        .size;
-
-    let final_size = known_dimensions
-        .unwrap_or(measured_size)
-        .maybe_clamp(min_size, max_size);
-
-    let layout_output = tree.compute_child_layout(
-        node_id,
-        taffy::LayoutInput {
-            known_dimensions: final_size.map(Some),
-            known_dimensions_are_definite: taffy::Size {
-                width: true,
-                height: true,
-            },
-            parent_size: area_size.map(Some),
-            available_space: Size {
-                width: AvailableSpace::Definite(
-                    area_width.maybe_clamp(min_size.width, max_size.width),
-                ),
-                height: AvailableSpace::Definite(
-                    area_height.maybe_clamp(min_size.height, max_size.height),
-                ),
-            },
-            sizing_mode: SizingMode::ContentSize,
-            run_mode: RunMode::PerformLayout,
-            axis: taffy::RequestedAxis::Both,
-            vertical_margins_are_collapsible: taffy::Line::FALSE,
-        },
-    );
-
-    let non_auto_margin = taffy::Rect {
-        left: if left.is_some() {
-            margin.left.unwrap_or(0.0)
-        } else {
-            0.0
-        },
-        right: if right.is_some() {
-            margin.right.unwrap_or(0.0)
-        } else {
-            0.0
-        },
-        top: if top.is_some() {
-            margin.top.unwrap_or(0.0)
-        } else {
-            0.0
-        },
-        bottom: if bottom.is_some() {
-            margin.bottom.unwrap_or(0.0)
-        } else {
-            0.0
-        },
-    };
-
-    // Expand auto margins to fill available space
-    // https://www.w3.org/TR/CSS21/visudet.html#abs-non-replaced-width
-    let auto_margin = {
-        // Auto margins for absolutely positioned elements in block containers only resolve
-        // if inset is set. Otherwise they resolve to 0.
-        let absolute_auto_margin_space = Point {
-            x: right
-                .map(|right| area_size.width - right - left.unwrap_or(0.0))
-                .unwrap_or(final_size.width),
-            y: bottom
-                .map(|bottom| area_size.height - bottom - top.unwrap_or(0.0))
-                .unwrap_or(final_size.height),
-        };
-        let free_space = Size {
-            width: absolute_auto_margin_space.x
-                - final_size.width
-                - non_auto_margin.horizontal_axis_sum(),
-            height: absolute_auto_margin_space.y
-                - final_size.height
-                - non_auto_margin.vertical_axis_sum(),
-        };
-
-        let auto_margin_size = Size {
-            // If all three of 'left', 'width', and 'right' are 'auto': First set any 'auto' values for 'margin-left' and 'margin-right' to 0.
-            // Then, if the 'direction' property of the element establishing the static-position containing block is 'ltr' set 'left' to the
-            // static position and apply rule number three below; otherwise, set 'right' to the static position and apply rule number one below.
-            //
-            // If none of the three is 'auto': If both 'margin-left' and 'margin-right' are 'auto', solve the equation under the extra constraint
-            // that the two margins get equal values, unless this would make them negative, in which case when direction of the containing block is
-            // 'ltr' ('rtl'), set 'margin-left' ('margin-right') to zero and solve for 'margin-right' ('margin-left'). If one of 'margin-left' or
-            // 'margin-right' is 'auto', solve the equation for that value. If the values are over-constrained, ignore the value for 'left' (in case
-            // the 'direction' property of the containing block is 'rtl') or 'right' (in case 'direction' is 'ltr') and solve for that value.
-            width: {
-                let auto_margin_count = margin.left.is_none() as u8 + margin.right.is_none() as u8;
-                if auto_margin_count == 2
-                    && (style_size.width.is_none() || style_size.width.unwrap() >= free_space.width)
-                {
-                    0.0
-                } else if auto_margin_count > 0 {
-                    free_space.width / auto_margin_count as f32
-                } else {
-                    0.0
-                }
-            },
-            height: {
-                let auto_margin_count = margin.top.is_none() as u8 + margin.bottom.is_none() as u8;
-                if auto_margin_count == 2
-                    && (style_size.height.is_none()
-                        || style_size.height.unwrap() >= free_space.height)
-                {
-                    0.0
-                } else if auto_margin_count > 0 {
-                    free_space.height / auto_margin_count as f32
-                } else {
-                    0.0
-                }
-            },
-        };
-
-        taffy::Rect {
-            left: margin.left.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-            right: margin.right.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-            top: margin.top.map(|_| 0.0).unwrap_or(auto_margin_size.height),
-            bottom: margin
-                .bottom
-                .map(|_| 0.0)
-                .unwrap_or(auto_margin_size.height),
-        }
-    };
-
-    let resolved_margin = taffy::Rect {
-        left: margin.left.unwrap_or(auto_margin.left),
-        right: margin.right.unwrap_or(auto_margin.right),
-        top: margin.top.unwrap_or(auto_margin.top),
-        bottom: margin.bottom.unwrap_or(auto_margin.bottom),
-    };
-
-    let x_offset = match (left, right) {
-        (Some(left), Some(right)) => {
-            if direction == Direction::Rtl {
-                area_size.width - final_size.width - right - resolved_margin.right
-            } else {
-                left + resolved_margin.left
-            }
-        }
-        (Some(left), None) => left + resolved_margin.left,
-        (None, Some(right)) => area_size.width - final_size.width - right - resolved_margin.right,
-        (None, None) => {
-            if direction == Direction::Rtl && is_inline_level {
-                static_position.x - final_size.width - resolved_margin.right - area_offset.x
-            } else {
-                static_position.x + resolved_margin.left - area_offset.x
-            }
-        }
-    };
-    let location = Point {
-        x: x_offset + area_offset.x,
-        y: top
-            .map(|top| top + resolved_margin.top)
-            .or(bottom.map(|bottom| {
-                area_size.height - final_size.height - bottom - resolved_margin.bottom
-            }))
-            .maybe_add(area_offset.y)
-            .unwrap_or(static_position.y + resolved_margin.top),
-    };
-    // Note: axis intentionally switched here as scrollbars take up space in the opposite axis
-    // to the axis in which scrolling is enabled.
-    let scrollbar_size = Size {
-        width: if overflow.y == Overflow::Scroll {
-            scrollbar_width
-        } else {
-            0.0
-        },
-        height: if overflow.x == Overflow::Scroll {
-            scrollbar_width
-        } else {
-            0.0
-        },
-    };
-
-    tree.set_unrounded_layout(
-        node_id,
-        &taffy::Layout {
-            order: 0, // TODO: order
-            size: final_size,
-            scrollable_overflow_rect: layout_output.scrollable_overflow_rect,
-            scrollbar_size,
-            location,
-            padding,
-            border,
-            margin: resolved_margin,
-        },
-    );
 }

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -484,7 +484,9 @@ impl LayoutContainingBlock for BaseDocument {
         let is_positioned = node.layout_style().position().is_positioned();
         let establishes_fixed_cb = node.establishes_fixed_containing_block();
         OofClaims {
-            absolute: is_positioned || establishes_fixed_cb,
+            absolute: is_positioned
+                || establishes_fixed_cb
+                || node.establishes_absolute_containing_block(),
             fixed: establishes_fixed_cb,
         }
     }

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -15,9 +15,9 @@ use style::values::computed::length_percentage::CalcLengthPercentage;
 use stylo_taffy::TaffyStyloStyle;
 use taffy::{
     BlockContext, CoreStyle as _, DetailedLayoutInfo, FlexDirection, LayoutContainingBlock,
-    LayoutPartialTree, NodeId, OofClaims, ResolveOrZero, RoundTree, TraversePartialTree,
-    TraverseTree, compute_block_layout, compute_cached_layout, compute_flexbox_layout,
-    compute_grid_layout, compute_leaf_layout, compute_oof_layout, prelude::*,
+    LayoutPartialTree, NodeId, ResolveOrZero, RoundTree, TraversePartialTree, TraverseTree,
+    compute_block_layout, compute_cached_layout, compute_flexbox_layout, compute_grid_layout,
+    compute_leaf_layout, compute_oof_layout, prelude::*,
 };
 
 pub(crate) mod construct;
@@ -478,18 +478,6 @@ impl LayoutContainingBlock for BaseDocument {
             self.node_from_id(hoisted_id)
                 .layout_parent
                 .set(Some(containing_block));
-        }
-    }
-
-    fn oof_claims(&self, node_id: NodeId) -> OofClaims {
-        let node = self.node_from_id(node_id);
-        let is_positioned = node.layout_style().position().is_positioned();
-        let establishes_fixed_cb = node.establishes_fixed_containing_block();
-        OofClaims {
-            absolute: is_positioned
-                || establishes_fixed_cb
-                || node.establishes_absolute_containing_block(),
-            fixed: establishes_fixed_cb,
         }
     }
 

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -457,6 +457,11 @@ impl LayoutContainingBlock for BaseDocument {
         vec.clear();
         vec.extend(hoisted.iter().copied().map(dom_node_id));
         drop(vec);
+        if hoisted.is_empty() {
+            self.oof_containing_blocks.remove(&containing_block);
+        } else {
+            self.oof_containing_blocks.insert(containing_block);
+        }
         for &hoisted_id in hoisted {
             self.node_from_id(hoisted_id)
                 .layout_parent
@@ -473,7 +478,11 @@ impl LayoutContainingBlock for BaseDocument {
                 vec.push(id);
             }
         }
+        let is_empty = vec.is_empty();
         drop(vec);
+        if !is_empty {
+            self.oof_containing_blocks.insert(containing_block);
+        }
         for &hoisted_id in hoisted {
             self.node_from_id(hoisted_id)
                 .layout_parent

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -432,7 +432,9 @@ impl LayoutPartialTree for BaseDocument {
     ) -> taffy::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
             let mut output = tree.compute_child_layout_internal(node_id, inputs, None);
-            compute_oof_layout(tree, node_id, &mut output);
+            if inputs.run_mode == taffy::RunMode::PerformLayout {
+                compute_oof_layout(tree, node_id, &mut output);
+            }
             output
         })
     }
@@ -558,7 +560,9 @@ impl taffy::LayoutBlockContainer for BaseDocument {
     ) -> taffy::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
             let mut output = tree.compute_child_layout_internal(node_id, inputs, block_ctx);
-            compute_oof_layout(tree, node_id, &mut output);
+            if inputs.run_mode == taffy::RunMode::PerformLayout {
+                compute_oof_layout(tree, node_id, &mut output);
+            }
             output
         })
     }

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -14,9 +14,10 @@ use style::values::computed::CSSPixelLength;
 use style::values::computed::length_percentage::CalcLengthPercentage;
 use stylo_taffy::TaffyStyloStyle;
 use taffy::{
-    BlockContext, CoreStyle as _, FlexDirection, LayoutPartialTree, NodeId, ResolveOrZero,
-    RoundTree, TraversePartialTree, TraverseTree, compute_block_layout, compute_cached_layout,
-    compute_flexbox_layout, compute_grid_layout, compute_leaf_layout, prelude::*,
+    BlockContext, CoreStyle as _, DetailedLayoutInfo, FlexDirection, LayoutContainingBlock,
+    LayoutPartialTree, NodeId, OofClaims, ResolveOrZero, RoundTree, TraversePartialTree,
+    TraverseTree, compute_block_layout, compute_cached_layout, compute_flexbox_layout,
+    compute_grid_layout, compute_leaf_layout, compute_oof_layout, prelude::*,
 };
 
 pub(crate) mod construct;
@@ -430,8 +431,69 @@ impl LayoutPartialTree for BaseDocument {
         inputs: taffy::LayoutInput,
     ) -> taffy::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
-            tree.compute_child_layout_internal(node_id, inputs, None)
+            let mut output = tree.compute_child_layout_internal(node_id, inputs, None);
+            compute_oof_layout(tree, node_id, &mut output);
+            output
         })
+    }
+}
+
+impl LayoutContainingBlock for BaseDocument {
+    type OofItemStyle<'a>
+        = TaffyStyloStyle<ComputedStyleRef<'a>>
+    where
+        Self: 'a;
+
+    fn get_oof_item_style(&self, node_id: NodeId) -> Self::OofItemStyle<'_> {
+        self.node_from_id(node_id).layout_style()
+    }
+
+    fn set_hoisted_children(&mut self, node_id: NodeId, hoisted: &[NodeId]) {
+        let containing_block = dom_node_id(node_id);
+        let node = self.node_from_id(node_id);
+        let mut vec = node.hoisted_children.borrow_mut();
+        vec.clear();
+        vec.extend(hoisted.iter().copied().map(dom_node_id));
+        drop(vec);
+        for &hoisted_id in hoisted {
+            self.node_from_id(hoisted_id)
+                .layout_parent
+                .set(Some(containing_block));
+        }
+    }
+
+    fn add_hoisted_children(&mut self, node_id: NodeId, hoisted: &[NodeId]) {
+        let containing_block = dom_node_id(node_id);
+        let node = self.node_from_id(node_id);
+        let mut vec = node.hoisted_children.borrow_mut();
+        for id in hoisted.iter().copied().map(dom_node_id) {
+            if !vec.contains(&id) {
+                vec.push(id);
+            }
+        }
+        drop(vec);
+        for &hoisted_id in hoisted {
+            self.node_from_id(hoisted_id)
+                .layout_parent
+                .set(Some(containing_block));
+        }
+    }
+
+    fn oof_claims(&self, node_id: NodeId) -> OofClaims {
+        let node = self.node_from_id(node_id);
+        let is_positioned = node.layout_style().position().is_positioned();
+        let establishes_fixed_cb = node.establishes_fixed_containing_block();
+        OofClaims {
+            absolute: is_positioned || establishes_fixed_cb,
+            fixed: establishes_fixed_cb,
+        }
+    }
+
+    fn get_detailed_layout_info(&self, node_id: NodeId) -> &DetailedLayoutInfo<Atom> {
+        self.node_from_id(node_id)
+            .element_data()
+            .map(|element| &element.detailed_layout_info)
+            .unwrap_or(&DetailedLayoutInfo::None)
     }
 }
 
@@ -493,7 +555,9 @@ impl taffy::LayoutBlockContainer for BaseDocument {
         block_ctx: Option<&mut BlockContext<'_>>,
     ) -> taffy::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
-            tree.compute_child_layout_internal(node_id, inputs, block_ctx)
+            let mut output = tree.compute_child_layout_internal(node_id, inputs, block_ctx);
+            compute_oof_layout(tree, node_id, &mut output);
+            output
         })
     }
 }
@@ -544,7 +608,7 @@ impl taffy::LayoutGridContainer for BaseDocument {
     ) {
         let node = self.node_from_id_mut(node_id);
         if let Some(element) = node.element_data_mut() {
-            element.detailed_grid_info = Some(Box::new(detailed_grid_info));
+            element.detailed_layout_info = DetailedLayoutInfo::Grid(Box::new(detailed_grid_info));
         }
     }
 }
@@ -556,6 +620,19 @@ impl RoundTree for BaseDocument {
 
     fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout) {
         *self.node_from_id_mut(node_id).final_layout_mut() = *layout;
+    }
+
+    fn is_hoisted(&self, node_id: NodeId) -> bool {
+        let node = self.node_from_id(node_id);
+        node.taffy_position().is_out_of_flow() && node.taffy_display() != Display::None
+    }
+
+    fn hoisted_child_count(&self, node_id: NodeId) -> usize {
+        self.node_from_id(node_id).hoisted_children.borrow().len()
+    }
+
+    fn get_hoisted_child_id(&self, node_id: NodeId, index: usize) -> NodeId {
+        taffy_node_id(self.node_from_id(node_id).hoisted_children.borrow()[index])
     }
 }
 

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -105,9 +105,10 @@ pub struct ElementData {
     pub before: Option<NodeId>,
     pub after: Option<NodeId>,
 
-    /// Detailed grid track sizing information from the most recent layout
-    /// (grid containers only). Used by devtools grid inspection.
-    pub detailed_grid_info: Option<Box<taffy::DetailedGridInfo<Atom>>>,
+    /// Detailed layout information from the most recent layout (currently
+    /// grid track sizing information for grid containers only). Used by
+    /// devtools grid inspection and out-of-flow grid-area positioning.
+    pub detailed_layout_info: taffy::DetailedLayoutInfo<Atom>,
 
     // Taffy layout data:
     pub display_constructed_as: StyloDisplay,
@@ -314,7 +315,7 @@ impl Clone for ElementData {
             damaged_descendants: AtomicBool::new(true),
             before: None,
             after: None,
-            detailed_grid_info: None,
+            detailed_layout_info: taffy::DetailedLayoutInfo::None,
             display_constructed_as: StyloDisplay::Block,
             layout_data: None,
             transform: None,
@@ -421,7 +422,7 @@ impl ElementData {
             damaged_descendants: AtomicBool::new(true),
             before: None,
             after: None,
-            detailed_grid_info: None,
+            detailed_layout_info: taffy::DetailedLayoutInfo::None,
             display_constructed_as: StyloDisplay::Block,
             layout_data: None,
             transform: None,

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -98,6 +98,10 @@ pub struct Node {
     pub layout_parent: Cell<Option<NodeId>>,
     /// A separate child list that includes anonymous collections of inline elements
     pub layout_children: RefCell<Option<ThinVec<NodeId>>>,
+    /// Out-of-flow (absolutely/fixed positioned) boxes for which this node is the
+    /// containing block. Recorded by Taffy's out-of-flow positioning pass. The
+    /// `Layout.location` of these boxes is relative to this node's border box.
+    pub hoisted_children: RefCell<ThinVec<NodeId>>,
     /// Anonymous block boxes created for this node during layout construction.
     ///
     /// Anonymous blocks live only in the slab (they are not part of the DOM
@@ -385,6 +389,7 @@ impl Node {
             children: ThinVec::new(),
             layout_parent: Cell::new(None),
             layout_children: RefCell::new(None),
+            hoisted_children: RefCell::new(ThinVec::new()),
             anonymous_blocks: ThinVec::new(),
             paint_children: RefCell::new(None),
             stacking_context: None,
@@ -1201,6 +1206,14 @@ impl Node {
             .unwrap_or(taffy::Display::Block)
     }
 
+    /// The node's `position` as a [`taffy::Position`]. Returns [`taffy::Position::Static`]
+    /// for nodes without computed styles (e.g. text nodes).
+    pub fn taffy_position(&self) -> taffy::Position {
+        self.primary_styles()
+            .map(|s| stylo_taffy::convert::position(s.get_box().position))
+            .unwrap_or(taffy::Position::Static)
+    }
+
     pub fn text_content(&self) -> String {
         let mut out = String::new();
         self.write_text_content(&mut out);
@@ -1276,6 +1289,51 @@ impl Node {
         // TODO: contain
 
         false
+    }
+
+    /// Whether this node's styles establish a containing block for
+    /// `position: fixed` (and therefore also `position: absolute`) descendants.
+    ///
+    /// <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Containing_block#identifying_the_containing_block>
+    pub(crate) fn establishes_fixed_containing_block(&self) -> bool {
+        use style::values::computed::{Perspective, Rotate, Scale, Translate};
+        use style::values::specified::box_::{Contain, ContainerType, WillChangeBits};
+
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+
+        let box_style = style.get_box();
+        if !box_style.transform.0.is_empty()
+            || !matches!(box_style.translate, Translate::None)
+            || !matches!(box_style.rotate, Rotate::None)
+            || !matches!(box_style.scale, Scale::None)
+            || !matches!(box_style.perspective, Perspective::None)
+        {
+            return true;
+        }
+        if box_style.will_change.bits.intersects(
+            WillChangeBits::TRANSFORM
+                | WillChangeBits::PERSPECTIVE
+                | WillChangeBits::FIXPOS_CB_NON_SVG,
+        ) {
+            return true;
+        }
+        if box_style
+            .contain
+            .intersects(Contain::LAYOUT | Contain::PAINT)
+        {
+            return true;
+        }
+        if box_style
+            .container_type
+            .intersects(ContainerType::SIZE | ContainerType::INLINE_SIZE)
+        {
+            return true;
+        }
+
+        let effects = style.get_effects();
+        !effects.filter.0.is_empty() || !effects.backdrop_filter.0.is_empty()
     }
 
     /// Takes an (x, y) position (relative to the *parent's* top-left corner) and returns:
@@ -1376,11 +1434,11 @@ impl Node {
             *scrollbar = Some(sb);
         }
 
+        let content_box_offset = taffy::Point {
+            x: self.final_layout().padding.left + self.final_layout().border.left,
+            y: self.final_layout().padding.top + self.final_layout().border.top,
+        };
         if self.flags.is_inline_root() {
-            let content_box_offset = taffy::Point {
-                x: self.final_layout().padding.left + self.final_layout().border.left,
-                y: self.final_layout().padding.top + self.final_layout().border.top,
-            };
             x -= content_box_offset.x;
             y -= content_box_offset.y;
         }
@@ -1403,7 +1461,24 @@ impl Node {
 
         // Call `.hit()` on each child in turn. If any return `Some` then return that value. Else return `Some(self.id).
         for child_id in self.paint_children.borrow().iter().flatten().rev() {
-            if let Some(hit) = self.with(*child_id).hit_inner(x, y, scale, scrollbar) {
+            let child = self.with(*child_id);
+            let child_position = child.taffy_position();
+            let mut child_x = x;
+            let mut child_y = y;
+            if child_position.is_out_of_flow() {
+                // Out-of-flow children's layout location is relative to this node's
+                // border box, so undo the inline-root content-box offset applied above
+                if self.flags.is_inline_root() {
+                    child_x += content_box_offset.x;
+                    child_y += content_box_offset.y;
+                }
+                // Fixed-position children do not scroll with their containing block
+                if child_position == taffy::Position::Fixed {
+                    child_x -= self.scroll_offset().x as f32;
+                    child_y -= self.scroll_offset().y as f32;
+                }
+            }
+            if let Some(hit) = child.hit_inner(child_x, child_y, scale, scrollbar) {
                 return Some(hit);
             }
         }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1345,7 +1345,7 @@ impl Node {
     /// TODO: z-index
     /// (If multiple children are positioned at the position then a random one will be recursed into)
     pub fn hit(&self, x: f32, y: f32, scale: f64) -> Option<HitResult> {
-        self.hit_inner(x, y, scale, &mut None)
+        self.hit_inner(x, y, scale, &mut None, taffy::Point::ZERO)
     }
 
     /// [`hit`](Self::hit), also resolving the innermost overlay scrollbar
@@ -1358,6 +1358,11 @@ impl Node {
         y: f32,
         scale: f64,
         scrollbar: &mut Option<crate::node::ScrollbarRef>,
+        // The viewport scroll offset, passed in by the document for the root
+        // element only (the root element scrolls the viewport, so its scroll
+        // offset is stored on the document): fixed-position children of the
+        // root must not move with it. Zero for all other nodes.
+        viewport_scroll: taffy::Point<f32>,
     ) -> Option<HitResult> {
         use style::computed_values::pointer_events::T as PointerEvents;
         use style::computed_values::visibility::T as Visibility;
@@ -1449,10 +1454,13 @@ impl Node {
                 for hoisted_child in hoisted.pos_z_hoisted_children().rev() {
                     let x = x - hoisted_child.position.x;
                     let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self
-                        .with(hoisted_child.node_id)
-                        .hit_inner(x, y, scale, scrollbar)
-                    {
+                    if let Some(hit) = self.with(hoisted_child.node_id).hit_inner(
+                        x,
+                        y,
+                        scale,
+                        scrollbar,
+                        taffy::Point::ZERO,
+                    ) {
                         return Some(hit);
                     }
                 }
@@ -1474,11 +1482,13 @@ impl Node {
                 }
                 // Fixed-position children do not scroll with their containing block
                 if child_position == taffy::Position::Fixed {
-                    child_x -= self.scroll_offset().x as f32;
-                    child_y -= self.scroll_offset().y as f32;
+                    child_x -= self.scroll_offset().x as f32 + viewport_scroll.x;
+                    child_y -= self.scroll_offset().y as f32 + viewport_scroll.y;
                 }
             }
-            if let Some(hit) = child.hit_inner(child_x, child_y, scale, scrollbar) {
+            if let Some(hit) =
+                child.hit_inner(child_x, child_y, scale, scrollbar, taffy::Point::ZERO)
+            {
                 return Some(hit);
             }
         }
@@ -1489,10 +1499,13 @@ impl Node {
                 for hoisted_child in hoisted.neg_z_hoisted_children().rev() {
                     let x = x - hoisted_child.position.x;
                     let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self
-                        .with(hoisted_child.node_id)
-                        .hit_inner(x, y, scale, scrollbar)
-                    {
+                    if let Some(hit) = self.with(hoisted_child.node_id).hit_inner(
+                        x,
+                        y,
+                        scale,
+                        scrollbar,
+                        taffy::Point::ZERO,
+                    ) {
                         return Some(hit);
                     }
                 }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1324,69 +1324,12 @@ impl Node {
             .any(|image| !matches!(image, GenericImage::None))
     }
 
-    /// Whether this node's styles establish a containing block for
-    /// `position: fixed` (and therefore also `position: absolute`) descendants.
-    ///
-    /// <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Containing_block#identifying_the_containing_block>
-    pub(crate) fn establishes_fixed_containing_block(&self) -> bool {
-        use style::values::computed::{Perspective, Rotate, Scale, Translate};
-        use style::values::specified::box_::{Contain, ContainerType, WillChangeBits};
-
-        let Some(style) = self.primary_styles() else {
-            return false;
-        };
-
-        let box_style = style.get_box();
-        if !box_style.transform.0.is_empty()
-            || !matches!(box_style.translate, Translate::None)
-            || !matches!(box_style.rotate, Rotate::None)
-            || !matches!(box_style.scale, Scale::None)
-            || !matches!(box_style.perspective, Perspective::None)
-        {
-            return true;
-        }
-        if box_style.will_change.bits.intersects(
-            WillChangeBits::TRANSFORM
-                | WillChangeBits::PERSPECTIVE
-                | WillChangeBits::FIXPOS_CB_NON_SVG
-                | WillChangeBits::CONTAIN,
-        ) {
-            return true;
-        }
-        if box_style
-            .contain
-            .intersects(Contain::LAYOUT | Contain::PAINT)
-        {
-            return true;
-        }
-        if box_style
-            .container_type
-            .intersects(ContainerType::SIZE | ContainerType::INLINE_SIZE)
-        {
-            return true;
-        }
-
-        let effects = style.get_effects();
-        !effects.filter.0.is_empty() || !effects.backdrop_filter.0.is_empty()
-    }
-
-    /// Whether this node's styles establish a containing block for
-    /// `position: absolute` descendants even when the node is not positioned
-    /// (e.g. `will-change: position`).
-    ///
-    /// <https://drafts.csswg.org/css-will-change/#will-change>
-    pub(crate) fn establishes_absolute_containing_block(&self) -> bool {
-        use style::values::specified::box_::WillChangeBits;
-
-        let Some(style) = self.primary_styles() else {
-            return false;
-        };
-
-        style
-            .get_box()
-            .will_change
-            .bits
-            .intersects(WillChangeBits::POSITION)
+    /// Which out-of-flow positions this node's styles establish a containing block for
+    /// (see [`stylo_taffy::convert::containing_block_claims`]). Nodes without styles claim nothing.
+    pub(crate) fn containing_block_claims(&self) -> taffy::ContainingBlockClaims {
+        self.primary_styles()
+            .map(|style| stylo_taffy::convert::containing_block_claims(&style))
+            .unwrap_or(taffy::ContainingBlockClaims::NONE)
     }
 
     /// Takes an (x, y) position (relative to the *parent's* top-left corner) and returns:

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1,5 +1,5 @@
 use crate::Document;
-use crate::layout::damage::HoistedPaintChildren;
+use crate::layout::damage::{HoistedPaintChild, HoistedPaintChildren};
 use bitflags::bitflags;
 use blitz_traits::events::{
     BlitzPointerEvent, BlitzPointerId, DomEventData, HitResult, PointerCoords,
@@ -111,6 +111,11 @@ pub struct Node {
     /// The same as layout_children, but sorted by z-index
     pub paint_children: RefCell<Option<ThinVec<NodeId>>>,
     pub stacking_context: Option<Box<HoistedPaintChildren>>,
+    /// The `HoistedPaintChild` entries that this node's subtree contributed to
+    /// the nearest ancestor stacking context during the last style flush.
+    /// Allows the flush to skip clean subtrees while still reproducing their
+    /// contributions when an ancestor stacking context is rebuilt.
+    pub sc_contribution_cache: RefCell<ThinVec<HoistedPaintChild>>,
 
     // Flags
     pub flags: NodeFlags,
@@ -393,6 +398,7 @@ impl Node {
             anonymous_blocks: ThinVec::new(),
             paint_children: RefCell::new(None),
             stacking_context: None,
+            sc_contribution_cache: RefCell::new(ThinVec::new()),
 
             flags: NodeFlags::empty(),
             data,

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1315,7 +1315,8 @@ impl Node {
         if box_style.will_change.bits.intersects(
             WillChangeBits::TRANSFORM
                 | WillChangeBits::PERSPECTIVE
-                | WillChangeBits::FIXPOS_CB_NON_SVG,
+                | WillChangeBits::FIXPOS_CB_NON_SVG
+                | WillChangeBits::CONTAIN,
         ) {
             return true;
         }
@@ -1334,6 +1335,25 @@ impl Node {
 
         let effects = style.get_effects();
         !effects.filter.0.is_empty() || !effects.backdrop_filter.0.is_empty()
+    }
+
+    /// Whether this node's styles establish a containing block for
+    /// `position: absolute` descendants even when the node is not positioned
+    /// (e.g. `will-change: position`).
+    ///
+    /// <https://drafts.csswg.org/css-will-change/#will-change>
+    pub(crate) fn establishes_absolute_containing_block(&self) -> bool {
+        use style::values::specified::box_::WillChangeBits;
+
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+
+        style
+            .get_box()
+            .will_change
+            .bits
+            .intersects(WillChangeBits::POSITION)
     }
 
     /// Takes an (x, y) position (relative to the *parent's* top-left corner) and returns:

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1255,6 +1255,53 @@ impl Node {
             .unwrap_or(0)
     }
 
+    /// The position of a hoisted paint child's coordinate origin (the border
+    /// box of its `layout_parent`) relative to this node, which owns the
+    /// stacking-context entry list the child is painted from.
+    ///
+    /// Derived from the `layout_parent` chain at use-time (rather than baked
+    /// in when the child is hoisted) so that it is always in sync with the
+    /// current layout and scroll offsets. Usually this node is an ancestor on
+    /// the child's `layout_parent` chain; when it is instead an atomic paint
+    /// effect ancestor *below* the child's containing block (see
+    /// `attach_hoisted_children`), the offset is accumulated walking from this
+    /// node up to the containing block and negated.
+    pub fn hoisted_child_position(&self, child_id: NodeId) -> taffy::Point<f32> {
+        let start = self.with(child_id).layout_parent.get();
+
+        let mut position = taffy::Point::<f32>::ZERO;
+        let mut current = start;
+        while let Some(id) = current {
+            if id == self.id {
+                return position;
+            }
+            let node = self.with(id);
+            let location = node.final_layout().location;
+            let scroll = *node.scroll_offset();
+            position.x += location.x - scroll.x as f32;
+            position.y += location.y - scroll.y as f32;
+            current = node.layout_parent.get();
+        }
+
+        let Some(start) = start else {
+            return taffy::Point::ZERO;
+        };
+        let mut position = taffy::Point::<f32>::ZERO;
+        let mut current = self.id;
+        while current != start {
+            let node = self.with(current);
+            let location = node.final_layout().location;
+            let scroll = *node.scroll_offset();
+            position.x -= location.x - scroll.x as f32;
+            position.y -= location.y - scroll.y as f32;
+            match node.layout_parent.get() {
+                Some(parent) => current = parent,
+                None => break,
+            }
+        }
+        position
+    }
+
     // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context#features_creating_stacking_contexts
     pub fn is_stacking_context_root(&self, is_flex_or_grid_item: bool) -> bool {
         let Some(style) = self.primary_styles() else {
@@ -1448,8 +1495,9 @@ impl Node {
         if matches_hoisted_content {
             if let Some(hoisted) = &self.stacking_context {
                 for hoisted_child in hoisted.pos_z_hoisted_children().rev() {
-                    let x = x - hoisted_child.position.x;
-                    let y = y - hoisted_child.position.y;
+                    let position = self.hoisted_child_position(hoisted_child.node_id);
+                    let x = x - position.x;
+                    let y = y - position.y;
                     if let Some(hit) = self.with(hoisted_child.node_id).hit_inner(
                         x,
                         y,
@@ -1493,8 +1541,9 @@ impl Node {
         if matches_hoisted_content {
             if let Some(hoisted) = &self.stacking_context {
                 for hoisted_child in hoisted.neg_z_hoisted_children().rev() {
-                    let x = x - hoisted_child.position.x;
-                    let y = y - hoisted_child.position.y;
+                    let position = self.hoisted_child_position(hoisted_child.node_id);
+                    let x = x - position.x;
+                    let y = y - position.y;
                     if let Some(hit) = self.with(hoisted_child.node_id).hit_inner(
                         x,
                         y,

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1281,14 +1281,47 @@ impl Node {
             return true;
         }
 
+        if self.applies_atomic_paint_effect() {
+            return true;
+        }
+
         // TODO: mix-blend-mode
-        // TODO: filter
-        // TODO: clip-path
-        // TODO: mask
         // TODO: isolation
         // TODO: contain
 
         false
+    }
+
+    /// Whether this node's styles apply an atomic paint effect (opacity, filter,
+    /// clip-path, mask) to its subtree. Such effects apply to out-of-flow descendants
+    /// even when this node is not their containing block.
+    pub(crate) fn applies_atomic_paint_effect(&self) -> bool {
+        use style::values::computed::basic_shape::ClipPath;
+        use style::values::generics::image::GenericImage;
+
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+
+        if style.clone_opacity() != 1.0 {
+            return true;
+        }
+
+        let effects = style.get_effects();
+        if !effects.filter.0.is_empty() {
+            return true;
+        }
+
+        if !matches!(style.clone_clip_path(), ClipPath::None) {
+            return true;
+        }
+
+        style
+            .get_svg()
+            .mask_image
+            .0
+            .iter()
+            .any(|image| !matches!(image, GenericImage::None))
     }
 
     /// Whether this node's styles establish a containing block for

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -241,6 +241,23 @@ impl BaseDocument {
         full.transform_rect_bbox(overflow)
     }
 
+    /// The innermost DOM ancestor of `node_id`, strictly below `cb_id`, that applies
+    /// an atomic paint effect (opacity, clip-path, mask) to its subtree.
+    fn innermost_paint_effect_ancestor(&self, node_id: NodeId, cb_id: NodeId) -> Option<NodeId> {
+        let mut ancestor = self.nodes[node_id].parent;
+        while let Some(ancestor_id) = ancestor {
+            if ancestor_id == cb_id {
+                return None;
+            }
+            let node = &self.nodes[ancestor_id];
+            if node.applies_atomic_paint_effect() {
+                return Some(ancestor_id);
+            }
+            ancestor = node.parent;
+        }
+        None
+    }
+
     /// Attach out-of-flow (absolutely/fixed positioned) boxes to their containing
     /// block, as recorded by Taffy's out-of-flow positioning pass in each node's
     /// `hoisted_children` list:
@@ -286,6 +303,7 @@ impl BaseDocument {
                 .unwrap_or_default();
 
             let mut z_indexed: Vec<NodeId> = Vec::new();
+            let mut effect_attached: Vec<(NodeId, NodeId)> = Vec::new();
             {
                 let mut paint_children = self.nodes[cb_id].paint_children.borrow_mut();
                 let paint_children = paint_children.get_or_insert_with(thin_vec::ThinVec::new);
@@ -297,8 +315,48 @@ impl BaseDocument {
                     if direct_layout_children.contains(&child_id) {
                         continue;
                     }
+                    // Atomic paint effects (opacity, clip-path, mask) on a DOM ancestor
+                    // apply to out-of-flow descendants even when the ancestor is not
+                    // their containing block, so paint the box inside the innermost such
+                    // ancestor's effect layers rather than directly under the containing
+                    // block.
+                    if let Some(effect_ancestor) =
+                        self.innermost_paint_effect_ancestor(child_id, cb_id)
+                    {
+                        effect_attached.push((child_id, effect_ancestor));
+                        continue;
+                    }
                     if !paint_children.contains(&child_id) {
                         paint_children.push(child_id);
+                    }
+                }
+            }
+
+            // Boxes painted inside an intermediate effect ancestor keep their
+            // containing-block-relative layout location, so record the offset of the
+            // effect ancestor relative to the containing block to compensate.
+            for (child_id, effect_ancestor) in effect_attached {
+                let mut position = taffy::Point::<f32>::ZERO;
+                let mut ancestor = effect_ancestor;
+                while ancestor != cb_id {
+                    let node = &self.nodes[ancestor];
+                    let location = node.final_layout().location;
+                    let scroll = *node.scroll_offset();
+                    position.x -= location.x - scroll.x as f32;
+                    position.y -= location.y - scroll.y as f32;
+                    let Some(parent) = node.layout_parent.get() else {
+                        break;
+                    };
+                    ancestor = parent;
+                }
+                if let Some(sc) = self.nodes[effect_ancestor].stacking_context.as_mut() {
+                    if !sc.children.iter().any(|c| c.node_id == child_id) {
+                        sc.children.push(crate::layout::damage::HoistedPaintChild {
+                            node_id: child_id,
+                            z_index: 0,
+                            position,
+                        });
+                        modified_stacking_roots.push(effect_ancestor);
                     }
                 }
             }

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -303,12 +303,28 @@ impl BaseDocument {
     fn attach_hoisted_children(&mut self) {
         let mut modified_stacking_roots: Vec<NodeId> = Vec::new();
         let mut pairs: Vec<(NodeId, Vec<NodeId>)> = Vec::new();
-        for (cb_id, node) in self.nodes.iter() {
-            let hoisted = node.hoisted_children.borrow();
-            if !hoisted.is_empty() {
-                pairs.push((cb_id, hoisted.iter().copied().collect()));
+        let mut stale_cbs: Vec<NodeId> = Vec::new();
+        for &cb_id in self.oof_containing_blocks.iter() {
+            let hoisted = self
+                .nodes
+                .get(cb_id)
+                .map(|node| node.hoisted_children.borrow());
+            match hoisted {
+                Some(hoisted) if !hoisted.is_empty() => {
+                    pairs.push((cb_id, hoisted.iter().copied().collect()));
+                }
+                // The containing block was removed from the document (or no
+                // longer has hoisted children): drop it from the registry.
+                _ => stale_cbs.push(cb_id),
             }
         }
+        for cb_id in stale_cbs {
+            self.oof_containing_blocks.remove(&cb_id);
+        }
+        // Iterate containing blocks in a deterministic order: entries pushed to
+        // a shared stacking context below keep a stable relative order (its
+        // z-index sort is stable).
+        pairs.sort_unstable_by_key(|(cb_id, _)| *cb_id);
 
         for (cb_id, hoisted) in pairs {
             // Nodes can be removed from the slab between layout passes; drop stale ids

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -108,6 +108,10 @@ impl BaseDocument {
         self.resolve_layout();
         timer.record_time("layout");
 
+        // Attach out-of-flow boxes to their containing block for painting and
+        // hit-testing, and repoint their layout_parent at the containing block
+        self.attach_hoisted_children();
+
         // Resolve transforms
         self.resolve_transforms(root_node_id);
         timer.record_time("transform");
@@ -193,10 +197,26 @@ impl BaseDocument {
 
         if let Some(ref children) = layout_children {
             for &child_id in children {
+                // Out-of-flow children are laid out relative to their containing
+                // block, not their DOM parent: their overflow contribution is
+                // accounted for at the containing block (below) instead.
+                let is_out_of_flow = self.nodes[child_id].taffy_position().is_out_of_flow();
                 let child_rect_in_self = self.resolve_transforms(child_id);
-                overflow = overflow.union(child_rect_in_self);
+                if !is_out_of_flow {
+                    overflow = overflow.union(child_rect_in_self);
+                }
             }
         }
+        let hoisted_children =
+            std::mem::take(&mut *self.nodes[node_id].hoisted_children.borrow_mut());
+        for &child_id in &hoisted_children {
+            if !self.nodes.contains_key(child_id) {
+                continue;
+            }
+            let child_rect_in_self = self.resolve_transforms(child_id);
+            overflow = overflow.union(child_rect_in_self);
+        }
+        *self.nodes[node_id].hoisted_children.borrow_mut() = hoisted_children;
         if let Some(before) = self.nodes[node_id].before() {
             let child_rect_in_self = self.resolve_transforms(before);
             overflow = overflow.union(child_rect_in_self);
@@ -219,6 +239,48 @@ impl BaseDocument {
         };
 
         full.transform_rect_bbox(overflow)
+    }
+
+    /// Attach out-of-flow (absolutely/fixed positioned) boxes to their containing
+    /// block, as recorded by Taffy's out-of-flow positioning pass in each node's
+    /// `hoisted_children` list:
+    ///
+    /// - repoints each hoisted box's `layout_parent` at its containing block so
+    ///   that coordinate accumulation (e.g. `absolute_position`) follows the
+    ///   containing block chain that its `Layout.location` is relative to; and
+    /// - appends each hoisted box to its containing block's `paint_children` so
+    ///   that paint and hit-testing visit it with the correct coordinates
+    ///   (out-of-flow boxes are skipped in their DOM parent's paint list).
+    fn attach_hoisted_children(&mut self) {
+        let mut pairs: Vec<(NodeId, Vec<NodeId>)> = Vec::new();
+        for (cb_id, node) in self.nodes.iter() {
+            let hoisted = node.hoisted_children.borrow();
+            if !hoisted.is_empty() {
+                pairs.push((cb_id, hoisted.iter().copied().collect()));
+            }
+        }
+
+        for (cb_id, hoisted) in pairs {
+            // Nodes can be removed from the slab between layout passes; drop stale ids
+            let mut valid: Vec<NodeId> = hoisted
+                .into_iter()
+                .filter(|id| self.nodes.contains_key(*id))
+                .collect();
+            // Sort by z-index (stable sort preserves document order within a z-index)
+            valid.sort_by_key(|id| self.nodes[*id].z_index());
+
+            for &child_id in &valid {
+                self.nodes[child_id].layout_parent.set(Some(cb_id));
+            }
+
+            let mut paint_children = self.nodes[cb_id].paint_children.borrow_mut();
+            let paint_children = paint_children.get_or_insert_with(thin_vec::ThinVec::new);
+            for &child_id in &valid {
+                if !paint_children.contains(&child_id) {
+                    paint_children.push(child_id);
+                }
+            }
+        }
     }
 
     /// Ensure that the layout_children field is populated for all nodes

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -389,28 +389,15 @@ impl BaseDocument {
             }
 
             // Boxes painted inside an intermediate effect ancestor keep their
-            // containing-block-relative layout location, so record the offset of the
-            // effect ancestor relative to the containing block to compensate.
+            // containing-block-relative layout location; the compensating offset
+            // of the effect ancestor relative to the containing block is derived
+            // at paint/hit-test time (see `Node::hoisted_child_position`).
             for (child_id, effect_ancestor) in effect_attached {
-                let mut position = taffy::Point::<f32>::ZERO;
-                let mut ancestor = effect_ancestor;
-                while ancestor != cb_id {
-                    let node = &self.nodes[ancestor];
-                    let location = node.final_layout().location;
-                    let scroll = *node.scroll_offset();
-                    position.x -= location.x - scroll.x as f32;
-                    position.y -= location.y - scroll.y as f32;
-                    let Some(parent) = node.layout_parent.get() else {
-                        break;
-                    };
-                    ancestor = parent;
-                }
                 if let Some(sc) = self.nodes[effect_ancestor].stacking_context.as_mut() {
                     if !sc.children.iter().any(|c| c.node_id == child_id) {
                         sc.children.push(crate::layout::damage::HoistedPaintChild {
                             node_id: child_id,
                             z_index: 0,
-                            position,
                         });
                         modified_stacking_roots.push(effect_ancestor);
                     }
@@ -419,18 +406,13 @@ impl BaseDocument {
 
             // Children with a z-index belong to the nearest stacking context at
             // or above the containing block: hoist them there (matching
-            // `flush_styles_to_layout`'s z-index hoisting), with their position
-            // recorded relative to the stacking context root.
+            // `flush_styles_to_layout`'s z-index hoisting). Their position
+            // relative to the stacking context root is derived at paint/hit-test
+            // time (see `Node::hoisted_child_position`).
             for child_id in z_indexed {
-                let mut position = taffy::Point::<f32>::ZERO;
                 let mut sc_root = cb_id;
                 while self.nodes[sc_root].stacking_context.is_none() {
-                    let node = &self.nodes[sc_root];
-                    let location = node.final_layout().location;
-                    let scroll = *node.scroll_offset();
-                    position.x += location.x - scroll.x as f32;
-                    position.y += location.y - scroll.y as f32;
-                    let Some(parent) = node.layout_parent.get() else {
+                    let Some(parent) = self.nodes[sc_root].layout_parent.get() else {
                         break;
                     };
                     sc_root = parent;
@@ -442,7 +424,6 @@ impl BaseDocument {
                         sc.children.push(crate::layout::damage::HoistedPaintChild {
                             node_id: child_id,
                             z_index,
-                            position,
                         });
                         modified_stacking_roots.push(sc_root);
                     }
@@ -456,7 +437,7 @@ impl BaseDocument {
             let mut sc = self.nodes[sc_root].stacking_context.take();
             if let Some(sc) = sc.as_mut() {
                 sc.sort();
-                sc.compute_content_size(self);
+                sc.compute_content_size(self, sc_root);
             }
             self.nodes[sc_root].stacking_context = sc;
         }

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -252,6 +252,7 @@ impl BaseDocument {
     ///   that paint and hit-testing visit it with the correct coordinates
     ///   (out-of-flow boxes are skipped in their DOM parent's paint list).
     fn attach_hoisted_children(&mut self) {
+        let mut modified_stacking_roots: Vec<NodeId> = Vec::new();
         let mut pairs: Vec<(NodeId, Vec<NodeId>)> = Vec::new();
         for (cb_id, node) in self.nodes.iter() {
             let hoisted = node.hoisted_children.borrow();
@@ -273,13 +274,77 @@ impl BaseDocument {
                 self.nodes[child_id].layout_parent.set(Some(cb_id));
             }
 
-            let mut paint_children = self.nodes[cb_id].paint_children.borrow_mut();
-            let paint_children = paint_children.get_or_insert_with(thin_vec::ThinVec::new);
-            for &child_id in &valid {
-                if !paint_children.contains(&child_id) {
-                    paint_children.push(child_id);
+            // Boxes whose containing block is their direct layout parent were kept
+            // in its paint tree by `flush_styles_to_layout` (paint_children or the
+            // stacking context, depending on z-index) in tree order, so only append
+            // the ones hoisted past their DOM parent.
+            let direct_layout_children: Vec<NodeId> = self.nodes[cb_id]
+                .layout_children
+                .borrow()
+                .as_ref()
+                .map(|c| c.to_vec())
+                .unwrap_or_default();
+
+            let mut z_indexed: Vec<NodeId> = Vec::new();
+            {
+                let mut paint_children = self.nodes[cb_id].paint_children.borrow_mut();
+                let paint_children = paint_children.get_or_insert_with(thin_vec::ThinVec::new);
+                for &child_id in &valid {
+                    if self.nodes[child_id].z_index() != 0 {
+                        z_indexed.push(child_id);
+                        continue;
+                    }
+                    if direct_layout_children.contains(&child_id) {
+                        continue;
+                    }
+                    if !paint_children.contains(&child_id) {
+                        paint_children.push(child_id);
+                    }
                 }
             }
+
+            // Children with a z-index belong to the nearest stacking context at
+            // or above the containing block: hoist them there (matching
+            // `flush_styles_to_layout`'s z-index hoisting), with their position
+            // recorded relative to the stacking context root.
+            for child_id in z_indexed {
+                let mut position = taffy::Point::<f32>::ZERO;
+                let mut sc_root = cb_id;
+                while self.nodes[sc_root].stacking_context.is_none() {
+                    let node = &self.nodes[sc_root];
+                    let location = node.final_layout().location;
+                    let scroll = *node.scroll_offset();
+                    position.x += location.x - scroll.x as f32;
+                    position.y += location.y - scroll.y as f32;
+                    let Some(parent) = node.layout_parent.get() else {
+                        break;
+                    };
+                    sc_root = parent;
+                }
+
+                let z_index = self.nodes[child_id].z_index();
+                if let Some(sc) = self.nodes[sc_root].stacking_context.as_mut() {
+                    if !sc.children.iter().any(|c| c.node_id == child_id) {
+                        sc.children.push(crate::layout::damage::HoistedPaintChild {
+                            node_id: child_id,
+                            z_index,
+                            position,
+                        });
+                        modified_stacking_roots.push(sc_root);
+                    }
+                }
+            }
+        }
+
+        modified_stacking_roots.sort_unstable();
+        modified_stacking_roots.dedup();
+        for sc_root in modified_stacking_roots {
+            let mut sc = self.nodes[sc_root].stacking_context.take();
+            if let Some(sc) = sc.as_mut() {
+                sc.sort();
+                sc.compute_content_size(self);
+            }
+            self.nodes[sc_root].stacking_context = sc;
         }
     }
 

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -258,6 +258,38 @@ impl BaseDocument {
         None
     }
 
+    /// Whether `a` precedes `b` in DOM pre-order (each node's ancestor path is
+    /// compared by child index at the first point of divergence; an ancestor
+    /// precedes its descendants).
+    fn is_before_in_tree_order(&self, a: NodeId, b: NodeId) -> bool {
+        if a == b {
+            return false;
+        }
+        let path = |mut id: NodeId| {
+            let mut path = vec![id];
+            while let Some(parent) = self.nodes[id].parent {
+                path.push(parent);
+                id = parent;
+            }
+            path.reverse();
+            path
+        };
+        let path_a = path(a);
+        let path_b = path(b);
+        for (i, (&na, &nb)) in path_a.iter().zip(path_b.iter()).enumerate() {
+            if na != nb {
+                if i == 0 {
+                    // Disjoint trees; fall back to a stable arbitrary order
+                    return na < nb;
+                }
+                let parent = &self.nodes[path_a[i - 1]];
+                return parent.index_of_child(na) < parent.index_of_child(nb);
+            }
+        }
+        // One is an ancestor of the other: the shorter path comes first
+        path_a.len() < path_b.len()
+    }
+
     /// Attach out-of-flow (absolutely/fixed positioned) boxes to their containing
     /// block, as recorded by Taffy's out-of-flow positioning pass in each node's
     /// `hoisted_children` list:
@@ -302,6 +334,10 @@ impl BaseDocument {
                 .map(|c| c.to_vec())
                 .unwrap_or_default();
 
+            let cb_is_flex_or_grid = matches!(
+                self.nodes[cb_id].taffy_display(),
+                taffy::Display::Flex | taffy::Display::Grid
+            );
             let mut z_indexed: Vec<NodeId> = Vec::new();
             let mut effect_attached: Vec<(NodeId, NodeId)> = Vec::new();
             {
@@ -327,7 +363,27 @@ impl BaseDocument {
                         continue;
                     }
                     if !paint_children.contains(&child_id) {
-                        paint_children.push(child_id);
+                        // Splice into the containing block's paint list at the
+                        // hoisted box's (paint level, tree order) position: z-index:
+                        // auto positioned boxes paint in tree order among positioned
+                        // siblings (CSS 2.1 Appendix E step 8), not last.
+                        let key = crate::layout::damage::node_to_paint_order(
+                            &self.nodes[child_id],
+                            cb_is_flex_or_grid,
+                        );
+                        let insert_at = paint_children
+                            .iter()
+                            .position(|&existing| {
+                                let existing_key = crate::layout::damage::node_to_paint_order(
+                                    &self.nodes[existing],
+                                    cb_is_flex_or_grid,
+                                );
+                                existing_key > key
+                                    || (existing_key == key
+                                        && self.is_before_in_tree_order(child_id, existing))
+                            })
+                            .unwrap_or(paint_children.len());
+                        paint_children.insert(insert_at, child_id);
                     }
                 }
             }

--- a/packages/blitz-dom/src/resolved_style.rs
+++ b/packages/blitz-dom/src/resolved_style.rs
@@ -276,9 +276,12 @@ impl BaseDocument {
             "grid-template-columns" | "grid-template-rows"
                 if display.inside() == DisplayInside::Grid =>
             {
-                if let Some(info) = node
-                    .element_data()
-                    .and_then(|data| data.detailed_grid_info.as_ref())
+                if let Some(info) =
+                    node.element_data()
+                        .and_then(|data| match &data.detailed_layout_info {
+                            taffy::DetailedLayoutInfo::Grid(info) => Some(info),
+                            _ => None,
+                        })
                 {
                     return if property_name == "grid-template-columns" {
                         info.grid_template_columns()

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -988,7 +988,26 @@ impl ElementCx<'_, '_> {
         // Regular children
         if let Some(children) = &*self.node.paint_children.borrow() {
             for child_id in children {
-                self.render_node(scene, *child_id, parent_style_transform, clip_rect);
+                // Fixed-position children do not scroll with their containing block
+                // (their layout location is relative to its unscrolled border box),
+                // so cancel out the scroll offset applied to the transform above.
+                let child = &self.context.dom.as_ref().tree()[*child_id];
+                let child_transform = if child.taffy_position() == taffy::Position::Fixed {
+                    // The root element's scroll is the viewport scroll (applied in
+                    // `paint_scene`), not the node's own scroll offset.
+                    let scroll = if Some(self.node.id) == self.context.root_element_id {
+                        self.context.dom.as_ref().viewport_scroll()
+                    } else {
+                        *self.node.scroll_offset()
+                    };
+                    parent_style_transform.pre_translate(kurbo::Vec2 {
+                        x: self.node.scroll_offset().x * self.scale,
+                        y: self.node.scroll_offset().y * self.scale,
+                    })
+                } else {
+                    parent_style_transform
+                };
+                self.render_node(scene, *child_id, child_transform, clip_rect);
             }
         }
 

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -972,9 +972,10 @@ impl ElementCx<'_, '_> {
 
         if let Some(hoisted) = &self.node.stacking_context {
             for hoisted_child in hoisted.neg_z_hoisted_children() {
+                let position = self.node.hoisted_child_position(hoisted_child.node_id);
                 let pos = kurbo::Vec2 {
-                    x: hoisted_child.position.x as f64 * self.scale,
-                    y: hoisted_child.position.y as f64 * self.scale,
+                    x: position.x as f64 * self.scale,
+                    y: position.y as f64 * self.scale,
                 };
                 self.render_node(
                     scene,
@@ -1014,9 +1015,10 @@ impl ElementCx<'_, '_> {
         // Positive z_index hoisted nodes
         if let Some(hoisted) = &self.node.stacking_context {
             for hoisted_child in hoisted.pos_z_hoisted_children() {
+                let position = self.node.hoisted_child_position(hoisted_child.node_id);
                 let pos = kurbo::Vec2 {
-                    x: hoisted_child.position.x as f64 * self.scale,
-                    y: hoisted_child.position.y as f64 * self.scale,
+                    x: position.x as f64 * self.scale,
+                    y: position.y as f64 * self.scale,
                 };
                 self.render_node(
                     scene,

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -1001,8 +1001,8 @@ impl ElementCx<'_, '_> {
                         *self.node.scroll_offset()
                     };
                     parent_style_transform.pre_translate(kurbo::Vec2 {
-                        x: self.node.scroll_offset().x * self.scale,
-                        y: self.node.scroll_offset().y * self.scale,
+                        x: scroll.x * self.scale,
+                        y: scroll.y * self.scale,
                     })
                 } else {
                     parent_style_transform

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -258,6 +258,76 @@ pub fn position(input: stylo::Position) -> taffy::Position {
     }
 }
 
+/// Whether a style establishes a containing block for `position: fixed` (and therefore also
+/// `position: absolute`) descendants, independently of its `position` value.
+///
+/// <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Containing_block#identifying_the_containing_block>
+pub fn establishes_fixed_containing_block(style: &stylo::ComputedValues) -> bool {
+    use style::values::computed::{Perspective, Rotate, Scale, Translate};
+    use style::values::specified::box_::{Contain, ContainerType, WillChangeBits};
+
+    let box_style = style.get_box();
+    if !box_style.transform.0.is_empty()
+        || !matches!(box_style.translate, Translate::None)
+        || !matches!(box_style.rotate, Rotate::None)
+        || !matches!(box_style.scale, Scale::None)
+        || !matches!(box_style.perspective, Perspective::None)
+    {
+        return true;
+    }
+    if box_style.will_change.bits.intersects(
+        WillChangeBits::TRANSFORM
+            | WillChangeBits::PERSPECTIVE
+            | WillChangeBits::FIXPOS_CB_NON_SVG
+            | WillChangeBits::CONTAIN,
+    ) {
+        return true;
+    }
+    if box_style
+        .contain
+        .intersects(Contain::LAYOUT | Contain::PAINT)
+    {
+        return true;
+    }
+    if box_style
+        .container_type
+        .intersects(ContainerType::SIZE | ContainerType::INLINE_SIZE)
+    {
+        return true;
+    }
+
+    let effects = style.get_effects();
+    !effects.filter.0.is_empty() || !effects.backdrop_filter.0.is_empty()
+}
+
+/// Whether a style establishes a containing block for `position: absolute` descendants even
+/// when it is not positioned (e.g. `will-change: position`).
+///
+/// <https://drafts.csswg.org/css-will-change/#will-change>
+pub fn establishes_absolute_containing_block(style: &stylo::ComputedValues) -> bool {
+    use style::values::specified::box_::WillChangeBits;
+
+    style
+        .get_box()
+        .will_change
+        .bits
+        .intersects(WillChangeBits::POSITION)
+}
+
+/// Which out-of-flow positions a style establishes a containing block for.
+///
+/// Positioned (non-`static`) elements are containing blocks for `absolute` boxes; elements that
+/// establish a fixed containing block (transforms, filters, `will-change`, `contain`, ...) are
+/// containing blocks for both `absolute` and `fixed` boxes.
+pub fn containing_block_claims(style: &stylo::ComputedValues) -> taffy::ContainingBlockClaims {
+    let is_positioned = style.get_box().position != stylo::Position::Static;
+    let fixed = establishes_fixed_containing_block(style);
+    taffy::ContainingBlockClaims {
+        absolute: is_positioned || fixed || establishes_absolute_containing_block(style),
+        fixed,
+    }
+}
+
 #[inline]
 pub fn overflow(input: stylo::Overflow) -> taffy::Overflow {
     match input {

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -249,13 +249,11 @@ pub fn box_sizing(input: stylo::BoxSizing) -> taffy::BoxSizing {
 #[inline]
 pub fn position(input: stylo::Position) -> taffy::Position {
     match input {
-        // TODO: support position:static
+        stylo::Position::Static => taffy::Position::Static,
         stylo::Position::Relative => taffy::Position::Relative,
-        stylo::Position::Static => taffy::Position::Relative,
-
-        // TODO: support position:fixed and sticky
         stylo::Position::Absolute => taffy::Position::Absolute,
-        stylo::Position::Fixed => taffy::Position::Absolute,
+        stylo::Position::Fixed => taffy::Position::Fixed,
+        // TODO: support position:sticky
         stylo::Position::Sticky => taffy::Position::Relative,
     }
 }

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -113,6 +113,11 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
     }
 
     #[inline]
+    fn is_containing_block(&self) -> taffy::ContainingBlockClaims {
+        convert::containing_block_claims(&self.style)
+    }
+
+    #[inline]
     fn inset(&self) -> taffy::Rect<taffy::LengthPercentageAuto> {
         let position_styles = self.style.get_position();
         taffy::Rect {

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -627,3 +627,23 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridItemStyle for TaffyStyloStyle
         )
     }
 }
+
+impl<T: Deref<Target = ComputedValues>> taffy::OofItemStyle for TaffyStyloStyle<T> {
+    #[inline]
+    fn grid_row(&self) -> taffy::Line<taffy::GridPlacement<Atom>> {
+        let position_styles = self.style.get_position();
+        taffy::Line {
+            start: convert::grid_line(&position_styles.grid_row_start),
+            end: convert::grid_line(&position_styles.grid_row_end),
+        }
+    }
+
+    #[inline]
+    fn grid_column(&self) -> taffy::Line<taffy::GridPlacement<Atom>> {
+        let position_styles = self.style.get_position();
+        taffy::Line {
+            start: convert::grid_line(&position_styles.grid_column_start),
+            end: convert::grid_line(&position_styles.grid_column_end),
+        }
+    }
+}

--- a/tests/blitz-tests/tests/measure_clobber.rs
+++ b/tests/blitz-tests/tests/measure_clobber.rs
@@ -1,0 +1,77 @@
+//! Regression test: a measure (ComputeSize) pass must not overwrite the stored
+//! layouts of a node's children. If it does, a later cache hit on the parent's
+//! PerformLayout leaves the children with measure-time geometry (observed as
+//! the README image becoming too wide on github.com after a relayout).
+
+use blitz_test_harness::Harness;
+use markup5ever::{QualName, local_name, ns};
+use taffy::{AvailableSpace, LayoutPartialTree as _, Size};
+
+fn style_attr() -> QualName {
+    QualName::new(None, ns!(), local_name!("style"))
+}
+
+#[test]
+fn measure_pass_does_not_clobber_inline_child_layout() {
+    let html = r#"
+        <!DOCTYPE html>
+        <html>
+        <body style="margin: 0">
+            <div id="other" style="height: 10px"></div>
+            <p id="target" style="margin: 0">
+                <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAADUlEQVR4nGNgYGD4DwABBAEAX+XBhAAAAABJRU5ErkJggg==" width="1600" height="200" style="max-width: 100%">
+            </p>
+        </body>
+        </html>
+    "#;
+    let mut harness = Harness::from_html(html);
+
+    let width_before = harness.layout_rect("img").width;
+    assert_eq!(width_before, 800.0);
+
+    // Measure the paragraph at a different width, as e.g. block or flexbox
+    // intrinsic-height sizing does when a distant ancestor relayouts.
+    let p_id = harness.query("#target").unwrap();
+    let mut doc = harness.base_mut();
+    doc.compute_child_layout(
+        blitz_dom::taffy_node_id(p_id),
+        taffy::LayoutInput {
+            run_mode: taffy::RunMode::ComputeSize,
+            sizing_mode: taffy::SizingMode::InherentSize,
+            axis: taffy::RequestedAxis::Both,
+            known_dimensions: Size {
+                width: Some(500.0),
+                height: None,
+            },
+            known_dimensions_are_definite: taffy::geometry::Size {
+                width: true,
+                height: false,
+            },
+            parent_size: Size {
+                width: Some(500.0),
+                height: None,
+            },
+            available_space: Size {
+                width: AvailableSpace::Definite(500.0),
+                height: AvailableSpace::MaxContent,
+            },
+            vertical_margins_are_collapsible: taffy::Line::FALSE,
+        },
+    );
+    drop(doc);
+
+    // Trigger a relayout in which the paragraph's PerformLayout is a cache hit,
+    // so its children keep whatever geometry is stored for them.
+    let other_id = harness.query("#other").unwrap();
+    harness
+        .base_mut()
+        .mutate()
+        .set_attribute(other_id, style_attr(), "height: 20px");
+    harness.pump();
+
+    let width_after = harness.layout_rect("img").width;
+    assert_eq!(
+        width_after, 800.0,
+        "measure pass must not modify stored child layouts"
+    );
+}

--- a/tests/blitz-tests/tests/oof_dynamic_cb.rs
+++ b/tests/blitz-tests/tests/oof_dynamic_cb.rs
@@ -1,0 +1,290 @@
+//! Dynamic containing-block changes: when a style change adds or removes a
+//! containing-block-establishing property (transform, will-change, filter,
+//! contain, position) on an ancestor, hoisted `position: absolute` / `fixed`
+//! descendants must move to their new containing block on the next relayout,
+//! even with incremental layout's hot caches.
+//!
+//! Rust ports of the script-driven WPT tests
+//! `css/css-transforms/transform-containing-block-dynamic-1b.html`,
+//! `css/filter-effects/filter-cb-dynamic-1b.html`,
+//! `css/css-will-change/will-change-abspos-cb-dynamic-001.html` and
+//! `css/css-contain/contain-layout-020.html`, which Blitz's WPT runner cannot
+//! run (they require script).
+
+use blitz_test_harness::Harness;
+use blitz_traits::node_id::NodeId;
+use markup5ever::{QualName, local_name, ns};
+
+fn style_attr() -> QualName {
+    QualName::new(None, ns!(), local_name!("style"))
+}
+
+/// A fixed box nested inside `#anc` (offset 50,50 from the page origin).
+/// Without a CB-establishing property on `#anc` the fixed box is positioned
+/// against the viewport at (10, 10); with one it is positioned against
+/// `#anc` at (60, 60) in page coordinates.
+fn fixed_page(anc_style: &str) -> Harness {
+    let html = format!(
+        "<html><head><style>body {{ margin: 0 }}</style></head><body>\
+         <div id=anc style='margin: 50px; width: 300px; height: 300px; {anc_style}'>\
+         <div id=spacer style='height: 30px'></div>\
+         <div id=target style='position: fixed; top: 10px; left: 10px; width: 20px; height: 20px'></div>\
+         </div></body></html>"
+    );
+    Harness::from_html(&html)
+}
+
+fn set_style(harness: &mut Harness, node: NodeId, style: &str) {
+    harness
+        .base_mut()
+        .mutate()
+        .set_attribute(node, style_attr(), style);
+    harness.pump();
+}
+
+const ANC_BASE: &str = "margin: 50px; width: 300px; height: 300px;";
+
+fn assert_fixed_cb_toggle(cb_prop: &str) {
+    // Add the CB-establishing property dynamically
+    let mut harness = fixed_page("");
+    let anc = harness.node("#anc");
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        10.0,
+        "initial (viewport CB)"
+    );
+    assert_eq!(
+        harness.layout_rect("#target").y,
+        10.0,
+        "initial (viewport CB)"
+    );
+
+    set_style(&mut harness, anc, &format!("{ANC_BASE} {cb_prop}"));
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        60.0,
+        "after adding `{cb_prop}`"
+    );
+    assert_eq!(
+        harness.layout_rect("#target").y,
+        60.0,
+        "after adding `{cb_prop}`"
+    );
+
+    // And remove it again
+    set_style(&mut harness, anc, ANC_BASE);
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        10.0,
+        "after removing `{cb_prop}`"
+    );
+    assert_eq!(
+        harness.layout_rect("#target").y,
+        10.0,
+        "after removing `{cb_prop}`"
+    );
+}
+
+#[test]
+fn transform_toggles_fixed_containing_block() {
+    assert_fixed_cb_toggle("transform: translateX(0px)");
+}
+
+#[test]
+fn will_change_toggles_fixed_containing_block() {
+    assert_fixed_cb_toggle("will-change: transform");
+}
+
+#[test]
+fn filter_toggles_fixed_containing_block() {
+    assert_fixed_cb_toggle("filter: grayscale(50%)");
+}
+
+#[test]
+fn contain_toggles_fixed_containing_block() {
+    assert_fixed_cb_toggle("contain: layout");
+}
+
+/// Toggling `position: relative` on a static intermediate ancestor moves an
+/// absolutely positioned descendant between containing blocks.
+#[test]
+fn position_toggles_absolute_containing_block() {
+    let html = "<html><head><style>body { margin: 0 }</style></head><body>\
+         <div id=outer style='position: relative; margin: 20px; width: 400px; height: 400px'>\
+         <div id=mid style='margin: 30px; width: 300px; height: 300px'>\
+         <div id=target style='position: absolute; top: 10px; left: 10px; width: 20px; height: 20px'></div>\
+         </div></div></body></html>";
+    let mut harness = Harness::from_html(html);
+    let mid = harness.node("#mid");
+
+    // CB is #outer at (20, 30): #mid's 30px top margin collapses through #outer
+    assert_eq!(harness.layout_rect("#target").x, 30.0);
+    assert_eq!(harness.layout_rect("#target").y, 40.0);
+
+    // Make #mid positioned: CB becomes #mid at (50, 30)
+    set_style(
+        &mut harness,
+        mid,
+        "position: relative; margin: 30px; width: 300px; height: 300px",
+    );
+    assert_eq!(harness.layout_rect("#target").x, 60.0);
+    assert_eq!(harness.layout_rect("#target").y, 40.0);
+
+    // Back to static: CB is #outer again
+    set_style(
+        &mut harness,
+        mid,
+        "margin: 30px; width: 300px; height: 300px",
+    );
+    assert_eq!(harness.layout_rect("#target").x, 30.0);
+    assert_eq!(harness.layout_rect("#target").y, 40.0);
+}
+
+/// CB changes driven purely by a restyle (`:hover`), with no DOM mutation. This
+/// exercises the pure restyle-damage path (DOM mutations like `set_attribute`
+/// insert full damage unconditionally, masking under-damaging bugs).
+fn assert_hover_toggles_fixed_cb(cb_prop: &str) {
+    let html = format!(
+        "<html><head><style>\
+         body {{ margin: 0 }}\
+         #anc {{ margin: 50px; width: 300px; height: 300px; }}\
+         #anc:hover {{ {cb_prop} }}\
+         </style></head><body>\
+         <div id=anc>\
+         <div id=target style='position: fixed; top: 10px; left: 10px; width: 20px; height: 20px'></div>\
+         </div></body></html>"
+    );
+    let mut harness = Harness::from_html(&html);
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        10.0,
+        "initial (viewport CB)"
+    );
+
+    // Hover #anc: it now establishes the fixed containing block
+    harness.base_mut().set_hover_to(60.0, 60.0);
+    harness.pump();
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        60.0,
+        "hovered: `{cb_prop}` makes #anc the CB"
+    );
+
+    // Unhover: back to the viewport
+    harness.base_mut().set_hover_to(700.0, 500.0);
+    harness.pump();
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        10.0,
+        "unhovered (viewport CB)"
+    );
+}
+
+#[test]
+fn hover_transform_toggles_fixed_containing_block() {
+    assert_hover_toggles_fixed_cb("transform: translateX(0px)");
+}
+
+#[test]
+fn hover_will_change_toggles_fixed_containing_block() {
+    assert_hover_toggles_fixed_cb("will-change: transform");
+}
+
+#[test]
+fn hover_filter_toggles_fixed_containing_block() {
+    assert_hover_toggles_fixed_cb("filter: grayscale(50%)");
+}
+
+/// Dynamically inserting and removing a hoisted box (the common fixed-position
+/// popup/modal pattern). The box must be laid out via its containing block on
+/// insertion and fully disappear from layout/paint/hit-test on removal.
+#[test]
+fn insert_and_remove_hoisted_box() {
+    let html = "<html><head><style>body { margin: 0 }</style></head><body>\
+         <div id=anc style='margin: 50px; width: 300px; height: 300px'></div>\
+         </body></html>";
+    let mut harness = Harness::from_html(html);
+    let anc = harness.node("#anc");
+
+    // Insert a fixed box inside #anc
+    let target = {
+        let mut doc = harness.base_mut();
+        let mut mutator = doc.mutate();
+        let target = mutator.create_element(
+            QualName::new(None, ns!(html), local_name!("div")),
+            vec![blitz_dom::Attribute {
+                name: style_attr(),
+                value: "position: fixed; top: 10px; left: 10px; width: 20px; height: 20px".into(),
+            }],
+        );
+        mutator.append_children(anc, &[target]);
+        target
+    };
+    harness.pump();
+
+    // Positioned against the viewport, and hit-testable there
+    assert_eq!(harness.layout_rect_of(target).x, 10.0);
+    assert_eq!(harness.layout_rect_of(target).y, 10.0);
+    assert_eq!(harness.hit_node(15.0, 15.0), target);
+
+    // Remove it again: it must stop being laid out / hit-testable
+    harness.base_mut().mutate().remove_node(target);
+    harness.pump();
+    assert_ne!(
+        harness.hit(15.0, 15.0).map(|h| h.node_id),
+        Some(target.into())
+    );
+}
+
+/// Toggling `display: none` on a hoisted box's static parent must hide and
+/// re-show the hoisted box.
+#[test]
+fn display_none_toggle_on_static_parent() {
+    let html = "<html><head><style>body { margin: 0 }</style></head><body>\
+         <div id=parent style='width: 300px; height: 300px'>\
+         <div id=target style='position: fixed; top: 10px; left: 10px; width: 20px; height: 20px'></div>\
+         </div></body></html>";
+    let mut harness = Harness::from_html(html);
+    let parent = harness.node("#parent");
+    let target = harness.node("#target");
+
+    assert_eq!(harness.hit_node(15.0, 15.0), target);
+
+    set_style(
+        &mut harness,
+        parent,
+        "display: none; width: 300px; height: 300px",
+    );
+    assert_ne!(
+        harness.hit(15.0, 15.0).map(|h| h.node_id),
+        Some(target.into()),
+        "hidden with its parent"
+    );
+
+    set_style(&mut harness, parent, "width: 300px; height: 300px");
+    assert_eq!(
+        harness.hit_node(15.0, 15.0),
+        target,
+        "re-shown with its parent"
+    );
+    assert_eq!(harness.layout_rect("#target").x, 10.0);
+}
+
+/// A layout change (not a CB change) inside a hoisted subtree must relayout the
+/// hoisted box through its containing block.
+#[test]
+fn content_change_inside_hoisted_subtree() {
+    let html = "<html><head><style>body { margin: 0 }</style></head><body>\
+         <div style='width: 300px; height: 300px'>\
+         <div id=target style='position: fixed; top: 10px; left: 10px'>\
+         <div id=inner style='width: 20px; height: 20px'></div>\
+         </div></div></body></html>";
+    let mut harness = Harness::from_html(html);
+    let inner = harness.node("#inner");
+
+    assert_eq!(harness.layout_rect("#target").width, 20.0);
+
+    set_style(&mut harness, inner, "width: 50px; height: 40px");
+    assert_eq!(harness.layout_rect("#target").width, 50.0);
+    assert_eq!(harness.layout_rect("#target").height, 40.0);
+}


### PR DESCRIPTION
## Summary

Stacked on #805 (this PR's branch includes #805's commits; the diff reduces to the three commits below once #805 merges). Removes the avoidable O(tree) per-frame work from the paint-placement side of the OOF hoisting branch, with no behavior change. Three independent commits:

**1. Hoisted paint-child positions are derived at use-time, not baked.**

```diff
 pub struct HoistedPaintChild {
     pub node_id: NodeId,
     pub z_index: i32,
-    pub position: taffy::Point<f32>,
 }
```

Paint, hit-testing, and `compute_content_size` now compute the offset via `Node::hoisted_child_position(child_id)`, which accumulates `location - scroll_offset` along the child's `containing_block()` chain (the OOF containing block for hoisted boxes, otherwise `layout_parent`) up to the owning node (with a negated walk for the effect-ancestor case where the owner is *below* the containing block). Since nothing baked can go stale, layout/scroll changes elsewhere no longer require re-baking every hoisted entry.

**2. `attach_hoisted_children` no longer scans the whole node slab.**

`BaseDocument` gains `oof_containing_blocks: HashSet<NodeId>`, maintained by Taffy's OOF callbacks (`add_hoisted_children` inserts, `clear_hoisted_children` removes). Attach iterates only these registered containing blocks (sorted for determinism, lazily pruning removed/emptied ones), so its cost is bounded by the number of OOF boxes, not document size.

**3. `flush_styles_to_layout` skips clean subtrees (incremental mode).**

Damage propagation already bubbles descendant damage into each ancestor's stored damage, so `damage.is_empty() && !has_damaged_descendants() && !is_anonymous()` proves the whole subtree is unchanged: its taffy styles, `layout_children` order-sort, `paint_children`, and stacking contexts are all still valid, and the flush returns early. The one piece a skipped subtree still owes its surroundings — the `HoistedPaintChild` entries it contributed to the nearest ancestor stacking context — is replayed from a per-node `sc_contribution_cache` captured on the last flush that visited it, so a *damaged* ancestor SC that rebuilds its list keeps entries from clean descendant subtrees. This makes the flush's per-frame cost O(damaged nodes).

Not addressed (intentionally): the tree-order splice and `is_before_in_tree_order` are unchanged (same ordering semantics as the base branch), Appendix E step-8 interleaving remains approximate (`grid-items-relative-positioned-containing-block-003` still fails), and attach still visits every registered CB each frame — it can't be safely damage-gated because a rebuilt ancestor stacking context needs clean CBs' z-indexed entries re-pushed.

## Testing

- Per-test WPT comparison vs the #763 baseline (55127ef1) over `css/css-position`, `css/CSS2/positioning`, `css/CSS2/zindex`, `css/css-grid/grid-items`, `css/css-grid/abspos`, `css/css-flexbox`: **zero status differences**.
- After rebasing onto #805 (`2cbce9b0`): `cargo test --workspace`, `cargo clippy --workspace`, `cargo fmt` all clean.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/2641a1705e2547a0b385ec07a70a3abb
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/2641a1705e2547a0b385ec07a70a3abb?variant=devin-insiders
Requested by: @nicoburns