### PR TITLE
wpt: raise testharness timeouts to deflake heavy interpolation tests

### DIFF
--- a/wpt/runner/src/test_runners/harness_test.rs
+++ b/wpt/runner/src/test_runners/harness_test.rs
@@ -13,7 +13,7 @@ use super::{SubtestResult, parse_and_resolve_document, pump_timers, run_document
 use crate::{SubtestCounts, TestStatus, ThreadCtx};
 
 /// How long to wait for the harness to complete (async tests, timers)
-const HARNESS_TIMEOUT: Duration = Duration::from_secs(5);
+const HARNESS_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Custom `testharnessreport.js` served in place of WPT's stock one (which is
 /// designed to be replaced by test runners). It disables the DOM output section
@@ -26,8 +26,14 @@ const HARNESS_TIMEOUT: Duration = Duration::from_secs(5);
 /// TIMEOUT harness status quickly instead of hitting the runner's
 /// [`HARNESS_TIMEOUT`] backstop. It also proportionally shortens
 /// `step_timeout()` delays, speeding up legitimately-passing async tests.
+///
+/// The internal timeout is real (wall-clock) time and races against the
+/// test's own script execution, so it must comfortably exceed the runtime of
+/// the heaviest completing tests (the interpolation suites run for ~1s of
+/// script time each, longer on loaded CI machines) or their results flap
+/// between TIMEOUT and their true status from run to run.
 const TESTHARNESSREPORT_JS: &str = r#"
-setup({ output: false, debug: false, timeout_multiplier: 0.1 });
+setup({ output: false, debug: false, timeout_multiplier: 0.5 });
 add_completion_callback(function (tests, harness_status) {
     __blitz_send_message(JSON.stringify({
         type: "wpt_results",


### PR DESCRIPTION
## Summary

WPT runs have been producing flaky `Timeout ⇄ Fail` flips (e.g. ~35 spurious status changes on #814), almost all in the heavy interpolation/parsing testharness suites (`css/*/animations/*-interpolation.html`, `color-mix` parsing, `test_font_family_parsing.html`, `has-complexity.html`).

Root cause: the injected `testharnessreport.js` sets `timeout_multiplier: 0.1`, scaling testharness's internal 10s timeout down to **1s of wall-clock time** — and these tests take ~0.6–1.2s of real script time even on an idle machine. Since timers are pumped in real time, the internal timeout races the test's own execution; on loaded CI machines the same tests fall on either side of 1s from run to run. They are not hangs: given budget, every one of them completes (as `Fail`, mostly — Blitz lacks animation support).

Reproduced locally: with 8 busy-loop processes saturating the cores, the same test flips `FAILED`/`TIMED OUT` across runs at multiplier 0.1, and is deterministically `FAILED` (3/3 runs × 5 tests) with this change.

Change:
- `timeout_multiplier: 0.1` → `0.5` (internal timeout 1s → 5s)
- `HARNESS_TIMEOUT` backstop 5s → 10s (so the scaled internal timeout still fires first and hangs get a proper harness TIMEOUT status)

Cost is negligible: genuine hangers are already covered by the 259-entry timeout quarantine; the latest full CI run had only **17** TIMEOUT results, nearly all of which are these borderline tests that will now complete instead of waiting out the timeout.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/dbb484350ccd420bb69efaf2f0f462ce
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/dbb484350ccd420bb69efaf2f0f462ce?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**4** newly passing, **0** newly failing (net +4), **50** other status changes.

<details>
<summary>Full diff (54 changed tests)</summary>

```diff
! Timeout => Fail css/css-anchor-position/anchor-parse-valid.html
! Timeout => Fail css/css-anchor-position/anchor-position-writing-modes-001.html
+ Timeout => Pass css/css-anchor-position/position-area-parsing.html
! Timeout => Fail css/css-anchor-position/property-interpolations.html
! Timeout => Fail css/css-backgrounds/animations/background-position-origin-interpolation.html
! Timeout => Fail css/css-backgrounds/animations/background-size-interpolation.html
! Timeout => Fail css/css-backgrounds/animations/border-image-slice-interpolation.html
! Timeout => Fail css/css-backgrounds/animations/border-image-source-interpolation.html
! Timeout => Fail css/css-backgrounds/animations/border-image-width-interpolation.html
! Timeout => Fail css/css-borders/corner-shape/corner-shape-interpolation.html
! Timeout => Fail css/css-color/parsing/color-computed-color-mix-function.html
! Timeout => Fail css/css-color/parsing/color-computed-relative-color.html
! Timeout => Fail css/css-color/parsing/color-valid-color-mix-function.html
+ Timeout => Pass css/css-color/parsing/color-valid-relative-color.html
! Timeout => Fail css/css-fonts/animations/font-size-adjust-composition.html
! Timeout => Fail css/css-fonts/animations/font-size-adjust-interpolation.html
! Timeout => Fail css/css-fonts/test_font_family_parsing.html
! Timeout => Fail css/css-gaps/animation/column-rule-inset-interpolation.html
! Timeout => Fail css/css-gaps/animation/row-rule-inset-interpolation.html
! Timeout => Fail css/css-grid/animation/grid-no-interpolation.html
+ Timeout => Pass css/css-images/parsing/gradient-interpolation-method-computed.html
+ Timeout => Pass css/css-images/parsing/gradient-interpolation-method-valid.html
! Timeout => Fail css/css-lists/css-lists-no-interpolation.html
! Timeout => Fail css/css-masking/animations/clip-interpolation.html
! Timeout => Fail css/css-masking/animations/clip-path-interpolation-shape-control-points.html
! Timeout => Fail css/css-masking/animations/clip-path-interpolation-xywh-rect.html
! Timeout => Fail css/css-masking/animations/mask-border-slice-interpolation.html
! Timeout => Fail css/css-masking/animations/mask-border-width-interpolation.html
! Timeout => Fail css/css-masking/animations/mask-image-interpolation.html
! Timeout => Fail css/css-shapes/animation/shape-outside-interpolation.html
! Timeout => Fail css/css-shapes/animation/shape-outside-path-interpolation.html
! Timeout => Fail css/css-shapes/animation/shape-outside-shape-interpolation.html
! Timeout => Fail css/css-shapes/shape-outside/values/shape-outside-inset-001.html
! Timeout => Fail css/css-sizing/animation/height-interpolation.html
! Timeout => Fail css/css-sizing/animation/max-height-interpolation.html
! Timeout => Fail css/css-sizing/animation/max-width-interpolation.html
! Timeout => Fail css/css-sizing/animation/min-height-interpolation.html
! Timeout => Fail css/css-sizing/animation/min-width-interpolation.html
! Timeout => Fail css/css-sizing/animation/width-interpolation.html
! Timeout => Fail css/css-transforms/animation/rotate-interpolation.html
! Timeout => Fail css/css-transforms/animation/scale-interpolation.html
! Timeout => Fail css/css-transforms/animation/transform-interpolation-001.html
! Timeout => Fail css/css-transforms/animation/transform-interpolation-004.html
! Timeout => Fail css/css-transforms/animation/transform-interpolation-005.html
! Timeout => Fail css/css-transforms/animation/translate-interpolation.html
! Timeout => Fail css/css-values/calc-size/animation/calc-size-width-interpolation.html
! Timeout => Fail css/css-values/calc-size/animation/interpolate-size-max-width-interpolation.html
! Timeout => Fail css/filter-effects/animation/backdrop-filter-composition-001.html
! Timeout => Fail css/filter-effects/animation/filter-interpolation-003.html
! Timeout => Fail css/motion/animation/offset-path-interpolation-001.html
! Timeout => Fail css/motion/animation/offset-path-interpolation-005.html
! Timeout => Fail css/motion/animation/offset-path-interpolation-006.html
! Timeout => Fail css/motion/animation/offset-rotate-interpolation.html
! Timeout => Fail css/selectors/invalidation/has-complexity.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33324643249).</sub>
<!-- wpt-results-end -->
