### PR TITLE
Separate stacking-context membership from layout/geometry ancestry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,12 +29,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_android"
-version = "0.7.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e27dedd5e1932e1f52fedcde681bc2ae4213df53bad5b295103aa36b1d0ffb6"
+checksum = "b3081278e68324dd6cf602508cf52359ec9d99374b50d3172b8ee888b73e00f6"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.38.0",
+ "accesskit_consumer 0.37.0",
  "jni 0.21.1",
  "log",
 ]
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.38.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+checksum = "f950720ce064757a1b629caad3a408e8d2c63bb01f29b8a3ff8daa331053ffeb"
 dependencies = [
  "accesskit",
  "hashbrown 0.16.1",
@@ -85,12 +85,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.26.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+checksum = "17cb8b66cef272d48161b02a6317cc2bdd5f98bb0a5e79c68f704a5862aa396b"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.38.0",
+ "accesskit_consumer 0.37.0",
  "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.5"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -219,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cc",
  "jni 0.22.4",
  "libc",
@@ -228,7 +228,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -239,9 +239,9 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.104"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "anyrender"
@@ -489,7 +489,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -641,7 +641,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -670,13 +670,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.92"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
@@ -768,7 +768,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -820,7 +820,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -831,7 +831,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.3",
  "shlex 1.3.0",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -872,9 +872,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -921,7 +921,7 @@ dependencies = [
  "anyrender",
  "app_units",
  "atomic_refcell",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "blitz-traits",
  "color",
  "cssparser",
@@ -1105,7 +1105,7 @@ name = "blitz-traits"
 version = "0.3.0-beta.2"
 dependencies = [
  "atomic_refcell",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bytes",
  "cursor-icon",
  "http",
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.7.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -1163,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1261,22 +1261,22 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.12.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
@@ -1293,9 +1293,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -1333,7 +1333,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "polling",
  "rustix 1.1.4",
  "slab",
@@ -1363,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1401,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.9"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -1417,9 +1417,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgl"
@@ -1432,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.9.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -1443,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.6"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.6"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1465,14 +1465,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.4"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
@@ -1496,7 +1496,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1634,7 +1634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e42cd5aabba86f128b3763da1fec1491c0f728ce99245062cd49b6f9e6d235b"
 dependencies = [
  "const-serialize 0.7.2",
- "const-serialize-macro 0.8.0-alpha.1",
+ "const-serialize-macro 0.8.0-alpha.0",
  "serde",
 ]
 
@@ -1646,18 +1646,18 @@ checksum = "4f160aad86b4343e8d4e261fee9965c3005b2fd6bc117d172ab65948779e4acf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "const-serialize-macro"
-version = "0.8.0-alpha.1"
+version = "0.8.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4c3b1c2ce89797adff100c510b92c7cf32983fdbc632e703253f2ef516ef56"
+checksum = "42571ed01eb46d2e1adcf99c8ca576f081e46f2623d13500eba70d1d99a4c439"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.18.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "percent-encoding",
  "time",
@@ -1809,27 +1809,27 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1837,18 +1837,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1887,7 +1887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -1935,7 +1935,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -1948,7 +1948,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -1959,7 +1959,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -1970,14 +1970,14 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-url"
@@ -1992,7 +1992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee89cb860616069c67520dcd66cacdb900b57c799f634a0eb6d91f6e2a82b61"
 dependencies = [
  "av-data",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "dav1d-sys",
  "static_assertions",
 ]
@@ -2036,7 +2036,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -2045,7 +2045,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2062,7 +2062,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.119",
+ "syn",
  "unicode-xid",
 ]
 
@@ -2113,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9320593eda4f01858f046698b42441603d2af5fcb62a6c1f9046a0c2eebd6d9b"
+checksum = "7c01ecf7ddbae18a419ad3d83c486101a85ffc5740ea09cdd0f09a30dc12170d"
 dependencies = [
  "dioxus-asset-resolver",
  "dioxus-cli-config",
@@ -2139,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-asset-resolver"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84235ff0e272f15d4537603cdd50df6d45d50e51bb96326dbc0bdfd01d825226"
+checksum = "69387edbbc60c7cb93ad96d8cc7a22b49a76e21643380b89b1c49a78d347ff60"
 dependencies = [
  "dioxus-cli-config",
  "http",
@@ -2151,24 +2151,24 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "percent-encoding",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "dioxus-cli-config"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322d10f47effebd85ee0662a2cb083ff920d40dd6295a4afd8cfa4f9bc2e05c6"
+checksum = "c000f584ddf608e2b272b3074bf11512a474eeeb2eb85a1915f276ce5c4a8615"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "dioxus-config-macro"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3a906c8219e94fa48189a793c760a4e3193cbb7791f799e9d37633fe41161d"
+checksum = "7637091592978fbfdb45a16b26bd99fd97fb1bd7e31c6a963530e00c022af321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2176,15 +2176,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-config-macros"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20de015bc89c20f4ffc7b4f849943420308365fa66f991250b5c075261990a21"
+checksum = "54f9ed8fc1a215ad34bb8dbae42a4ea54efbcd26ca9006bbe5cca78e511bf25f"
 
 [[package]]
 name = "dioxus-core"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b232228ada232c0adc151e41ebd9ef70cc04683db097fa0dc6015979fa01722"
+checksum = "45887100ff0cf89abeb8b659808294fda48cd53f3b424e36407dedffcfea830b"
 dependencies = [
  "anyhow",
  "const_format",
@@ -2204,28 +2204,28 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-macro"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6256a68462222f0600f5fd7d9542cbd9f299bc19355d900f7827dd3fc9e09fdb"
+checksum = "370c63663dff0f24df5dfea643ca239283542c6b228a302f69b32e1d36762b7f"
 dependencies = [
  "convert_case 0.8.0",
  "dioxus-rsx",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "dioxus-core-types"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96007ed6cbad951dfed82d83c581aabd95bc591f351f5666d454ddbe7845b324"
+checksum = "36963eab106b169737762f9cd5ee5fd97f585989dcb2d8e30a596e97a6999009"
 
 [[package]]
 name = "dioxus-devtools"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434cebb282b3f820a341582ebfd37dab907d5a25c3eeafd87802468afcd2a959"
+checksum = "2349cedbdf1b429df1f1bea61fdee0ad3dae7b2548eedfbeca82710122a57da0"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -2234,16 +2234,16 @@ dependencies = [
  "serde",
  "serde_json",
  "subsecond",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tracing",
  "tungstenite",
 ]
 
 [[package]]
 name = "dioxus-devtools-types"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfd6f3475e38c93be245a664a9ce11679a8f2b99832620705cf7837f42aa39ce"
+checksum = "0ab9b0f7565d1916b70915f59b89ea8054ef0a9d67a364a32bbee68ef5f3818d"
 dependencies = [
  "dioxus-core",
  "serde",
@@ -2252,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-document"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f6fadd5c6d886b48b762820abae1a08142a2159f8a1136c0466b4b4ed9f547e"
+checksum = "37e3a5bec7ffc999ff23446a487eb5cd86111d1574a23533dd3f8b3c69a53a22"
 dependencies = [
  "dioxus-core",
  "dioxus-core-macro",
@@ -2271,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-history"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2404b77d4441e694a5e93afb5c9a729efb26a3f6920f769cfe6cfedf5c7ac210"
+checksum = "1a15232302d1933015fcf2d6fe9e286ad36f6e9c205a546089a0f326023bb0d2"
 dependencies = [
  "dioxus-core",
  "tracing",
@@ -2281,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-hooks"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3807a1bc039299cd37ad85f1c56ae7088210e8a38e3e877f01034d68c15fbb"
+checksum = "4534f91cf6305204b948bdec130076ac9ecc7c22faab29475b76870558bf73ea"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -2297,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9a85679c4dfd8699407a9ad5041a6a4fe6be0ee386353951cd03b57a12030"
+checksum = "e03d6ad4040b667f2b2eefcb678840e630938c09bf9ec39b04ea4d1d96d90d44"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2324,21 +2324,21 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html-internal-macro"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500282dad5b62e91f93e127cbf41c587bf1c457d52514a75f3ff2a55fd0ea9f6"
+checksum = "584e2772127ab00f0d5e1d4d9795f39fecebc828ece0b7a02349d438bc1b1ce7"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "dioxus-interpreter-js"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa22cc3431e7efdbae28069542a1763c977d5edbe4d4fbfb0b7667b9c9966e9"
+checksum = "11999d6eb5bb179a9512dad30e5de408aab66f2cb65de9098c9fbe02927e2978"
 dependencies = [
  "js-sys",
  "lazy-js-bundle",
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-logger"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f36b2dac4df8c747431f77f2a6644dd033ea98e7f8ac80271ff47fd4ba8a548"
+checksum = "a28ccdfe36d2cb830a2784e40f7e6f7199805a2c6da99bd65b1ca308f11aed28"
 dependencies = [
  "dioxus-cli-config",
  "tracing",
@@ -2421,22 +2421,22 @@ dependencies = [
 
 [[package]]
 name = "dioxus-rsx"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea662c9e13a91279d8acbc0d02a80430c7081704c20e8c791e4c4a151268596"
+checksum = "2106afda239a4c7c22ffa1ca19117011225fc1c735c139c0a5b765996aa8bb1d"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
  "rustversion",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "dioxus-signals"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d85e36fcaf7abdc986836801bf248776da7d5961f5fac65fdbf5ed491afb4f"
+checksum = "3705754f5e043deec9fc7af0d159f18e5b21c02c47d255c7e477f31368f0b6d2"
 dependencies = [
  "dioxus-core",
  "futures-channel",
@@ -2450,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15eaa9f2ccc5ce962d056515e61345c846a54b13a2b880cf7e8ac93faa53a178"
+checksum = "64bec7b21c86b1360ec965a07a53a2c96b7caee3465049e1c299a45024e87614"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -2462,21 +2462,21 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores-macro"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13bd8a693d7042544fa3ac79698a08783bbc698d1ed257e88c5d4059e9ac476"
+checksum = "40a5875e9f890f27b1cc3e5b56c1e23601211470315a1fb8627c4ca4f3b2be9a"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "dioxus-web"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481093233d789c5ffbdde66e7970e803b01a199a7ab0c0f8ef84c65d30b7384f"
+checksum = "bc0a0be76b404e8242a597db0fb239d05f8dee4e7856bc1fc7144f7e244822fd"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -2532,7 +2532,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -2540,13 +2540,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
@@ -2585,7 +2585,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
@@ -2648,9 +2648,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.18.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-io"
@@ -2712,14 +2712,14 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "enumset"
-version = "1.1.14"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
 dependencies = [
  "enumset_derive",
 ]
@@ -2733,7 +2733,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -2776,7 +2776,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -2797,9 +2797,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.4.0"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "euclid"
@@ -2813,10 +2813,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.2"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
+ "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2854,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -2885,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "finl_unicode"
@@ -2943,9 +2944,9 @@ checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 
 [[package]]
 name = "font-types"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
+checksum = "75382bc7392ef10aad10935f92fc3db36d2d4dad0e5d96d8d65e04f89a07ec39"
 dependencies = [
  "bytemuck",
 ]
@@ -3015,13 +3016,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
@@ -3056,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.34"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3071,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.34"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3081,15 +3082,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.34"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.34"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3109,9 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.34"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -3128,26 +3129,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.34"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.34"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.34"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -3161,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.34"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3178,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "generational-box"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b2dc9b873cd1a8adb80aa5dcef9a8205f781a8a313d5ffb867248cb3bcb764"
+checksum = "8cd0d825b8d339701ad330dbcd6399519ced4d143484954daf6e3185dace4f77"
 dependencies = [
  "parking_lot",
  "tracing",
@@ -3298,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -3344,7 +3345,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cfg_aliases",
  "cgl",
  "dispatch2",
@@ -3402,7 +3403,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "windows",
 ]
 
@@ -3412,7 +3413,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -3423,7 +3424,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3438,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.19"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3473,7 +3474,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "read-fonts",
  "smallvec",
@@ -3563,9 +3564,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "html-escape"
-version = "0.2.15"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5"
+checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
 
 [[package]]
 name = "html5ever"
@@ -3579,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.5.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -3589,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
@@ -3599,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.5"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3687,9 +3688,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3762,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -3775,10 +3776,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.3.0"
+name = "icu_locale"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3789,30 +3805,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locale_fallback"
-version = "2.3.0"
+name = "icu_locale_data"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251af8e57c9400e3eb58242fe5b8b1152b2a64fdf4cf632f923c38ccee6f2fa9"
-dependencies = [
- "icu_locale_core",
- "icu_locale_fallback_data",
- "icu_provider",
- "potential_utf",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_fallback_data"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decf2a22ec8fa68f1a0c1129a3f8583f8f8bc24e8b9ccbe98ead99f62a4dc3a8"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3824,17 +3826,16 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -3845,15 +3846,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3868,26 +3869,25 @@ dependencies = [
 
 [[package]]
 name = "icu_segmenter"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d07aafccd67af15d02512a6adf5896fbc5ed00f2e99b471d2efa14016db3db"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
 dependencies = [
  "core_maths",
  "icu_collections",
- "icu_locale_fallback",
+ "icu_locale",
  "icu_provider",
  "icu_segmenter_data",
  "potential_utf",
- "smallvec",
  "utf8_iter",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_segmenter_data"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae293c039020f9ec10710af98d29ce6aa2051486638b49c9a6409f3b4a9e98ad"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "ident_case"
@@ -3977,20 +3977,20 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.5"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
 dependencies = [
  "libc",
 ]
@@ -4003,14 +4003,14 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -4050,12 +4050,11 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "jiff"
-version = "0.2.35"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
- "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -4064,24 +4063,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
-dependencies = [
- "defmt",
-]
-
-[[package]]
 name = "jiff-static"
-version = "0.2.35"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
- "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -4112,7 +4101,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -4127,7 +4116,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -4155,7 +4144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -4170,9 +4159,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4194,7 +4183,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -4205,7 +4194,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fbe853b403ae61a04233030ae8a79d94975281ed9770a1f9e246732b534b28d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "serde",
 ]
 
@@ -4243,9 +4232,9 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -4257,7 +4246,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -4307,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-js-bundle"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51cdaa5abc885e2d606e6985281ace220778bde190be20aab1ec2346ed8bd1fa"
+checksum = "ccafada6c9541db44db758619236f2748f6e1bdaa84d04ded858567cd1e89321"
 
 [[package]]
 name = "lazy_static"
@@ -4385,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.189"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -4426,14 +4415,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
- "redox_syscall 0.9.3",
+ "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -4477,9 +4466,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -4498,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.34"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -4522,7 +4511,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -4557,7 +4546,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -4576,15 +4565,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f44db74bde26fdf427af23f1d146c211aed857c59e3be750cf2617f6b0b05c94"
 dependencies = [
  "proc-macro2",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "manganis"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed2af894a724a0b6e521f9efe84f98cfdc74a4de6828efef77ffd3b1679fd52"
+checksum = "8bfcf56309de35b48b8780ea097ace5c3b773a617b52edc49dfc9a63a7d9dc43"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -4593,14 +4582,14 @@ dependencies = [
  "manganis-macro",
  "ndk-context",
  "objc2 0.6.4",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "manganis-core"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e258c71b137bf48deaffb48b8a8a2f994af9e5c3ca201daa20d41e26b379da11"
+checksum = "a24d6be68f594495aea60850a284029d585d7b7839b26096c1b6d758f8518648"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -4612,16 +4601,16 @@ dependencies = [
 
 [[package]]
 name = "manganis-macro"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae8346bbf637e6d21ac3831863bd5a98657517f5cd2d69d651046b95e7ce9"
+checksum = "5e782a10318d707c0833e31876ded8acf91287eee0010af8392559af614c7226"
 dependencies = [
  "dunce",
  "macro-string",
  "manganis-core",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -4655,9 +4644,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.3"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memfd"
@@ -4715,7 +4704,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -4761,9 +4750,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -4803,7 +4792,7 @@ checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -4817,7 +4806,7 @@ dependencies = [
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "unicode-ident",
 ]
 
@@ -4844,7 +4833,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -4880,7 +4869,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4926,7 +4915,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -4944,7 +4933,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5001,14 +4990,14 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.47"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
  "num-traits",
 ]
@@ -5063,7 +5052,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -5115,7 +5104,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -5131,7 +5120,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -5146,7 +5135,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -5157,7 +5146,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -5179,7 +5168,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
  "objc2 0.6.4",
@@ -5191,7 +5180,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "libc",
  "objc2 0.6.4",
@@ -5237,7 +5226,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -5249,7 +5238,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -5266,7 +5255,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -5278,7 +5267,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -5291,7 +5280,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -5302,7 +5291,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -5314,7 +5303,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
@@ -5326,7 +5315,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -5339,7 +5328,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -5352,7 +5341,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-cloud-kit",
@@ -5395,7 +5384,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -5411,7 +5400,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -5469,9 +5458,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.5.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -5662,7 +5651,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -5706,7 +5695,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -5728,14 +5717,14 @@ dependencies = [
 
 [[package]]
 name = "pixels"
-version = "0.17.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27af78f16789b973b8b340fe3f68cc2ec9f5e6f4aea64e4d794d5833ac9ca52e"
+checksum = "f7ddc5048a90da4dab8f3f81fb280f44c9e1d76b68fb2f62dce78b22d55546b1"
 dependencies = [
  "bytemuck",
  "pollster",
  "raw-window-handle",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "ultraviolet",
  "wgpu",
 ]
@@ -5753,9 +5742,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.34"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -5782,7 +5771,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5820,9 +5809,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.15.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
@@ -5847,9 +5836,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "serde_core",
  "writeable",
@@ -5890,7 +5879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -5899,14 +5888,14 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.107"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -5919,7 +5908,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "version_check",
 ]
 
@@ -5939,7 +5928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -5964,7 +5953,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "memchr",
  "pulldown-cmark-escape",
  "unicase",
@@ -5990,18 +5979,19 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.47"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -6020,9 +6010,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -6083,7 +6073,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "simd_helpers",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -6184,7 +6174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
- "font-types 0.12.4",
+ "font-types 0.12.3",
  "once_cell",
 ]
 
@@ -6194,16 +6184,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6214,7 +6204,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6231,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.1"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6243,9 +6233,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.18"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6320,7 +6310,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tower-service",
 ]
 
@@ -6389,7 +6379,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6434,7 +6424,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6447,7 +6437,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -6456,9 +6446,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -6469,18 +6459,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.15"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6489,9 +6479,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -6540,9 +6530,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2a4360b9abcdcee43809e6fc11d6d61ca5d25734026a8fc46c2883eea3f13f"
+checksum = "1dd3accc0f3f4bbaf2c9e1957a030dc582028130c67660d44c0a0345a22ca69b"
 dependencies = [
  "ab_glyph",
  "log",
@@ -6557,7 +6547,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6580,7 +6570,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeee001a77567bb05e71652718d3ff76d8697c151ac523e68e9513194eb2b75a"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cssparser",
  "derive_more",
  "log",
@@ -6612,9 +6602,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -6653,29 +6643,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.151"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -6686,13 +6676,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.21"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
@@ -6751,9 +6741,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.7"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -6814,15 +6804,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.10"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -6866,7 +6856,7 @@ checksum = "7ef75eddaf703e5a3e9eb837b9a7426ff995042a9a410f85981446cffed1e21e"
 dependencies = [
  "hashbrown 0.17.1",
  "skrifa",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "write-fonts",
 ]
 
@@ -6893,7 +6883,7 @@ version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "skia-bindings",
 ]
 
@@ -6930,7 +6920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb251b407f50028476a600541542b605bb864d35d9ee1de4f6cab45d88475e6d"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -6973,7 +6963,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -6981,7 +6971,7 @@ dependencies = [
  "log",
  "memmap2 0.9.11",
  "rustix 1.1.4",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -7006,9 +6996,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -7065,7 +7055,7 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7164,7 +7154,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -7176,7 +7166,7 @@ dependencies = [
  "app_units",
  "arrayvec",
  "atomic_refcell",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "byteorder",
  "cssparser",
  "derive_more",
@@ -7243,7 +7233,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
@@ -7253,7 +7243,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346fde14a66fdc568ef79a8c81f8b6a35722a0906295bce2997df6c90c7b848f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "stylo_malloc_size_of",
 ]
 
@@ -7288,7 +7278,7 @@ dependencies = [
 name = "stylo_taffy"
 version = "0.3.0-beta.2"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "stylo",
  "stylo_atoms",
  "taffy",
@@ -7301,7 +7291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00a8d2ca5b29c7f5dd94ec66fbb256b274b76ecaab164417c92ce9a4586c8259"
 dependencies = [
  "app_units",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cssparser",
  "euclid",
  "malloc_size_of_derive",
@@ -7318,9 +7308,9 @@ dependencies = [
 
 [[package]]
 name = "subsecond"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d350d5788fa94d560d92269266a50efc77b036bfca6675e420b64df7b3211f37"
+checksum = "9cc79674bd55726e6b123204403389400229a95fe4a3b2c5453dada70b06ca95"
 dependencies = [
  "js-sys",
  "libc",
@@ -7329,7 +7319,7 @@ dependencies = [
  "memmap2 0.9.11",
  "serde",
  "subsecond-types",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -7337,9 +7327,9 @@ dependencies = [
 
 [[package]]
 name = "subsecond-types"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf32d66269b5fbb8558334e8d22b657b2f7af0dd2ef56c231541099a862e464"
+checksum = "e9798bfed58797aed51c672aa99810aac30a50d3120ecfdcf28c13784e9a8f1c"
 dependencies = [
  "serde",
 ]
@@ -7374,20 +7364,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.119"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7411,7 +7390,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -7430,8 +7409,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639627c87f43b9181c811f40a6296409e093a17bc761214cba3c15df74f86b99"
+source = "git+https://github.com/DioxusLabs/taffy?rev=4da301158398d53ab898eb90f97b30bbaace6b67#4da301158398d53ab898eb90f97b30bbaace6b67"
 dependencies = [
  "arrayvec",
  "serde",
@@ -7471,11 +7449,12 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -7504,9 +7483,9 @@ checksum = "253bcead4f3aa96243b0f8fa46f9010e87ca23bd5d0c723d474ff1d2417bbdf8"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
@@ -7519,11 +7498,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.20"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.20",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -7534,34 +7513,34 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.20"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.10"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.55"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -7579,9 +7558,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.32"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7589,16 +7568,27 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia"
-version = "0.12.0"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
 dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
  "cfg-if",
  "log",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -7627,9 +7617,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -7638,9 +7628,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7674,7 +7664,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
@@ -7693,9 +7683,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.53.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -7708,13 +7698,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
@@ -7739,9 +7729,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.19"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7750,23 +7740,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.19"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -7774,7 +7763,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7806,23 +7795,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.4",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.4",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7833,9 +7822,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -7858,7 +7847,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -7902,7 +7891,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -7988,7 +7977,7 @@ dependencies = [
  "brotli",
  "byteorder",
  "clap",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8004,7 +7993,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -8152,7 +8141,7 @@ dependencies = [
  "skrifa",
  "strict-num",
  "svgtypes",
- "tiny-skia-path",
+ "tiny-skia-path 0.12.0",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -8179,9 +8168,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -8224,7 +8213,7 @@ dependencies = [
  "png 0.18.1",
  "skrifa",
  "static_assertions",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "vello_encoding",
  "vello_shaders",
  "wgpu",
@@ -8243,7 +8232,7 @@ dependencies = [
  "peniko",
  "png 0.18.1",
  "smallvec",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8287,7 +8276,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "js-sys",
  "log",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "vello_common",
  "vello_sparse_shaders",
  "web-sys",
@@ -8303,7 +8292,7 @@ dependencies = [
  "bytemuck",
  "log",
  "naga",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "vello_encoding",
 ]
 
@@ -8376,7 +8365,7 @@ checksum = "59195a1db0e95b920366d949ba5e0d3fc0e70b67c09be15ce5abb790106b0571"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -8396,9 +8385,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8409,9 +8398,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8419,9 +8408,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8429,22 +8418,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -8494,9 +8483,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.17"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -8508,11 +8497,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.15"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -8524,7 +8513,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -8546,7 +8535,7 @@ version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -8558,7 +8547,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -8571,7 +8560,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -8584,7 +8573,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -8597,7 +8586,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -8606,9 +8595,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.11"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -8629,9 +8618,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8649,9 +8638,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -8661,15 +8650,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
+ "core-foundation 0.10.1",
  "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
@@ -8692,7 +8681,7 @@ dependencies = [
  "half",
  "itertools 0.14.0",
  "num-traits",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "wesl-macros",
  "wgsl-parse",
  "wgsl-types",
@@ -8707,7 +8696,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -8717,7 +8706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -8749,7 +8738,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
  "bit-vec 0.9.1",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -8764,7 +8753,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-wasm",
@@ -8820,7 +8809,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set 0.9.1",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "bytemuck",
  "cfg-if",
@@ -8853,7 +8842,7 @@ dependencies = [
  "raw-window-metal 1.1.0",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wayland-sys",
  "web-sys",
@@ -8880,7 +8869,7 @@ version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -8932,7 +8921,7 @@ dependencies = [
  "lalrpop-util",
  "lexical",
  "logos",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "wgsl-types",
 ]
 
@@ -9019,7 +9008,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -9030,7 +9019,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -9313,7 +9302,7 @@ version = "0.31.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2879d2854d1a43e48f67322d4bd097afcb6eb8f8f775c8de0260a71aea1df1aa"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cfg_aliases",
  "cursor-icon",
  "dpi",
@@ -9341,7 +9330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d9c0d2cd93efec3a9f9ad819cfaf0834782403af7c0d248c784ec0c61761df"
 dependencies = [
  "android-activity",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "dpi",
  "ndk",
  "raw-window-handle",
@@ -9356,7 +9345,7 @@ version = "0.31.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21310ca07851a49c348e0c2cc768e36b52ca65afda2c2354d78ed4b90074d8aa"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
  "dpi",
@@ -9395,7 +9384,7 @@ version = "0.31.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4f0ccd7abb43740e2c6124ac7cae7d865ecec74eec63783e8922577ac232583"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cursor-icon",
  "dpi",
  "keyboard-types 0.8.3",
@@ -9410,7 +9399,7 @@ version = "0.31.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ea1fb262e7209f265f12bd0cc792c399b14355675e65531e9c8a87db287d46"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "dpi",
  "orbclient",
  "raw-window-handle",
@@ -9426,7 +9415,7 @@ version = "0.31.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680a356e798837d8eb274d4556e83bceaf81698194e31aafc5cfb8a9f2fab643"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
  "dpi",
@@ -9448,7 +9437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce5afb2ba07da603f84b722c95f9f9396d2cedae3944fb6c0cda4a6f88de545"
 dependencies = [
  "ahash",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "calloop",
  "cursor-icon",
  "dpi",
@@ -9475,7 +9464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2490a953fb776fbbd5e295d54f1c3847f4f15b6c3929ec53c09acda6487a92"
 dependencies = [
  "atomic-waker",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "concurrent-queue",
  "cursor-icon",
  "dpi",
@@ -9497,7 +9486,7 @@ version = "0.31.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644ea78af0e858aa3b092e5d1c67c41995a98220c81813f1353b28bc8bb91eaa"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cursor-icon",
  "dpi",
  "raw-window-handle",
@@ -9514,7 +9503,7 @@ version = "0.31.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa5b600756534c7041aa93cd0d244d44b09fca1b89e202bd1cd80dd9f3636c46"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "calloop",
  "cursor-icon",
@@ -9543,9 +9532,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -9564,7 +9553,7 @@ dependencies = [
  "anyrender_vello",
  "anyrender_vello_cpu",
  "atomic_float",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "blitz-dom",
  "blitz-html",
  "blitz-paint",
@@ -9613,23 +9602,24 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae90d1d9f6d1d36ef116b0b1e651a6d7c12ba925439d4d06ff9adc94662a3d8"
 dependencies = [
- "font-types 0.12.4",
+ "font-types 0.12.3",
  "log",
  "read-fonts",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wuff"
-version = "0.2.8"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f625c6894838ab68e8c1c6e0f728e67363c9d4391cfa82333e58e6e30bc3a627"
+checksum = "d77cd3107d02dc860d9377a7e28a60e2a77c6d1964f4119999b03dd95f007719"
 dependencies = [
+ "arrayvec",
  "brotli-decompressor",
  "bytes",
  "flate2",
@@ -9680,9 +9670,9 @@ dependencies = [
 
 [[package]]
 name = "xcursor"
-version = "0.3.11"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163b33ed8786455e2fa5d72f554057ce3f3182425434f756cd39c99839d88e23"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
 name = "xkbcommon-dl"
@@ -9690,7 +9680,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",
@@ -9705,9 +9695,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.29"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xml5ever"
@@ -9727,9 +9717,9 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.18"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "y4m"
@@ -9767,15 +9757,15 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.19.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -9800,7 +9790,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.4",
+ "winnow 1.0.3",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -9824,7 +9814,7 @@ checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
@@ -9832,14 +9822,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.19.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -9847,54 +9837,45 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.4"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.4",
+ "winnow 1.0.3",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "5.2.1"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
 dependencies = [
+ "quick-xml",
  "serde",
- "winnow 1.0.4",
  "zbus_names",
  "zvariant",
 ]
 
 [[package]]
-name = "zcheapstr"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -9914,7 +9895,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
@@ -9926,9 +9907,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -9938,9 +9919,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.8"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -9950,13 +9931,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.6"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
 ]
 
 [[package]]
@@ -9972,15 +9953,15 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "zopfli",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.23"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"
@@ -9996,9 +9977,9 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.5.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
@@ -10011,41 +9992,40 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.15.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.4",
- "zcheapstr",
+ "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.15.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "4.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.4",
- "winnow 1.0.4",
+ "syn",
+ "winnow 1.0.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { version = "0.14.0", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "4da301158398d53ab898eb90f97b30bbaace6b67", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1784,9 +1784,16 @@ impl BaseDocument {
             return (None, None);
         }
         let mut scrollbar = None;
-        let hit = self
-            .root_element()
-            .hit_inner(x, y, self.viewport().scale_f64(), &mut scrollbar);
+        let hit = self.root_element().hit_inner(
+            x,
+            y,
+            self.viewport().scale_f64(),
+            &mut scrollbar,
+            taffy::Point {
+                x: self.viewport_scroll.x as f32,
+                y: self.viewport_scroll.y as f32,
+            },
+        );
         (hit, scrollbar)
     }
 

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -1,23 +1,17 @@
 use blitz_traits::node_id::NodeId;
-use std::ops::Range;
 
-use crate::Node;
 use crate::net::ResourceHandler;
 use crate::node::NodeFlags;
 use crate::{
     BaseDocument, net::ImageHandler, node::ImageResourceData, node::Status, util::ImageLayerKind,
 };
 use style::properties::ComputedValues;
-use style::properties::generated::longhands::position::computed_value::T as Position;
 use style::selector_parser::RestyleDamage;
 use style::url::ComputedUrl;
-use style::values::computed::Float;
 use style::values::generics::image::Image as StyloImage;
 use style::values::specified::align::AlignFlags;
 use style::values::specified::box_::DisplayInside;
 use style::values::specified::box_::DisplayOutside;
-use taffy::Rect;
-use thin_vec::ThinVec;
 
 pub(crate) const CONSTRUCT_BOX: RestyleDamage =
     RestyleDamage::from_bits_retain(0b_0000_0000_0001_0000);
@@ -292,93 +286,6 @@ pub(crate) fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) 
     }
 }
 
-/// A child with a z_index that is hoisted up to it's containing Stacking Context for paint purposes
-#[derive(Debug, Clone)]
-pub struct HoistedPaintChild {
-    pub node_id: NodeId,
-    pub z_index: i32,
-    pub position: taffy::Point<f32>,
-}
-
-#[derive(Debug)]
-pub struct HoistedPaintChildren {
-    pub children: Vec<HoistedPaintChild>,
-    /// The number of hoisted point children with negative z_index
-    pub negative_z_count: u32,
-
-    pub content_area: taffy::Rect<f32>,
-}
-
-impl HoistedPaintChildren {
-    fn new() -> Self {
-        Self {
-            children: Vec::new(),
-            negative_z_count: 0,
-            content_area: taffy::Rect::ZERO,
-        }
-    }
-
-    pub fn reset(&mut self) {
-        self.children.clear();
-        self.negative_z_count = 0;
-    }
-
-    pub fn compute_content_size(&mut self, doc: &BaseDocument) {
-        fn child_pos(child: &HoistedPaintChild, doc: &BaseDocument) -> Rect<f32> {
-            let node = &doc.nodes[child.node_id];
-            let left = child.position.x + node.final_layout().location.x;
-            let top = child.position.y + node.final_layout().location.y;
-            let right = left + node.final_layout().size.width;
-            let bottom = top + node.final_layout().size.height;
-
-            taffy::Rect {
-                top,
-                left,
-                bottom,
-                right,
-            }
-        }
-
-        if self.children.is_empty() {
-            self.content_area = taffy::Rect::ZERO;
-        } else {
-            self.content_area = child_pos(&self.children[0], doc);
-            for child in self.children[1..].iter() {
-                let pos = child_pos(child, doc);
-                self.content_area.left = self.content_area.left.min(pos.left);
-                self.content_area.top = self.content_area.top.min(pos.top);
-                self.content_area.right = self.content_area.right.max(pos.right);
-                self.content_area.bottom = self.content_area.bottom.max(pos.bottom);
-            }
-        }
-    }
-
-    pub fn sort(&mut self) {
-        self.children.sort_by_key(|c| c.z_index);
-        self.negative_z_count = self.children.iter().take_while(|c| c.z_index < 0).count() as u32;
-    }
-
-    pub fn neg_z_range(&self) -> Range<usize> {
-        0..(self.negative_z_count as usize)
-    }
-
-    pub fn pos_z_range(&self) -> Range<usize> {
-        (self.negative_z_count as usize)..self.children.len()
-    }
-
-    pub fn neg_z_hoisted_children(
-        &self,
-    ) -> impl ExactSizeIterator<Item = &HoistedPaintChild> + DoubleEndedIterator {
-        self.children[self.neg_z_range()].iter()
-    }
-
-    pub fn pos_z_hoisted_children(
-        &self,
-    ) -> impl ExactSizeIterator<Item = &HoistedPaintChild> + DoubleEndedIterator {
-        self.children[self.pos_z_range()].iter()
-    }
-}
-
 impl BaseDocument {
     pub(crate) fn invalidate_inline_contexts(&mut self) {
         let scale = self.viewport.scale();
@@ -419,7 +326,7 @@ impl BaseDocument {
     }
 
     pub fn flush_styles_to_layout(&mut self, node_id: NodeId) {
-        self.flush_styles_to_layout_impl(node_id, None);
+        self.flush_styles_to_layout_impl(node_id);
     }
 
     /// Flush the image layers of nodes whose style changed during the last
@@ -531,15 +438,11 @@ impl BaseDocument {
         }
     }
 
-    /// Walk the whole tree, rebuilding paint children and hoisting z-indexed boxes
-    fn flush_styles_to_layout_impl(
-        &mut self,
-        node_id: NodeId,
-        parent_stacking_context: Option<&mut HoistedPaintChildren>,
-    ) {
-        let mut new_stacking_context: HoistedPaintChildren = HoistedPaintChildren::new();
-        let stacking_context = &mut new_stacking_context;
-
+    /// Walk the whole layout tree performing pre-layout preparation: clearing
+    /// layout caches (in non-incremental mode) and sorting flex/grid children
+    /// by `order`. Paint/stacking membership is derived *after* layout by
+    /// [`BaseDocument::resolve_stacking_contexts`].
+    fn flush_styles_to_layout_impl(&mut self, node_id: NodeId) {
         let incremental = self.incremental_layout;
         let display = {
             let node = self.nodes.get_mut(node_id).unwrap();
@@ -572,13 +475,7 @@ impl BaseDocument {
 
             // Recursively call flush_styles_to_layout on each child
             for &child in children.iter() {
-                self.flush_styles_to_layout_impl(
-                    child,
-                    match self.nodes[child].is_stacking_context_root(is_flex_or_grid) {
-                        true => None,
-                        false => Some(stacking_context),
-                    },
-                );
+                self.flush_styles_to_layout_impl(child);
             }
 
             // Sort layout_children
@@ -590,146 +487,8 @@ impl BaseDocument {
                 });
             }
 
-            // Reserve space for paint_children
-            let mut paint_children = self.nodes[node_id].paint_children.borrow_mut();
-            if paint_children.is_none() {
-                *paint_children = Some(ThinVec::new());
-            }
-            let paint_children = paint_children.as_mut().unwrap();
-            paint_children.clear();
-            paint_children.reserve(children.len());
-
-            // Push children to either paint_children or layout_children depending on
-            for &child_id in children.iter() {
-                let child = &self.nodes[child_id];
-
-                let Some(style) = child.primary_styles() else {
-                    paint_children.push(child_id);
-                    continue;
-                };
-
-                let position = style.clone_position();
-                let z_index = style.clone_z_index().integer_or(0);
-
-                // Out-of-flow boxes are hoisted to their containing block by Taffy's
-                // out-of-flow positioning pass and their layout location is relative to
-                // the containing block's border box. When this node is the child's
-                // containing block (it claims the child's position type), the child
-                // stays in this node's paint list, preserving tree order among
-                // positioned siblings. Otherwise it is painted (and hit-tested) via
-                // the containing block's `hoisted_children` list (see
-                // `attach_hoisted_children`), not via its DOM parent.
-                if matches!(position, Position::Absolute | Position::Fixed) {
-                    let parent = &self.nodes[node_id];
-                    // The root element is the initial containing block: it claims
-                    // every candidate not claimed by a closer containing block.
-                    let is_root = self.try_root_element().is_some_and(|el| el.id == node_id);
-                    let parent_claims = is_root
-                        || match position {
-                            Position::Fixed => parent.establishes_fixed_containing_block(),
-                            _ => {
-                                parent
-                                    .primary_styles()
-                                    .is_some_and(|s| s.clone_position() != Position::Static)
-                                    || parent.establishes_fixed_containing_block()
-                                    || parent.establishes_absolute_containing_block()
-                            }
-                        };
-                    if !parent_claims {
-                        continue;
-                    }
-                    // Z-indexed out-of-flow boxes are routed to their stacking
-                    // context by `attach_hoisted_children` after layout, when
-                    // their containing-block-relative location is known.
-                    if z_index != 0 {
-                        continue;
-                    }
-                }
-
-                // TODO: more complete hoisting detection
-                // z-index applies to static flex/grid items too
-                // (css-flexbox-1 §painting, css-grid-1 §z-order).
-                if z_index != 0 && (position != Position::Static || is_flex_or_grid) {
-                    stacking_context.children.push(HoistedPaintChild {
-                        node_id: child_id,
-                        z_index,
-                        position: taffy::Point::ZERO,
-                    })
-                } else {
-                    paint_children.push(child_id);
-                }
-            }
-
-            // Sort paint_children
-            paint_children.sort_by(|left, right| {
-                let left_node = self.nodes.get(*left).unwrap();
-                let right_node = self.nodes.get(*right).unwrap();
-                node_to_paint_order(left_node, is_flex_or_grid)
-                    .cmp(&node_to_paint_order(right_node, is_flex_or_grid))
-            });
-
             // Put children back
             *self.nodes[node_id].layout_children.borrow_mut() = Some(children);
         }
-
-        if let Some(parent_stacking_context) = parent_stacking_context {
-            let position = self.nodes[node_id].final_layout().location;
-            let scroll_offset = *self.nodes[node_id].scroll_offset();
-            for hoisted in stacking_context.children.iter_mut() {
-                hoisted.position.x += position.x - scroll_offset.x as f32;
-                hoisted.position.y += position.y - scroll_offset.y as f32;
-            }
-            parent_stacking_context
-                .children
-                .extend(stacking_context.children.iter().cloned());
-        } else {
-            stacking_context.sort();
-            stacking_context.compute_content_size(self);
-            self.nodes[node_id].stacking_context = Some(Box::new(new_stacking_context));
-        }
-    }
-}
-
-#[inline(always)]
-fn position_to_order(pos: Position) -> i32 {
-    match pos {
-        Position::Static => 0,
-        // All positioned descendants with z-index: auto share one paint
-        // level (CSS 2.1 Appendix E step 8); the stable sort keeps them in
-        // tree order among themselves, above in-flow content and floats.
-        Position::Relative | Position::Sticky | Position::Absolute | Position::Fixed => 2,
-    }
-}
-#[inline(always)]
-fn float_to_order(pos: Float) -> i32 {
-    match pos {
-        Float::None => 0,
-        _ => 1,
-    }
-}
-
-/// Paint sort key: (paint level, order-modified position). Positioned
-/// (z-index: auto) descendants paint above in-flow content (CSS 2.1
-/// Appendix E step 8); within a level the stable sort preserves
-/// (order-modified) document order.
-#[inline(always)]
-pub(crate) fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> (i32, i32) {
-    let Some(style) = node.primary_styles() else {
-        return (0, 0);
-    };
-    let position = style.clone_position();
-    if is_flex_or_grid {
-        match position {
-            Position::Static => (0, style.clone_order()),
-            Position::Relative | Position::Sticky => (2, style.clone_order()),
-            // Out-of-flow children are not flex/grid items: `order` does
-            // not apply; tree order does.
-            Position::Absolute | Position::Fixed => (2, 0),
-        }
-    } else {
-        (
-            position_to_order(position) + float_to_order(style.clone_float()),
-            0,
-        )
     }
 }

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -713,7 +713,7 @@ fn float_to_order(pos: Float) -> i32 {
 /// Appendix E step 8); within a level the stable sort preserves
 /// (order-modified) document order.
 #[inline(always)]
-fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> (i32, i32) {
+pub(crate) fn node_to_paint_order(node: &Node, is_flex_or_grid: bool) -> (i32, i32) {
     let Some(style) = node.primary_styles() else {
         return (0, 0);
     };

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -613,11 +613,37 @@ impl BaseDocument {
 
                 // Out-of-flow boxes are hoisted to their containing block by Taffy's
                 // out-of-flow positioning pass and their layout location is relative to
-                // the containing block's border box. They are painted (and hit-tested)
-                // via the containing block's `hoisted_children` list (see
-                // `attach_hoisted_children`), not via their DOM parent.
+                // the containing block's border box. When this node is the child's
+                // containing block (it claims the child's position type), the child
+                // stays in this node's paint list, preserving tree order among
+                // positioned siblings. Otherwise it is painted (and hit-tested) via
+                // the containing block's `hoisted_children` list (see
+                // `attach_hoisted_children`), not via its DOM parent.
                 if matches!(position, Position::Absolute | Position::Fixed) {
-                    continue;
+                    let parent = &self.nodes[node_id];
+                    // The root element is the initial containing block: it claims
+                    // every candidate not claimed by a closer containing block.
+                    let is_root = self.try_root_element().is_some_and(|el| el.id == node_id);
+                    let parent_claims = is_root
+                        || match position {
+                            Position::Fixed => parent.establishes_fixed_containing_block(),
+                            _ => {
+                                parent
+                                    .primary_styles()
+                                    .is_some_and(|s| s.clone_position() != Position::Static)
+                                    || parent.establishes_fixed_containing_block()
+                                    || parent.establishes_absolute_containing_block()
+                            }
+                        };
+                    if !parent_claims {
+                        continue;
+                    }
+                    // Z-indexed out-of-flow boxes are routed to their stacking
+                    // context by `attach_hoisted_children` after layout, when
+                    // their containing-block-relative location is known.
+                    if z_index != 0 {
+                        continue;
+                    }
                 }
 
                 // TODO: more complete hoisting detection

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -611,6 +611,15 @@ impl BaseDocument {
                 let position = style.clone_position();
                 let z_index = style.clone_z_index().integer_or(0);
 
+                // Out-of-flow boxes are hoisted to their containing block by Taffy's
+                // out-of-flow positioning pass and their layout location is relative to
+                // the containing block's border box. They are painted (and hit-tested)
+                // via the containing block's `hoisted_children` list (see
+                // `attach_hoisted_children`), not via their DOM parent.
+                if matches!(position, Position::Absolute | Position::Fixed) {
+                    continue;
+                }
+
                 // TODO: more complete hoisting detection
                 // z-index applies to static flex/grid items too
                 // (css-flexbox-1 §painting, css-grid-1 §z-order).

--- a/packages/blitz-dom/src/layout/damage.rs
+++ b/packages/blitz-dom/src/layout/damage.rs
@@ -478,13 +478,19 @@ impl BaseDocument {
                 self.flush_styles_to_layout_impl(child);
             }
 
-            // Sort layout_children
+            // Sort layout_children. `order` only applies to flex/grid items;
+            // out-of-flow children are not items, so they sort as 0 (the sort
+            // is stable, so they keep document order among themselves).
             if is_flex_or_grid {
-                children.sort_by(|left, right| {
-                    let left_node = self.nodes.get(*left).unwrap();
-                    let right_node = self.nodes.get(*right).unwrap();
-                    left_node.order().cmp(&right_node.order())
-                });
+                let effective_order = |node_id: NodeId| {
+                    let node = self.nodes.get(node_id).unwrap();
+                    if node.taffy_position().is_out_of_flow() {
+                        0
+                    } else {
+                        node.order()
+                    }
+                };
+                children.sort_by_key(|&child_id| effective_order(child_id));
             }
 
             // Put children back

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -815,13 +815,18 @@ impl BaseDocument {
                         let size = output.size;
                         let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
 
-                        let inset_offset = taffy::Point {
-                            x: if container_direction == Direction::Rtl {
-                                inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)
-                            } else {
-                                inset.left.or(inset.right.map(|x| -x)).unwrap_or(0.0)
-                            },
-                            y: inset.top.or(inset.bottom.map(|x| -x)).unwrap_or(0.0),
+                        let is_relative = position == taffy::Position::Relative;
+                        let inset_offset = if is_relative {
+                            taffy::Point {
+                                x: if container_direction == Direction::Rtl {
+                                    inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)
+                                } else {
+                                    inset.left.or(inset.right.map(|x| -x)).unwrap_or(0.0)
+                                },
+                                y: inset.top.or(inset.bottom.map(|x| -x)).unwrap_or(0.0),
+                            }
+                        } else {
+                            taffy::Point::ZERO
                         };
 
                         let layout = node.unrounded_layout_mut();

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -275,6 +275,14 @@ impl BaseDocument {
                 }),
         };
 
+        let perform_layout = inputs.run_mode == taffy::RunMode::PerformLayout;
+
+        // Measure passes must not leave measure-time state (inline box sizes, line breaks)
+        // in the persistent inline layout: painting uses that state, and a cache hit on a
+        // later full layout pass would not recompute it. Snapshot it here and restore it
+        // before returning.
+        let saved_layout = (!perform_layout).then(|| inline_layout.layout.clone());
+
         // Compute size of inline boxes
         let child_inputs = taffy::tree::LayoutInput {
             known_dimensions: Size::NONE,
@@ -474,7 +482,10 @@ impl BaseDocument {
         if inputs.run_mode == taffy::RunMode::ComputeSize
             && inputs.axis == RequestedAxis::Horizontal
         {
-            // Put layout back
+            // Restore the pre-measure inline layout state and put the layout back
+            if let Some(saved) = saved_layout {
+                inline_layout.layout = saved;
+            }
             self.nodes[node_id]
                 .data
                 .downcast_element_mut()
@@ -600,15 +611,20 @@ impl BaseDocument {
                         state.set_line_x(next_slot.x * scale);
                         state.set_line_y((next_slot.y * scale) as f64);
 
-                        let layout = self.nodes[node_id].unrounded_layout_mut();
-                        layout.size = output.size;
-                        layout.location.x = pos.x + margin.left + container_pb.left;
-                        layout.location.y = pos.y + margin.top + container_pb.top;
+                        let location = taffy::Point {
+                            x: pos.x + margin.left + container_pb.left,
+                            y: pos.y + margin.top + container_pb.top,
+                        };
+                        if perform_layout {
+                            let layout = self.nodes[node_id].unrounded_layout_mut();
+                            layout.size = output.size;
+                            layout.location = location;
+                        }
 
                         // Translate anchors from item-relative to container-relative
                         // coordinates and collect candidates bubbled from the float's subtree
                         if !output.oof_candidates.is_empty() {
-                            output.oof_candidates.translate(layout.location);
+                            output.oof_candidates.translate(location);
                             oof_candidates.append(&mut output.oof_candidates);
                         }
 
@@ -715,140 +731,147 @@ impl BaseDocument {
 
         // Store sizes and positions of inline boxes
         let mut ibox_order: u32 = 0;
-        for line in inline_layout.layout.lines() {
-            for item in line.items() {
-                if let parley::layout::PositionedLayoutItem::InlineBox(ibox) = item {
-                    let order = ibox_order;
-                    ibox_order += 1;
-                    let node = &self.nodes[NodeId::from_u64(ibox.id)];
-                    let style = node.layout_style();
-                    let padding = style
-                        .padding()
-                        .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
-                    let border = style
-                        .border()
-                        .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
-                    let margin = style
-                        .margin()
-                        .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
+        if perform_layout {
+            for line in inline_layout.layout.lines() {
+                for item in line.items() {
+                    if let parley::layout::PositionedLayoutItem::InlineBox(ibox) = item {
+                        let order = ibox_order;
+                        ibox_order += 1;
+                        let node = &self.nodes[NodeId::from_u64(ibox.id)];
+                        let style = node.layout_style();
+                        let padding = style
+                            .padding()
+                            .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
+                        let border = style
+                            .border()
+                            .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
+                        let margin = style
+                            .margin()
+                            .resolve_or_zero(child_inputs.parent_size, resolve_calc_value);
 
-                    #[cfg(feature = "floats")]
-                    let is_floated = style.float() != Float::None;
-                    #[cfg(not(feature = "floats"))]
-                    let is_floated = false;
+                        #[cfg(feature = "floats")]
+                        let is_floated = style.float() != Float::None;
+                        #[cfg(not(feature = "floats"))]
+                        let is_floated = false;
 
-                    let position = style.position();
-                    let is_absolute = position.is_out_of_flow();
+                        let position = style.position();
+                        let is_absolute = position.is_out_of_flow();
 
-                    // The static position of an absolutely positioned box depends on the
-                    // display its hypothetical box would have had (the display specified
-                    // before position:absolute blockified it): inline-level boxes sit at
-                    // their position within the line, while block-level boxes start at the
-                    // content-box left edge of their containing block.
-                    let is_inline_level =
-                        style.style.get_box().original_display.outside() == DisplayOutside::Inline;
+                        // The static position of an absolutely positioned box depends on the
+                        // display its hypothetical box would have had (the display specified
+                        // before position:absolute blockified it): inline-level boxes sit at
+                        // their position within the line, while block-level boxes start at the
+                        // content-box left edge of their containing block.
+                        let is_inline_level = style.style.get_box().original_display.outside()
+                            == DisplayOutside::Inline;
 
-                    // Resolve relative inset offsets against the containing block
-                    // (the content box of the inline container).
-                    let container_content_size = final_size - content_box_inset.sum_axes();
-                    let inset_style = style.inset();
-                    let inset = taffy::Rect {
-                        left: inset_style
-                            .left
-                            .maybe_resolve(container_content_size.width, resolve_calc_value),
-                        right: inset_style
-                            .right
-                            .maybe_resolve(container_content_size.width, resolve_calc_value),
-                        top: inset_style
-                            .top
-                            .maybe_resolve(container_content_size.height, resolve_calc_value),
-                        bottom: inset_style
-                            .bottom
-                            .maybe_resolve(container_content_size.height, resolve_calc_value),
-                    };
-                    drop(style);
-
-                    if is_absolute {
-                        // Inline-level boxes are placed at the top of the line box they would
-                        // have occupied (`ibox.y` is the baseline as out-of-flow boxes are
-                        // zero-sized), and block-level boxes below it.
-                        let line_metrics = line.metrics();
-                        let static_position = taffy::Point {
-                            x: if is_inline_level {
-                                (ibox.x / scale) + container_pb.left
-                            } else {
-                                container_pb.left
-                            },
-                            y: if is_inline_level {
-                                (line_metrics.block_min_coord / scale) + container_pb.top
-                            } else {
-                                (line_metrics.block_max_coord / scale) + container_pb.top
-                            },
+                        // Resolve relative inset offsets against the containing block
+                        // (the content box of the inline container).
+                        let container_content_size = final_size - content_box_inset.sum_axes();
+                        let inset_style = style.inset();
+                        let inset = taffy::Rect {
+                            left: inset_style
+                                .left
+                                .maybe_resolve(container_content_size.width, resolve_calc_value),
+                            right: inset_style
+                                .right
+                                .maybe_resolve(container_content_size.width, resolve_calc_value),
+                            top: inset_style
+                                .top
+                                .maybe_resolve(container_content_size.height, resolve_calc_value),
+                            bottom: inset_style
+                                .bottom
+                                .maybe_resolve(container_content_size.height, resolve_calc_value),
                         };
+                        drop(style);
 
-                        oof_candidates.push(OofCandidate {
-                            node: taffy::NodeId::from(ibox.id),
-                            order,
-                            position,
-                            static_position: taffy::Point {
-                                x: StaticPosition::from_edge(
-                                    static_position.x,
-                                    if container_direction == Direction::Rtl && is_inline_level {
-                                        StaticEdge::End
-                                    } else {
-                                        StaticEdge::Start
-                                    },
-                                ),
-                                y: StaticPosition::from_edge(static_position.y, StaticEdge::Start),
-                            },
-                        });
-                    } else if is_floated {
-                        let layout = self.nodes[NodeId::from_u64(ibox.id)].unrounded_layout_mut();
-                        layout.padding = padding; //.map(|p| p / scale);
-                        layout.border = border; //.map(|p| p / scale);
-                    } else {
-                        // Re-measure the box to get its border-box size (this hits the layout
-                        // cache). The size cannot be recovered from `ibox` dimensions as the
-                        // space reserved in the line is clamped to be non-negative.
-                        let mut output =
-                            self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
-                        let size = output.size;
-                        let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
-
-                        let is_relative = position == taffy::Position::Relative;
-                        let inset_offset = if is_relative {
-                            taffy::Point {
-                                x: if container_direction == Direction::Rtl {
-                                    inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)
+                        if is_absolute {
+                            // Inline-level boxes are placed at the top of the line box they would
+                            // have occupied (`ibox.y` is the baseline as out-of-flow boxes are
+                            // zero-sized), and block-level boxes below it.
+                            let line_metrics = line.metrics();
+                            let static_position = taffy::Point {
+                                x: if is_inline_level {
+                                    (ibox.x / scale) + container_pb.left
                                 } else {
-                                    inset.left.or(inset.right.map(|x| -x)).unwrap_or(0.0)
+                                    container_pb.left
                                 },
-                                y: inset.top.or(inset.bottom.map(|x| -x)).unwrap_or(0.0),
-                            }
+                                y: if is_inline_level {
+                                    (line_metrics.block_min_coord / scale) + container_pb.top
+                                } else {
+                                    (line_metrics.block_max_coord / scale) + container_pb.top
+                                },
+                            };
+
+                            oof_candidates.push(OofCandidate {
+                                node: taffy::NodeId::from(ibox.id),
+                                order,
+                                position,
+                                static_position: taffy::Point {
+                                    x: StaticPosition::from_edge(
+                                        static_position.x,
+                                        if container_direction == Direction::Rtl && is_inline_level
+                                        {
+                                            StaticEdge::End
+                                        } else {
+                                            StaticEdge::Start
+                                        },
+                                    ),
+                                    y: StaticPosition::from_edge(
+                                        static_position.y,
+                                        StaticEdge::Start,
+                                    ),
+                                },
+                            });
+                        } else if is_floated {
+                            let layout =
+                                self.nodes[NodeId::from_u64(ibox.id)].unrounded_layout_mut();
+                            layout.padding = padding; //.map(|p| p / scale);
+                            layout.border = border; //.map(|p| p / scale);
                         } else {
-                            taffy::Point::ZERO
-                        };
+                            // Re-measure the box to get its border-box size (this hits the layout
+                            // cache). The size cannot be recovered from `ibox` dimensions as the
+                            // space reserved in the line is clamped to be non-negative.
+                            let mut output = self
+                                .compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
+                            let size = output.size;
+                            let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
 
-                        let layout = node.unrounded_layout_mut();
-                        layout.size = size;
-                        layout.location.x =
-                            (ibox.x / scale) + margin.left + container_pb.left + inset_offset.x;
-                        // A negative `margin-top` shrinks the space the box reserves in the
-                        // line but does not move the box itself, which stays anchored to the
-                        // bottom of the reserved space.
-                        layout.location.y = (ibox.y / scale)
-                            + margin.top.max(0.0)
-                            + container_pb.top
-                            + inset_offset.y;
-                        layout.padding = padding; //.map(|p| p / scale);
-                        layout.border = border; //.map(|p| p / scale);
+                            let is_relative = position == taffy::Position::Relative;
+                            let inset_offset = if is_relative {
+                                taffy::Point {
+                                    x: if container_direction == Direction::Rtl {
+                                        inset.right.map(|x| -x).or(inset.left).unwrap_or(0.0)
+                                    } else {
+                                        inset.left.or(inset.right.map(|x| -x)).unwrap_or(0.0)
+                                    },
+                                    y: inset.top.or(inset.bottom.map(|x| -x)).unwrap_or(0.0),
+                                }
+                            } else {
+                                taffy::Point::ZERO
+                            };
 
-                        // Translate anchors from item-relative to container-relative
-                        // coordinates and collect candidates bubbled from the box's subtree
-                        if !output.oof_candidates.is_empty() {
-                            let location = layout.location;
-                            output.oof_candidates.translate(location);
-                            oof_candidates.append(&mut output.oof_candidates);
+                            let layout = node.unrounded_layout_mut();
+                            layout.size = size;
+                            layout.location.x =
+                                (ibox.x / scale) + margin.left + container_pb.left + inset_offset.x;
+                            // A negative `margin-top` shrinks the space the box reserves in the
+                            // line but does not move the box itself, which stays anchored to the
+                            // bottom of the reserved space.
+                            layout.location.y = (ibox.y / scale)
+                                + margin.top.max(0.0)
+                                + container_pb.top
+                                + inset_offset.y;
+                            layout.padding = padding; //.map(|p| p / scale);
+                            layout.border = border; //.map(|p| p / scale);
+
+                            // Translate anchors from item-relative to container-relative
+                            // coordinates and collect candidates bubbled from the box's subtree
+                            if !output.oof_candidates.is_empty() {
+                                let location = layout.location;
+                                output.oof_candidates.translate(location);
+                                oof_candidates.append(&mut output.oof_candidates);
+                            }
                         }
                     }
                 }
@@ -867,7 +890,10 @@ impl BaseDocument {
             .next()
             .map(|line| (line.metrics().baseline / scale) + container_pb.top);
 
-        // Put layout back
+        // Restore the pre-measure inline layout state and put the layout back
+        if let Some(saved) = saved_layout {
+            inline_layout.layout = saved;
+        }
         self.nodes[node_id]
             .data
             .downcast_element_mut()

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -5,8 +5,8 @@ use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent}
 use taffy::{
     AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
     CoreStyle as _, Direction, LayoutInput, LayoutOutput, LayoutPartialTree as _, MaybeMath as _,
-    MaybeResolve as _, Overflow, Point, Position, RequestedAxis, ResolveOrZero as _, RunMode, Size,
-    SizingMode,
+    MaybeResolve as _, OofCandidate, OofCandidates, OofPositioningArea, Overflow, Point,
+    RequestedAxis, ResolveOrZero as _, RunMode, Size, SizingMode, StaticEdge, StaticPosition,
 };
 
 #[cfg(feature = "floats")]
@@ -189,7 +189,7 @@ impl BaseDocument {
         let has_styles_preventing_being_collapsed_through = !style.is_block()
             || style.overflow().x.is_scroll_container()
             || style.overflow().y.is_scroll_container()
-            || style.position() == Position::Absolute
+            || style.position().is_out_of_flow()
             || padding.top > 0.0
             || padding.bottom > 0.0
             || border.top > 0.0
@@ -304,10 +304,10 @@ impl BaseDocument {
             #[cfg(not(feature = "floats"))]
             let is_floated = false;
 
-            let is_absolute = style.position() == Position::Absolute;
+            let is_out_of_flow = style.position().is_out_of_flow();
             drop(style);
 
-            if is_absolute || is_floated {
+            if is_out_of_flow || is_floated {
                 ibox.width = 0.0;
                 ibox.height = 0.0;
             } else {
@@ -502,6 +502,10 @@ impl BaseDocument {
             inline_layout.layout.break_all_lines(Some(width));
         }
 
+        // Out-of-flow candidates bubbled up from this container and its in-flow subtree.
+        // These are laid out by the out-of-flow positioning pass (`compute_oof_layout`).
+        let mut oof_candidates = OofCandidates::new();
+
         // Perform inline layout
         #[cfg(feature = "floats")]
         {
@@ -572,7 +576,7 @@ impl BaseDocument {
 
                         let margin_sum = margin.sum_axes();
 
-                        let output = self.compute_child_layout(
+                        let mut output = self.compute_child_layout(
                             crate::taffy_node_id(node_id),
                             float_child_inputs,
                         );
@@ -600,6 +604,13 @@ impl BaseDocument {
                         layout.size = output.size;
                         layout.location.x = pos.x + margin.left + container_pb.left;
                         layout.location.y = pos.y + margin.top + container_pb.top;
+
+                        // Translate anchors from item-relative to container-relative
+                        // coordinates and collect candidates bubbled from the float's subtree
+                        if !output.oof_candidates.is_empty() {
+                            output.oof_candidates.translate(layout.location);
+                            oof_candidates.append(&mut output.oof_candidates);
+                        }
 
                         // dbg!(&layout.size);
                         // dbg!(&layout.location);
@@ -703,9 +714,12 @@ impl BaseDocument {
         let container_direction = self.nodes[node_id].layout_style().direction();
 
         // Store sizes and positions of inline boxes
+        let mut ibox_order: u32 = 0;
         for line in inline_layout.layout.lines() {
             for item in line.items() {
                 if let parley::layout::PositionedLayoutItem::InlineBox(ibox) = item {
+                    let order = ibox_order;
+                    ibox_order += 1;
                     let node = &self.nodes[NodeId::from_u64(ibox.id)];
                     let style = node.layout_style();
                     let padding = style
@@ -723,8 +737,8 @@ impl BaseDocument {
                     #[cfg(not(feature = "floats"))]
                     let is_floated = false;
 
-                    let is_absolute = style.position() == Position::Absolute;
-                    let direction = style.direction();
+                    let position = style.position();
+                    let is_absolute = position.is_out_of_flow();
 
                     // The static position of an absolutely positioned box depends on the
                     // display its hypothetical box would have had (the display specified
@@ -772,15 +786,22 @@ impl BaseDocument {
                             },
                         };
 
-                        layout_abspos_child(
-                            self,
-                            ibox.id,
-                            static_position,
-                            is_inline_level,
-                            final_size,
-                            taffy::Point::ZERO,
-                            direction,
-                        );
+                        oof_candidates.push(OofCandidate {
+                            node: taffy::NodeId::from(ibox.id),
+                            order,
+                            position,
+                            static_position: taffy::Point {
+                                x: StaticPosition::from_edge(
+                                    static_position.x,
+                                    if container_direction == Direction::Rtl && is_inline_level {
+                                        StaticEdge::End
+                                    } else {
+                                        StaticEdge::Start
+                                    },
+                                ),
+                                y: StaticPosition::from_edge(static_position.y, StaticEdge::Start),
+                            },
+                        });
                     } else if is_floated {
                         let layout = self.nodes[NodeId::from_u64(ibox.id)].unrounded_layout_mut();
                         layout.padding = padding; //.map(|p| p / scale);
@@ -789,9 +810,9 @@ impl BaseDocument {
                         // Re-measure the box to get its border-box size (this hits the layout
                         // cache). The size cannot be recovered from `ibox` dimensions as the
                         // space reserved in the line is clamped to be non-negative.
-                        let size = self
-                            .compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs)
-                            .size;
+                        let mut output =
+                            self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
+                        let size = output.size;
                         let node = &mut self.nodes[NodeId::from_u64(ibox.id)];
 
                         let inset_offset = taffy::Point {
@@ -816,6 +837,14 @@ impl BaseDocument {
                             + inset_offset.y;
                         layout.padding = padding; //.map(|p| p / scale);
                         layout.border = border; //.map(|p| p / scale);
+
+                        // Translate anchors from item-relative to container-relative
+                        // coordinates and collect candidates bubbled from the box's subtree
+                        if !output.oof_candidates.is_empty() {
+                            let location = layout.location;
+                            output.oof_candidates.translate(location);
+                            oof_candidates.append(&mut output.oof_candidates);
+                        }
                     }
                 }
             }
@@ -840,6 +869,13 @@ impl BaseDocument {
             .unwrap()
             .inline_layout_data = Some(inline_layout);
 
+        let oof_position_inset = taffy::Rect {
+            left: border.left,
+            right: border.right + scrollbar_gutter.x,
+            top: border.top,
+            bottom: border.bottom + scrollbar_gutter.y,
+        };
+
         LayoutOutput {
             size: final_size,
             scrollable_overflow_rect: {
@@ -860,6 +896,14 @@ impl BaseDocument {
             margins_can_collapse_through: !has_styles_preventing_being_collapsed_through
                 && final_size.height == 0.0
                 && measured_size.height == 0.0,
+            oof_candidates,
+            oof_positioning_area: Some(OofPositioningArea {
+                size: final_size - oof_position_inset.sum_axes(),
+                offset: Point {
+                    x: oof_position_inset.left,
+                    y: oof_position_inset.top,
+                },
+            }),
         }
     }
 }
@@ -867,323 +911,4 @@ impl BaseDocument {
 #[inline(always)]
 fn f32_max(a: f32, b: f32) -> f32 {
     a.max(b)
-}
-
-/// Perform absolute layout on all absolutely positioned children.
-#[inline]
-fn layout_abspos_child(
-    tree: &mut impl taffy::LayoutBlockContainer,
-    item_id: u64,
-    static_position: Point<f32>,
-    is_inline_level: bool,
-    area_size: Size<f32>,
-    area_offset: Point<f32>,
-    direction: taffy::Direction,
-) {
-    let area_width = area_size.width;
-    let area_height = area_size.height;
-
-    let node_id = taffy::NodeId::from(item_id);
-    let child_style = tree.get_block_child_style(node_id);
-
-    // Skip items that are display:none or are not position:absolute
-    if child_style.box_generation_mode() == taffy::BoxGenerationMode::None
-        || child_style.position() != taffy::Position::Absolute
-    {
-        return;
-    }
-
-    let aspect_ratio = child_style.aspect_ratio();
-    let overflow = child_style.overflow();
-    let scrollbar_width = child_style.scrollbar_width();
-    let margin = child_style
-        .margin()
-        .map(|margin| margin.resolve_to_option(area_width, resolve_calc_value));
-    let padding = child_style
-        .padding()
-        .resolve_or_zero(Some(area_width), resolve_calc_value);
-    let border = child_style
-        .border()
-        .resolve_or_zero(Some(area_width), resolve_calc_value);
-    let padding_border_sum = (padding + border).sum_axes();
-    let box_sizing_adjustment = if child_style.box_sizing() == taffy::BoxSizing::ContentBox {
-        padding_border_sum
-    } else {
-        Size::ZERO
-    };
-
-    // Resolve inset
-    let left = child_style
-        .inset()
-        .left
-        .maybe_resolve(area_width, resolve_calc_value);
-    let right = child_style
-        .inset()
-        .right
-        .maybe_resolve(area_width, resolve_calc_value);
-    let top = child_style
-        .inset()
-        .top
-        .maybe_resolve(area_height, resolve_calc_value);
-    let bottom = child_style
-        .inset()
-        .bottom
-        .maybe_resolve(area_height, resolve_calc_value);
-
-    // Compute known dimensions from min/max/inherent size styles
-    let style_size = child_style
-        .size()
-        .maybe_resolve(area_size, resolve_calc_value)
-        .maybe_apply_aspect_ratio(aspect_ratio)
-        .maybe_add(box_sizing_adjustment);
-    let min_size = child_style
-        .min_size()
-        .maybe_resolve(area_size, resolve_calc_value)
-        .maybe_apply_aspect_ratio(aspect_ratio)
-        .maybe_add(box_sizing_adjustment)
-        .or(padding_border_sum.map(Some))
-        .maybe_max(padding_border_sum);
-    let max_size = child_style
-        .max_size()
-        .maybe_resolve(area_size, resolve_calc_value)
-        .maybe_apply_aspect_ratio(aspect_ratio)
-        .maybe_add(box_sizing_adjustment);
-    let mut known_dimensions = style_size.maybe_clamp(min_size, max_size);
-
-    drop(child_style);
-
-    // Fill in width from left/right and reapply aspect ratio if:
-    //   - Width is not already known
-    //   - Item has both left and right inset properties set
-    if let (None, Some(left), Some(right)) = (known_dimensions.width, left, right) {
-        let new_width_raw =
-            area_width.maybe_sub(margin.left).maybe_sub(margin.right) - left - right;
-        known_dimensions.width = Some(f32_max(new_width_raw, 0.0));
-        known_dimensions = known_dimensions
-            .maybe_apply_aspect_ratio(aspect_ratio)
-            .maybe_clamp(min_size, max_size);
-    }
-
-    // Fill in height from top/bottom and reapply aspect ratio if:
-    //   - Height is not already known
-    //   - Item has both top and bottom inset properties set
-    if let (None, Some(top), Some(bottom)) = (known_dimensions.height, top, bottom) {
-        let new_height_raw =
-            area_height.maybe_sub(margin.top).maybe_sub(margin.bottom) - top - bottom;
-        known_dimensions.height = Some(f32_max(new_height_raw, 0.0));
-        known_dimensions = known_dimensions
-            .maybe_apply_aspect_ratio(aspect_ratio)
-            .maybe_clamp(min_size, max_size);
-    }
-
-    let measured_size = tree
-        .compute_child_layout(
-            node_id,
-            taffy::LayoutInput {
-                known_dimensions,
-                known_dimensions_are_definite: taffy::Size {
-                    width: true,
-                    height: true,
-                },
-                parent_size: area_size.map(Some),
-                available_space: Size {
-                    width: AvailableSpace::Definite(
-                        area_width.maybe_clamp(min_size.width, max_size.width),
-                    ),
-                    height: AvailableSpace::Definite(
-                        area_height.maybe_clamp(min_size.height, max_size.height),
-                    ),
-                },
-                sizing_mode: SizingMode::ContentSize,
-                run_mode: RunMode::ComputeSize,
-                axis: taffy::RequestedAxis::Both,
-                vertical_margins_are_collapsible: taffy::Line::FALSE,
-            },
-        )
-        .size;
-
-    let final_size = known_dimensions
-        .unwrap_or(measured_size)
-        .maybe_clamp(min_size, max_size);
-
-    let layout_output = tree.compute_child_layout(
-        node_id,
-        taffy::LayoutInput {
-            known_dimensions: final_size.map(Some),
-            known_dimensions_are_definite: taffy::Size {
-                width: true,
-                height: true,
-            },
-            parent_size: area_size.map(Some),
-            available_space: Size {
-                width: AvailableSpace::Definite(
-                    area_width.maybe_clamp(min_size.width, max_size.width),
-                ),
-                height: AvailableSpace::Definite(
-                    area_height.maybe_clamp(min_size.height, max_size.height),
-                ),
-            },
-            sizing_mode: SizingMode::ContentSize,
-            run_mode: RunMode::PerformLayout,
-            axis: taffy::RequestedAxis::Both,
-            vertical_margins_are_collapsible: taffy::Line::FALSE,
-        },
-    );
-
-    let non_auto_margin = taffy::Rect {
-        left: if left.is_some() {
-            margin.left.unwrap_or(0.0)
-        } else {
-            0.0
-        },
-        right: if right.is_some() {
-            margin.right.unwrap_or(0.0)
-        } else {
-            0.0
-        },
-        top: if top.is_some() {
-            margin.top.unwrap_or(0.0)
-        } else {
-            0.0
-        },
-        bottom: if bottom.is_some() {
-            margin.bottom.unwrap_or(0.0)
-        } else {
-            0.0
-        },
-    };
-
-    // Expand auto margins to fill available space
-    // https://www.w3.org/TR/CSS21/visudet.html#abs-non-replaced-width
-    let auto_margin = {
-        // Auto margins for absolutely positioned elements in block containers only resolve
-        // if inset is set. Otherwise they resolve to 0.
-        let absolute_auto_margin_space = Point {
-            x: right
-                .map(|right| area_size.width - right - left.unwrap_or(0.0))
-                .unwrap_or(final_size.width),
-            y: bottom
-                .map(|bottom| area_size.height - bottom - top.unwrap_or(0.0))
-                .unwrap_or(final_size.height),
-        };
-        let free_space = Size {
-            width: absolute_auto_margin_space.x
-                - final_size.width
-                - non_auto_margin.horizontal_axis_sum(),
-            height: absolute_auto_margin_space.y
-                - final_size.height
-                - non_auto_margin.vertical_axis_sum(),
-        };
-
-        let auto_margin_size = Size {
-            // If all three of 'left', 'width', and 'right' are 'auto': First set any 'auto' values for 'margin-left' and 'margin-right' to 0.
-            // Then, if the 'direction' property of the element establishing the static-position containing block is 'ltr' set 'left' to the
-            // static position and apply rule number three below; otherwise, set 'right' to the static position and apply rule number one below.
-            //
-            // If none of the three is 'auto': If both 'margin-left' and 'margin-right' are 'auto', solve the equation under the extra constraint
-            // that the two margins get equal values, unless this would make them negative, in which case when direction of the containing block is
-            // 'ltr' ('rtl'), set 'margin-left' ('margin-right') to zero and solve for 'margin-right' ('margin-left'). If one of 'margin-left' or
-            // 'margin-right' is 'auto', solve the equation for that value. If the values are over-constrained, ignore the value for 'left' (in case
-            // the 'direction' property of the containing block is 'rtl') or 'right' (in case 'direction' is 'ltr') and solve for that value.
-            width: {
-                let auto_margin_count = margin.left.is_none() as u8 + margin.right.is_none() as u8;
-                if auto_margin_count == 2
-                    && (style_size.width.is_none() || style_size.width.unwrap() >= free_space.width)
-                {
-                    0.0
-                } else if auto_margin_count > 0 {
-                    free_space.width / auto_margin_count as f32
-                } else {
-                    0.0
-                }
-            },
-            height: {
-                let auto_margin_count = margin.top.is_none() as u8 + margin.bottom.is_none() as u8;
-                if auto_margin_count == 2
-                    && (style_size.height.is_none()
-                        || style_size.height.unwrap() >= free_space.height)
-                {
-                    0.0
-                } else if auto_margin_count > 0 {
-                    free_space.height / auto_margin_count as f32
-                } else {
-                    0.0
-                }
-            },
-        };
-
-        taffy::Rect {
-            left: margin.left.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-            right: margin.right.map(|_| 0.0).unwrap_or(auto_margin_size.width),
-            top: margin.top.map(|_| 0.0).unwrap_or(auto_margin_size.height),
-            bottom: margin
-                .bottom
-                .map(|_| 0.0)
-                .unwrap_or(auto_margin_size.height),
-        }
-    };
-
-    let resolved_margin = taffy::Rect {
-        left: margin.left.unwrap_or(auto_margin.left),
-        right: margin.right.unwrap_or(auto_margin.right),
-        top: margin.top.unwrap_or(auto_margin.top),
-        bottom: margin.bottom.unwrap_or(auto_margin.bottom),
-    };
-
-    let x_offset = match (left, right) {
-        (Some(left), Some(right)) => {
-            if direction == Direction::Rtl {
-                area_size.width - final_size.width - right - resolved_margin.right
-            } else {
-                left + resolved_margin.left
-            }
-        }
-        (Some(left), None) => left + resolved_margin.left,
-        (None, Some(right)) => area_size.width - final_size.width - right - resolved_margin.right,
-        (None, None) => {
-            if direction == Direction::Rtl && is_inline_level {
-                static_position.x - final_size.width - resolved_margin.right - area_offset.x
-            } else {
-                static_position.x + resolved_margin.left - area_offset.x
-            }
-        }
-    };
-    let location = Point {
-        x: x_offset + area_offset.x,
-        y: top
-            .map(|top| top + resolved_margin.top)
-            .or(bottom.map(|bottom| {
-                area_size.height - final_size.height - bottom - resolved_margin.bottom
-            }))
-            .maybe_add(area_offset.y)
-            .unwrap_or(static_position.y + resolved_margin.top),
-    };
-    // Note: axis intentionally switched here as scrollbars take up space in the opposite axis
-    // to the axis in which scrolling is enabled.
-    let scrollbar_size = Size {
-        width: if overflow.y == Overflow::Scroll {
-            scrollbar_width
-        } else {
-            0.0
-        },
-        height: if overflow.x == Overflow::Scroll {
-            scrollbar_width
-        } else {
-            0.0
-        },
-    };
-
-    tree.set_unrounded_layout(
-        node_id,
-        &taffy::Layout {
-            order: 0, // TODO: order
-            size: final_size,
-            scrollable_overflow_rect: layout_output.scrollable_overflow_rect,
-            scrollbar_size,
-            location,
-            padding,
-            border,
-            margin: resolved_margin,
-        },
-    );
 }

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -484,7 +484,9 @@ impl LayoutContainingBlock for BaseDocument {
         let is_positioned = node.layout_style().position().is_positioned();
         let establishes_fixed_cb = node.establishes_fixed_containing_block();
         OofClaims {
-            absolute: is_positioned || establishes_fixed_cb,
+            absolute: is_positioned
+                || establishes_fixed_cb
+                || node.establishes_absolute_containing_block(),
             fixed: establishes_fixed_cb,
         }
     }

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod damage;
 pub(crate) mod inline;
 pub(crate) mod list;
 pub(crate) mod replaced;
+pub mod stacking;
 pub(crate) mod table;
 
 use self::replaced::{
@@ -454,12 +455,22 @@ impl LayoutContainingBlock for BaseDocument {
         let containing_block = dom_node_id(node_id);
         let node = self.node_from_id(node_id);
         let mut vec = node.hoisted_children.borrow_mut();
+        // Clear the inverse pointer of boxes which are no longer hoisted to
+        // this containing block (`layout_parent` is left untouched: it tracks
+        // structural ancestry, not containing-block geometry).
+        for &old_id in vec.iter() {
+            if self.nodes.contains_key(old_id)
+                && self.nodes[old_id].oof_containing_block.get() == Some(containing_block)
+            {
+                self.nodes[old_id].oof_containing_block.set(None);
+            }
+        }
         vec.clear();
         vec.extend(hoisted.iter().copied().map(dom_node_id));
         drop(vec);
         for &hoisted_id in hoisted {
             self.node_from_id(hoisted_id)
-                .layout_parent
+                .oof_containing_block
                 .set(Some(containing_block));
         }
     }
@@ -476,7 +487,7 @@ impl LayoutContainingBlock for BaseDocument {
         drop(vec);
         for &hoisted_id in hoisted {
             self.node_from_id(hoisted_id)
-                .layout_parent
+                .oof_containing_block
                 .set(Some(containing_block));
         }
     }

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -432,7 +432,9 @@ impl LayoutPartialTree for BaseDocument {
     ) -> taffy::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
             let mut output = tree.compute_child_layout_internal(node_id, inputs, None);
-            compute_oof_layout(tree, node_id, &mut output);
+            if inputs.run_mode == taffy::RunMode::PerformLayout {
+                compute_oof_layout(tree, node_id, &mut output);
+            }
             output
         })
     }
@@ -558,7 +560,9 @@ impl taffy::LayoutBlockContainer for BaseDocument {
     ) -> taffy::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
             let mut output = tree.compute_child_layout_internal(node_id, inputs, block_ctx);
-            compute_oof_layout(tree, node_id, &mut output);
+            if inputs.run_mode == taffy::RunMode::PerformLayout {
+                compute_oof_layout(tree, node_id, &mut output);
+            }
             output
         })
     }

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -14,9 +14,10 @@ use style::values::computed::CSSPixelLength;
 use style::values::computed::length_percentage::CalcLengthPercentage;
 use stylo_taffy::TaffyStyloStyle;
 use taffy::{
-    BlockContext, CoreStyle as _, FlexDirection, LayoutPartialTree, NodeId, ResolveOrZero,
-    RoundTree, TraversePartialTree, TraverseTree, compute_block_layout, compute_cached_layout,
-    compute_flexbox_layout, compute_grid_layout, compute_leaf_layout, prelude::*,
+    BlockContext, CoreStyle as _, DetailedLayoutInfo, FlexDirection, LayoutContainingBlock,
+    LayoutPartialTree, NodeId, OofClaims, ResolveOrZero, RoundTree, TraversePartialTree,
+    TraverseTree, compute_block_layout, compute_cached_layout, compute_flexbox_layout,
+    compute_grid_layout, compute_leaf_layout, compute_oof_layout, prelude::*,
 };
 
 pub(crate) mod construct;
@@ -430,8 +431,69 @@ impl LayoutPartialTree for BaseDocument {
         inputs: taffy::LayoutInput,
     ) -> taffy::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
-            tree.compute_child_layout_internal(node_id, inputs, None)
+            let mut output = tree.compute_child_layout_internal(node_id, inputs, None);
+            compute_oof_layout(tree, node_id, &mut output);
+            output
         })
+    }
+}
+
+impl LayoutContainingBlock for BaseDocument {
+    type OofItemStyle<'a>
+        = TaffyStyloStyle<ComputedStyleRef<'a>>
+    where
+        Self: 'a;
+
+    fn get_oof_item_style(&self, node_id: NodeId) -> Self::OofItemStyle<'_> {
+        self.node_from_id(node_id).layout_style()
+    }
+
+    fn set_hoisted_children(&mut self, node_id: NodeId, hoisted: &[NodeId]) {
+        let containing_block = dom_node_id(node_id);
+        let node = self.node_from_id(node_id);
+        let mut vec = node.hoisted_children.borrow_mut();
+        vec.clear();
+        vec.extend(hoisted.iter().copied().map(dom_node_id));
+        drop(vec);
+        for &hoisted_id in hoisted {
+            self.node_from_id(hoisted_id)
+                .layout_parent
+                .set(Some(containing_block));
+        }
+    }
+
+    fn add_hoisted_children(&mut self, node_id: NodeId, hoisted: &[NodeId]) {
+        let containing_block = dom_node_id(node_id);
+        let node = self.node_from_id(node_id);
+        let mut vec = node.hoisted_children.borrow_mut();
+        for id in hoisted.iter().copied().map(dom_node_id) {
+            if !vec.contains(&id) {
+                vec.push(id);
+            }
+        }
+        drop(vec);
+        for &hoisted_id in hoisted {
+            self.node_from_id(hoisted_id)
+                .layout_parent
+                .set(Some(containing_block));
+        }
+    }
+
+    fn oof_claims(&self, node_id: NodeId) -> OofClaims {
+        let node = self.node_from_id(node_id);
+        let is_positioned = node.layout_style().position().is_positioned();
+        let establishes_fixed_cb = node.establishes_fixed_containing_block();
+        OofClaims {
+            absolute: is_positioned || establishes_fixed_cb,
+            fixed: establishes_fixed_cb,
+        }
+    }
+
+    fn get_detailed_layout_info(&self, node_id: NodeId) -> &DetailedLayoutInfo<Atom> {
+        self.node_from_id(node_id)
+            .element_data()
+            .map(|element| &element.detailed_layout_info)
+            .unwrap_or(&DetailedLayoutInfo::None)
     }
 }
 
@@ -493,7 +555,9 @@ impl taffy::LayoutBlockContainer for BaseDocument {
         block_ctx: Option<&mut BlockContext<'_>>,
     ) -> taffy::LayoutOutput {
         compute_cached_layout(self, node_id, inputs, |tree, node_id, inputs| {
-            tree.compute_child_layout_internal(node_id, inputs, block_ctx)
+            let mut output = tree.compute_child_layout_internal(node_id, inputs, block_ctx);
+            compute_oof_layout(tree, node_id, &mut output);
+            output
         })
     }
 }
@@ -544,7 +608,7 @@ impl taffy::LayoutGridContainer for BaseDocument {
     ) {
         let node = self.node_from_id_mut(node_id);
         if let Some(element) = node.element_data_mut() {
-            element.detailed_grid_info = Some(Box::new(detailed_grid_info));
+            element.detailed_layout_info = DetailedLayoutInfo::Grid(Box::new(detailed_grid_info));
         }
     }
 }
@@ -556,6 +620,19 @@ impl RoundTree for BaseDocument {
 
     fn set_final_layout(&mut self, node_id: NodeId, layout: &Layout) {
         *self.node_from_id_mut(node_id).final_layout_mut() = *layout;
+    }
+
+    fn is_hoisted(&self, node_id: NodeId) -> bool {
+        let node = self.node_from_id(node_id);
+        node.taffy_position().is_out_of_flow() && node.taffy_display() != Display::None
+    }
+
+    fn hoisted_child_count(&self, node_id: NodeId) -> usize {
+        self.node_from_id(node_id).hoisted_children.borrow().len()
+    }
+
+    fn get_hoisted_child_id(&self, node_id: NodeId, index: usize) -> NodeId {
+        taffy_node_id(self.node_from_id(node_id).hoisted_children.borrow()[index])
     }
 }
 

--- a/packages/blitz-dom/src/layout/stacking.rs
+++ b/packages/blitz-dom/src/layout/stacking.rs
@@ -1,0 +1,174 @@
+//! Stacking-context membership resolution.
+//!
+//! After layout, a post-layout pass walks the structural (layout) tree and
+//! derives paint membership:
+//!
+//! - `paint_children` on each node retains only its in-flow (non-stacked)
+//!   children, sorted so floats paint above other in-flow content and
+//!   flex/grid `order` is honoured.
+//! - Every *stacked* box (positioned boxes, flex/grid items with a z-index,
+//!   and boxes which establish a real stacking context for any other reason)
+//!   is recorded as a [`StackingEntry`] in the entry list of the nearest
+//!   enclosing *real* stacking context.
+//!
+//! A positioned box with `z-index: auto` is a *stacking container*: it gets
+//! its own entry (painted in tree order among the zero/auto entries), but is
+//! not atomic — its own stacked descendants continue to collect into the same
+//! enclosing real stacking context. A real stacking context is atomic: it
+//! owns its stacked descendants in its own entry list.
+//!
+//! Entries carry no baked geometry. Paint and hit-testing resolve an entry's
+//! offset from its stacking-context root on demand by walking the geometry
+//! (containing-block) parent chain — see [`Node::stacked_entry_offset`].
+
+use blitz_traits::node_id::NodeId;
+use style::selector_parser::RestyleDamage;
+use style::values::specified::box_::DisplayInside;
+use thin_vec::ThinVec;
+
+use crate::BaseDocument;
+use crate::node::Node;
+
+/// A stacked box recorded in the entry list of its nearest enclosing real
+/// stacking context.
+#[derive(Debug, Clone, Copy)]
+pub struct StackingEntry {
+    pub node_id: NodeId,
+    /// The used z-index: the integer value when z-index applies to the box,
+    /// otherwise 0 (`z-index: auto` containers and non-positioned boxes that
+    /// establish a stacking context, e.g. via `opacity`).
+    pub z_index: i32,
+}
+
+/// The derived paint membership of a real stacking context: all stacked
+/// descendant boxes up to (but not into) descendant real stacking contexts,
+/// sorted by z-index (stable, so equal-z entries keep tree order).
+#[derive(Debug, Default)]
+pub struct StackingContext {
+    pub entries: Vec<StackingEntry>,
+    /// The number of entries with a negative z-index.
+    pub negative_z_count: usize,
+}
+
+impl StackingContext {
+    fn finish(mut entries: Vec<StackingEntry>) -> Self {
+        entries.sort_by_key(|e| e.z_index);
+        let negative_z_count = entries.iter().take_while(|e| e.z_index < 0).count();
+        Self {
+            entries,
+            negative_z_count,
+        }
+    }
+
+    /// Entries with a negative z-index, in paint order.
+    pub fn negative_entries(&self) -> &[StackingEntry] {
+        &self.entries[..self.negative_z_count]
+    }
+
+    /// Entries with a zero/auto or positive z-index, in paint order.
+    pub fn non_negative_entries(&self) -> &[StackingEntry] {
+        &self.entries[self.negative_z_count..]
+    }
+}
+
+/// The stacking-relevant damage bit (`REBUILD_STACKING_CONTEXT` without the
+/// `REPAINT` bit it contains).
+pub(crate) const STACKING_DAMAGE: RestyleDamage = RestyleDamage::from_bits_retain(0b_0010);
+
+impl BaseDocument {
+    /// Rebuild stacking-context membership and `paint_children` for the whole
+    /// tree. Runs post-layout; gated by stacking damage in the caller.
+    pub(crate) fn resolve_stacking_contexts(&mut self, root_node_id: NodeId) {
+        let mut entries = Vec::new();
+        self.collect_stacked_children(root_node_id, &mut entries);
+        self.nodes[root_node_id].stacking_context = Some(Box::new(StackingContext::finish(
+            std::mem::take(&mut entries),
+        )));
+    }
+
+    /// Classify the children of `node_id`, rebuilding its `paint_children`
+    /// (in-flow children only) and recording stacked children as entries of
+    /// the current enclosing real stacking context (`entries`).
+    fn collect_stacked_children(&mut self, node_id: NodeId, entries: &mut Vec<StackingEntry>) {
+        let Some(display) = self.nodes[node_id].display_style() else {
+            return;
+        };
+        let is_flex_or_grid = matches!(display.inside(), DisplayInside::Flex | DisplayInside::Grid);
+
+        let children = self.nodes[node_id].layout_children.borrow_mut().take();
+        let Some(children) = children else {
+            return;
+        };
+
+        // Rebuild paint_children: in-flow (non-stacked) children only, with
+        // floats painting above other in-flow content (CSS 2.1 Appendix E
+        // step 4 vs step 3) and flex/grid `order` honoured.
+        {
+            let mut paint_children = self.nodes[node_id].paint_children.borrow_mut();
+            let paint_children = paint_children.get_or_insert_with(ThinVec::new);
+            paint_children.clear();
+            for &child_id in children.iter() {
+                if !self.nodes[child_id].is_stacked(is_flex_or_grid) {
+                    paint_children.push(child_id);
+                }
+            }
+            paint_children.sort_by_key(|&child_id| {
+                in_flow_paint_order(&self.nodes[child_id], is_flex_or_grid)
+            });
+        }
+
+        for &child_id in children.iter() {
+            let child = &self.nodes[child_id];
+            if child.is_stacked(is_flex_or_grid) {
+                let is_context = child.is_stacking_context_root(is_flex_or_grid);
+                // z-index only applies to positioned boxes and flex/grid items;
+                // other stacking-context roots (e.g. opacity) stack at 0.
+                let z_index =
+                    if child.taffy_position() != taffy::Position::Static || is_flex_or_grid {
+                        child.z_index()
+                    } else {
+                        0
+                    };
+                entries.push(StackingEntry {
+                    node_id: child_id,
+                    z_index,
+                });
+                if is_context {
+                    // Atomic: the child owns its stacked descendants.
+                    let mut inner = Vec::new();
+                    self.collect_stacked_children(child_id, &mut inner);
+                    self.nodes[child_id].stacking_context =
+                        Some(Box::new(StackingContext::finish(inner)));
+                } else {
+                    // Stacking container: descendants keep collecting into the
+                    // current context.
+                    self.nodes[child_id].stacking_context = None;
+                    self.collect_stacked_children(child_id, entries);
+                }
+            } else {
+                self.nodes[child_id].stacking_context = None;
+                self.collect_stacked_children(child_id, entries);
+            }
+        }
+
+        // Put children back
+        *self.nodes[node_id].layout_children.borrow_mut() = Some(children);
+    }
+}
+
+/// Paint sort key for in-flow children: floats above other in-flow content
+/// (CSS 2.1 Appendix E step 4 vs step 3); within a level the stable sort
+/// preserves document order (order-modified document order for flex/grid
+/// items, where `float` does not apply).
+#[inline(always)]
+fn in_flow_paint_order(node: &Node, is_flex_or_grid: bool) -> (i32, i32) {
+    use style::values::computed::Float;
+    let Some(style) = node.primary_styles() else {
+        return (0, 0);
+    };
+    if is_flex_or_grid {
+        (0, style.clone_order())
+    } else {
+        ((style.clone_float() != Float::None) as i32, 0)
+    }
+}

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -105,9 +105,10 @@ pub struct ElementData {
     pub before: Option<NodeId>,
     pub after: Option<NodeId>,
 
-    /// Detailed grid track sizing information from the most recent layout
-    /// (grid containers only). Used by devtools grid inspection.
-    pub detailed_grid_info: Option<Box<taffy::DetailedGridInfo<Atom>>>,
+    /// Detailed layout information from the most recent layout (currently
+    /// grid track sizing information for grid containers only). Used by
+    /// devtools grid inspection and out-of-flow grid-area positioning.
+    pub detailed_layout_info: taffy::DetailedLayoutInfo<Atom>,
 
     // Taffy layout data:
     pub display_constructed_as: StyloDisplay,
@@ -314,7 +315,7 @@ impl Clone for ElementData {
             damaged_descendants: AtomicBool::new(true),
             before: None,
             after: None,
-            detailed_grid_info: None,
+            detailed_layout_info: taffy::DetailedLayoutInfo::None,
             display_constructed_as: StyloDisplay::Block,
             layout_data: None,
             transform: None,
@@ -421,7 +422,7 @@ impl ElementData {
             damaged_descendants: AtomicBool::new(true),
             before: None,
             after: None,
-            detailed_grid_info: None,
+            detailed_layout_info: taffy::DetailedLayoutInfo::None,
             display_constructed_as: StyloDisplay::Block,
             layout_data: None,
             transform: None,

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1467,6 +1467,22 @@ impl Node {
         Some((offset, clip))
     }
 
+    /// Whether a stacked entry of this node's stacking context escapes this
+    /// node's own overflow clip: true when the entry's geometry
+    /// (containing-block) chain does not pass through this node (e.g. a
+    /// fixed-position descendant of a scroll container whose containing block
+    /// is an ancestor of the scroll container).
+    pub fn stacked_entry_escapes_clip(&self, entry_id: NodeId) -> bool {
+        let mut cur = entry_id;
+        loop {
+            match self.with(cur).paint_geometry_parent() {
+                Some(p) if p == self.id => return false,
+                Some(p) => cur = p,
+                None => return true,
+            }
+        }
+    }
+
     /// Whether this box clips its overflowing content (scroll containers,
     /// `overflow: hidden/clip`, `contain: paint`).
     pub(crate) fn clips_overflow(&self) -> bool {

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1338,6 +1338,12 @@ impl Node {
             return true;
         }
 
+        // CSS animations create a stacking context (approximation: for any
+        // animated property, not only stacking-context-inducing ones).
+        if style.get_ui().specifies_animations() {
+            return true;
+        }
+
         false
     }
 
@@ -1599,8 +1605,8 @@ impl Node {
     ///    - The result of recursively calling child.hit() on the the child element that is
     ///      positioned at that position if there is one.
     ///
-    /// TODO: z-index
-    /// (If multiple children are positioned at the position then a random one will be recursed into)
+    /// Stacked boxes are tested in reverse paint order (highest z-index first),
+    /// so the topmost box at the position wins.
     pub fn hit(&self, x: f32, y: f32, scale: f64) -> Option<HitResult> {
         self.hit_inner(x, y, scale, &mut None, taffy::Point::ZERO)
     }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1351,7 +1351,7 @@ impl Node {
     /// TODO: z-index
     /// (If multiple children are positioned at the position then a random one will be recursed into)
     pub fn hit(&self, x: f32, y: f32, scale: f64) -> Option<HitResult> {
-        self.hit_inner(x, y, scale, &mut None)
+        self.hit_inner(x, y, scale, &mut None, taffy::Point::ZERO)
     }
 
     /// [`hit`](Self::hit), also resolving the innermost overlay scrollbar
@@ -1364,6 +1364,11 @@ impl Node {
         y: f32,
         scale: f64,
         scrollbar: &mut Option<crate::node::ScrollbarRef>,
+        // The viewport scroll offset, passed in by the document for the root
+        // element only (the root element scrolls the viewport, so its scroll
+        // offset is stored on the document): fixed-position children of the
+        // root must not move with it. Zero for all other nodes.
+        viewport_scroll: taffy::Point<f32>,
     ) -> Option<HitResult> {
         use style::computed_values::pointer_events::T as PointerEvents;
         use style::computed_values::visibility::T as Visibility;
@@ -1455,10 +1460,13 @@ impl Node {
                 for hoisted_child in hoisted.pos_z_hoisted_children().rev() {
                     let x = x - hoisted_child.position.x;
                     let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self
-                        .with(hoisted_child.node_id)
-                        .hit_inner(x, y, scale, scrollbar)
-                    {
+                    if let Some(hit) = self.with(hoisted_child.node_id).hit_inner(
+                        x,
+                        y,
+                        scale,
+                        scrollbar,
+                        taffy::Point::ZERO,
+                    ) {
                         return Some(hit);
                     }
                 }
@@ -1480,11 +1488,13 @@ impl Node {
                 }
                 // Fixed-position children do not scroll with their containing block
                 if child_position == taffy::Position::Fixed {
-                    child_x -= self.scroll_offset().x as f32;
-                    child_y -= self.scroll_offset().y as f32;
+                    child_x -= self.scroll_offset().x as f32 + viewport_scroll.x;
+                    child_y -= self.scroll_offset().y as f32 + viewport_scroll.y;
                 }
             }
-            if let Some(hit) = child.hit_inner(child_x, child_y, scale, scrollbar) {
+            if let Some(hit) =
+                child.hit_inner(child_x, child_y, scale, scrollbar, taffy::Point::ZERO)
+            {
                 return Some(hit);
             }
         }
@@ -1495,10 +1505,13 @@ impl Node {
                 for hoisted_child in hoisted.neg_z_hoisted_children().rev() {
                     let x = x - hoisted_child.position.x;
                     let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self
-                        .with(hoisted_child.node_id)
-                        .hit_inner(x, y, scale, scrollbar)
-                    {
+                    if let Some(hit) = self.with(hoisted_child.node_id).hit_inner(
+                        x,
+                        y,
+                        scale,
+                        scrollbar,
+                        taffy::Point::ZERO,
+                    ) {
                         return Some(hit);
                     }
                 }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1287,14 +1287,47 @@ impl Node {
             return true;
         }
 
+        if self.applies_atomic_paint_effect() {
+            return true;
+        }
+
         // TODO: mix-blend-mode
-        // TODO: filter
-        // TODO: clip-path
-        // TODO: mask
         // TODO: isolation
         // TODO: contain
 
         false
+    }
+
+    /// Whether this node's styles apply an atomic paint effect (opacity, filter,
+    /// clip-path, mask) to its subtree. Such effects apply to out-of-flow descendants
+    /// even when this node is not their containing block.
+    pub(crate) fn applies_atomic_paint_effect(&self) -> bool {
+        use style::values::computed::basic_shape::ClipPath;
+        use style::values::generics::image::GenericImage;
+
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+
+        if style.clone_opacity() != 1.0 {
+            return true;
+        }
+
+        let effects = style.get_effects();
+        if !effects.filter.0.is_empty() {
+            return true;
+        }
+
+        if !matches!(style.clone_clip_path(), ClipPath::None) {
+            return true;
+        }
+
+        style
+            .get_svg()
+            .mask_image
+            .0
+            .iter()
+            .any(|image| !matches!(image, GenericImage::None))
     }
 
     /// Whether this node's styles establish a containing block for

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1321,7 +1321,8 @@ impl Node {
         if box_style.will_change.bits.intersects(
             WillChangeBits::TRANSFORM
                 | WillChangeBits::PERSPECTIVE
-                | WillChangeBits::FIXPOS_CB_NON_SVG,
+                | WillChangeBits::FIXPOS_CB_NON_SVG
+                | WillChangeBits::CONTAIN,
         ) {
             return true;
         }
@@ -1340,6 +1341,25 @@ impl Node {
 
         let effects = style.get_effects();
         !effects.filter.0.is_empty() || !effects.backdrop_filter.0.is_empty()
+    }
+
+    /// Whether this node's styles establish a containing block for
+    /// `position: absolute` descendants even when the node is not positioned
+    /// (e.g. `will-change: position`).
+    ///
+    /// <https://drafts.csswg.org/css-will-change/#will-change>
+    pub(crate) fn establishes_absolute_containing_block(&self) -> bool {
+        use style::values::specified::box_::WillChangeBits;
+
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+
+        style
+            .get_box()
+            .will_change
+            .bits
+            .intersects(WillChangeBits::POSITION)
     }
 
     /// Takes an (x, y) position (relative to the *parent's* top-left corner) and returns:

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -98,6 +98,10 @@ pub struct Node {
     pub layout_parent: Cell<Option<NodeId>>,
     /// A separate child list that includes anonymous collections of inline elements
     pub layout_children: RefCell<Option<ThinVec<NodeId>>>,
+    /// Out-of-flow (absolutely/fixed positioned) boxes for which this node is the
+    /// containing block. Recorded by Taffy's out-of-flow positioning pass. The
+    /// `Layout.location` of these boxes is relative to this node's border box.
+    pub hoisted_children: RefCell<ThinVec<NodeId>>,
     /// Anonymous block boxes created for this node during layout construction.
     ///
     /// Anonymous blocks live only in the slab (they are not part of the DOM
@@ -385,6 +389,7 @@ impl Node {
             children: ThinVec::new(),
             layout_parent: Cell::new(None),
             layout_children: RefCell::new(None),
+            hoisted_children: RefCell::new(ThinVec::new()),
             anonymous_blocks: ThinVec::new(),
             paint_children: RefCell::new(None),
             stacking_context: None,
@@ -1207,6 +1212,14 @@ impl Node {
             .unwrap_or(taffy::Display::Block)
     }
 
+    /// The node's `position` as a [`taffy::Position`]. Returns [`taffy::Position::Static`]
+    /// for nodes without computed styles (e.g. text nodes).
+    pub fn taffy_position(&self) -> taffy::Position {
+        self.primary_styles()
+            .map(|s| stylo_taffy::convert::position(s.get_box().position))
+            .unwrap_or(taffy::Position::Static)
+    }
+
     pub fn text_content(&self) -> String {
         let mut out = String::new();
         self.write_text_content(&mut out);
@@ -1282,6 +1295,51 @@ impl Node {
         // TODO: contain
 
         false
+    }
+
+    /// Whether this node's styles establish a containing block for
+    /// `position: fixed` (and therefore also `position: absolute`) descendants.
+    ///
+    /// <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Containing_block#identifying_the_containing_block>
+    pub(crate) fn establishes_fixed_containing_block(&self) -> bool {
+        use style::values::computed::{Perspective, Rotate, Scale, Translate};
+        use style::values::specified::box_::{Contain, ContainerType, WillChangeBits};
+
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+
+        let box_style = style.get_box();
+        if !box_style.transform.0.is_empty()
+            || !matches!(box_style.translate, Translate::None)
+            || !matches!(box_style.rotate, Rotate::None)
+            || !matches!(box_style.scale, Scale::None)
+            || !matches!(box_style.perspective, Perspective::None)
+        {
+            return true;
+        }
+        if box_style.will_change.bits.intersects(
+            WillChangeBits::TRANSFORM
+                | WillChangeBits::PERSPECTIVE
+                | WillChangeBits::FIXPOS_CB_NON_SVG,
+        ) {
+            return true;
+        }
+        if box_style
+            .contain
+            .intersects(Contain::LAYOUT | Contain::PAINT)
+        {
+            return true;
+        }
+        if box_style
+            .container_type
+            .intersects(ContainerType::SIZE | ContainerType::INLINE_SIZE)
+        {
+            return true;
+        }
+
+        let effects = style.get_effects();
+        !effects.filter.0.is_empty() || !effects.backdrop_filter.0.is_empty()
     }
 
     /// Takes an (x, y) position (relative to the *parent's* top-left corner) and returns:
@@ -1382,11 +1440,11 @@ impl Node {
             *scrollbar = Some(sb);
         }
 
+        let content_box_offset = taffy::Point {
+            x: self.final_layout().padding.left + self.final_layout().border.left,
+            y: self.final_layout().padding.top + self.final_layout().border.top,
+        };
         if self.flags.is_inline_root() {
-            let content_box_offset = taffy::Point {
-                x: self.final_layout().padding.left + self.final_layout().border.left,
-                y: self.final_layout().padding.top + self.final_layout().border.top,
-            };
             x -= content_box_offset.x;
             y -= content_box_offset.y;
         }
@@ -1409,7 +1467,24 @@ impl Node {
 
         // Call `.hit()` on each child in turn. If any return `Some` then return that value. Else return `Some(self.id).
         for child_id in self.paint_children.borrow().iter().flatten().rev() {
-            if let Some(hit) = self.with(*child_id).hit_inner(x, y, scale, scrollbar) {
+            let child = self.with(*child_id);
+            let child_position = child.taffy_position();
+            let mut child_x = x;
+            let mut child_y = y;
+            if child_position.is_out_of_flow() {
+                // Out-of-flow children's layout location is relative to this node's
+                // border box, so undo the inline-root content-box offset applied above
+                if self.flags.is_inline_root() {
+                    child_x += content_box_offset.x;
+                    child_y += content_box_offset.y;
+                }
+                // Fixed-position children do not scroll with their containing block
+                if child_position == taffy::Position::Fixed {
+                    child_x -= self.scroll_offset().x as f32;
+                    child_y -= self.scroll_offset().y as f32;
+                }
+            }
+            if let Some(hit) = child.hit_inner(child_x, child_y, scale, scrollbar) {
                 return Some(hit);
             }
         }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1,5 +1,5 @@
 use crate::Document;
-use crate::layout::damage::HoistedPaintChildren;
+use crate::layout::stacking::StackingContext;
 use bitflags::bitflags;
 use blitz_traits::events::{
     BlitzPointerEvent, BlitzPointerId, DomEventData, HitResult, PointerCoords,
@@ -102,15 +102,23 @@ pub struct Node {
     /// containing block. Recorded by Taffy's out-of-flow positioning pass. The
     /// `Layout.location` of these boxes is relative to this node's border box.
     pub hoisted_children: RefCell<ThinVec<NodeId>>,
+    /// The inverse of `hoisted_children`: for an out-of-flow box, the node that
+    /// is its containing block (whose `hoisted_children` list contains it).
+    pub oof_containing_block: Cell<Option<NodeId>>,
     /// Anonymous block boxes created for this node during layout construction.
     ///
     /// Anonymous blocks live only in the slab (they are not part of the DOM
     /// `children` list), so we track the ones we own here to be able to
     /// deallocate them when this node is reconstructed.
     pub anonymous_blocks: ThinVec<NodeId>,
-    /// The same as layout_children, but sorted by z-index
+    /// The in-flow (non-stacked) subset of layout_children, in paint order
+    /// (floats above other in-flow content, flex/grid `order` honoured).
+    /// Stacked children are recorded as entries of the nearest enclosing real
+    /// stacking context instead (see [`StackingContext`]).
     pub paint_children: RefCell<Option<ThinVec<NodeId>>>,
-    pub stacking_context: Option<Box<HoistedPaintChildren>>,
+    /// The derived stacking-context membership, present iff this node
+    /// establishes a real stacking context.
+    pub stacking_context: Option<Box<StackingContext>>,
 
     // Flags
     pub flags: NodeFlags,
@@ -388,6 +396,7 @@ impl Node {
             parent: None,
             children: ThinVec::new(),
             layout_parent: Cell::new(None),
+            oof_containing_block: Cell::new(None),
             layout_children: RefCell::new(None),
             hoisted_children: RefCell::new(ThinVec::new()),
             anonymous_blocks: ThinVec::new(),
@@ -785,6 +794,34 @@ impl Node {
 
         0.0
     }
+}
+
+/// The contribution of one geometry-chain hop (from `child` to its geometry
+/// parent `parent`) to a box's position in an ancestor's coordinate space:
+/// the child's layout location, adjusted for the parent's scroll offset
+/// (which fixed-position boxes are exempt from; fixed boxes whose containing
+/// block is the root element are additionally exempt from the viewport
+/// scroll, which the paint/hit roots apply globally).
+fn hop_contribution(
+    child: &Node,
+    parent: &Node,
+    viewport_scroll: taffy::Point<f32>,
+) -> taffy::Point<f32> {
+    let location = child.final_layout().location;
+    let mut out = taffy::Point {
+        x: location.x,
+        y: location.y,
+    };
+    if child.taffy_position() == taffy::Position::Fixed {
+        if parent.is_root_element_node() {
+            out.x += viewport_scroll.x;
+            out.y += viewport_scroll.y;
+        }
+    } else {
+        out.x -= parent.scroll_offset().x as f32;
+        out.y -= parent.scroll_offset().y as f32;
+    }
+    out
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1263,16 +1300,15 @@ impl Node {
 
     // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context#features_creating_stacking_contexts
     pub fn is_stacking_context_root(&self, is_flex_or_grid_item: bool) -> bool {
+        use style::computed_values::isolation::T as Isolation;
+        use style::computed_values::mix_blend_mode::T as MixBlendMode;
+
         let Some(style) = self.primary_styles() else {
             return false;
         };
 
         let position = style.clone_position();
         let has_z_index = !style.clone_z_index().is_auto();
-
-        if style.clone_opacity() != 1.0 {
-            return true;
-        }
 
         let position_based = match position {
             Position::Fixed | Position::Sticky => true,
@@ -1283,19 +1319,165 @@ impl Node {
             return true;
         }
 
-        if self.transform().is_some() {
-            return true;
-        }
-
+        // opacity, filter, clip-path, mask
         if self.applies_atomic_paint_effect() {
             return true;
         }
 
-        // TODO: mix-blend-mode
-        // TODO: isolation
-        // TODO: contain
+        let effects = style.get_effects();
+        if effects.mix_blend_mode != MixBlendMode::Normal {
+            return true;
+        }
+        if style.get_box().isolation == Isolation::Isolate {
+            return true;
+        }
+
+        // transform/translate/rotate/scale/perspective, backdrop-filter,
+        // will-change, contain: layout/paint, container-type
+        if self.establishes_fixed_containing_block() {
+            return true;
+        }
 
         false
+    }
+
+    /// Whether this box is *stacked*: painted as a stacking-context entry of
+    /// the nearest enclosing real stacking context rather than as an in-flow
+    /// `paint_children` member of its parent. This is true for all positioned
+    /// boxes (including `z-index: auto` "stacking containers"), flex/grid
+    /// items with a non-auto z-index, and any box that establishes a real
+    /// stacking context for another reason (opacity, transform, etc).
+    pub fn is_stacked(&self, is_flex_or_grid_item: bool) -> bool {
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+        if style.clone_position() != Position::Static {
+            return true;
+        }
+        if is_flex_or_grid_item && !style.clone_z_index().is_auto() {
+            return true;
+        }
+        self.is_stacking_context_root(is_flex_or_grid_item)
+    }
+
+    /// The parent whose coordinate space this node's `Layout.location` is
+    /// relative to: the containing block for out-of-flow boxes (as recorded by
+    /// Taffy's out-of-flow positioning pass), the structural layout parent
+    /// otherwise.
+    pub fn paint_geometry_parent(&self) -> Option<NodeId> {
+        if self.taffy_position().is_out_of_flow() {
+            if let Some(cb) = self.oof_containing_block.get() {
+                return Some(cb);
+            }
+        }
+        self.layout_parent.get()
+    }
+
+    /// Whether this node is the document's root element (its DOM parent is the
+    /// document node).
+    pub(crate) fn is_root_element_node(&self) -> bool {
+        self.parent
+            .is_some_and(|pid| matches!(self.with(pid).data, NodeData::Document(_)))
+    }
+
+    /// Resolve the offset of a stacked entry's coordinate space relative to
+    /// this stacking-context root's *unscrolled* border-box space (the space
+    /// in which a direct in-flow child paints at
+    /// `Layout.location - root.scroll_offset()`), by walking the geometry
+    /// (containing-block) parent chains of both nodes to their common
+    /// ancestor.
+    ///
+    /// Also accumulates the clip rectangles (padding boxes, in the same space,
+    /// in CSS pixels) of clipping ancestors on the entry's geometry chain
+    /// below the common ancestor. The root's own clip (and the clips of
+    /// ancestors of the common ancestor) are excluded: those are applied by
+    /// the layers the root paints inside of.
+    ///
+    /// Returns `None` if the nodes have no common geometry ancestor.
+    pub fn stacked_entry_offset(
+        &self,
+        entry_id: NodeId,
+        viewport_scroll: taffy::Point<f32>,
+    ) -> Option<(taffy::Point<f32>, Option<KurboRect>)> {
+        // The entry's geometry ancestor chain (entry itself first).
+        let mut chain: Vec<NodeId> = Vec::new();
+        let mut cur = entry_id;
+        loop {
+            chain.push(cur);
+            match self.with(cur).paint_geometry_parent() {
+                Some(p) => cur = p,
+                None => break,
+            }
+        }
+
+        // Walk up from this root, accumulating hop contributions, until we
+        // reach a node on the entry's chain (the common geometry ancestor).
+        let mut root_sum = taffy::Point {
+            x: 0.0f32,
+            y: 0.0f32,
+        };
+        let mut q = self.id;
+        let common_idx = loop {
+            if let Some(idx) = chain.iter().position(|&id| id == q) {
+                break idx;
+            }
+            let parent_id = self.with(q).paint_geometry_parent()?;
+            let c = hop_contribution(self.with(q), self.with(parent_id), viewport_scroll);
+            root_sum.x += c.x;
+            root_sum.y += c.y;
+            q = parent_id;
+        };
+
+        // Accumulate the entry's hop contributions up to the common ancestor,
+        // and the clips of clipping ancestors strictly between the entry and
+        // the common ancestor.
+        let mut entry_sum = taffy::Point {
+            x: 0.0f32,
+            y: 0.0f32,
+        };
+        let mut clip: Option<KurboRect> = None;
+        for i in (0..common_idx).rev() {
+            let child = self.with(chain[i]);
+            let parent = self.with(chain[i + 1]);
+            // `entry_sum` currently holds B(parent -> Q): the position of
+            // `parent`'s border-box origin, plus `root_sum`.
+            if i + 1 < common_idx && parent.clips_overflow() {
+                let layout = parent.final_layout();
+                let rect = KurboRect::new(
+                    (entry_sum.x - root_sum.x + layout.border.left) as f64,
+                    (entry_sum.y - root_sum.y + layout.border.top) as f64,
+                    (entry_sum.x - root_sum.x + layout.size.width - layout.border.right) as f64,
+                    (entry_sum.y - root_sum.y + layout.size.height - layout.border.bottom) as f64,
+                );
+                clip = Some(match clip {
+                    Some(existing) => existing.intersect(rect),
+                    None => rect,
+                });
+            }
+            let c = hop_contribution(child, parent, viewport_scroll);
+            entry_sum.x += c.x;
+            entry_sum.y += c.y;
+        }
+
+        let entry_location = self.with(entry_id).final_layout().location;
+        let offset = taffy::Point {
+            x: entry_sum.x - root_sum.x - entry_location.x,
+            y: entry_sum.y - root_sum.y - entry_location.y,
+        };
+        Some((offset, clip))
+    }
+
+    /// Whether this box clips its overflowing content (scroll containers,
+    /// `overflow: hidden/clip`, `contain: paint`).
+    pub(crate) fn clips_overflow(&self) -> bool {
+        use style::values::computed::{Contain, Overflow};
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+        let box_style = style.get_box();
+        !matches!(box_style.overflow_x, Overflow::Visible)
+            || !matches!(box_style.overflow_y, Overflow::Visible)
+            || box_style.clone_contain().contains(Contain::PAINT)
     }
 
     /// Whether this node's styles apply an atomic paint effect (opacity, filter,
@@ -1463,16 +1645,13 @@ impl Node {
             || y < 0.0
             || y > overflow_rect.bottom + self.scroll_offset().y as f32);
 
-        let matches_hoisted_content = match &self.stacking_context {
-            Some(sc) => {
-                let content_area = sc.content_area;
-                x >= content_area.left + self.scroll_offset().x as f32
-                    && x <= content_area.right + self.scroll_offset().x as f32
-                    && y >= content_area.top + self.scroll_offset().y as f32
-                    && y <= content_area.bottom + self.scroll_offset().y as f32
-            }
-            None => false,
-        };
+        // Stacked entries may lie outside this node's own bounds and overflow
+        // (e.g. an out-of-flow box whose containing block is an ancestor), so
+        // a stacking context with entries can never be culled early.
+        let has_stacked_entries = self
+            .stacking_context
+            .as_ref()
+            .is_some_and(|sc| !sc.entries.is_empty());
 
         // `scrollable_overflow` is stored in device (scaled) pixels, whereas the
         // coordinates here are in CSS pixels, so unscale it before comparing.
@@ -1483,7 +1662,7 @@ impl Node {
             && y >= (overflow.y0 / scale) as f32
             && y <= (overflow.y1 / scale) as f32;
 
-        if !matches_self && !matches_content && !matches_hoisted_content && !matches_overflow {
+        if !matches_self && !matches_content && !has_stacked_entries && !matches_overflow {
             return None;
         }
 
@@ -1507,66 +1686,32 @@ impl Node {
             y -= content_box_offset.y;
         }
 
-        // Positive z_index hoisted children
-        if matches_hoisted_content {
-            if let Some(hoisted) = &self.stacking_context {
-                for hoisted_child in hoisted.pos_z_hoisted_children().rev() {
-                    let x = x - hoisted_child.position.x;
-                    let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self.with(hoisted_child.node_id).hit_inner(
-                        x,
-                        y,
-                        scale,
-                        scrollbar,
-                        taffy::Point::ZERO,
-                    ) {
-                        return Some(hit);
-                    }
+        // Stacked entries with a zero/auto or positive z-index (topmost first)
+        if let Some(sc) = &self.stacking_context {
+            for entry in sc.non_negative_entries().iter().rev() {
+                if let Some(hit) =
+                    self.hit_stacked_entry(entry.node_id, x, y, scale, scrollbar, viewport_scroll)
+                {
+                    return Some(hit);
                 }
             }
         }
 
-        // Call `.hit()` on each child in turn. If any return `Some` then return that value. Else return `Some(self.id).
+        // Call `.hit()` on each in-flow child in turn. If any return `Some` then return that value.
         for child_id in self.paint_children.borrow().iter().flatten().rev() {
             let child = self.with(*child_id);
-            let child_position = child.taffy_position();
-            let mut child_x = x;
-            let mut child_y = y;
-            if child_position.is_out_of_flow() {
-                // Out-of-flow children's layout location is relative to this node's
-                // border box, so undo the inline-root content-box offset applied above
-                if self.flags.is_inline_root() {
-                    child_x += content_box_offset.x;
-                    child_y += content_box_offset.y;
-                }
-                // Fixed-position children do not scroll with their containing block
-                if child_position == taffy::Position::Fixed {
-                    child_x -= self.scroll_offset().x as f32 + viewport_scroll.x;
-                    child_y -= self.scroll_offset().y as f32 + viewport_scroll.y;
-                }
-            }
-            if let Some(hit) =
-                child.hit_inner(child_x, child_y, scale, scrollbar, taffy::Point::ZERO)
-            {
+            if let Some(hit) = child.hit_inner(x, y, scale, scrollbar, viewport_scroll) {
                 return Some(hit);
             }
         }
 
-        // Negative z_index hoisted children
-        if matches_hoisted_content {
-            if let Some(hoisted) = &self.stacking_context {
-                for hoisted_child in hoisted.neg_z_hoisted_children().rev() {
-                    let x = x - hoisted_child.position.x;
-                    let y = y - hoisted_child.position.y;
-                    if let Some(hit) = self.with(hoisted_child.node_id).hit_inner(
-                        x,
-                        y,
-                        scale,
-                        scrollbar,
-                        taffy::Point::ZERO,
-                    ) {
-                        return Some(hit);
-                    }
+        // Stacked entries with a negative z-index (topmost first)
+        if let Some(sc) = &self.stacking_context {
+            for entry in sc.negative_entries().iter().rev() {
+                if let Some(hit) =
+                    self.hit_stacked_entry(entry.node_id, x, y, scale, scrollbar, viewport_scroll)
+                {
+                    return Some(hit);
                 }
             }
         }
@@ -1610,6 +1755,54 @@ impl Node {
         }
 
         None
+    }
+
+    /// Hit-test a stacked entry of this node's stacking context, resolving its
+    /// coordinate space offset (and any intermediate clips) from the geometry
+    /// (containing-block) chain. `x`/`y` are in this node's scrolled content
+    /// space, as adjusted by `hit_inner`.
+    #[allow(clippy::too_many_arguments)]
+    fn hit_stacked_entry(
+        &self,
+        entry_id: NodeId,
+        x: f32,
+        y: f32,
+        scale: f64,
+        scrollbar: &mut Option<crate::node::ScrollbarRef>,
+        viewport_scroll: taffy::Point<f32>,
+    ) -> Option<HitResult> {
+        let (offset, clip) = self.stacked_entry_offset(entry_id, viewport_scroll)?;
+
+        // Convert to this node's unscrolled border-box space (undoing the
+        // inline-root content-box offset applied by `hit_inner`, since entry
+        // offsets are resolved in border-box space).
+        let mut px = x - self.scroll_offset().x as f32;
+        let mut py = y - self.scroll_offset().y as f32;
+        if self.flags.is_inline_root() {
+            let layout = self.final_layout();
+            px += layout.padding.left + layout.border.left;
+            py += layout.padding.top + layout.border.top;
+        }
+
+        // Reject points clipped away by scroll/clip containers between the
+        // entry and its stacking context root.
+        if let Some(clip) = clip {
+            if (px as f64) < clip.x0
+                || (px as f64) > clip.x1
+                || (py as f64) < clip.y0
+                || (py as f64) > clip.y1
+            {
+                return None;
+            }
+        }
+
+        self.with(entry_id).hit_inner(
+            px - offset.x,
+            py - offset.y,
+            scale,
+            scrollbar,
+            viewport_scroll,
+        )
     }
 
     /// Find the inline root ancestor of this node (or self if this is an inline root).
@@ -1666,14 +1859,22 @@ impl Node {
 
     /// Computes the Document-relative coordinates of the `Node`
     pub fn absolute_position(&self, x: f32, y: f32) -> crate::util::Point<f32> {
-        let x = x + self.final_layout().location.x - self.scroll_offset().x as f32;
-        let y = y + self.final_layout().location.y - self.scroll_offset().y as f32;
+        let mut x = x + self.final_layout().location.x - self.scroll_offset().x as f32;
+        let mut y = y + self.final_layout().location.y - self.scroll_offset().y as f32;
 
-        // Recurse up the layout hierarchy
-        self.layout_parent
-            .get()
-            .map(|i| self.with(i).absolute_position(x, y))
-            .unwrap_or(crate::util::Point { x, y })
+        // Recurse up the geometry (containing block) hierarchy
+        match self.paint_geometry_parent() {
+            Some(i) => {
+                let parent = self.with(i);
+                // Fixed-position boxes do not scroll with their containing block
+                if self.taffy_position() == taffy::Position::Fixed {
+                    x += parent.scroll_offset().x as f32;
+                    y += parent.scroll_offset().y as f32;
+                }
+                parent.absolute_position(x, y)
+            }
+            None => crate::util::Point { x, y },
+        }
     }
 
     /// Whether this node can act as an [`offset_parent`](Self::offset_parent): a positioned
@@ -1705,7 +1906,7 @@ impl Node {
     pub fn offset_parent(&self) -> Option<&Node> {
         let mut node = self;
         loop {
-            node = self.with(node.layout_parent.get()?);
+            node = self.with(node.paint_geometry_parent()?);
             if node.is_offset_parent() {
                 return Some(node);
             }
@@ -1723,7 +1924,7 @@ impl Node {
             x += layout.location.x;
             y += layout.location.y;
 
-            let Some(parent_id) = current.layout_parent.get() else {
+            let Some(parent_id) = current.paint_geometry_parent() else {
                 break;
             };
             let parent = self.with(parent_id);

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -241,6 +241,23 @@ impl BaseDocument {
         full.transform_rect_bbox(overflow)
     }
 
+    /// The innermost DOM ancestor of `node_id`, strictly below `cb_id`, that applies
+    /// an atomic paint effect (opacity, clip-path, mask) to its subtree.
+    fn innermost_paint_effect_ancestor(&self, node_id: NodeId, cb_id: NodeId) -> Option<NodeId> {
+        let mut ancestor = self.nodes[node_id].parent;
+        while let Some(ancestor_id) = ancestor {
+            if ancestor_id == cb_id {
+                return None;
+            }
+            let node = &self.nodes[ancestor_id];
+            if node.applies_atomic_paint_effect() {
+                return Some(ancestor_id);
+            }
+            ancestor = node.parent;
+        }
+        None
+    }
+
     /// Attach out-of-flow (absolutely/fixed positioned) boxes to their containing
     /// block, as recorded by Taffy's out-of-flow positioning pass in each node's
     /// `hoisted_children` list:
@@ -286,6 +303,7 @@ impl BaseDocument {
                 .unwrap_or_default();
 
             let mut z_indexed: Vec<NodeId> = Vec::new();
+            let mut effect_attached: Vec<(NodeId, NodeId)> = Vec::new();
             {
                 let mut paint_children = self.nodes[cb_id].paint_children.borrow_mut();
                 let paint_children = paint_children.get_or_insert_with(thin_vec::ThinVec::new);
@@ -297,8 +315,48 @@ impl BaseDocument {
                     if direct_layout_children.contains(&child_id) {
                         continue;
                     }
+                    // Atomic paint effects (opacity, clip-path, mask) on a DOM ancestor
+                    // apply to out-of-flow descendants even when the ancestor is not
+                    // their containing block, so paint the box inside the innermost such
+                    // ancestor's effect layers rather than directly under the containing
+                    // block.
+                    if let Some(effect_ancestor) =
+                        self.innermost_paint_effect_ancestor(child_id, cb_id)
+                    {
+                        effect_attached.push((child_id, effect_ancestor));
+                        continue;
+                    }
                     if !paint_children.contains(&child_id) {
                         paint_children.push(child_id);
+                    }
+                }
+            }
+
+            // Boxes painted inside an intermediate effect ancestor keep their
+            // containing-block-relative layout location, so record the offset of the
+            // effect ancestor relative to the containing block to compensate.
+            for (child_id, effect_ancestor) in effect_attached {
+                let mut position = taffy::Point::<f32>::ZERO;
+                let mut ancestor = effect_ancestor;
+                while ancestor != cb_id {
+                    let node = &self.nodes[ancestor];
+                    let location = node.final_layout().location;
+                    let scroll = *node.scroll_offset();
+                    position.x -= location.x - scroll.x as f32;
+                    position.y -= location.y - scroll.y as f32;
+                    let Some(parent) = node.layout_parent.get() else {
+                        break;
+                    };
+                    ancestor = parent;
+                }
+                if let Some(sc) = self.nodes[effect_ancestor].stacking_context.as_mut() {
+                    if !sc.children.iter().any(|c| c.node_id == child_id) {
+                        sc.children.push(crate::layout::damage::HoistedPaintChild {
+                            node_id: child_id,
+                            z_index: 0,
+                            position,
+                        });
+                        modified_stacking_roots.push(effect_ancestor);
                     }
                 }
             }

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -83,9 +83,12 @@ impl BaseDocument {
         self.resolve_stylist(current_time_for_animations);
         timer.record_time("style");
 
-        // Propagate damage flags (from mutation and restyles) up and down the tree
+        // Propagate damage flags (from mutation and restyles) up and down the tree.
+        // The accumulated damage gates the post-layout stacking membership pass.
+        let mut stacking_dirty = !self.incremental_layout;
         if self.incremental_layout {
-            self.propagate_damage_flags(root_node_id, RestyleDamage::empty());
+            let root_damage = self.propagate_damage_flags(root_node_id, RestyleDamage::empty());
+            stacking_dirty = root_damage.intersects(crate::layout::stacking::STACKING_DAMAGE);
             timer.record_time("damage");
         }
 
@@ -108,9 +111,12 @@ impl BaseDocument {
         self.resolve_layout();
         timer.record_time("layout");
 
-        // Attach out-of-flow boxes to their containing block for painting and
-        // hit-testing, and repoint their layout_parent at the containing block
-        self.attach_hoisted_children();
+        // Derive stacking-context membership and paint_children from the
+        // structural tree (post-layout, gated by stacking damage).
+        if stacking_dirty {
+            self.resolve_stacking_contexts(root_node_id);
+            timer.record_time("stacking");
+        }
 
         // Resolve transforms
         self.resolve_transforms(root_node_id);
@@ -239,227 +245,6 @@ impl BaseDocument {
         };
 
         full.transform_rect_bbox(overflow)
-    }
-
-    /// The innermost DOM ancestor of `node_id`, strictly below `cb_id`, that applies
-    /// an atomic paint effect (opacity, clip-path, mask) to its subtree.
-    fn innermost_paint_effect_ancestor(&self, node_id: NodeId, cb_id: NodeId) -> Option<NodeId> {
-        let mut ancestor = self.nodes[node_id].parent;
-        while let Some(ancestor_id) = ancestor {
-            if ancestor_id == cb_id {
-                return None;
-            }
-            let node = &self.nodes[ancestor_id];
-            if node.applies_atomic_paint_effect() {
-                return Some(ancestor_id);
-            }
-            ancestor = node.parent;
-        }
-        None
-    }
-
-    /// Whether `a` precedes `b` in DOM pre-order (each node's ancestor path is
-    /// compared by child index at the first point of divergence; an ancestor
-    /// precedes its descendants).
-    fn is_before_in_tree_order(&self, a: NodeId, b: NodeId) -> bool {
-        if a == b {
-            return false;
-        }
-        let path = |mut id: NodeId| {
-            let mut path = vec![id];
-            while let Some(parent) = self.nodes[id].parent {
-                path.push(parent);
-                id = parent;
-            }
-            path.reverse();
-            path
-        };
-        let path_a = path(a);
-        let path_b = path(b);
-        for (i, (&na, &nb)) in path_a.iter().zip(path_b.iter()).enumerate() {
-            if na != nb {
-                if i == 0 {
-                    // Disjoint trees; fall back to a stable arbitrary order
-                    return na < nb;
-                }
-                let parent = &self.nodes[path_a[i - 1]];
-                return parent.index_of_child(na) < parent.index_of_child(nb);
-            }
-        }
-        // One is an ancestor of the other: the shorter path comes first
-        path_a.len() < path_b.len()
-    }
-
-    /// Attach out-of-flow (absolutely/fixed positioned) boxes to their containing
-    /// block, as recorded by Taffy's out-of-flow positioning pass in each node's
-    /// `hoisted_children` list:
-    ///
-    /// - repoints each hoisted box's `layout_parent` at its containing block so
-    ///   that coordinate accumulation (e.g. `absolute_position`) follows the
-    ///   containing block chain that its `Layout.location` is relative to; and
-    /// - appends each hoisted box to its containing block's `paint_children` so
-    ///   that paint and hit-testing visit it with the correct coordinates
-    ///   (out-of-flow boxes are skipped in their DOM parent's paint list).
-    fn attach_hoisted_children(&mut self) {
-        let mut modified_stacking_roots: Vec<NodeId> = Vec::new();
-        let mut pairs: Vec<(NodeId, Vec<NodeId>)> = Vec::new();
-        for (cb_id, node) in self.nodes.iter() {
-            let hoisted = node.hoisted_children.borrow();
-            if !hoisted.is_empty() {
-                pairs.push((cb_id, hoisted.iter().copied().collect()));
-            }
-        }
-
-        for (cb_id, hoisted) in pairs {
-            // Nodes can be removed from the slab between layout passes; drop stale ids
-            let mut valid: Vec<NodeId> = hoisted
-                .into_iter()
-                .filter(|id| self.nodes.contains_key(*id))
-                .collect();
-            // Sort by z-index (stable sort preserves document order within a z-index)
-            valid.sort_by_key(|id| self.nodes[*id].z_index());
-
-            for &child_id in &valid {
-                self.nodes[child_id].layout_parent.set(Some(cb_id));
-            }
-
-            // Boxes whose containing block is their direct layout parent were kept
-            // in its paint tree by `flush_styles_to_layout` (paint_children or the
-            // stacking context, depending on z-index) in tree order, so only append
-            // the ones hoisted past their DOM parent.
-            let direct_layout_children: Vec<NodeId> = self.nodes[cb_id]
-                .layout_children
-                .borrow()
-                .as_ref()
-                .map(|c| c.to_vec())
-                .unwrap_or_default();
-
-            let cb_is_flex_or_grid = matches!(
-                self.nodes[cb_id].taffy_display(),
-                taffy::Display::Flex | taffy::Display::Grid
-            );
-            let mut z_indexed: Vec<NodeId> = Vec::new();
-            let mut effect_attached: Vec<(NodeId, NodeId)> = Vec::new();
-            {
-                let mut paint_children = self.nodes[cb_id].paint_children.borrow_mut();
-                let paint_children = paint_children.get_or_insert_with(thin_vec::ThinVec::new);
-                for &child_id in &valid {
-                    if self.nodes[child_id].z_index() != 0 {
-                        z_indexed.push(child_id);
-                        continue;
-                    }
-                    if direct_layout_children.contains(&child_id) {
-                        continue;
-                    }
-                    // Atomic paint effects (opacity, clip-path, mask) on a DOM ancestor
-                    // apply to out-of-flow descendants even when the ancestor is not
-                    // their containing block, so paint the box inside the innermost such
-                    // ancestor's effect layers rather than directly under the containing
-                    // block.
-                    if let Some(effect_ancestor) =
-                        self.innermost_paint_effect_ancestor(child_id, cb_id)
-                    {
-                        effect_attached.push((child_id, effect_ancestor));
-                        continue;
-                    }
-                    if !paint_children.contains(&child_id) {
-                        // Splice into the containing block's paint list at the
-                        // hoisted box's (paint level, tree order) position: z-index:
-                        // auto positioned boxes paint in tree order among positioned
-                        // siblings (CSS 2.1 Appendix E step 8), not last.
-                        let key = crate::layout::damage::node_to_paint_order(
-                            &self.nodes[child_id],
-                            cb_is_flex_or_grid,
-                        );
-                        let insert_at = paint_children
-                            .iter()
-                            .position(|&existing| {
-                                let existing_key = crate::layout::damage::node_to_paint_order(
-                                    &self.nodes[existing],
-                                    cb_is_flex_or_grid,
-                                );
-                                existing_key > key
-                                    || (existing_key == key
-                                        && self.is_before_in_tree_order(child_id, existing))
-                            })
-                            .unwrap_or(paint_children.len());
-                        paint_children.insert(insert_at, child_id);
-                    }
-                }
-            }
-
-            // Boxes painted inside an intermediate effect ancestor keep their
-            // containing-block-relative layout location, so record the offset of the
-            // effect ancestor relative to the containing block to compensate.
-            for (child_id, effect_ancestor) in effect_attached {
-                let mut position = taffy::Point::<f32>::ZERO;
-                let mut ancestor = effect_ancestor;
-                while ancestor != cb_id {
-                    let node = &self.nodes[ancestor];
-                    let location = node.final_layout().location;
-                    let scroll = *node.scroll_offset();
-                    position.x -= location.x - scroll.x as f32;
-                    position.y -= location.y - scroll.y as f32;
-                    let Some(parent) = node.layout_parent.get() else {
-                        break;
-                    };
-                    ancestor = parent;
-                }
-                if let Some(sc) = self.nodes[effect_ancestor].stacking_context.as_mut() {
-                    if !sc.children.iter().any(|c| c.node_id == child_id) {
-                        sc.children.push(crate::layout::damage::HoistedPaintChild {
-                            node_id: child_id,
-                            z_index: 0,
-                            position,
-                        });
-                        modified_stacking_roots.push(effect_ancestor);
-                    }
-                }
-            }
-
-            // Children with a z-index belong to the nearest stacking context at
-            // or above the containing block: hoist them there (matching
-            // `flush_styles_to_layout`'s z-index hoisting), with their position
-            // recorded relative to the stacking context root.
-            for child_id in z_indexed {
-                let mut position = taffy::Point::<f32>::ZERO;
-                let mut sc_root = cb_id;
-                while self.nodes[sc_root].stacking_context.is_none() {
-                    let node = &self.nodes[sc_root];
-                    let location = node.final_layout().location;
-                    let scroll = *node.scroll_offset();
-                    position.x += location.x - scroll.x as f32;
-                    position.y += location.y - scroll.y as f32;
-                    let Some(parent) = node.layout_parent.get() else {
-                        break;
-                    };
-                    sc_root = parent;
-                }
-
-                let z_index = self.nodes[child_id].z_index();
-                if let Some(sc) = self.nodes[sc_root].stacking_context.as_mut() {
-                    if !sc.children.iter().any(|c| c.node_id == child_id) {
-                        sc.children.push(crate::layout::damage::HoistedPaintChild {
-                            node_id: child_id,
-                            z_index,
-                            position,
-                        });
-                        modified_stacking_roots.push(sc_root);
-                    }
-                }
-            }
-        }
-
-        modified_stacking_roots.sort_unstable();
-        modified_stacking_roots.dedup();
-        for sc_root in modified_stacking_roots {
-            let mut sc = self.nodes[sc_root].stacking_context.take();
-            if let Some(sc) = sc.as_mut() {
-                sc.sort();
-                sc.compute_content_size(self);
-            }
-            self.nodes[sc_root].stacking_context = sc;
-        }
     }
 
     /// Ensure that the layout_children field is populated for all nodes

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -108,6 +108,10 @@ impl BaseDocument {
         self.resolve_layout();
         timer.record_time("layout");
 
+        // Attach out-of-flow boxes to their containing block for painting and
+        // hit-testing, and repoint their layout_parent at the containing block
+        self.attach_hoisted_children();
+
         // Resolve transforms
         self.resolve_transforms(root_node_id);
         timer.record_time("transform");
@@ -193,10 +197,26 @@ impl BaseDocument {
 
         if let Some(ref children) = layout_children {
             for &child_id in children {
+                // Out-of-flow children are laid out relative to their containing
+                // block, not their DOM parent: their overflow contribution is
+                // accounted for at the containing block (below) instead.
+                let is_out_of_flow = self.nodes[child_id].taffy_position().is_out_of_flow();
                 let child_rect_in_self = self.resolve_transforms(child_id);
-                overflow = overflow.union(child_rect_in_self);
+                if !is_out_of_flow {
+                    overflow = overflow.union(child_rect_in_self);
+                }
             }
         }
+        let hoisted_children =
+            std::mem::take(&mut *self.nodes[node_id].hoisted_children.borrow_mut());
+        for &child_id in &hoisted_children {
+            if !self.nodes.contains_key(child_id) {
+                continue;
+            }
+            let child_rect_in_self = self.resolve_transforms(child_id);
+            overflow = overflow.union(child_rect_in_self);
+        }
+        *self.nodes[node_id].hoisted_children.borrow_mut() = hoisted_children;
         if let Some(before) = self.nodes[node_id].before() {
             let child_rect_in_self = self.resolve_transforms(before);
             overflow = overflow.union(child_rect_in_self);
@@ -219,6 +239,48 @@ impl BaseDocument {
         };
 
         full.transform_rect_bbox(overflow)
+    }
+
+    /// Attach out-of-flow (absolutely/fixed positioned) boxes to their containing
+    /// block, as recorded by Taffy's out-of-flow positioning pass in each node's
+    /// `hoisted_children` list:
+    ///
+    /// - repoints each hoisted box's `layout_parent` at its containing block so
+    ///   that coordinate accumulation (e.g. `absolute_position`) follows the
+    ///   containing block chain that its `Layout.location` is relative to; and
+    /// - appends each hoisted box to its containing block's `paint_children` so
+    ///   that paint and hit-testing visit it with the correct coordinates
+    ///   (out-of-flow boxes are skipped in their DOM parent's paint list).
+    fn attach_hoisted_children(&mut self) {
+        let mut pairs: Vec<(NodeId, Vec<NodeId>)> = Vec::new();
+        for (cb_id, node) in self.nodes.iter() {
+            let hoisted = node.hoisted_children.borrow();
+            if !hoisted.is_empty() {
+                pairs.push((cb_id, hoisted.iter().copied().collect()));
+            }
+        }
+
+        for (cb_id, hoisted) in pairs {
+            // Nodes can be removed from the slab between layout passes; drop stale ids
+            let mut valid: Vec<NodeId> = hoisted
+                .into_iter()
+                .filter(|id| self.nodes.contains_key(*id))
+                .collect();
+            // Sort by z-index (stable sort preserves document order within a z-index)
+            valid.sort_by_key(|id| self.nodes[*id].z_index());
+
+            for &child_id in &valid {
+                self.nodes[child_id].layout_parent.set(Some(cb_id));
+            }
+
+            let mut paint_children = self.nodes[cb_id].paint_children.borrow_mut();
+            let paint_children = paint_children.get_or_insert_with(thin_vec::ThinVec::new);
+            for &child_id in &valid {
+                if !paint_children.contains(&child_id) {
+                    paint_children.push(child_id);
+                }
+            }
+        }
     }
 
     /// Ensure that the layout_children field is populated for all nodes

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -252,6 +252,7 @@ impl BaseDocument {
     ///   that paint and hit-testing visit it with the correct coordinates
     ///   (out-of-flow boxes are skipped in their DOM parent's paint list).
     fn attach_hoisted_children(&mut self) {
+        let mut modified_stacking_roots: Vec<NodeId> = Vec::new();
         let mut pairs: Vec<(NodeId, Vec<NodeId>)> = Vec::new();
         for (cb_id, node) in self.nodes.iter() {
             let hoisted = node.hoisted_children.borrow();
@@ -273,13 +274,77 @@ impl BaseDocument {
                 self.nodes[child_id].layout_parent.set(Some(cb_id));
             }
 
-            let mut paint_children = self.nodes[cb_id].paint_children.borrow_mut();
-            let paint_children = paint_children.get_or_insert_with(thin_vec::ThinVec::new);
-            for &child_id in &valid {
-                if !paint_children.contains(&child_id) {
-                    paint_children.push(child_id);
+            // Boxes whose containing block is their direct layout parent were kept
+            // in its paint tree by `flush_styles_to_layout` (paint_children or the
+            // stacking context, depending on z-index) in tree order, so only append
+            // the ones hoisted past their DOM parent.
+            let direct_layout_children: Vec<NodeId> = self.nodes[cb_id]
+                .layout_children
+                .borrow()
+                .as_ref()
+                .map(|c| c.to_vec())
+                .unwrap_or_default();
+
+            let mut z_indexed: Vec<NodeId> = Vec::new();
+            {
+                let mut paint_children = self.nodes[cb_id].paint_children.borrow_mut();
+                let paint_children = paint_children.get_or_insert_with(thin_vec::ThinVec::new);
+                for &child_id in &valid {
+                    if self.nodes[child_id].z_index() != 0 {
+                        z_indexed.push(child_id);
+                        continue;
+                    }
+                    if direct_layout_children.contains(&child_id) {
+                        continue;
+                    }
+                    if !paint_children.contains(&child_id) {
+                        paint_children.push(child_id);
+                    }
                 }
             }
+
+            // Children with a z-index belong to the nearest stacking context at
+            // or above the containing block: hoist them there (matching
+            // `flush_styles_to_layout`'s z-index hoisting), with their position
+            // recorded relative to the stacking context root.
+            for child_id in z_indexed {
+                let mut position = taffy::Point::<f32>::ZERO;
+                let mut sc_root = cb_id;
+                while self.nodes[sc_root].stacking_context.is_none() {
+                    let node = &self.nodes[sc_root];
+                    let location = node.final_layout().location;
+                    let scroll = *node.scroll_offset();
+                    position.x += location.x - scroll.x as f32;
+                    position.y += location.y - scroll.y as f32;
+                    let Some(parent) = node.layout_parent.get() else {
+                        break;
+                    };
+                    sc_root = parent;
+                }
+
+                let z_index = self.nodes[child_id].z_index();
+                if let Some(sc) = self.nodes[sc_root].stacking_context.as_mut() {
+                    if !sc.children.iter().any(|c| c.node_id == child_id) {
+                        sc.children.push(crate::layout::damage::HoistedPaintChild {
+                            node_id: child_id,
+                            z_index,
+                            position,
+                        });
+                        modified_stacking_roots.push(sc_root);
+                    }
+                }
+            }
+        }
+
+        modified_stacking_roots.sort_unstable();
+        modified_stacking_roots.dedup();
+        for sc_root in modified_stacking_roots {
+            let mut sc = self.nodes[sc_root].stacking_context.take();
+            if let Some(sc) = sc.as_mut() {
+                sc.sort();
+                sc.compute_content_size(self);
+            }
+            self.nodes[sc_root].stacking_context = sc;
         }
     }
 

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -258,6 +258,38 @@ impl BaseDocument {
         None
     }
 
+    /// Whether `a` precedes `b` in DOM pre-order (each node's ancestor path is
+    /// compared by child index at the first point of divergence; an ancestor
+    /// precedes its descendants).
+    fn is_before_in_tree_order(&self, a: NodeId, b: NodeId) -> bool {
+        if a == b {
+            return false;
+        }
+        let path = |mut id: NodeId| {
+            let mut path = vec![id];
+            while let Some(parent) = self.nodes[id].parent {
+                path.push(parent);
+                id = parent;
+            }
+            path.reverse();
+            path
+        };
+        let path_a = path(a);
+        let path_b = path(b);
+        for (i, (&na, &nb)) in path_a.iter().zip(path_b.iter()).enumerate() {
+            if na != nb {
+                if i == 0 {
+                    // Disjoint trees; fall back to a stable arbitrary order
+                    return na < nb;
+                }
+                let parent = &self.nodes[path_a[i - 1]];
+                return parent.index_of_child(na) < parent.index_of_child(nb);
+            }
+        }
+        // One is an ancestor of the other: the shorter path comes first
+        path_a.len() < path_b.len()
+    }
+
     /// Attach out-of-flow (absolutely/fixed positioned) boxes to their containing
     /// block, as recorded by Taffy's out-of-flow positioning pass in each node's
     /// `hoisted_children` list:
@@ -302,6 +334,10 @@ impl BaseDocument {
                 .map(|c| c.to_vec())
                 .unwrap_or_default();
 
+            let cb_is_flex_or_grid = matches!(
+                self.nodes[cb_id].taffy_display(),
+                taffy::Display::Flex | taffy::Display::Grid
+            );
             let mut z_indexed: Vec<NodeId> = Vec::new();
             let mut effect_attached: Vec<(NodeId, NodeId)> = Vec::new();
             {
@@ -327,7 +363,27 @@ impl BaseDocument {
                         continue;
                     }
                     if !paint_children.contains(&child_id) {
-                        paint_children.push(child_id);
+                        // Splice into the containing block's paint list at the
+                        // hoisted box's (paint level, tree order) position: z-index:
+                        // auto positioned boxes paint in tree order among positioned
+                        // siblings (CSS 2.1 Appendix E step 8), not last.
+                        let key = crate::layout::damage::node_to_paint_order(
+                            &self.nodes[child_id],
+                            cb_is_flex_or_grid,
+                        );
+                        let insert_at = paint_children
+                            .iter()
+                            .position(|&existing| {
+                                let existing_key = crate::layout::damage::node_to_paint_order(
+                                    &self.nodes[existing],
+                                    cb_is_flex_or_grid,
+                                );
+                                existing_key > key
+                                    || (existing_key == key
+                                        && self.is_before_in_tree_order(child_id, existing))
+                            })
+                            .unwrap_or(paint_children.len());
+                        paint_children.insert(insert_at, child_id);
                     }
                 }
             }

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -988,7 +988,26 @@ impl ElementCx<'_, '_> {
         // Regular children
         if let Some(children) = &*self.node.paint_children.borrow() {
             for child_id in children {
-                self.render_node(scene, *child_id, parent_style_transform, clip_rect);
+                // Fixed-position children do not scroll with their containing block
+                // (their layout location is relative to its unscrolled border box),
+                // so cancel out the scroll offset applied to the transform above.
+                let child = &self.context.dom.as_ref().tree()[*child_id];
+                let child_transform = if child.taffy_position() == taffy::Position::Fixed {
+                    // The root element's scroll is the viewport scroll (applied in
+                    // `paint_scene`), not the node's own scroll offset.
+                    let scroll = if Some(self.node.id) == self.context.root_element_id {
+                        self.context.dom.as_ref().viewport_scroll()
+                    } else {
+                        *self.node.scroll_offset()
+                    };
+                    parent_style_transform.pre_translate(kurbo::Vec2 {
+                        x: self.node.scroll_offset().x * self.scale,
+                        y: self.node.scroll_offset().y * self.scale,
+                    })
+                } else {
+                    parent_style_transform
+                };
+                self.render_node(scene, *child_id, child_transform, clip_rect);
             }
         }
 

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -393,10 +393,18 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         // Cull elements that fall entirely outside the current clip rectangle. In addition to
         // the viewport, `clip_rect` is narrowed by any ancestor scrollport (see below), so this
         // also culls elements scrolled out of view inside a clipping/scrolling container.
-        if screen_bbox.x1 < clip_rect.x0
-            || screen_bbox.x0 > clip_rect.x1
-            || screen_bbox.y1 < clip_rect.y0
-            || screen_bbox.y0 > clip_rect.y1
+        // Stacking contexts with stacked entries are never culled: their entries may lie
+        // outside the element's own bounds and overflow (e.g. an out-of-flow box whose
+        // containing block is an ancestor).
+        let has_stacked_entries = node
+            .stacking_context
+            .as_ref()
+            .is_some_and(|sc| !sc.entries.is_empty());
+        if !has_stacked_entries
+            && (screen_bbox.x1 < clip_rect.x0
+                || screen_bbox.x0 > clip_rect.x1
+                || screen_bbox.y1 < clip_rect.y0
+                || screen_bbox.y0 > clip_rect.y1)
         {
             return;
         }
@@ -527,6 +535,14 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                                     x: -node.scroll_offset().x * self.scale,
                                     y: -node.scroll_offset().y * self.scale,
                                 });
+                                // Stacked entries with a negative z-index paint below
+                                // this context's in-flow content (CSS 2.1 Appendix E
+                                // step 3), just above its background and borders.
+                                cx.draw_negative_stacked_entries(
+                                    scene,
+                                    unscrolled_transform,
+                                    child_clip_rect,
+                                );
                                 cx.draw_image(scene);
                                 #[cfg(feature = "svg")]
                                 cx.draw_svg(scene);
@@ -538,6 +554,14 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                                 cx.draw_inline_layout(scene, content_position);
                                 cx.draw_marker(scene, content_position);
                                 cx.draw_children(scene, cx.transform, child_clip_rect);
+                                // Stacked entries with a zero/auto or positive z-index
+                                // paint above this context's in-flow content (CSS 2.1
+                                // Appendix E steps 8-9), in z order then tree order.
+                                cx.draw_non_negative_stacked_entries(
+                                    scene,
+                                    unscrolled_transform,
+                                    child_clip_rect,
+                                );
                             },
                         );
 
@@ -962,67 +986,102 @@ impl ElementCx<'_, '_> {
         }
     }
 
+    /// Draw this node's in-flow (non-stacked) children. Stacked children are
+    /// drawn as stacking-context entries by `draw_negative_stacked_entries` /
+    /// `draw_non_negative_stacked_entries` on their stacking context root.
     fn draw_children(
         &self,
         scene: &mut impl PaintScene,
         parent_style_transform: Affine,
         clip_rect: Rect,
     ) {
-        // Negative z_index hoisted nodes
-
-        if let Some(hoisted) = &self.node.stacking_context {
-            for hoisted_child in hoisted.neg_z_hoisted_children() {
-                let pos = kurbo::Vec2 {
-                    x: hoisted_child.position.x as f64 * self.scale,
-                    y: hoisted_child.position.y as f64 * self.scale,
-                };
-                self.render_node(
-                    scene,
-                    hoisted_child.node_id,
-                    parent_style_transform.pre_translate(pos),
-                    clip_rect,
-                );
-            }
-        }
-
-        // Regular children
         if let Some(children) = &*self.node.paint_children.borrow() {
             for child_id in children {
-                // Fixed-position children do not scroll with their containing block
-                // (their layout location is relative to its unscrolled border box),
-                // so cancel out the scroll offset applied to the transform above.
-                let child = &self.context.dom.as_ref().tree()[*child_id];
-                let child_transform = if child.taffy_position() == taffy::Position::Fixed {
-                    // The root element's scroll is the viewport scroll (applied in
-                    // `paint_scene`), not the node's own scroll offset.
-                    let scroll = if Some(self.node.id) == self.context.root_element_id {
-                        self.context.dom.as_ref().viewport_scroll()
-                    } else {
-                        *self.node.scroll_offset()
-                    };
-                    parent_style_transform.pre_translate(kurbo::Vec2 {
-                        x: scroll.x * self.scale,
-                        y: scroll.y * self.scale,
-                    })
-                } else {
-                    parent_style_transform
-                };
-                self.render_node(scene, *child_id, child_transform, clip_rect);
+                self.render_node(scene, *child_id, parent_style_transform, clip_rect);
             }
         }
+    }
 
-        // Positive z_index hoisted nodes
-        if let Some(hoisted) = &self.node.stacking_context {
-            for hoisted_child in hoisted.pos_z_hoisted_children() {
-                let pos = kurbo::Vec2 {
-                    x: hoisted_child.position.x as f64 * self.scale,
-                    y: hoisted_child.position.y as f64 * self.scale,
-                };
-                self.render_node(
+    fn draw_negative_stacked_entries(
+        &self,
+        scene: &mut impl PaintScene,
+        unscrolled_transform: Affine,
+        clip_rect: Rect,
+    ) {
+        if let Some(sc) = &self.node.stacking_context {
+            for entry in sc.negative_entries() {
+                self.draw_stacked_entry(scene, entry.node_id, unscrolled_transform, clip_rect);
+            }
+        }
+    }
+
+    fn draw_non_negative_stacked_entries(
+        &self,
+        scene: &mut impl PaintScene,
+        unscrolled_transform: Affine,
+        clip_rect: Rect,
+    ) {
+        if let Some(sc) = &self.node.stacking_context {
+            for entry in sc.non_negative_entries() {
+                self.draw_stacked_entry(scene, entry.node_id, unscrolled_transform, clip_rect);
+            }
+        }
+    }
+
+    /// Draw one stacked entry of this node's stacking context, resolving its
+    /// coordinate space offset (and any intermediate scroll-container clips)
+    /// from the geometry (containing-block) chain. `unscrolled_transform` is
+    /// this node's border-box transform, *without* its scroll offset applied
+    /// (the offset resolution accounts for scrolling itself, since fixed
+    /// descendants are exempt from it).
+    fn draw_stacked_entry(
+        &self,
+        scene: &mut impl PaintScene,
+        entry_id: NodeId,
+        unscrolled_transform: Affine,
+        clip_rect: Rect,
+    ) {
+        let viewport_scroll = self.context.dom.as_ref().viewport_scroll();
+        let viewport_scroll = taffy::Point {
+            x: viewport_scroll.x as f32,
+            y: viewport_scroll.y as f32,
+        };
+        let Some((offset, clip)) = self.node.stacked_entry_offset(entry_id, viewport_scroll) else {
+            return;
+        };
+        let transform = unscrolled_transform.pre_translate(kurbo::Vec2 {
+            x: offset.x as f64 * self.scale,
+            y: offset.y as f64 * self.scale,
+        });
+        match clip {
+            None => self.render_node(scene, entry_id, transform, clip_rect),
+            Some(clip) => {
+                // Clip to the padding boxes of scroll/clip containers between
+                // the entry and this stacking context root. The clip is in
+                // this node's unscrolled border-box space (CSS pixels).
+                let scaled_clip = Rect::new(
+                    clip.x0 * self.scale,
+                    clip.y0 * self.scale,
+                    clip.x1 * self.scale,
+                    clip.y1 * self.scale,
+                );
+                let screen_transform = Affine::translate(Vec2 {
+                    x: -self.context.initial_x,
+                    y: -self.context.initial_y,
+                }) * unscrolled_transform;
+                let clip_rect =
+                    clip_rect.intersect(screen_transform.transform_rect_bbox(scaled_clip));
+                self.context.layer_manager.maybe_with_layer(
                     scene,
-                    hoisted_child.node_id,
-                    parent_style_transform.pre_translate(pos),
-                    clip_rect,
+                    true,
+                    1.0,
+                    unscrolled_transform,
+                    &scaled_clip,
+                    None,
+                    None,
+                    |scene| {
+                        self.render_node(scene, entry_id, transform, clip_rect);
+                    },
                 );
             }
         }

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -1001,8 +1001,8 @@ impl ElementCx<'_, '_> {
                         *self.node.scroll_offset()
                     };
                     parent_style_transform.pre_translate(kurbo::Vec2 {
-                        x: self.node.scroll_offset().x * self.scale,
-                        y: self.node.scroll_offset().y * self.scale,
+                        x: scroll.x * self.scale,
+                        y: scroll.y * self.scale,
                     })
                 } else {
                     parent_style_transform

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -508,6 +508,20 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                         cx.draw_border(scene);
                         cx.stroke_devtools(scene);
 
+                        // Stacked entries whose geometry chain bypasses this
+                        // element's overflow clip (e.g. fixed-position boxes
+                        // whose containing block is an ancestor of a scroll
+                        // container) must not be clipped by it, so they are
+                        // drawn outside the clip layer.
+                        if should_clip {
+                            cx.draw_negative_stacked_entries(
+                                scene,
+                                unscrolled_transform,
+                                clip_rect,
+                                Some(true),
+                            );
+                        }
+
                         // TODO: allow layers with opacity to be unclipped (overflow: visible)
                         let clip = if is_text_input {
                             &cx.frame.content_box_path()
@@ -542,6 +556,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                                     scene,
                                     unscrolled_transform,
                                     child_clip_rect,
+                                    should_clip.then_some(false),
                                 );
                                 cx.draw_image(scene);
                                 #[cfg(feature = "svg")]
@@ -561,9 +576,19 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                                     scene,
                                     unscrolled_transform,
                                     child_clip_rect,
+                                    should_clip.then_some(false),
                                 );
                             },
                         );
+
+                        if should_clip {
+                            cx.draw_non_negative_stacked_entries(
+                                scene,
+                                unscrolled_transform,
+                                clip_rect,
+                                Some(true),
+                            );
+                        }
 
                         // Overlay scrollbars, drawn unscrolled above the
                         // clipped content.
@@ -1002,28 +1027,45 @@ impl ElementCx<'_, '_> {
         }
     }
 
+    /// Draw this context's negative-z stacked entries. When this node clips
+    /// its overflow, `escaping` filters the entries: `Some(true)` draws only
+    /// entries whose geometry chain bypasses this node's clip (called outside
+    /// the clip layer), `Some(false)` only entries clipped by it (called
+    /// inside the clip layer). `None` draws all entries.
     fn draw_negative_stacked_entries(
         &self,
         scene: &mut impl PaintScene,
         unscrolled_transform: Affine,
         clip_rect: Rect,
+        escaping: Option<bool>,
     ) {
         if let Some(sc) = &self.node.stacking_context {
             for entry in sc.negative_entries() {
-                self.draw_stacked_entry(scene, entry.node_id, unscrolled_transform, clip_rect);
+                if escaping
+                    .is_none_or(|esc| self.node.stacked_entry_escapes_clip(entry.node_id) == esc)
+                {
+                    self.draw_stacked_entry(scene, entry.node_id, unscrolled_transform, clip_rect);
+                }
             }
         }
     }
 
+    /// Draw this context's zero/auto/positive-z stacked entries; `escaping`
+    /// as for [`Self::draw_negative_stacked_entries`].
     fn draw_non_negative_stacked_entries(
         &self,
         scene: &mut impl PaintScene,
         unscrolled_transform: Affine,
         clip_rect: Rect,
+        escaping: Option<bool>,
     ) {
         if let Some(sc) = &self.node.stacking_context {
             for entry in sc.non_negative_entries() {
-                self.draw_stacked_entry(scene, entry.node_id, unscrolled_transform, clip_rect);
+                if escaping
+                    .is_none_or(|esc| self.node.stacked_entry_escapes_clip(entry.node_id) == esc)
+                {
+                    self.draw_stacked_entry(scene, entry.node_id, unscrolled_transform, clip_rect);
+                }
             }
         }
     }

--- a/packages/stylo_taffy/src/convert.rs
+++ b/packages/stylo_taffy/src/convert.rs
@@ -249,13 +249,11 @@ pub fn box_sizing(input: stylo::BoxSizing) -> taffy::BoxSizing {
 #[inline]
 pub fn position(input: stylo::Position) -> taffy::Position {
     match input {
-        // TODO: support position:static
+        stylo::Position::Static => taffy::Position::Static,
         stylo::Position::Relative => taffy::Position::Relative,
-        stylo::Position::Static => taffy::Position::Relative,
-
-        // TODO: support position:fixed and sticky
         stylo::Position::Absolute => taffy::Position::Absolute,
-        stylo::Position::Fixed => taffy::Position::Absolute,
+        stylo::Position::Fixed => taffy::Position::Fixed,
+        // TODO: support position:sticky
         stylo::Position::Sticky => taffy::Position::Relative,
     }
 }

--- a/packages/stylo_taffy/src/wrapper.rs
+++ b/packages/stylo_taffy/src/wrapper.rs
@@ -627,3 +627,23 @@ impl<T: Deref<Target = ComputedValues>> taffy::GridItemStyle for TaffyStyloStyle
         )
     }
 }
+
+impl<T: Deref<Target = ComputedValues>> taffy::OofItemStyle for TaffyStyloStyle<T> {
+    #[inline]
+    fn grid_row(&self) -> taffy::Line<taffy::GridPlacement<Atom>> {
+        let position_styles = self.style.get_position();
+        taffy::Line {
+            start: convert::grid_line(&position_styles.grid_row_start),
+            end: convert::grid_line(&position_styles.grid_row_end),
+        }
+    }
+
+    #[inline]
+    fn grid_column(&self) -> taffy::Line<taffy::GridPlacement<Atom>> {
+        let position_styles = self.style.get_position();
+        taffy::Line {
+            start: convert::grid_line(&position_styles.grid_column_start),
+            end: convert::grid_line(&position_styles.grid_column_end),
+        }
+    }
+}

--- a/tests/blitz-tests/tests/measure_clobber.rs
+++ b/tests/blitz-tests/tests/measure_clobber.rs
@@ -1,0 +1,77 @@
+//! Regression test: a measure (ComputeSize) pass must not overwrite the stored
+//! layouts of a node's children. If it does, a later cache hit on the parent's
+//! PerformLayout leaves the children with measure-time geometry (observed as
+//! the README image becoming too wide on github.com after a relayout).
+
+use blitz_test_harness::Harness;
+use markup5ever::{QualName, local_name, ns};
+use taffy::{AvailableSpace, LayoutPartialTree as _, Size};
+
+fn style_attr() -> QualName {
+    QualName::new(None, ns!(), local_name!("style"))
+}
+
+#[test]
+fn measure_pass_does_not_clobber_inline_child_layout() {
+    let html = r#"
+        <!DOCTYPE html>
+        <html>
+        <body style="margin: 0">
+            <div id="other" style="height: 10px"></div>
+            <p id="target" style="margin: 0">
+                <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAADUlEQVR4nGNgYGD4DwABBAEAX+XBhAAAAABJRU5ErkJggg==" width="1600" height="200" style="max-width: 100%">
+            </p>
+        </body>
+        </html>
+    "#;
+    let mut harness = Harness::from_html(html);
+
+    let width_before = harness.layout_rect("img").width;
+    assert_eq!(width_before, 800.0);
+
+    // Measure the paragraph at a different width, as e.g. block or flexbox
+    // intrinsic-height sizing does when a distant ancestor relayouts.
+    let p_id = harness.query("#target").unwrap();
+    let mut doc = harness.base_mut();
+    doc.compute_child_layout(
+        blitz_dom::taffy_node_id(p_id),
+        taffy::LayoutInput {
+            run_mode: taffy::RunMode::ComputeSize,
+            sizing_mode: taffy::SizingMode::InherentSize,
+            axis: taffy::RequestedAxis::Both,
+            known_dimensions: Size {
+                width: Some(500.0),
+                height: None,
+            },
+            known_dimensions_are_definite: taffy::geometry::Size {
+                width: true,
+                height: false,
+            },
+            parent_size: Size {
+                width: Some(500.0),
+                height: None,
+            },
+            available_space: Size {
+                width: AvailableSpace::Definite(500.0),
+                height: AvailableSpace::MaxContent,
+            },
+            vertical_margins_are_collapsible: taffy::Line::FALSE,
+        },
+    );
+    drop(doc);
+
+    // Trigger a relayout in which the paragraph's PerformLayout is a cache hit,
+    // so its children keep whatever geometry is stored for them.
+    let other_id = harness.query("#other").unwrap();
+    harness
+        .base_mut()
+        .mutate()
+        .set_attribute(other_id, style_attr(), "height: 20px");
+    harness.pump();
+
+    let width_after = harness.layout_rect("img").width;
+    assert_eq!(
+        width_after, 800.0,
+        "measure pass must not modify stored child layouts"
+    );
+}

--- a/tests/blitz-tests/tests/oof_dynamic_cb.rs
+++ b/tests/blitz-tests/tests/oof_dynamic_cb.rs
@@ -1,0 +1,290 @@
+//! Dynamic containing-block changes: when a style change adds or removes a
+//! containing-block-establishing property (transform, will-change, filter,
+//! contain, position) on an ancestor, hoisted `position: absolute` / `fixed`
+//! descendants must move to their new containing block on the next relayout,
+//! even with incremental layout's hot caches.
+//!
+//! Rust ports of the script-driven WPT tests
+//! `css/css-transforms/transform-containing-block-dynamic-1b.html`,
+//! `css/filter-effects/filter-cb-dynamic-1b.html`,
+//! `css/css-will-change/will-change-abspos-cb-dynamic-001.html` and
+//! `css/css-contain/contain-layout-020.html`, which Blitz's WPT runner cannot
+//! run (they require script).
+
+use blitz_test_harness::Harness;
+use blitz_traits::node_id::NodeId;
+use markup5ever::{QualName, local_name, ns};
+
+fn style_attr() -> QualName {
+    QualName::new(None, ns!(), local_name!("style"))
+}
+
+/// A fixed box nested inside `#anc` (offset 50,50 from the page origin).
+/// Without a CB-establishing property on `#anc` the fixed box is positioned
+/// against the viewport at (10, 10); with one it is positioned against
+/// `#anc` at (60, 60) in page coordinates.
+fn fixed_page(anc_style: &str) -> Harness {
+    let html = format!(
+        "<html><head><style>body {{ margin: 0 }}</style></head><body>\
+         <div id=anc style='margin: 50px; width: 300px; height: 300px; {anc_style}'>\
+         <div id=spacer style='height: 30px'></div>\
+         <div id=target style='position: fixed; top: 10px; left: 10px; width: 20px; height: 20px'></div>\
+         </div></body></html>"
+    );
+    Harness::from_html(&html)
+}
+
+fn set_style(harness: &mut Harness, node: NodeId, style: &str) {
+    harness
+        .base_mut()
+        .mutate()
+        .set_attribute(node, style_attr(), style);
+    harness.pump();
+}
+
+const ANC_BASE: &str = "margin: 50px; width: 300px; height: 300px;";
+
+fn assert_fixed_cb_toggle(cb_prop: &str) {
+    // Add the CB-establishing property dynamically
+    let mut harness = fixed_page("");
+    let anc = harness.node("#anc");
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        10.0,
+        "initial (viewport CB)"
+    );
+    assert_eq!(
+        harness.layout_rect("#target").y,
+        10.0,
+        "initial (viewport CB)"
+    );
+
+    set_style(&mut harness, anc, &format!("{ANC_BASE} {cb_prop}"));
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        60.0,
+        "after adding `{cb_prop}`"
+    );
+    assert_eq!(
+        harness.layout_rect("#target").y,
+        60.0,
+        "after adding `{cb_prop}`"
+    );
+
+    // And remove it again
+    set_style(&mut harness, anc, ANC_BASE);
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        10.0,
+        "after removing `{cb_prop}`"
+    );
+    assert_eq!(
+        harness.layout_rect("#target").y,
+        10.0,
+        "after removing `{cb_prop}`"
+    );
+}
+
+#[test]
+fn transform_toggles_fixed_containing_block() {
+    assert_fixed_cb_toggle("transform: translateX(0px)");
+}
+
+#[test]
+fn will_change_toggles_fixed_containing_block() {
+    assert_fixed_cb_toggle("will-change: transform");
+}
+
+#[test]
+fn filter_toggles_fixed_containing_block() {
+    assert_fixed_cb_toggle("filter: grayscale(50%)");
+}
+
+#[test]
+fn contain_toggles_fixed_containing_block() {
+    assert_fixed_cb_toggle("contain: layout");
+}
+
+/// Toggling `position: relative` on a static intermediate ancestor moves an
+/// absolutely positioned descendant between containing blocks.
+#[test]
+fn position_toggles_absolute_containing_block() {
+    let html = "<html><head><style>body { margin: 0 }</style></head><body>\
+         <div id=outer style='position: relative; margin: 20px; width: 400px; height: 400px'>\
+         <div id=mid style='margin: 30px; width: 300px; height: 300px'>\
+         <div id=target style='position: absolute; top: 10px; left: 10px; width: 20px; height: 20px'></div>\
+         </div></div></body></html>";
+    let mut harness = Harness::from_html(html);
+    let mid = harness.node("#mid");
+
+    // CB is #outer at (20, 30): #mid's 30px top margin collapses through #outer
+    assert_eq!(harness.layout_rect("#target").x, 30.0);
+    assert_eq!(harness.layout_rect("#target").y, 40.0);
+
+    // Make #mid positioned: CB becomes #mid at (50, 30)
+    set_style(
+        &mut harness,
+        mid,
+        "position: relative; margin: 30px; width: 300px; height: 300px",
+    );
+    assert_eq!(harness.layout_rect("#target").x, 60.0);
+    assert_eq!(harness.layout_rect("#target").y, 40.0);
+
+    // Back to static: CB is #outer again
+    set_style(
+        &mut harness,
+        mid,
+        "margin: 30px; width: 300px; height: 300px",
+    );
+    assert_eq!(harness.layout_rect("#target").x, 30.0);
+    assert_eq!(harness.layout_rect("#target").y, 40.0);
+}
+
+/// CB changes driven purely by a restyle (`:hover`), with no DOM mutation. This
+/// exercises the pure restyle-damage path (DOM mutations like `set_attribute`
+/// insert full damage unconditionally, masking under-damaging bugs).
+fn assert_hover_toggles_fixed_cb(cb_prop: &str) {
+    let html = format!(
+        "<html><head><style>\
+         body {{ margin: 0 }}\
+         #anc {{ margin: 50px; width: 300px; height: 300px; }}\
+         #anc:hover {{ {cb_prop} }}\
+         </style></head><body>\
+         <div id=anc>\
+         <div id=target style='position: fixed; top: 10px; left: 10px; width: 20px; height: 20px'></div>\
+         </div></body></html>"
+    );
+    let mut harness = Harness::from_html(&html);
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        10.0,
+        "initial (viewport CB)"
+    );
+
+    // Hover #anc: it now establishes the fixed containing block
+    harness.base_mut().set_hover_to(60.0, 60.0);
+    harness.pump();
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        60.0,
+        "hovered: `{cb_prop}` makes #anc the CB"
+    );
+
+    // Unhover: back to the viewport
+    harness.base_mut().set_hover_to(700.0, 500.0);
+    harness.pump();
+    assert_eq!(
+        harness.layout_rect("#target").x,
+        10.0,
+        "unhovered (viewport CB)"
+    );
+}
+
+#[test]
+fn hover_transform_toggles_fixed_containing_block() {
+    assert_hover_toggles_fixed_cb("transform: translateX(0px)");
+}
+
+#[test]
+fn hover_will_change_toggles_fixed_containing_block() {
+    assert_hover_toggles_fixed_cb("will-change: transform");
+}
+
+#[test]
+fn hover_filter_toggles_fixed_containing_block() {
+    assert_hover_toggles_fixed_cb("filter: grayscale(50%)");
+}
+
+/// Dynamically inserting and removing a hoisted box (the common fixed-position
+/// popup/modal pattern). The box must be laid out via its containing block on
+/// insertion and fully disappear from layout/paint/hit-test on removal.
+#[test]
+fn insert_and_remove_hoisted_box() {
+    let html = "<html><head><style>body { margin: 0 }</style></head><body>\
+         <div id=anc style='margin: 50px; width: 300px; height: 300px'></div>\
+         </body></html>";
+    let mut harness = Harness::from_html(html);
+    let anc = harness.node("#anc");
+
+    // Insert a fixed box inside #anc
+    let target = {
+        let mut doc = harness.base_mut();
+        let mut mutator = doc.mutate();
+        let target = mutator.create_element(
+            QualName::new(None, ns!(html), local_name!("div")),
+            vec![blitz_dom::Attribute {
+                name: style_attr(),
+                value: "position: fixed; top: 10px; left: 10px; width: 20px; height: 20px".into(),
+            }],
+        );
+        mutator.append_children(anc, &[target]);
+        target
+    };
+    harness.pump();
+
+    // Positioned against the viewport, and hit-testable there
+    assert_eq!(harness.layout_rect_of(target).x, 10.0);
+    assert_eq!(harness.layout_rect_of(target).y, 10.0);
+    assert_eq!(harness.hit_node(15.0, 15.0), target);
+
+    // Remove it again: it must stop being laid out / hit-testable
+    harness.base_mut().mutate().remove_node(target);
+    harness.pump();
+    assert_ne!(
+        harness.hit(15.0, 15.0).map(|h| h.node_id),
+        Some(target.into())
+    );
+}
+
+/// Toggling `display: none` on a hoisted box's static parent must hide and
+/// re-show the hoisted box.
+#[test]
+fn display_none_toggle_on_static_parent() {
+    let html = "<html><head><style>body { margin: 0 }</style></head><body>\
+         <div id=parent style='width: 300px; height: 300px'>\
+         <div id=target style='position: fixed; top: 10px; left: 10px; width: 20px; height: 20px'></div>\
+         </div></body></html>";
+    let mut harness = Harness::from_html(html);
+    let parent = harness.node("#parent");
+    let target = harness.node("#target");
+
+    assert_eq!(harness.hit_node(15.0, 15.0), target);
+
+    set_style(
+        &mut harness,
+        parent,
+        "display: none; width: 300px; height: 300px",
+    );
+    assert_ne!(
+        harness.hit(15.0, 15.0).map(|h| h.node_id),
+        Some(target.into()),
+        "hidden with its parent"
+    );
+
+    set_style(&mut harness, parent, "width: 300px; height: 300px");
+    assert_eq!(
+        harness.hit_node(15.0, 15.0),
+        target,
+        "re-shown with its parent"
+    );
+    assert_eq!(harness.layout_rect("#target").x, 10.0);
+}
+
+/// A layout change (not a CB change) inside a hoisted subtree must relayout the
+/// hoisted box through its containing block.
+#[test]
+fn content_change_inside_hoisted_subtree() {
+    let html = "<html><head><style>body { margin: 0 }</style></head><body>\
+         <div style='width: 300px; height: 300px'>\
+         <div id=target style='position: fixed; top: 10px; left: 10px'>\
+         <div id=inner style='width: 20px; height: 20px'></div>\
+         </div></div></body></html>";
+    let mut harness = Harness::from_html(html);
+    let inner = harness.node("#inner");
+
+    assert_eq!(harness.layout_rect("#target").width, 20.0);
+
+    set_style(&mut harness, inner, "width: 50px; height: 40px");
+    assert_eq!(harness.layout_rect("#target").width, 50.0);
+    assert_eq!(harness.layout_rect("#target").height, 40.0);
+}

--- a/tests/blitz-tests/tests/paint_order.rs
+++ b/tests/blitz-tests/tests/paint_order.rs
@@ -76,3 +76,41 @@ fn earlier_abspos_stays_below_static_when_later_in_tree_order_is_static() {
         "positioned content paints above in-flow content regardless of tree order"
     );
 }
+
+#[test]
+fn abspos_under_opacity_ancestor_keeps_effect() {
+    // The opacity div is not the abspos child's containing block (that's the
+    // outer relative div), but it IS its paint/effect ancestor: the abspos
+    // content must still be blended by the ancestor's opacity.
+    let px = center_pixel(
+        r#"<html><body style="margin:0; background:#ffffff">
+            <div style="position:relative; width:100px; height:100px;">
+                <div style="opacity:0.5; width:100px; height:100px;">
+                    <div style="position:absolute; inset:0; background:#ff0000;"></div>
+                </div>
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(
+        px,
+        [255, 127, 127],
+        "abspos under an opacity ancestor (not its CB) must be blended by that opacity"
+    );
+}
+
+#[test]
+fn negative_z_abspos_paints_below_in_flow_sibling() {
+    let px = center_pixel(
+        r#"<html><body style="margin:0">
+            <div style="position:relative; width:100px; height:100px;">
+                <div style="position:absolute; inset:0; background:#ff0000; z-index:-1;"></div>
+                <div style="width:100px; height:100px; background:#0000ff;"></div>
+            </div>
+        </body></html>"#,
+    );
+    assert_eq!(
+        px,
+        [0, 0, 255],
+        "negative z-index abspos must paint below in-flow sibling content"
+    );
+}


### PR DESCRIPTION
## Summary

Replaces the baked-position OOF paint hoisting (from the base branch) with a browser-like architecture that keeps three relationships separate: structural/layout ancestry (`layout_parent` / `layout_children`, never mutated for paint), Taffy containing-block geometry (`hoisted_children` + new inverse `oof_containing_block`), and paint order (a new derived stacking structure).

**Stacking membership** (`layout/stacking.rs`, run post-layout, gated by `STACKING_DAMAGE`):
- Walks the structural tree; each node gets `paint_children` (in-flow + floats only) and, if it's a real stacking context, a `StackingContext { entries, negative_z_count }` of its stacked descendants.
- `Node::is_stacked` vs `Node::is_stacking_context_root` distinguish `z-index: auto` stacking *containers* (positioned boxes that contribute an entry but whose stacked descendants promote into the same enclosing context) from atomic real stacking contexts (non-auto z-index, opacity/filter/mask/clip-path, transform-ish properties via `establishes_fixed_containing_block`, mix-blend-mode, isolation, sticky/fixed, CSS animations).
- OOF boxes are classified at their *structural* position, so effect ancestors (e.g. opacity) that are not the containing block still apply to them.

**Geometry at paint time** (no baked positions):
- `Node::paint_geometry_parent()` = OOF containing block if out-of-flow, else `layout_parent`.
- `Node::stacked_entry_offset()` resolves an entry's offset dynamically by walking geometry-parent chains from the entry and the stacking-context root to their common ancestor, accumulating layout locations, scroll offsets, and intermediate overflow clips.
- `stacked_entry_escapes_clip()` lets entries whose geometry chain bypasses a clipping stacking context (e.g. a fixed box inside a scrollable fixed ancestor) paint outside that ancestor's clip layer.

**Painting/hit testing**: `blitz-paint` draws negative entries before content and non-negative entries after (`draw_stacked_entries` split on `negative_z_count`); `hit_inner` traverses the exact same entries in reverse. The old hoisted-paint-children plumbing, `layout_parent` repointing in `attach_hoisted_children`, and fixed-scroll hit-test special cases are removed.

Also fixes flex/grid `order` sorting to ignore out-of-flow children (they aren't flex/grid items, per `flexbox-paint-ordering-003.html`).

## WPT

vs the base branch: `css-position` +5, `css-flexbox` +3, `css-grid` +1, `CSS2/positioning` +4, `css-transforms` +4/-1, `CSS2/zindex` and `CSS2/abspos` unchanged. The one new failure, `css/css-transforms/perspective-split-by-zero-w.html`, is a pre-existing preserve-3d/perspective rendering limitation that was previously masked: the test's reference hides a red patch under a 3D-transformed div that Blitz can't fully render; the old code incorrectly painted the ref's negative-z patch below the canvas background, making test and ref equally wrong.

## Tests

New `paint_order.rs` cases: abspos under an opacity ancestor that is not its CB keeps the opacity effect; negative-z abspos paints below in-flow sibling content. Existing `oof_dynamic_cb.rs` suite passes.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/2e5b5e83db014e14be353d6e89c14433
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/2e5b5e83db014e14be353d6e89c14433?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**138** newly passing, **44** newly failing (net +94).

<details>
<summary>Full diff (182 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/abspos/static-inside-inline-002.html
+ Fail => Pass css/CSS2/backgrounds/background-bg-pos-204.xht
- Pass => Fail css/CSS2/backgrounds/background-position-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-023.xht
+ Fail => Pass css/CSS2/box-display/containing-block-007.xht
+ Fail => Pass css/CSS2/box-display/containing-block-008.xht
+ Fail => Pass css/CSS2/box-display/containing-block-009.xht
+ Fail => Pass css/CSS2/box-display/containing-block-010.xht
+ Fail => Pass css/CSS2/floats-clear/clear-applies-to-012.xht
+ Fail => Pass css/CSS2/floats-clear/clear-applies-to-014.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-004.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-005.xht
+ Fail => Pass css/CSS2/floats-clear/floats-019.xht
+ Fail => Pass css/CSS2/generated-content/before-after-positioned-002.html
+ Fail => Pass css/CSS2/generated-content/before-after-positioned-003.html
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-037.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-width-026.xht
+ Fail => Pass css/CSS2/positioning/abspos-014.xht
+ Fail => Pass css/CSS2/positioning/abspos-015.xht
+ Fail => Pass css/CSS2/positioning/abspos-016.xht
+ Fail => Pass css/CSS2/positioning/abspos-017.xht
+ Fail => Pass css/CSS2/positioning/abspos-018.xht
+ Fail => Pass css/CSS2/positioning/abspos-022.xht
+ Fail => Pass css/CSS2/positioning/abspos-026.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-005.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-006.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-001.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-002.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-003.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-004.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-005.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-006.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-007.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-008.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-009.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-012.xht
+ Fail => Pass css/CSS2/positioning/dynamic-top-change-003.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-014.xht
+ Fail => Pass css/CSS2/positioning/position-fixed-007.xht
+ Fail => Pass css/CSS2/positioning/position-static-001.xht
+ Fail => Pass css/CSS2/positioning/relpos-calcs-001.xht
+ Fail => Pass css/CSS2/positioning/relpos-calcs-002.xht
+ Fail => Pass css/CSS2/positioning/relpos-calcs-007.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-014.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-014.xht
+ Fail => Pass css/CSS2/tables/separated-border-model-007.xht
+ Fail => Pass css/CSS2/tables/separated-border-model-008.xht
+ Fail => Pass css/CSS2/tables/separated-border-model-009.xht
+ Fail => Pass css/CSS2/visuren/anonymous-boxes-001b.xht
+ Fail => Pass css/CSS2/visuren/inherit-static-offset-001.xht
+ Fail => Pass css/CSS2/visuren/inherit-static-offset-002.xht
+ Fail => Pass css/CSS2/visuren/inherit-static-offset-003.xht
+ Fail => Pass css/CSS2/visuren/position-absolute-percentage-inherit-001.xht
- Pass => Fail css/WOFF2/blocks-extraneous-data-003.xht
- Pass => Fail css/WOFF2/blocks-extraneous-data-004.xht
- Pass => Fail css/WOFF2/blocks-extraneous-data-005.xht
- Pass => Fail css/WOFF2/blocks-extraneous-data-006.xht
- Pass => Fail css/WOFF2/blocks-extraneous-data-007.xht
- Pass => Fail css/WOFF2/blocks-extraneous-data-008.xht
- Pass => Fail css/WOFF2/blocks-overlap-003.xht
- Pass => Fail css/WOFF2/header-reserved-001.xht
- Pass => Fail css/WOFF2/tabledata-extraneous-data-001.xht
- Pass => Fail css/WOFF2/tabledata-recontruct-loca-001.xht
+ Fail => Pass css/compositing/isolation/isolation-establishes-stacking-context.html
+ Fail => Pass css/css-align/abspos/align-self-with-flex-grid-parent.html
- Pass => Fail css/css-anchor-position/anchor-position-dynamic-005.html
- Pass => Fail css/css-anchor-position/anchor-scroll-fixedpos-003.html
- Pass => Fail css/css-anchor-position/anchor-scroll-fixedpos-004.html
- Pass => Fail css/css-anchor-position/anchor-scroll-nested.html
- Pass => Fail css/css-anchor-position/position-visibility-anchors-visible-in-overflow.html
+ Fail => Pass css/css-backgrounds/background-origin-006.html
+ Fail => Pass css/css-backgrounds/background-rounded-image-clip-001.html
+ Fail => Pass css/css-backgrounds/background-size-percentage-root.html
+ Fail => Pass css/css-backgrounds/box-shadow/slice-inline-fragmentation-002.html
- Pass => Fail css/css-break/grid/grid-item-oof-012.html
+ Fail => Pass css/css-break/out-of-flow-in-multicolumn-091.html
+ Fail => Pass css/css-break/out-of-flow-in-multicolumn-092.html
+ Fail => Pass css/css-break/out-of-flow-in-multicolumn-104.html
+ Fail => Pass css/css-conditional/container-queries/no-layout-containment-abspos.html
+ Fail => Pass css/css-conditional/container-queries/no-layout-containment-fixedpos.html
- Pass => Fail css/css-contain/contain-layout-020.html
- Pass => Fail css/css-contain/contain-layout-ignored-cases-ib-split-001.html
+ Fail => Pass css/css-contain/contain-layout-stacking-context-001.html
+ Fail => Pass css/css-contain/contain-paint-clip-001.html
- Pass => Fail css/css-contain/contain-paint-ignored-cases-ib-split-001.html
- Pass => Fail css/css-contain/contain-paint-ignored-cases-ruby-stacking-and-clipping-001.html
+ Fail => Pass css/css-contain/contain-paint-stacking-context-001a.html
+ Fail => Pass css/css-contain/contain-paint-stacking-context-001b.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-095.html
+ Fail => Pass css/css-flexbox/abspos/position-absolute-002.html
+ Fail => Pass css/css-flexbox/flex-item-position-relative-001.html
+ Fail => Pass css/css-flexbox/flexbox-items-as-stacking-contexts-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-paint-ordering-003.html
+ Fail => Pass css/css-flexbox/flexbox_margin-left-ex.html
+ Fail => Pass css/css-flexbox/order/order-abs-children-painting-order.html
- Pass => Fail css/css-flexbox/table-as-item-large-intrinsic-size.html
+ Fail => Pass css/css-grid/abspos/absolute-positioning-grid-container-containing-block-001.html
- Pass => Fail css/css-grid/abspos/grid-abspos-staticpos-align-self-safe-outer-cb-003.tentative.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-004.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-006.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-007.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-008.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-012.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-014.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-015.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-016.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendants-017.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-items-019.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-items-024.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-items-should-not-take-up-space-001.html
+ Fail => Pass css/css-grid/grid-items/grid-items-percentage-paddings-015.html
+ Fail => Pass css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/column-subgrid-abs-pos-001.html
+ Fail => Pass css/css-grid/subgrid/abs-pos-001.html
- Pass => Fail css/css-images/image-orientation/image-orientation-img-object-fit.html
+ Fail => Pass css/css-multicol/multicol-contained-absolute.html
+ Fail => Pass css/css-multicol/multicol-oof-inline-cb-001.html
+ Fail => Pass css/css-overflow/overflow-clip-margin-021.html
+ Fail => Pass css/css-overflow/overflow-clip-margin-022.html
+ Fail => Pass css/css-page/fixedpos-005-print.html
+ Fail => Pass css/css-page/fixedpos-007-print.html
+ Fail => Pass css/css-page/fixedpos-008-print.html
- Pass => Fail css/css-position/nested-inline-abspos-child-with-siblings.html
- Pass => Fail css/css-position/nested-inline-abspos-child.html
+ Fail => Pass css/css-position/position-absolute-center-003.html
+ Fail => Pass css/css-position/position-absolute-center-004.html
+ Fail => Pass css/css-position/position-fixed-overflow-print.html
+ Fail => Pass css/css-position/position-fixed-scroll-nested-fixed.html
+ Fail => Pass css/css-position/position-relative-table-td-left.html
+ Fail => Pass css/css-position/position-relative-table-td-top.html
+ Fail => Pass css/css-position/position-static-001.html
+ Fail => Pass css/css-position/sticky/position-sticky-large-top-2.tentative.html
+ Fail => Pass css/css-position/sticky/position-sticky-large-top.tentative.html
- Pass => Fail css/css-pseudo/first-letter-width-2.html
+ Fail => Pass css/css-pseudo/highlight-z-index-001.html
+ Fail => Pass css/css-tables/absolute-tables-010.tentative.html
+ Fail => Pass css/css-text-decor/text-shadow/text-shadow-emoji-transparent.html
- Pass => Fail css/css-transforms/backface-visibility-hidden-animated-001.html
- Pass => Fail css/css-transforms/backface-visibility-hidden-animated-002.html
+ Fail => Pass css/css-transforms/individual-transform/stacking-context-002.html
+ Fail => Pass css/css-transforms/individual-transform/stacking-context-003.html
+ Fail => Pass css/css-transforms/individual-transform/stacking-context-004.html
- Pass => Fail css/css-transforms/perspective-containing-block-dynamic-1b.html
- Pass => Fail css/css-transforms/perspective-split-by-zero-w.html
+ Fail => Pass css/css-transforms/preserve-3d-flat-grouping-properties-containing-block-inline.tentative.html
- Pass => Fail css/css-transforms/transform-containing-block-dynamic-1b.html
+ Fail => Pass css/css-transforms/transform-stacking-001.html
+ Fail => Pass css/css-transforms/ttwf-transform-translatex-001.html
+ Fail => Pass css/css-transforms/ttwf-transform-translatey-001.html
- Pass => Fail css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new.html
- Pass => Fail css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-old.html
- Pass => Fail css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-new.html
- Pass => Fail css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-old.html
- Pass => Fail css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html
+ Fail => Pass css/css-viewport/zoom/explicit-inherit/bottom.html
+ Fail => Pass css/css-viewport/zoom/explicit-inherit/left.html
+ Fail => Pass css/css-viewport/zoom/explicit-inherit/right.html
+ Fail => Pass css/css-viewport/zoom/explicit-inherit/top.html
- Pass => Fail css/css-will-change/will-change-abspos-cb-dynamic-001.html
+ Fail => Pass css/css-will-change/will-change-fixpos-cb-height-1.html
+ Fail => Pass css/css-will-change/will-change-fixpos-cb-position-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-backdrop-filter-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-filter-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-offset-path-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-perspective-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-transform-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-transform-style-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-translate-1.html
+ Fail => Pass css/css-writing-modes/float-rgt-orthog-htb-in-vrl-003.xht
- Pass => Fail css/cssom-view/cssom-getBoundingClientRect-vertical-rl.html
- Pass => Fail css/filter-effects/backdrop-filter-clip-rect-zoom.html
- Pass => Fail css/filter-effects/backdrop-filter-plus-mask-large.html
- Pass => Fail css/filter-effects/filter-cb-dynamic-1b.html
- Pass => Fail css/filter-effects/filtered-inline-is-container.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/32987930662).</sub>
<!-- wpt-results-end -->
