### PR TITLE
wpt: exclude non-test files (visual/manual/support) from wptreport.json

### DIFF
--- a/wpt/runner/src/report.rs
+++ b/wpt/runner/src/report.rs
@@ -6,7 +6,7 @@ use wptreport::{
     wpt_report::WptReport,
 };
 
-use crate::{TestResult, TestStatus};
+use crate::{TestKind, TestResult, TestStatus};
 
 fn get_git_hash(path: &Path) -> String {
     let output = Command::new("git")
@@ -81,6 +81,11 @@ pub fn generate_report(
 ) -> WptReport {
     let results: Vec<_> = results
         .into_iter()
+        // Files with no detectable test type (no reftest links, checkLayout()
+        // call, or testharness.js include) are "visual"/"manual"/"support"
+        // entries in the upstream WPT manifest: not automatable tests, and not
+        // run by other engines, so they don't belong in the report.
+        .filter(|test| !(test.kind == TestKind::Unknown && matches!(test.status, TestStatus::Skip)))
         .map(|test| wpt_report::TestResult {
             test: test.name,
             status: convert_status(test.status),

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -172,9 +172,11 @@ pub fn process_test_file(
 
 fn is_crash_test(relative_path: &str) -> bool {
     relative_path.split('/').any(|seg| seg == "crashtests")
-        || [".html", ".htm", ".xht", ".xhtml"]
-            .iter()
-            .any(|ext| relative_path.ends_with(&format!("-crash{ext}")))
+        || ["", ".https", ".h2", ".www"].iter().any(|flag| {
+            [".html", ".htm", ".xht", ".xhtml"]
+                .iter()
+                .any(|ext| relative_path.ends_with(&format!("-crash{flag}{ext}")))
+        })
 }
 
 fn parse_and_resolve_document(


### PR DESCRIPTION
## Summary

Comparing Blitz's published wptreport against wpt.fyi's latest master runs (Chrome/Firefox/Safari/Servo/Ladybird) showed **3,671 tests that only Blitz "runs"**. Classified against the WPT manifest: 2,707 `visual`, 793 `manual`, 106 `support` — files with no reftest links, no `checkLayout()`, and no testharness.js include, which no automated engine reports. The runner already detects these (`TestKind::Unknown` → `TestStatus::Skip`), because the filename/directory-based `filter_path` heuristics can't catch them (e.g. manual tests without a `-manual` suffix, `visual` CSS2 tests, support files outside `support/` dirs), but it still emitted them into `wptreport.json`.

Fix: filter them out of the report in `generate_report`:

```rust
.filter(|test| !(test.kind == TestKind::Unknown && matches!(test.status, TestStatus::Skip)))
```

- Testharness tests remain in the report as `SKIP` (they are real tests that other engines run).
- `Unknown` + `Crash` (panicked tests) remain reported.
- Console stats and `wpt_expectations.txt` are unchanged; only the wptreport output is filtered.

Verified with `css/css-ui` against a current WPT checkout: report shrinks 1288 → 1148 entries, and every remaining entry is manifest-classified `reftest`/`testharness`/`crashtest` (plus 5 `manual` files that include testharness.js, reported as SKIP).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f2f594019316461cae0fcda15b660ece
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/f2f594019316461cae0fcda15b660ece?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**11** newly passing, **0** newly failing (net +11), **3597** removed tests.

<details>
<summary>Full diff (3608 changed tests)</summary>

```diff
- REM css/CSS2/backgrounds/background-006a.xht
- REM css/CSS2/backgrounds/background-011.xht
- REM css/CSS2/backgrounds/background-012.xht
- REM css/CSS2/backgrounds/background-013.xht
- REM css/CSS2/backgrounds/background-015.xht
- REM css/CSS2/backgrounds/background-019.xht
- REM css/CSS2/backgrounds/background-023.xht
- REM css/CSS2/backgrounds/background-027.xht
- REM css/CSS2/backgrounds/background-028.xht
- REM css/CSS2/backgrounds/background-032.xht
- REM css/CSS2/backgrounds/background-035.xht
- REM css/CSS2/backgrounds/background-039.xht
- REM css/CSS2/backgrounds/background-040.xht
- REM css/CSS2/backgrounds/background-042.xht
- REM css/CSS2/backgrounds/background-044.xht
- REM css/CSS2/backgrounds/background-045.xht
- REM css/CSS2/backgrounds/background-046.xht
- REM css/CSS2/backgrounds/background-047.xht
- REM css/CSS2/backgrounds/background-049.xht
- REM css/CSS2/backgrounds/background-054.xht
- REM css/CSS2/backgrounds/background-057.xht
- REM css/CSS2/backgrounds/background-062.xht
- REM css/CSS2/backgrounds/background-065.xht
- REM css/CSS2/backgrounds/background-066.xht
- REM css/CSS2/backgrounds/background-067.xht
- REM css/CSS2/backgrounds/background-069.xht
- REM css/CSS2/backgrounds/background-072.xht
- REM css/CSS2/backgrounds/background-074.xht
- REM css/CSS2/backgrounds/background-077.xht
- REM css/CSS2/backgrounds/background-079.xht
- REM css/CSS2/backgrounds/background-084.xht
- REM css/CSS2/backgrounds/background-086.xht
- REM css/CSS2/backgrounds/background-088.xht
- REM css/CSS2/backgrounds/background-089.xht
- REM css/CSS2/backgrounds/background-091.xht
- REM css/CSS2/backgrounds/background-092.xht
- REM css/CSS2/backgrounds/background-094.xht
- REM css/CSS2/backgrounds/background-098.xht
- REM css/CSS2/backgrounds/background-099.xht
- REM css/CSS2/backgrounds/background-100.xht
- REM css/CSS2/backgrounds/background-102.xht
- REM css/CSS2/backgrounds/background-105.xht
- REM css/CSS2/backgrounds/background-108.xht
- REM css/CSS2/backgrounds/background-110.xht
- REM css/CSS2/backgrounds/background-112.xht
- REM css/CSS2/backgrounds/background-113.xht
- REM css/CSS2/backgrounds/background-115.xht
- REM css/CSS2/backgrounds/background-116.xht
- REM css/CSS2/backgrounds/background-118.xht
- REM css/CSS2/backgrounds/background-119.xht
- REM css/CSS2/backgrounds/background-121.xht
- REM css/CSS2/backgrounds/background-122.xht
- REM css/CSS2/backgrounds/background-123.xht
- REM css/CSS2/backgrounds/background-124.xht
- REM css/CSS2/backgrounds/background-125.xht
- REM css/CSS2/backgrounds/background-126.xht
- REM css/CSS2/backgrounds/background-127.xht
- REM css/CSS2/backgrounds/background-129.xht
- REM css/CSS2/backgrounds/background-131.xht
- REM css/CSS2/backgrounds/background-132.xht
- REM css/CSS2/backgrounds/background-133.xht
- REM css/CSS2/backgrounds/background-134.xht
- REM css/CSS2/backgrounds/background-136.xht
- REM css/CSS2/backgrounds/background-140.xht
- REM css/CSS2/backgrounds/background-142.xht
- REM css/CSS2/backgrounds/background-143.xht
- REM css/CSS2/backgrounds/background-145.xht
- REM css/CSS2/backgrounds/background-146.xht
- REM css/CSS2/backgrounds/background-148.xht
- REM css/CSS2/backgrounds/background-149.xht
- REM css/CSS2/backgrounds/background-151.xht
- REM css/CSS2/backgrounds/background-155.xht
- REM css/CSS2/backgrounds/background-157.xht
- REM css/CSS2/backgrounds/background-158.xht
- REM css/CSS2/backgrounds/background-159.xht
- REM css/CSS2/backgrounds/background-160.xht
- REM css/CSS2/backgrounds/background-162.xht
- REM css/CSS2/backgrounds/background-164.xht
- REM css/CSS2/backgrounds/background-165.xht
- REM css/CSS2/backgrounds/background-166.xht
- REM css/CSS2/backgrounds/background-167.xht
- REM css/CSS2/backgrounds/background-168.xht
- REM css/CSS2/backgrounds/background-169.xht
- REM css/CSS2/backgrounds/background-170.xht
- REM css/CSS2/backgrounds/background-172.xht
- REM css/CSS2/backgrounds/background-173.xht
- REM css/CSS2/backgrounds/background-175.xht
- REM css/CSS2/backgrounds/background-176.xht
- REM css/CSS2/backgrounds/background-178.xht
- REM css/CSS2/backgrounds/background-179.xht
- REM css/CSS2/backgrounds/background-181.xht
- REM css/CSS2/backgrounds/background-183.xht
- REM css/CSS2/backgrounds/background-186.xht
- REM css/CSS2/backgrounds/background-189.xht
- REM css/CSS2/backgrounds/background-191.xht
- REM css/CSS2/backgrounds/background-192.xht
- REM css/CSS2/backgrounds/background-193.xht
- REM css/CSS2/backgrounds/background-197.xht
- REM css/CSS2/backgrounds/background-199.xht
- REM css/CSS2/backgrounds/background-200.xht
- REM css/CSS2/backgrounds/background-202.xht
- REM css/CSS2/backgrounds/background-203.xht
- REM css/CSS2/backgrounds/background-205.xht
- REM css/CSS2/backgrounds/background-206.xht
- REM css/CSS2/backgrounds/background-207.xht
- REM css/CSS2/backgrounds/background-208.xht
- REM css/CSS2/backgrounds/background-209.xht
- REM css/CSS2/backgrounds/background-210.xht
- REM css/CSS2/backgrounds/background-211.xht
- REM css/CSS2/backgrounds/background-212.xht
- REM css/CSS2/backgrounds/background-213.xht
- REM css/CSS2/backgrounds/background-214.xht
- REM css/CSS2/backgrounds/background-215.xht
- REM css/CSS2/backgrounds/background-216.xht
- REM css/CSS2/backgrounds/background-217.xht
- REM css/CSS2/backgrounds/background-218.xht
- REM css/CSS2/backgrounds/background-219.xht
- REM css/CSS2/backgrounds/background-220.xht
- REM css/CSS2/backgrounds/background-221.xht
- REM css/CSS2/backgrounds/background-222.xht
- REM css/CSS2/backgrounds/background-223.xht
- REM css/CSS2/backgrounds/background-224.xht
- REM css/CSS2/backgrounds/background-225.xht
- REM css/CSS2/backgrounds/background-226.xht
- REM css/CSS2/backgrounds/background-227.xht
- REM css/CSS2/backgrounds/background-228.xht
- REM css/CSS2/backgrounds/background-229.xht
- REM css/CSS2/backgrounds/background-230.xht
- REM css/CSS2/backgrounds/background-231.xht
- REM css/CSS2/backgrounds/background-232.xht
- REM css/CSS2/backgrounds/background-233.xht
- REM css/CSS2/backgrounds/background-234.xht
- REM css/CSS2/backgrounds/background-235.xht
- REM css/CSS2/backgrounds/background-236.xht
- REM css/CSS2/backgrounds/background-237.xht
- REM css/CSS2/backgrounds/background-238.xht
- REM css/CSS2/backgrounds/background-239.xht
- REM css/CSS2/backgrounds/background-240.xht
- REM css/CSS2/backgrounds/background-241.xht
- REM css/CSS2/backgrounds/background-242.xht
- REM css/CSS2/backgrounds/background-243.xht
- REM css/CSS2/backgrounds/background-244.xht
- REM css/CSS2/backgrounds/background-245.xht
- REM css/CSS2/backgrounds/background-246.xht
- REM css/CSS2/backgrounds/background-247.xht
- REM css/CSS2/backgrounds/background-248.xht
- REM css/CSS2/backgrounds/background-249.xht
- REM css/CSS2/backgrounds/background-250.xht
- REM css/CSS2/backgrounds/background-251.xht
- REM css/CSS2/backgrounds/background-252.xht
- REM css/CSS2/backgrounds/background-253.xht
- REM css/CSS2/backgrounds/background-254.xht
- REM css/CSS2/backgrounds/background-255.xht
- REM css/CSS2/backgrounds/background-256.xht
- REM css/CSS2/backgrounds/background-257.xht
- REM css/CSS2/backgrounds/background-258.xht
- REM css/CSS2/backgrounds/background-259.xht
- REM css/CSS2/backgrounds/background-260.xht
- REM css/CSS2/backgrounds/background-261.xht
- REM css/CSS2/backgrounds/background-262.xht
- REM css/CSS2/backgrounds/background-263.xht
- REM css/CSS2/backgrounds/background-264.xht
- REM css/CSS2/backgrounds/background-265.xht
- REM css/CSS2/backgrounds/background-266.xht
- REM css/CSS2/backgrounds/background-267.xht
- REM css/CSS2/backgrounds/background-268.xht
- REM css/CSS2/backgrounds/background-269.xht
- REM css/CSS2/backgrounds/background-270.xht
- REM css/CSS2/backgrounds/background-271.xht
- REM css/CSS2/backgrounds/background-272.xht
- REM css/CSS2/backgrounds/background-273.xht
- REM css/CSS2/backgrounds/background-274.xht
- REM css/CSS2/backgrounds/background-275.xht
- REM css/CSS2/backgrounds/background-276.xht
- REM css/CSS2/backgrounds/background-277.xht
- REM css/CSS2/backgrounds/background-278.xht
- REM css/CSS2/backgrounds/background-279.xht
- REM css/CSS2/backgrounds/background-280.xht
- REM css/CSS2/backgrounds/background-281.xht
- REM css/CSS2/backgrounds/background-282.xht
- REM css/CSS2/backgrounds/background-283.xht
- REM css/CSS2/backgrounds/background-284.xht
- REM css/CSS2/backgrounds/background-285.xht
- REM css/CSS2/backgrounds/background-286.xht
- REM css/CSS2/backgrounds/background-287.xht
- REM css/CSS2/backgrounds/background-288.xht
- REM css/CSS2/backgrounds/background-289.xht
- REM css/CSS2/backgrounds/background-290.xht
- REM css/CSS2/backgrounds/background-291.xht
- REM css/CSS2/backgrounds/background-292.xht
- REM css/CSS2/backgrounds/background-293.xht
- REM css/CSS2/backgrounds/background-294.xht
- REM css/CSS2/backgrounds/background-295.xht
- REM css/CSS2/backgrounds/background-296.xht
- REM css/CSS2/backgrounds/background-297.xht
- REM css/CSS2/backgrounds/background-298.xht
- REM css/CSS2/backgrounds/background-299.xht
- REM css/CSS2/backgrounds/background-300.xht
- REM css/CSS2/backgrounds/background-301.xht
- REM css/CSS2/backgrounds/background-302.xht
- REM css/CSS2/backgrounds/background-303.xht
- REM css/CSS2/backgrounds/background-304.xht
- REM css/CSS2/backgrounds/background-305.xht
- REM css/CSS2/backgrounds/background-306.xht
- REM css/CSS2/backgrounds/background-307.xht
- REM css/CSS2/backgrounds/background-308.xht
- REM css/CSS2/backgrounds/background-309.xht
- REM css/CSS2/backgrounds/background-310.xht
- REM css/CSS2/backgrounds/background-311.xht
- REM css/CSS2/backgrounds/background-312.xht
- REM css/CSS2/backgrounds/background-313.xht
- REM css/CSS2/backgrounds/background-314.xht
- REM css/CSS2/backgrounds/background-315.xht
- REM css/CSS2/backgrounds/background-316.xht
- REM css/CSS2/backgrounds/background-317.xht
- REM css/CSS2/backgrounds/background-318.xht
- REM css/CSS2/backgrounds/background-319.xht
- REM css/CSS2/backgrounds/background-320.xht
- REM css/CSS2/backgrounds/background-321.xht
- REM css/CSS2/backgrounds/background-322.xht
- REM css/CSS2/backgrounds/background-323.xht
- REM css/CSS2/backgrounds/background-324.xht
- REM css/CSS2/backgrounds/background-325.xht
- REM css/CSS2/backgrounds/background-330.xht
- REM css/CSS2/backgrounds/background-alpha-001.xht
- REM css/CSS2/backgrounds/background-alpha-002.xht
- REM css/CSS2/backgrounds/background-alpha-003.xht
- REM css/CSS2/backgrounds/background-alpha-004.xht
- REM css/CSS2/backgrounds/background-alpha-005.xht
- REM css/CSS2/backgrounds/background-animated-001.xht
- REM css/CSS2/backgrounds/background-applies-to-008.xht
- REM css/CSS2/backgrounds/background-applies-to-010.xht
- REM css/CSS2/backgrounds/background-attachment-001.xht
- REM css/CSS2/backgrounds/background-attachment-002.xht
- REM css/CSS2/backgrounds/background-attachment-003.xht
- REM css/CSS2/backgrounds/background-attachment-004.xht
- REM css/CSS2/backgrounds/background-attachment-005.xht
- REM css/CSS2/backgrounds/background-attachment-006.xht
- REM css/CSS2/backgrounds/background-attachment-007.xht
- REM css/CSS2/backgrounds/background-attachment-008.xht
- REM css/CSS2/backgrounds/background-attachment-010.xht
- REM css/CSS2/backgrounds/background-attachment-applies-to-008.xht
- REM css/CSS2/backgrounds/background-attachment-applies-to-010.xht
- REM css/CSS2/backgrounds/background-bg-pos-205.xht
- REM css/CSS2/backgrounds/background-bg-pos-207.xht
- REM css/CSS2/backgrounds/background-body-002.xht
- REM css/CSS2/backgrounds/background-body-003.xht
- REM css/CSS2/backgrounds/background-color-applies-to-008.xht
- REM css/CSS2/backgrounds/background-color-applies-to-010.xht
- REM css/CSS2/backgrounds/background-cover-001.xht
- REM css/CSS2/backgrounds/background-cover-002.xht
- REM css/CSS2/backgrounds/background-cover-003.xht
- REM css/CSS2/backgrounds/background-cover-004.xht
- REM css/CSS2/backgrounds/background-html-body-001.xht
- REM css/CSS2/backgrounds/background-iframes-001.xht
- REM css/CSS2/backgrounds/background-image-applies-to-008.xht
- REM css/CSS2/backgrounds/background-image-applies-to-010.xht
- REM css/CSS2/backgrounds/background-image-cover-001.xht
- REM css/CSS2/backgrounds/background-image-cover-003.xht
- REM css/CSS2/backgrounds/background-position-019.xht
- REM css/CSS2/backgrounds/background-position-020.xht
- REM css/CSS2/backgrounds/background-position-031.xht
- REM css/CSS2/backgrounds/background-position-032.xht
- REM css/CSS2/backgrounds/background-position-043.xht
- REM css/CSS2/backgrounds/background-position-044.xht
- REM css/CSS2/backgrounds/background-position-055.xht
- REM css/CSS2/backgrounds/background-position-056.xht
- REM css/CSS2/backgrounds/background-position-067.xht
- REM css/CSS2/backgrounds/background-position-068.xht
- REM css/CSS2/backgrounds/background-position-079.xht
- REM css/CSS2/backgrounds/background-position-080.xht
- REM css/CSS2/backgrounds/background-position-091.xht
- REM css/CSS2/backgrounds/background-position-092.xht
- REM css/CSS2/backgrounds/background-position-103.xht
- REM css/CSS2/backgrounds/background-position-104.xht
- REM css/CSS2/backgrounds/background-position-201.xht
- REM css/CSS2/backgrounds/background-position-202.xht
- REM css/CSS2/backgrounds/background-position-203.xht
- REM css/CSS2/backgrounds/background-position-applies-to-003a.xht
- REM css/CSS2/backgrounds/background-position-applies-to-007a.xht
- REM css/CSS2/backgrounds/background-position-applies-to-008.xht
- REM css/CSS2/backgrounds/background-position-applies-to-010.xht
- REM css/CSS2/backgrounds/background-repeat-applies-to-008.xht
- REM css/CSS2/backgrounds/background-repeat-applies-to-010.xht
- REM css/CSS2/backgrounds/background-root-003.xht
- REM css/CSS2/backgrounds/background-transparency-001.xht
- REM css/CSS2/bidi-overflow-scroll-001.xht
- REM css/CSS2/bidi-text/bidi-alt-001.xht
- REM css/CSS2/bidi-text/direction-applies-to-010.xht
- REM css/CSS2/bidi-text/unicode-bidi-applies-to-010.xht
- REM css/CSS2/borders/border-002.xht
- REM css/CSS2/borders/border-004.xht
- REM css/CSS2/borders/border-007.xht
- REM css/CSS2/borders/border-009.xht
- REM css/CSS2/borders/border-010.xht
- REM css/CSS2/borders/border-011.xht
- REM css/CSS2/borders/border-012.xht
- REM css/CSS2/borders/border-013.xht
- REM css/CSS2/borders/border-014.xht
- REM css/CSS2/borders/border-015.xht
- REM css/CSS2/borders/border-016.xht
- REM css/CSS2/borders/border-017.xht
- REM css/CSS2/borders/border-018.xht
- REM css/CSS2/borders/border-applies-to-008.xht
- REM css/CSS2/borders/border-applies-to-010.xht
- REM css/CSS2/borders/border-bottom-002.xht
- REM css/CSS2/borders/border-bottom-003.xht
- REM css/CSS2/borders/border-bottom-004.xht
- REM css/CSS2/borders/border-bottom-007.xht
- REM css/CSS2/borders/border-bottom-009.xht
- REM css/CSS2/borders/border-bottom-010.xht
- REM css/CSS2/borders/border-bottom-011.xht
- REM css/CSS2/borders/border-bottom-012.xht
- REM css/CSS2/borders/border-bottom-013.xht
- REM css/CSS2/borders/border-bottom-014.xht
- REM css/CSS2/borders/border-bottom-015.xht
- REM css/CSS2/borders/border-bottom-017.xht
- REM css/CSS2/borders/border-bottom-applies-to-008.xht
- REM css/CSS2/borders/border-bottom-applies-to-010.xht
- REM css/CSS2/borders/border-bottom-color-applies-to-008.xht
- REM css/CSS2/borders/border-bottom-color-applies-to-010.xht
- REM css/CSS2/borders/border-bottom-style-003.xht
- REM css/CSS2/borders/border-bottom-style-004.xht
- REM css/CSS2/borders/border-bottom-style-006.xht
- REM css/CSS2/borders/border-bottom-style-007.xht
- REM css/CSS2/borders/border-bottom-style-008.xht
- REM css/CSS2/borders/border-bottom-style-009.xht
- REM css/CSS2/borders/border-bottom-style-010.xht
- REM css/CSS2/borders/border-bottom-style-011.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-001.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-002.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-003.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-004.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-005.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-006.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-007.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-008.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-009.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-010.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-012.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-013.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-014.xht
- REM css/CSS2/borders/border-bottom-style-applies-to-015.xht
- REM css/CSS2/borders/border-bottom-width-014.xht
- REM css/CSS2/borders/border-bottom-width-036.xht
- REM css/CSS2/borders/border-bottom-width-047.xht
- REM css/CSS2/borders/border-bottom-width-092.xht
- REM css/CSS2/borders/border-bottom-width-093.xht
- REM css/CSS2/borders/border-bottom-width-094.xht
- REM css/CSS2/borders/border-bottom-width-applies-to-008.xht
- REM css/CSS2/borders/border-bottom-width-applies-to-010.xht
- REM css/CSS2/borders/border-color-002.xht
- REM css/CSS2/borders/border-color-003.xht
- REM css/CSS2/borders/border-color-004.xht
- REM css/CSS2/borders/border-color-007.xht
- REM css/CSS2/borders/border-color-008.xht
- REM css/CSS2/borders/border-color-009.xht
- REM css/CSS2/borders/border-color-applies-to-008.xht
- REM css/CSS2/borders/border-color-applies-to-010.xht
- REM css/CSS2/borders/border-color-shorthand-002.xht
- REM css/CSS2/borders/border-color-shorthand-003.xht
- REM css/CSS2/borders/border-color-shorthand-004.xht
- REM css/CSS2/borders/border-left-002.xht
- REM css/CSS2/borders/border-left-004.xht
- REM css/CSS2/borders/border-left-007.xht
- REM css/CSS2/borders/border-left-009.xht
- REM css/CSS2/borders/border-left-010.xht
- REM css/CSS2/borders/border-left-011.xht
- REM css/CSS2/borders/border-left-012.xht
- REM css/CSS2/borders/border-left-013.xht
- REM css/CSS2/borders/border-left-014.xht
- REM css/CSS2/borders/border-left-015.xht
- REM css/CSS2/borders/border-left-016.xht
- REM css/CSS2/borders/border-left-017.xht
- REM css/CSS2/borders/border-left-applies-to-008.xht
- REM css/CSS2/borders/border-left-applies-to-010.xht
- REM css/CSS2/borders/border-left-color-applies-to-008.xht
- REM css/CSS2/borders/border-left-color-applies-to-010.xht
- REM css/CSS2/borders/border-left-style-003.xht
- REM css/CSS2/borders/border-left-style-004.xht
- REM css/CSS2/borders/border-left-style-006.xht
- REM css/CSS2/borders/border-left-style-007.xht
- REM css/CSS2/borders/border-left-style-008.xht
- REM css/CSS2/borders/border-left-style-009.xht
- REM css/CSS2/borders/border-left-style-010.xht
- REM css/CSS2/borders/border-left-style-011.xht
- REM css/CSS2/borders/border-left-style-applies-to-001.xht
- REM css/CSS2/borders/border-left-style-applies-to-002.xht
- REM css/CSS2/borders/border-left-style-applies-to-003.xht
- REM css/CSS2/borders/border-left-style-applies-to-004.xht
- REM css/CSS2/borders/border-left-style-applies-to-005.xht
- REM css/CSS2/borders/border-left-style-applies-to-006.xht
- REM css/CSS2/borders/border-left-style-applies-to-007.xht
- REM css/CSS2/borders/border-left-style-applies-to-008.xht
- REM css/CSS2/borders/border-left-style-applies-to-009.xht
- REM css/CSS2/borders/border-left-style-applies-to-010.xht
- REM css/CSS2/borders/border-left-style-applies-to-012.xht
- REM css/CSS2/borders/border-left-style-applies-to-013.xht
- REM css/CSS2/borders/border-left-style-applies-to-014.xht
- REM css/CSS2/borders/border-left-style-applies-to-015.xht
# ... and 3208 more (see the workflow logs)
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33173111324).</sub>
<!-- wpt-results-end -->
