### PR TITLE
Rename transformed overflow bounds

### DIFF
--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -116,7 +116,7 @@ pub struct ElementData {
     pub transform: Option<Affine>,
 }
 
-/// Taffy layout output state (cache, layouts, scroll offset and overflow).
+/// Taffy layout output state (cache, layouts, scroll offset and transformed overflow).
 ///
 /// Lazily boxed on [`ElementData`] / [`DocumentData`]: inline-level elements
 /// are positioned by the inline (parley) layout rather than by taffy, so most
@@ -127,7 +127,9 @@ pub struct LayoutData {
     pub unrounded_layout: Layout,
     pub final_layout: Layout,
     pub scroll_offset: crate::Point<f64>,
-    pub scrollable_overflow: KurboRect,
+    /// Device-pixel subtree bounds in this node's coordinate space, including
+    /// descendant transforms. This is distinct from Taffy's CSS scrollable overflow.
+    pub transformed_overflow: KurboRect,
 }
 
 impl LayoutData {
@@ -137,7 +139,7 @@ impl LayoutData {
             unrounded_layout: Layout::new(),
             final_layout: Layout::new(),
             scroll_offset: crate::Point::ZERO,
-            scrollable_overflow: KurboRect::ZERO,
+            transformed_overflow: KurboRect::ZERO,
         }
     }
 }

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -260,13 +260,13 @@ impl Node {
     }
 
     #[inline]
-    pub fn scrollable_overflow(&self) -> &KurboRect {
-        &self.layout_data().scrollable_overflow
+    pub fn transformed_overflow(&self) -> &KurboRect {
+        &self.layout_data().transformed_overflow
     }
 
     #[inline]
-    pub fn scrollable_overflow_mut(&mut self) -> &mut KurboRect {
-        &mut self.layout_data_mut().scrollable_overflow
+    pub fn transformed_overflow_mut(&mut self) -> &mut KurboRect {
+        &mut self.layout_data_mut().transformed_overflow
     }
 
     /// Style data from stylo, if this node kind carries it (element or document
@@ -1358,9 +1358,9 @@ impl Node {
             None => false,
         };
 
-        // `scrollable_overflow` is stored in device (scaled) pixels, whereas the
+        // `transformed_overflow` is stored in device (scaled) pixels, whereas the
         // coordinates here are in CSS pixels, so unscale it before comparing.
-        let overflow = *self.scrollable_overflow();
+        let overflow = *self.transformed_overflow();
 
         let matches_overflow = x >= (overflow.x0 / scale) as f32
             && x <= (overflow.x1 / scale) as f32

--- a/packages/blitz-dom/src/resolve.rs
+++ b/packages/blitz-dom/src/resolve.rs
@@ -179,7 +179,7 @@ impl BaseDocument {
                 transform *= *t
             }
 
-            let overflow = *node.scrollable_overflow();
+            let overflow = *node.transformed_overflow();
             return transform.transform_rect_bbox(overflow);
         }
 
@@ -206,7 +206,7 @@ impl BaseDocument {
             overflow = overflow.union(child_rect_in_self);
         }
 
-        *self.nodes[node_id].scrollable_overflow_mut() = overflow;
+        *self.nodes[node_id].transformed_overflow_mut() = overflow;
         *self.nodes[node_id].layout_children.get_mut() = layout_children;
 
         let scaled_x = self.nodes[node_id].final_layout().location.x as f64 * scale;

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -379,7 +379,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         };
 
         // Don't render things that are out of view
-        let overflow = *node.scrollable_overflow();
+        let overflow = *node.transformed_overflow();
         let transform = parent_style_transform
             * Affine::translate(box_position)
             * node.transform().unwrap_or_default();
@@ -404,7 +404,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         // Optimise zero-area (/very small area) clips by not rendering at all
         let clip_area = content_box_size.width * content_box_size.height;
         let overflow_area =
-            node.scrollable_overflow().width() * node.scrollable_overflow().height();
+            node.transformed_overflow().width() * node.transformed_overflow().height();
         if should_clip && clip_area < 0.01 && overflow_area < 0.01 {
             return;
         }

--- a/tests/blitz-tests/tests/details_element.rs
+++ b/tests/blitz-tests/tests/details_element.rs
@@ -106,7 +106,7 @@ fn clicking_summary_toggles_open() {
 
 #[test]
 fn summary_hit_area_matches_box_at_hidpi() {
-    // `scrollable_overflow` is stored in device (scaled) pixels while hit-test
+    // `transformed_overflow` is stored in device (scaled) pixels while hit-test
     // coordinates are CSS pixels. Before unscaling it in `Node::hit()`, every
     // element's hit area was inflated by the HiDPI scale factor, so at 2x the
     // summary's effective hit area was ~double its box (as seen on


### PR DESCRIPTION
## Summary

Rename Blitz's device-pixel, transform-aware subtree bound from `scrollable_overflow` to `transformed_overflow`.

`transformed_overflow` represents the bounds of an items content, accounting for `transforms` (so it is halfway to visual or ink overflow). Something closer to CSS scrollable overflow is actually stored in Taffy's `Layout::scrollable_overflow_rect` which drives scrolling metrics.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33012503576).</sub>
<!-- wpt-results-end -->
