### PR TITLE
Fix print_taffy_tree to use the real root node and recurse into subdocuments

### DIFF
--- a/packages/blitz-dom/src/debug.rs
+++ b/packages/blitz-dom/src/debug.rs
@@ -5,7 +5,13 @@ use crate::BaseDocument;
 
 impl BaseDocument {
     pub fn print_taffy_tree(&self) {
-        taffy::print_tree(self, taffy::NodeId::from(0usize));
+        taffy::print_tree(self, crate::taffy_node_id(self.root_element().id));
+        for &node_id in &self.sub_document_nodes {
+            if let Some(sub_doc) = self.nodes[node_id].subdoc() {
+                println!("\n=== Subdocument (node {node_id:?}) ===");
+                sub_doc.inner().print_taffy_tree();
+            }
+        }
     }
 
     pub fn debug_log_node(&self, node_id: NodeId) {


### PR DESCRIPTION
## Summary
`BaseDocument::print_taffy_tree` hardcoded `NodeId::from(0usize)` as the root, printing from the document node instead of the actual root element. It now starts from `taffy_node_id(self.root_element().id)` and additionally recurses into each entry in `sub_document_nodes`, printing each subdocument's taffy tree under a `=== Subdocument (node …) ===` header.

Split out of #763 as it is useful independently of the OOF-hoisting work.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/65c5463061c8403bade7888271d5eeb4
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/65c5463061c8403bade7888271d5eeb4?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32960892906).</sub>
<!-- wpt-results-end -->
