### PR TITLE
Resolve OOF layout against inline containing blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7430,7 +7430,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=4da301158398d53ab898eb90f97b30bbaace6b67#4da301158398d53ab898eb90f97b30bbaace6b67"
+source = "git+https://github.com/DioxusLabs/taffy?rev=0ee0e7f6801b2388382933af00ba36951c166817#0ee0e7f6801b2388382933af00ba36951c166817"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "4da301158398d53ab898eb90f97b30bbaace6b67", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "0ee0e7f6801b2388382933af00ba36951c166817", default-features = false, features = [
     "std",
     "flexbox",
     "grid",
@@ -308,4 +308,3 @@ rustc-hash = { workspace = true }
 # [patch."https://github.com/linebender/parley"]
 # parley = { path = "../parley/parley" }
 # fontique = { path = "../parley/fontique" }
-

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -1,12 +1,16 @@
+use std::collections::HashMap;
+
 use blitz_traits::node_id::NodeId;
-use parley::{AlignmentOptions, IndentOptions};
-use style::values::specified::box_::DisplayOutside;
+use parley::{AlignmentOptions, IndentOptions, PositionedLayoutItem};
+use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
 use taffy::{
     AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
-    CoreStyle as _, Direction, LayoutInput, LayoutOutput, LayoutPartialTree as _, MaybeMath as _,
-    MaybeResolve as _, OofCandidate, OofCandidates, OofPositioningArea, Overflow, Point,
-    RequestedAxis, ResolveOrZero as _, RunMode, Size, SizingMode, StaticEdge, StaticPosition,
+    CoreStyle as _, Direction, LayoutContainingBlock as _, LayoutInput, LayoutOutput,
+    LayoutPartialTree as _, MaybeMath as _, MaybeResolve as _, OofCandidate, OofCandidates,
+    OofClaims, OofPositioningArea, Overflow, Point, Position, Rect, RequestedAxis,
+    ResolveOrZero as _, RunMode, Size, SizingMode, StaticEdge, StaticPosition,
+    compute_oof_layout_for_area,
 };
 
 #[cfg(feature = "floats")]
@@ -15,9 +19,311 @@ use parley::YieldData;
 use taffy::{BlockItemStyle as _, Clear, Float, prelude::TaffyMaxContent};
 
 use super::resolve_calc_value;
-use crate::BaseDocument;
+use crate::node::{InlineOofAssignment, PendingInlineOofCandidate};
+use crate::{BaseDocument, dom_node_id};
+
+#[derive(Default)]
+struct InlineFragmentBounds {
+    first: Option<Rect<f32>>,
+    last: Option<Rect<f32>>,
+    current: Option<(usize, Rect<f32>)>,
+}
+
+impl InlineFragmentBounds {
+    fn add(&mut self, line_index: usize, rect: Rect<f32>) {
+        match self.current {
+            Some((current_line, current_rect)) if current_line == line_index => {
+                self.current = Some((line_index, union_rect(current_rect, rect)));
+            }
+            Some(_) => {
+                self.finish_fragment();
+                self.current = Some((line_index, rect));
+            }
+            None => self.current = Some((line_index, rect)),
+        }
+    }
+
+    fn finish(mut self) -> Option<(Rect<f32>, Rect<f32>)> {
+        self.finish_fragment();
+        Some((self.first?, self.last?))
+    }
+
+    fn finish_fragment(&mut self) {
+        let Some((_, rect)) = self.current.take() else {
+            return;
+        };
+        self.first.get_or_insert(rect);
+        self.last = Some(rect);
+    }
+}
+
+fn union_rect(a: Rect<f32>, b: Rect<f32>) -> Rect<f32> {
+    Rect {
+        left: a.left.min(b.left),
+        right: a.right.max(b.right),
+        top: a.top.min(b.top),
+        bottom: a.bottom.max(b.bottom),
+    }
+}
+
+struct InlineOofGroup {
+    containing_block: NodeId,
+    padding: Rect<f32>,
+    root_content_box_offset: Point<f32>,
+    candidates: OofCandidates,
+    bounds: InlineFragmentBounds,
+    matches_current_item: bool,
+}
 
 impl BaseDocument {
+    fn inline_oof_claims(&self, node_id: NodeId) -> OofClaims {
+        let node = &self.nodes[node_id];
+        let fixed = node.inline_establishes_fixed_containing_block();
+        OofClaims {
+            absolute: fixed
+                || node.layout_style().position().is_positioned()
+                || node.establishes_absolute_containing_block(),
+            fixed,
+        }
+    }
+
+    fn inline_containing_block(
+        &self,
+        inline_root: NodeId,
+        child: NodeId,
+        position: Position,
+    ) -> Option<NodeId> {
+        let mut current = self.nodes[child].parent?;
+        while current != inline_root {
+            let node = &self.nodes[current];
+            let display = node.display_style()?;
+            match (display.outside(), display.inside()) {
+                (DisplayOutside::None, DisplayInside::Contents) => {}
+                (DisplayOutside::Inline, DisplayInside::Flow) => {
+                    let claims = self.inline_oof_claims(current);
+                    let claimed = match position {
+                        Position::Absolute => claims.absolute,
+                        Position::Fixed => claims.fixed,
+                        _ => false,
+                    };
+                    if claimed {
+                        return Some(current);
+                    }
+                }
+                _ => return None,
+            }
+            current = node.parent?;
+        }
+        None
+    }
+
+    fn collect_inline_oof_groups(
+        &self,
+        inline_root: NodeId,
+        pending: Box<[PendingInlineOofCandidate]>,
+    ) -> Vec<InlineOofGroup> {
+        let mut groups: Vec<InlineOofGroup> = Vec::new();
+        for pending in pending {
+            if let Some(group) = groups
+                .iter_mut()
+                .find(|group| group.containing_block == pending.containing_block)
+            {
+                group.candidates.push(pending.candidate);
+            } else {
+                let mut candidates = OofCandidates::new();
+                candidates.push(pending.candidate);
+                groups.push(InlineOofGroup {
+                    containing_block: pending.containing_block,
+                    padding: pending.padding,
+                    root_content_box_offset: pending.root_content_box_offset,
+                    candidates,
+                    bounds: InlineFragmentBounds::default(),
+                    matches_current_item: false,
+                });
+            }
+        }
+
+        let Some(layout) = self.nodes[inline_root]
+            .element_data()
+            .and_then(|element| element.inline_layout_data.as_ref())
+            .map(|inline_layout| &inline_layout.layout)
+        else {
+            return groups;
+        };
+        let group_indices: HashMap<NodeId, usize> = groups
+            .iter()
+            .enumerate()
+            .map(|(index, group)| (group.containing_block, index))
+            .collect();
+
+        for (line_index, line) in layout.lines().enumerate() {
+            for item in line.items() {
+                for group in &mut groups {
+                    group.matches_current_item = false;
+                }
+                let (item_id, rect) = match item {
+                    PositionedLayoutItem::GlyphRun(glyph_run) => {
+                        let metrics = glyph_run.run().metrics();
+                        let left = glyph_run.offset();
+                        let right = left + glyph_run.advance();
+                        (
+                            glyph_run.style().brush.id,
+                            Rect {
+                                left: left.min(right),
+                                right: left.max(right),
+                                top: glyph_run.baseline() - metrics.ascent,
+                                bottom: glyph_run.baseline() + metrics.descent,
+                            },
+                        )
+                    }
+                    PositionedLayoutItem::InlineBox(inline_box)
+                        if inline_box.kind == parley::InlineBoxKind::InFlow =>
+                    {
+                        (
+                            NodeId::from_u64(inline_box.id),
+                            Rect {
+                                left: inline_box.x,
+                                right: inline_box.x + inline_box.width,
+                                top: inline_box.y,
+                                bottom: inline_box.y + inline_box.height,
+                            },
+                        )
+                    }
+                    PositionedLayoutItem::InlineBox(_) => continue,
+                };
+
+                let mut current = item_id;
+                while current != inline_root {
+                    if let Some(&group_index) = group_indices.get(&current) {
+                        groups[group_index].matches_current_item = true;
+                    }
+                    let Some(parent) = self.nodes.get(current).and_then(|node| node.parent) else {
+                        break;
+                    };
+                    current = parent;
+                }
+                for group in &mut groups {
+                    if group.matches_current_item {
+                        group.bounds.add(line_index, rect);
+                    } else {
+                        group.bounds.finish_fragment();
+                    }
+                }
+            }
+            for group in &mut groups {
+                group.bounds.finish_fragment();
+            }
+        }
+
+        groups
+    }
+
+    pub(crate) fn layout_inline_containing_block_oof(
+        &mut self,
+        node_id: taffy::NodeId,
+        output: &mut LayoutOutput,
+    ) {
+        let inline_root = dom_node_id(node_id);
+        let (pending, old_assignments) = {
+            let Some(inline_layout) = self.nodes[inline_root]
+                .data
+                .downcast_element_mut()
+                .and_then(|element| element.inline_layout_data.as_mut())
+            else {
+                return;
+            };
+            (
+                inline_layout.pending_inline_oof_candidates.take(),
+                inline_layout.inline_oof_assignments.take(),
+            )
+        };
+
+        let mut groups = pending
+            .map(|pending| self.collect_inline_oof_groups(inline_root, pending))
+            .unwrap_or_default();
+        let scale = self.nodes[inline_root]
+            .element_data()
+            .and_then(|element| element.inline_layout_data.as_ref())
+            .map(|inline_layout| inline_layout.layout.scale())
+            .unwrap_or(1.0);
+        let root_area_offset = output
+            .oof_positioning_area
+            .map(|area| area.offset)
+            .unwrap_or(Point::ZERO);
+
+        let mut hoisted = Vec::new();
+        let mut assignments = Vec::new();
+        for group in &mut groups {
+            let Some((first, last)) = std::mem::take(&mut group.bounds).finish() else {
+                output.oof_candidates.append(&mut group.candidates);
+                continue;
+            };
+
+            let direction = self.nodes[group.containing_block]
+                .layout_style()
+                .direction();
+            let claims = self.inline_oof_claims(group.containing_block);
+            let (content_left, content_right) = if direction == Direction::Rtl {
+                (last.left / scale, first.right / scale)
+            } else {
+                (first.left / scale, last.right / scale)
+            };
+            let left = content_left + group.root_content_box_offset.x - group.padding.left;
+            let right = content_right + group.root_content_box_offset.x + group.padding.right;
+            let top = first.top / scale + group.root_content_box_offset.y - group.padding.top;
+            let bottom =
+                last.bottom / scale + group.root_content_box_offset.y + group.padding.bottom;
+            let area = OofPositioningArea {
+                size: Size {
+                    width: (right - left).max(0.0),
+                    height: (bottom - top).max(0.0),
+                },
+                offset: Point { x: left, y: top },
+            };
+
+            let mut result = compute_oof_layout_for_area(
+                self,
+                node_id,
+                std::mem::take(&mut group.candidates),
+                area,
+                direction,
+                claims,
+            );
+            assignments.extend(result.hoisted.iter().map(|&child| InlineOofAssignment {
+                child: dom_node_id(child),
+                containing_block: group.containing_block,
+            }));
+            hoisted.append(&mut result.hoisted);
+            output.oof_candidates.append(&mut result.unclaimed);
+
+            let delta = Point {
+                x: area.offset.x - root_area_offset.x,
+                y: area.offset.y - root_area_offset.y,
+            };
+            let overflow = result.scrollable_overflow_rect;
+            output.scrollable_overflow_rect = output.scrollable_overflow_rect.union(Rect {
+                left: overflow.left + delta.x,
+                right: overflow.right + delta.x,
+                top: overflow.top + delta.y,
+                bottom: overflow.bottom + delta.y,
+            });
+        }
+        self.add_hoisted_children(node_id, &hoisted);
+
+        let new_assignments = (!assignments.is_empty()).then(|| assignments.into_boxed_slice());
+        if old_assignments.as_deref() != new_assignments.as_deref() {
+            self.nodes[inline_root].spatial_dirty_self.set(true);
+        }
+        self.nodes[inline_root]
+            .data
+            .downcast_element_mut()
+            .unwrap()
+            .inline_layout_data
+            .as_mut()
+            .unwrap()
+            .inline_oof_assignments = new_assignments;
+    }
+
     pub(crate) fn compute_inline_layout(
         &mut self,
         node_id: NodeId,
@@ -142,6 +448,7 @@ impl BaseDocument {
             parent_size,
             available_space,
             sizing_mode,
+            run_mode,
             ..
         } = inputs;
 
@@ -152,6 +459,10 @@ impl BaseDocument {
             .unwrap()
             .take_inline_layout()
             .unwrap();
+        let perform_layout = run_mode == RunMode::PerformLayout;
+        if perform_layout {
+            inline_layout.pending_inline_oof_candidates = None;
+        }
 
         let style = self.nodes[node_id].layout_style();
 
@@ -274,8 +585,6 @@ impl BaseDocument {
                         - content_box_inset.vertical_axis_sum()
                 }),
         };
-
-        let perform_layout = inputs.run_mode == taffy::RunMode::PerformLayout;
 
         // Measure passes must not leave measure-time state (inline box sizes, line breaks)
         // in the persistent inline layout: painting uses that state, and a cache hit on a
@@ -876,6 +1185,34 @@ impl BaseDocument {
                     }
                 }
             }
+
+            let mut unassigned = OofCandidates::new();
+            let mut pending = Vec::new();
+            for candidate in oof_candidates.iter().copied() {
+                let child = dom_node_id(candidate.node);
+                let Some(containing_block) =
+                    self.inline_containing_block(node_id, child, candidate.position)
+                else {
+                    unassigned.push(candidate);
+                    continue;
+                };
+                let padding = self.nodes[containing_block]
+                    .layout_style()
+                    .padding()
+                    .resolve_or_zero(inputs.parent_size.width, resolve_calc_value);
+                pending.push(PendingInlineOofCandidate {
+                    containing_block,
+                    candidate,
+                    padding,
+                    root_content_box_offset: Point {
+                        x: container_pb.left,
+                        y: container_pb.top,
+                    },
+                });
+            }
+            oof_candidates = unassigned;
+            inline_layout.pending_inline_oof_candidates =
+                (!pending.is_empty()).then(|| pending.into_boxed_slice());
         }
 
         // println!("INLINE LAYOUT FOR {:?}. max_advance: {:?}", node_id, max_advance);

--- a/packages/blitz-dom/src/layout/mod.rs
+++ b/packages/blitz-dom/src/layout/mod.rs
@@ -435,6 +435,7 @@ impl LayoutPartialTree for BaseDocument {
             let mut output = tree.compute_child_layout_internal(node_id, inputs, None);
             if inputs.run_mode == taffy::RunMode::PerformLayout {
                 compute_oof_layout(tree, node_id, &mut output);
+                tree.layout_inline_containing_block_oof(node_id, &mut output);
             }
             output
         })
@@ -583,6 +584,7 @@ impl taffy::LayoutBlockContainer for BaseDocument {
             let mut output = tree.compute_child_layout_internal(node_id, inputs, block_ctx);
             if inputs.run_mode == taffy::RunMode::PerformLayout {
                 compute_oof_layout(tree, node_id, &mut output);
+                tree.layout_inline_containing_block_oof(node_id, &mut output);
             }
             output
         })

--- a/packages/blitz-dom/src/node/mod.rs
+++ b/packages/blitz-dom/src/node/mod.rs
@@ -27,3 +27,4 @@ pub use stylo_data::ComputedStyleRef;
 #[cfg(feature = "svg")]
 pub use svg::{SvgImageData, SvgIntrinsicDimensions};
 pub use text::{GeneratedTextInputEvent, TextBrush, TextInputData, TextLayout};
+pub(crate) use text::{InlineOofAssignment, PendingInlineOofCandidate};

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1532,6 +1532,26 @@ impl Node {
         !effects.filter.0.is_empty() || !effects.backdrop_filter.0.is_empty()
     }
 
+    pub(crate) fn inline_establishes_fixed_containing_block(&self) -> bool {
+        use style::values::specified::box_::WillChangeBits;
+
+        let Some(style) = self.primary_styles() else {
+            return false;
+        };
+
+        if style
+            .get_box()
+            .will_change
+            .bits
+            .intersects(WillChangeBits::FIXPOS_CB_NON_SVG)
+        {
+            return true;
+        }
+
+        let effects = style.get_effects();
+        !effects.filter.0.is_empty() || !effects.backdrop_filter.0.is_empty()
+    }
+
     /// Whether this node's styles establish a containing block for
     /// `position: absolute` descendants even when the node is not positioned
     /// (e.g. `will-change: position`).

--- a/packages/blitz-dom/src/node/text.rs
+++ b/packages/blitz-dom/src/node/text.rs
@@ -5,6 +5,7 @@ use blitz_traits::{
 };
 use keyboard_types::{Key, Modifiers};
 use parley::{ContentWidths, FontContext, LayoutContext};
+use taffy::{OofCandidate, Rect};
 
 use crate::util::ACTION_MOD;
 
@@ -26,6 +27,22 @@ pub struct TextLayout {
     pub text: String,
     pub content_widths: Option<ContentWidths>,
     pub layout: parley::layout::Layout<TextBrush>,
+    pub(crate) pending_inline_oof_candidates: Option<Box<[PendingInlineOofCandidate]>>,
+    pub(crate) inline_oof_assignments: Option<Box<[InlineOofAssignment]>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PendingInlineOofCandidate {
+    pub containing_block: NodeId,
+    pub candidate: OofCandidate,
+    pub padding: Rect<f32>,
+    pub root_content_box_offset: taffy::Point<f32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InlineOofAssignment {
+    pub child: NodeId,
+    pub containing_block: NodeId,
 }
 
 impl TextLayout {

--- a/tests/blitz-tests/tests/inline_positioned_cb.rs
+++ b/tests/blitz-tests/tests/inline_positioned_cb.rs
@@ -1,0 +1,438 @@
+use blitz_test_harness::{Harness, Rect};
+use blitz_traits::node_id::NodeId;
+use markup5ever::{QualName, local_name, ns};
+
+fn style_attr() -> QualName {
+    QualName::new(None, ns!(), local_name!("style"))
+}
+
+fn after_pseudo(harness: &Harness, selector: &str) -> NodeId {
+    let node = harness.node(selector);
+    harness
+        .base()
+        .get_node(node)
+        .unwrap()
+        .after()
+        .expect("element should have an ::after pseudo-element")
+}
+
+fn fragment_rects(harness: &Harness, selector: &str) -> Vec<Rect> {
+    let node = harness.node(selector);
+    harness
+        .base()
+        .inline_fragment_rects(node)
+        .expect("element should be a non-atomic inline")
+        .into_iter()
+        .map(|rect| Rect {
+            x: rect.x as f32,
+            y: rect.y as f32,
+            width: rect.width as f32,
+            height: rect.height as f32,
+        })
+        .collect()
+}
+
+fn is_within(harness: &Harness, mut node: NodeId, ancestor: NodeId) -> bool {
+    loop {
+        if node == ancestor {
+            return true;
+        }
+        match harness.base().get_node(node).and_then(|node| node.parent) {
+            Some(parent) => node = parent,
+            None => return false,
+        }
+    }
+}
+
+const STRETCHED_LINK_PAGE: &str = r#"<!DOCTYPE html>
+<html><head><style>
+    body { margin: 0; font-size: 16px; line-height: 20px; }
+    #header { height: 40px; padding: 10px; }
+    #spacer { height: 300px; }
+    h2 { margin: 0 20px; width: 300px; }
+    .stretched { position: relative; }
+    .stretched::after { content: ""; position: absolute; inset: 0; z-index: 1; }
+</style></head>
+<body>
+<div id="header"><a id="home" href="/">Home</a> <a id="news" href="/news">News</a></div>
+<div id="spacer"></div>
+<h2><a id="sport" class="stretched" href="/sport"><span id="label">Sport</span></a></h2>
+</body></html>
+"#;
+
+#[test]
+fn stretched_link_pseudo_is_bounded_to_the_inline() {
+    let harness = Harness::from_html(STRETCHED_LINK_PAGE);
+    let pseudo = after_pseudo(&harness, "#sport");
+    let fragment = fragment_rects(&harness, "#sport")[0];
+    let actual = harness.layout_rect_of(pseudo);
+
+    assert!(
+        (actual.x - fragment.x).abs() < 1.0,
+        "{actual:?} {fragment:?}"
+    );
+    assert!(
+        (actual.width - fragment.width).abs() < 1.0,
+        "{actual:?} {fragment:?}"
+    );
+    assert!(actual.height > 0.0 && actual.height <= fragment.height + 1.0);
+    assert!(actual.y >= fragment.y - 1.0);
+    assert!(actual.y + actual.height <= fragment.y + fragment.height + 1.0);
+}
+
+#[test]
+fn stretched_link_pseudo_does_not_swallow_neighbor_hits() {
+    let harness = Harness::from_html(STRETCHED_LINK_PAGE);
+    let home = harness.node("#home");
+    let news = harness.node("#news");
+
+    for selector in ["#home", "#news"] {
+        let fragment = fragment_rects(&harness, selector)[0];
+        let hit = harness.hit_node(
+            fragment.x + fragment.width / 2.0,
+            fragment.y + fragment.height / 2.0,
+        );
+        let expected = if selector == "#home" { home } else { news };
+        assert!(is_within(&harness, hit, expected), "hit {hit:?}");
+    }
+}
+
+#[test]
+fn hover_moves_between_links_with_stretched_pseudo() {
+    let mut harness = Harness::from_html(STRETCHED_LINK_PAGE);
+    let home = harness.node("#home");
+    let news = harness.node("#news");
+    let sport = harness.node("#sport");
+
+    for (selector, expected) in [("#home", home), ("#news", news), ("#label", sport)] {
+        let fragment = fragment_rects(&harness, selector)[0];
+        harness.move_mouse_to(
+            fragment.x + fragment.width / 2.0,
+            fragment.y + fragment.height / 2.0,
+        );
+        let hovered = harness.hovered().expect("hovered link");
+        assert!(
+            is_within(&harness, hovered, expected),
+            "hovered {hovered:?}"
+        );
+    }
+}
+
+#[test]
+fn explicit_insets_resolve_against_positioned_inline() {
+    let harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            p { margin: 30px; width: 300px; }
+            #rel { position: relative; }
+            .abs { position: absolute; width: 20px; height: 10px; }
+        </style></head>
+        <body><p>aaaa <span id="rel">bbbb bbbb
+          <i id="origin" class="abs" style="left: 0; top: 0"></i>
+          <i id="offset" class="abs" style="left: 10px; top: 5px"></i>
+          <i id="br" class="abs" style="right: 0; bottom: 0"></i>
+        </span></p></body></html>
+        "#,
+    );
+    let origin = harness.layout_rect("#origin");
+    let offset = harness.layout_rect("#offset");
+    assert!((offset.x - origin.x - 10.0).abs() < 1.0);
+    assert!((offset.y - origin.y - 5.0).abs() < 1.0);
+
+    let br = harness.layout_rect("#br");
+    let fragment = fragment_rects(&harness, "#rel")[0];
+    assert!((br.x + br.width - (fragment.x + fragment.width)).abs() < 1.0);
+    assert!(br.y + br.height <= fragment.y + fragment.height + 1.0);
+}
+
+#[test]
+fn multiline_inline_uses_first_and_last_fragments() {
+    let harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            p { margin: 30px; width: 100px; }
+            #rel { position: relative; }
+            #abs { position: absolute; inset: 0; }
+        </style></head>
+        <body><p>aa <span id="rel">bbbb bbbb bbbb bbbb bbbb bbbb<i id="abs"></i></span></p></body></html>
+        "#,
+    );
+    let fragments = fragment_rects(&harness, "#rel");
+    assert!(fragments.len() >= 2, "{fragments:?}");
+    let first = fragments[0];
+    let last = fragments[fragments.len() - 1];
+    let actual = harness.layout_rect("#abs");
+
+    assert!((actual.x - first.x).abs() < 1.0, "{actual:?} {first:?}");
+    assert!(
+        (actual.x + actual.width - (last.x + last.width)).abs() < 1.0,
+        "{actual:?} {last:?}"
+    );
+    assert!(actual.y >= first.y - 1.0);
+    assert!(actual.y + actual.height <= last.y + last.height + 1.0);
+    assert!(actual.height > first.height);
+}
+
+#[test]
+fn mixed_font_size_does_not_use_the_whole_line_height() {
+    let harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; line-height: 1; }
+            #rel { position: relative; font-size: 10px; }
+            #large { font-size: 80px; }
+            #abs { position: absolute; inset: 0; }
+        </style></head>
+        <body><p><span id="rel">small<i id="abs"></i></span><span id="large">large</span></p></body></html>
+        "#,
+    );
+    let actual = harness.layout_rect("#abs");
+    assert!(actual.height > 5.0 && actual.height < 30.0, "{actual:?}");
+}
+
+#[test]
+fn inline_padding_expands_the_positioning_area() {
+    let harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            #rel { position: relative; padding: 5px 7px; }
+            #abs { position: absolute; inset: 0; }
+        </style></head>
+        <body><p><span id="rel">padded<i id="abs"></i></span></p></body></html>
+        "#,
+    );
+    let fragment = fragment_rects(&harness, "#rel")[0];
+    let actual = harness.layout_rect("#abs");
+    assert!((actual.x - (fragment.x - 7.0)).abs() < 1.0);
+    assert!((actual.width - (fragment.width + 14.0)).abs() < 1.0);
+    assert!(actual.y <= fragment.y);
+    assert!(actual.y + actual.height >= fragment.y + fragment.height);
+}
+
+#[test]
+fn rtl_multiline_inline_uses_directional_edges() {
+    let harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            p { margin: 30px; width: 100px; direction: rtl; }
+            #rel { position: relative; }
+            #abs { position: absolute; inset: 0; }
+        </style></head>
+        <body><p><span id="rel">אחד שתיים שלוש ארבע חמש שש<i id="abs"></i></span> סוף</p></body></html>
+        "#,
+    );
+    let fragments = fragment_rects(&harness, "#rel");
+    assert!(fragments.len() >= 2, "{fragments:?}");
+    let first = fragments[0];
+    let last = fragments[fragments.len() - 1];
+    let actual = harness.layout_rect("#abs");
+    assert!((actual.x - last.x).abs() < 1.0, "{actual:?} {last:?}");
+    assert!(
+        (actual.x + actual.width - (first.x + first.width)).abs() < 1.0,
+        "{actual:?} {first:?}"
+    );
+}
+
+#[test]
+fn auto_insets_keep_the_inline_static_position() {
+    let harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            #rel { position: relative; }
+            #abs { position: absolute; width: 10px; height: 10px; }
+        </style></head>
+        <body><p><span id="rel"><span id="before">before</span><i id="abs"></i>after</span></p></body></html>
+        "#,
+    );
+    let before = fragment_rects(&harness, "#before")[0];
+    let actual = harness.layout_rect("#abs");
+    assert!(
+        (actual.x - (before.x + before.width)).abs() < 1.0,
+        "{actual:?} {before:?}"
+    );
+    let containing_line = fragment_rects(&harness, "#rel")[0];
+    assert!(actual.y >= containing_line.y - 1.0);
+    assert!(actual.y < containing_line.y + containing_line.height);
+}
+
+#[test]
+fn filter_inline_claims_fixed_descendant() {
+    let harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            #rel { filter: grayscale(0); }
+            #fixed { position: fixed; inset: 0; }
+        </style></head>
+        <body><p><span id="rel">filtered<i id="fixed"></i></span></p></body></html>
+        "#,
+    );
+    let fragment = fragment_rects(&harness, "#rel")[0];
+    let actual = harness.layout_rect("#fixed");
+    assert!((actual.x - fragment.x).abs() < 1.0);
+    assert!((actual.width - fragment.width).abs() < 1.0);
+    assert!(actual.height <= fragment.height + 1.0);
+}
+
+#[test]
+fn abspos_falls_back_to_positioned_block_without_inline_claimant() {
+    let harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            #outer { position: relative; margin: 50px; border: 3px solid; width: 300px; }
+            #abs { position: absolute; left: 0; top: 0; width: 20px; height: 10px; }
+        </style></head>
+        <body><div id="outer"><p>aaaa <span>bbbb<i id="abs"></i></span></p></div></body></html>
+        "#,
+    );
+    let outer = harness.layout_rect("#outer");
+    let abs = harness.layout_rect("#abs");
+    assert_eq!((abs.x, abs.y), (outer.x + 3.0, outer.y + 3.0));
+}
+
+#[test]
+fn inline_claimant_changes_are_recomputed() {
+    let mut harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            #outer { position: relative; margin: 50px; width: 300px; height: 100px; }
+            #rel { display: inline; }
+            #abs { position: absolute; inset: 0; }
+        </style></head>
+        <body><div id="outer"><span id="rel">inline<i id="abs"></i></span></div></body></html>
+        "#,
+    );
+    let rel = harness.node("#rel");
+    assert!(harness.layout_rect("#abs").width > 200.0);
+
+    harness.base_mut().mutate().set_attribute(
+        rel,
+        style_attr(),
+        "display: inline; position: relative",
+    );
+    harness.pump();
+    let claimed = harness.layout_rect("#abs");
+    assert!(claimed.width < 100.0, "{claimed:?}");
+
+    harness
+        .base_mut()
+        .mutate()
+        .set_attribute(rel, style_attr(), "display: inline");
+    harness.pump();
+    assert!(harness.layout_rect("#abs").width > 200.0);
+}
+
+#[test]
+fn positioned_inline_containing_block_survives_viewport_resize() {
+    let mut harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            p { width: 50%; }
+            #rel { position: relative; }
+            #abs { position: absolute; inset: 0; }
+        </style></head>
+        <body><p><span id="rel">one two three four five six seven eight nine ten<i id="abs"></i></span></p></body></html>
+        "#,
+    );
+    let before = harness.layout_rect("#abs");
+    harness.set_viewport_size(300, 300);
+    let after = harness.layout_rect("#abs");
+    let fragments = fragment_rects(&harness, "#rel");
+    let first = fragments[0];
+    let last = fragments[fragments.len() - 1];
+
+    assert_ne!(before, after);
+    assert!((after.x - first.x).abs() < 1.0);
+    assert!((after.x + after.width - (last.x + last.width)).abs() < 1.0);
+    assert!(after.y >= first.y - 1.0);
+    assert!(after.y + after.height <= last.y + last.height + 1.0);
+}
+
+#[test]
+fn hover_can_move_descendant_in_and_out_of_inline_oof_layout() {
+    let mut harness = Harness::from_html(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body { margin: 0; font-size: 16px; line-height: 20px; }
+            #rel { position: relative; }
+            #rel:hover #child { position: absolute; inset: 0; }
+        </style></head>
+        <body><p><span id="rel">before<i id="child">child</i>after</span></p></body></html>
+        "#,
+    );
+    let fragment = fragment_rects(&harness, "#rel")[0];
+
+    harness
+        .base_mut()
+        .set_hover_to(fragment.x + 2.0, fragment.y + 2.0);
+    harness.pump();
+    let out_of_flow = harness.layout_rect("#child");
+    let out_of_flow_fragment = fragment_rects(&harness, "#rel")[0];
+    assert!((out_of_flow.x - out_of_flow_fragment.x).abs() < 1.0);
+    assert!(
+        (out_of_flow.width - out_of_flow_fragment.width).abs() < 1.0,
+        "{out_of_flow:?} {out_of_flow_fragment:?}"
+    );
+
+    harness.base_mut().set_hover_to(700.0, 500.0);
+    harness.pump();
+    let restored = fragment_rects(&harness, "#rel")[0];
+    assert!((restored.x - fragment.x).abs() < 1.0);
+    assert!((restored.width - fragment.width).abs() < 1.0);
+}
+
+fn assert_hover_toggles_inline_fixed_claimant(containing_block_style: &str) {
+    let html = format!(
+        r#"<!DOCTYPE html>
+        <html><head><style>
+            body {{ margin: 0; font-size: 16px; line-height: 20px; }}
+            #outer {{ margin: 50px; width: 400px; }}
+            #rel:hover {{ {containing_block_style} }}
+            #fixed {{ position: fixed; left: 200px; top: 10px; width: 10px; height: 10px; }}
+        </style></head>
+        <body><div id="outer">prefix prefix <span id="rel">target<i id="fixed"></i></span></div></body></html>
+        "#
+    );
+    let mut harness = Harness::from_html(&html);
+    assert!((harness.layout_rect("#fixed").x - 200.0).abs() < 1.0);
+
+    let fragment = fragment_rects(&harness, "#rel")[0];
+    harness.base_mut().set_hover_to(
+        fragment.x + fragment.width / 2.0,
+        fragment.y + fragment.height / 2.0,
+    );
+    harness.pump();
+    assert!(
+        (harness.layout_rect("#fixed").x - (fragment.x + 200.0)).abs() < 1.0,
+        "{}: {:?}",
+        containing_block_style,
+        harness.layout_rect("#fixed")
+    );
+
+    harness.base_mut().set_hover_to(700.0, 500.0);
+    harness.pump();
+    assert!(
+        (harness.layout_rect("#fixed").x - 200.0).abs() < 1.0,
+        "{}: {:?}",
+        containing_block_style,
+        harness.layout_rect("#fixed")
+    );
+}
+
+#[test]
+fn hover_filter_toggles_inline_fixed_claimant() {
+    assert_hover_toggles_inline_fixed_claimant("filter: grayscale(0)");
+}
+
+#[test]
+fn hover_will_change_toggles_inline_fixed_claimant() {
+    assert_hover_toggles_inline_fixed_claimant("will-change: filter");
+}

--- a/tests/blitz-tests/tests/inline_positioned_cb.rs
+++ b/tests/blitz-tests/tests/inline_positioned_cb.rs
@@ -60,6 +60,8 @@ const STRETCHED_LINK_PAGE: &str = r#"<!DOCTYPE html>
 </body></html>
 "#;
 
+const BBC_PAGE: &str = include_str!("../../../examples/assets/bbc.html");
+
 #[test]
 fn stretched_link_pseudo_is_bounded_to_the_inline() {
     let harness = Harness::from_html(STRETCHED_LINK_PAGE);
@@ -115,6 +117,38 @@ fn hover_moves_between_links_with_stretched_pseudo() {
             is_within(&harness, hovered, expected),
             "hovered {hovered:?}"
         );
+    }
+}
+
+#[test]
+fn bbc_header_hover_transfers_between_links() {
+    let mut harness = Harness::from_html(BBC_PAGE);
+    let selectors = [
+        ".ssrcss-en6he4-NavItemHoverState",
+        ".ssrcss-yg7y3n-NavItemHoverState",
+        ".ssrcss-ibt0yi-NavItemHoverState",
+        ".ssrcss-vgg72x-NavItemHoverState",
+    ];
+
+    for _ in 0..20 {
+        for selector in selectors {
+            let expected = harness.node(selector);
+            let rect = harness.layout_rect(selector);
+            harness.move_mouse_to(rect.x + rect.width / 2.0, rect.y + rect.height / 2.0);
+            let hovered = harness.hovered().expect("hovered BBC header link");
+            assert!(
+                is_within(&harness, hovered, expected),
+                "{selector}: hovered {hovered:?}"
+            );
+
+            let pseudo = after_pseudo(&harness, selector);
+            let pseudo_rect = harness.layout_rect_of(pseudo);
+            assert!(pseudo_rect.x >= rect.x - 1.0, "{selector}: {pseudo_rect:?}");
+            assert!(
+                pseudo_rect.x + pseudo_rect.width <= rect.x + rect.width + 1.0,
+                "{selector}: {pseudo_rect:?} {rect:?}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Resolve absolute/fixed descendants against non-atomic inline containing blocks within the same inline formatting context, on top of #809.

The inline root remains the Taffy geometry owner and structural ancestry is unchanged. Final Parley items are scanned only when an inline catches OOF candidates, retaining constant-size first/last fragment state; grouped candidates are then laid out through Taffy's explicit `OofPositioningArea` API. Exceptional `{ child, containing_block }` identity is retained on the inline root rather than adding another field to every node.

This intentionally leaves empty-inline boundary geometry and block-in-inline continuations for follow-up work. Depends on DioxusLabs/taffy#1174.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b6714d5757fa4fa7b858caed09087cdb
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/b6714d5757fa4fa7b858caed09087cdb?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**145** newly passing, **36** newly failing (net +109).

<details>
<summary>Full diff (181 changed tests)</summary>

```diff
+ Fail => Pass css/CSS2/abspos/static-inside-inline-002.html
+ Fail => Pass css/CSS2/backgrounds/background-bg-pos-204.xht
- Pass => Fail css/CSS2/backgrounds/background-position-002.xht
+ Fail => Pass css/CSS2/backgrounds/background-root-023.xht
+ Fail => Pass css/CSS2/box-display/containing-block-007.xht
+ Fail => Pass css/CSS2/box-display/containing-block-008.xht
+ Fail => Pass css/CSS2/box-display/containing-block-009.xht
+ Fail => Pass css/CSS2/box-display/containing-block-010.xht
+ Fail => Pass css/CSS2/floats-clear/clear-applies-to-012.xht
+ Fail => Pass css/CSS2/floats-clear/clear-applies-to-014.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-004.xht
+ Fail => Pass css/CSS2/floats-clear/clear-clearance-calculation-005.xht
+ Fail => Pass css/CSS2/floats-clear/floats-019.xht
+ Fail => Pass css/CSS2/generated-content/before-after-positioned-002.html
+ Fail => Pass css/CSS2/generated-content/before-after-positioned-003.html
+ Fail => Pass css/CSS2/margin-padding-clear/margin-collapse-037.xht
+ Fail => Pass css/CSS2/positioning/absolute-non-replaced-width-026.xht
+ Fail => Pass css/CSS2/positioning/abspos-014.xht
+ Fail => Pass css/CSS2/positioning/abspos-015.xht
+ Fail => Pass css/CSS2/positioning/abspos-016.xht
+ Fail => Pass css/CSS2/positioning/abspos-017.xht
+ Fail => Pass css/CSS2/positioning/abspos-018.xht
+ Fail => Pass css/CSS2/positioning/abspos-022.xht
+ Fail => Pass css/CSS2/positioning/abspos-026.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-005.xht
+ Fail => Pass css/CSS2/positioning/abspos-containing-block-006.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-001.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-002.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-003.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-004.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-005.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-006.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-007.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-008.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-009.xht
+ Fail => Pass css/CSS2/positioning/abspos-overflow-012.xht
+ Fail => Pass css/CSS2/positioning/dynamic-top-change-003.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/left-applies-to-014.xht
+ Fail => Pass css/CSS2/positioning/position-fixed-007.xht
+ Fail => Pass css/CSS2/positioning/position-static-001.xht
+ Fail => Pass css/CSS2/positioning/relpos-calcs-001.xht
+ Fail => Pass css/CSS2/positioning/relpos-calcs-002.xht
+ Fail => Pass css/CSS2/positioning/relpos-calcs-007.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/right-applies-to-014.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-009.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-012.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-013.xht
+ Fail => Pass css/CSS2/positioning/top-applies-to-014.xht
+ Fail => Pass css/CSS2/tables/separated-border-model-007.xht
+ Fail => Pass css/CSS2/tables/separated-border-model-008.xht
+ Fail => Pass css/CSS2/tables/separated-border-model-009.xht
+ Fail => Pass css/CSS2/visuren/anonymous-boxes-001b.xht
+ Fail => Pass css/CSS2/visuren/inherit-static-offset-001.xht
+ Fail => Pass css/CSS2/visuren/inherit-static-offset-002.xht
+ Fail => Pass css/CSS2/visuren/inherit-static-offset-003.xht
+ Fail => Pass css/CSS2/visuren/position-absolute-percentage-inherit-001.xht
+ Fail => Pass css/compositing/isolation/isolation-establishes-stacking-context.html
+ Fail => Pass css/css-align/abspos/align-self-with-flex-grid-parent.html
- Pass => Fail css/css-anchor-position/anchor-position-dynamic-005.html
- Pass => Fail css/css-anchor-position/anchor-scroll-fixedpos-003.html
- Pass => Fail css/css-anchor-position/anchor-scroll-fixedpos-004.html
- Pass => Fail css/css-anchor-position/anchor-scroll-nested.html
- Pass => Fail css/css-anchor-position/position-visibility-anchors-visible-in-overflow.html
+ Fail => Pass css/css-backgrounds/background-origin-006.html
+ Fail => Pass css/css-backgrounds/background-rounded-image-clip-001.html
+ Fail => Pass css/css-backgrounds/background-size-percentage-root.html
- Pass => Fail css/css-break/grid/grid-item-oof-012.html
+ Fail => Pass css/css-break/out-of-flow-in-multicolumn-091.html
+ Fail => Pass css/css-break/out-of-flow-in-multicolumn-092.html
+ Fail => Pass css/css-break/out-of-flow-in-multicolumn-104.html
+ Fail => Pass css/css-conditional/container-queries/no-layout-containment-abspos.html
+ Fail => Pass css/css-conditional/container-queries/no-layout-containment-fixedpos.html
- Pass => Fail css/css-contain/contain-layout-020.html
- Pass => Fail css/css-contain/contain-layout-ignored-cases-ib-split-001.html
+ Fail => Pass css/css-contain/contain-layout-stacking-context-001.html
+ Fail => Pass css/css-contain/contain-paint-clip-001.html
- Pass => Fail css/css-contain/contain-paint-ignored-cases-ib-split-001.html
- Pass => Fail css/css-contain/contain-paint-ignored-cases-ruby-stacking-and-clipping-001.html
+ Fail => Pass css/css-contain/contain-paint-stacking-context-001a.html
+ Fail => Pass css/css-contain/contain-paint-stacking-context-001b.html
- Pass => Fail css/css-contain/content-visibility/content-visibility-095.html
+ Fail => Pass css/css-flexbox/flex-item-position-relative-001.html
+ Fail => Pass css/css-flexbox/flexbox-items-as-stacking-contexts-001.xhtml
+ Fail => Pass css/css-flexbox/flexbox-paint-ordering-003.html
+ Fail => Pass css/css-flexbox/flexbox_margin-left-ex.html
+ Fail => Pass css/css-flexbox/order/order-abs-children-painting-order.html
- Pass => Fail css/css-flexbox/table-as-item-large-intrinsic-size.html
- Pass => Fail css/css-grid/abspos/grid-abspos-staticpos-align-self-safe-outer-cb-003.tentative.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-004.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-006.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-007.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-008.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-012.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-014.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-015.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendant-containing-block-016.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-descendants-017.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-items-019.html
+ Fail => Pass css/css-grid/abspos/positioned-grid-items-024.html
+ Fail => Pass css/css-grid/grid-items/grid-items-percentage-paddings-015.html
+ Fail => Pass css/css-grid/grid-lanes/subgrid/grid-subgridded-to-grid-lanes/column-subgrid-abs-pos-001.html
+ Fail => Pass css/css-grid/subgrid/abs-pos-001.html
- Pass => Fail css/css-images/image-orientation/image-orientation-img-object-fit.html
+ Fail => Pass css/css-inline/text-box-trim/text-box-trim-inline-box-001.html
+ Fail => Pass css/css-inline/text-box-trim/text-box-trim-inline-box-002.html
+ Fail => Pass css/css-multicol/multicol-contained-absolute.html
+ Fail => Pass css/css-overflow/overflow-clip-margin-021.html
+ Fail => Pass css/css-overflow/overflow-clip-margin-022.html
+ Fail => Pass css/css-page/fixedpos-005-print.html
+ Fail => Pass css/css-page/fixedpos-007-print.html
+ Fail => Pass css/css-page/fixedpos-008-print.html
+ Fail => Pass css/css-position/multicol/vlr-ltr-ltr-in-multicols.html
+ Fail => Pass css/css-position/multicol/vrl-ltr-ltr-in-multicols.html
- Pass => Fail css/css-position/nested-inline-abspos-child-with-siblings.html
- Pass => Fail css/css-position/nested-inline-abspos-child.html
+ Fail => Pass css/css-position/position-absolute-center-003.html
+ Fail => Pass css/css-position/position-absolute-center-004.html
+ Fail => Pass css/css-position/position-fixed-overflow-print.html
+ Fail => Pass css/css-position/position-relative-table-td-left.html
+ Fail => Pass css/css-position/position-relative-table-td-top.html
+ Fail => Pass css/css-position/position-static-001.html
+ Fail => Pass css/css-position/sticky/position-sticky-large-top-2.tentative.html
+ Fail => Pass css/css-position/sticky/position-sticky-large-top.tentative.html
- Pass => Fail css/css-pseudo/first-letter-width-2.html
+ Fail => Pass css/css-pseudo/highlight-z-index-001.html
+ Fail => Pass css/css-tables/absolute-tables-010.tentative.html
+ Fail => Pass css/css-text-decor/text-decoration-thickness-overline-001.html
+ Fail => Pass css/css-text-decor/text-decoration-thickness-underline-001.html
+ Fail => Pass css/css-text-decor/text-shadow/text-shadow-emoji-transparent.html
- Pass => Fail css/css-transforms/backface-visibility-hidden-animated-001.html
- Pass => Fail css/css-transforms/backface-visibility-hidden-animated-002.html
- Pass => Fail css/css-transforms/individual-transform/stacking-context-001.html
+ Fail => Pass css/css-transforms/individual-transform/stacking-context-002.html
+ Fail => Pass css/css-transforms/individual-transform/stacking-context-003.html
+ Fail => Pass css/css-transforms/individual-transform/stacking-context-004.html
- Pass => Fail css/css-transforms/perspective-containing-block-dynamic-1b.html
- Pass => Fail css/css-transforms/perspective-split-by-zero-w.html
+ Fail => Pass css/css-transforms/preserve-3d-flat-grouping-properties-containing-block-inline.tentative.html
- Pass => Fail css/css-transforms/transform-containing-block-dynamic-1b.html
+ Fail => Pass css/css-transforms/transform-stacking-001.html
+ Fail => Pass css/css-transforms/ttwf-transform-translatex-001.html
+ Fail => Pass css/css-transforms/ttwf-transform-translatey-001.html
- Pass => Fail css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-new.html
- Pass => Fail css/css-view-transitions/massive-element-below-and-on-top-of-viewport-partially-onscreen-old.html
- Pass => Fail css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-new.html
- Pass => Fail css/css-view-transitions/massive-element-right-and-left-of-viewport-partially-onscreen-old.html
- Pass => Fail css/css-view-transitions/snapshot-containing-block-includes-scrollbar-gutter.html
+ Fail => Pass css/css-viewport/zoom/explicit-inherit/bottom.html
+ Fail => Pass css/css-viewport/zoom/explicit-inherit/left.html
+ Fail => Pass css/css-viewport/zoom/explicit-inherit/right.html
+ Fail => Pass css/css-viewport/zoom/explicit-inherit/top.html
- Pass => Fail css/css-will-change/will-change-abspos-cb-dynamic-001.html
+ Fail => Pass css/css-will-change/will-change-fixpos-cb-height-1.html
+ Fail => Pass css/css-will-change/will-change-fixpos-cb-position-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-backdrop-filter-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-clip-path-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-filter-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-isolation-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-mask-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-mask-image-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-mix-blend-mode-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-offset-path-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-opacity-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-perspective-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-position-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-transform-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-transform-style-1.html
+ Fail => Pass css/css-will-change/will-change-stacking-context-translate-1.html
+ Fail => Pass css/css-writing-modes/float-rgt-orthog-htb-in-vrl-003.xht
- Pass => Fail css/cssom-view/cssom-getBoundingClientRect-vertical-rl.html
- Pass => Fail css/filter-effects/backdrop-filter-clip-rect-zoom.html
- Pass => Fail css/filter-effects/backdrop-filter-plus-mask-large.html
- Pass => Fail css/filter-effects/filter-cb-abspos-inline-002.html
- Pass => Fail css/filter-effects/filter-cb-abspos-inline-003.html
- Pass => Fail css/filter-effects/filter-cb-dynamic-1b.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33021734980).</sub>
<!-- wpt-results-end -->
