### PR TITLE
wpt: run .any.js / .window.js tests by synthesizing wptserve's HTML wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10110,6 +10110,7 @@ dependencies = [
  "dify",
  "env_logger",
  "glob",
+ "html-escape",
  "image",
  "log",
  "markup5ever",

--- a/wpt/runner/Cargo.toml
+++ b/wpt/runner/Cargo.toml
@@ -32,6 +32,7 @@ url = { workspace = true }
 data-url = { workspace = true }
 png = { version = "0.17" }
 glob = { version = "0.3.1" }
+html-escape = { workspace = true }
 dify = { version = "0.7.4", default-features = false }
 env_logger = { version = "0.11.5" }
 owo-colors = "4.1.0"

--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -233,9 +233,17 @@ fn collect_tests(wpt_dir: &Path) -> Vec<PathBuf> {
         suites.sort_unstable();
     }
 
+    // JS-file tests which wptserve wraps in an auto-generated HTML document
+    const JS_TEST_SUFFIXES: &[&str] = &["any.js", "window.js"];
+
     for suite in suites {
         for pat in std::iter::once(String::new())
             .chain(TEST_EXTENSIONS.iter().map(|ext| format!("/**/*.{ext}")))
+            .chain(
+                JS_TEST_SUFFIXES
+                    .iter()
+                    .map(|suffix| format!("/**/*.{suffix}")),
+            )
         {
             let pattern = format!("{}/{}{}", wpt_dir.display(), suite, pat);
 
@@ -624,8 +632,19 @@ fn main() {
                 Ordering::Relaxed,
             );
 
+            // JS-file tests are known by the URL of their auto-generated
+            // wrapper page (e.g. `foo.any.js` runs as `foo.any.html`), so
+            // report them under that name to match other engines' reports
+            let name = if let Some(stem) = relative_path.strip_suffix(".any.js") {
+                format!("{stem}.any.html")
+            } else if let Some(stem) = relative_path.strip_suffix(".window.js") {
+                format!("{stem}.window.html")
+            } else {
+                relative_path
+            };
+
             let result = TestResult {
-                name: relative_path,
+                name,
                 kind,
                 flags,
                 status,

--- a/wpt/runner/src/test_runners/js_wrapper.rs
+++ b/wpt/runner/src/test_runners/js_wrapper.rs
@@ -1,0 +1,136 @@
+//! Synthesizes the HTML wrapper documents which wptserve auto-generates for
+//! JS-file tests (`.any.js` and `.window.js`), mirroring `AnyHtmlHandler` and
+//! `WindowHandler` in wpt's `tools/serve/serve.py`. This lets the runner
+//! execute these tests through the regular testharness path without a server.
+
+/// The maximum set of `// META:` directives at the top of a JS test file,
+/// in file order. Parsing stops at the first non-META line (matching
+/// upstream's `read_script_metadata`).
+fn parse_metas(js_source: &str) -> Vec<(&str, &str)> {
+    let mut metas = Vec::new();
+    for line in js_source.lines() {
+        let Some(rest) = line.strip_prefix("//") else {
+            break;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix("META:") else {
+            break;
+        };
+        let Some((key, value)) = rest.trim_start().split_once('=') else {
+            break;
+        };
+        metas.push((key, value));
+    }
+    metas
+}
+
+fn escape_html_text(value: &str) -> String {
+    value.replace('&', "&amp;").replace('<', "&lt;")
+}
+
+fn escape_html_attr(value: &str) -> String {
+    value.replace('&', "&amp;").replace('"', "&quot;")
+}
+
+/// Does the test's `// META: global=` line (or the `.any.js` default of
+/// "window,dedicatedworker") include the `window` global?
+fn globals_include_window(metas: &[(&str, &str)]) -> bool {
+    let Some((_, value)) = metas.iter().find(|(key, _)| *key == "global") else {
+        return true;
+    };
+    value.split(',').any(|item| item.trim() == "window")
+}
+
+/// Build the wrapper HTML for a `.any.js` or `.window.js` test. Returns `None`
+/// for `.any.js` tests whose `// META: global=` list excludes the `window`
+/// global (worker-only tests), which have no window variant to run.
+pub fn wrapper_html_for_js_test(relative_path: &str, js_source: &str) -> Option<String> {
+    let is_any = relative_path.ends_with(".any.js");
+    let metas = parse_metas(js_source);
+
+    if is_any && !globals_include_window(&metas) {
+        return None;
+    }
+
+    let mut meta_tags = String::new();
+    let mut script_tags = String::new();
+    for (key, value) in &metas {
+        match *key {
+            "timeout" if *value == "long" => {
+                meta_tags.push_str("<meta name=\"timeout\" content=\"long\">\n");
+            }
+            "title" => {
+                meta_tags.push_str(&format!("<title>{}</title>\n", escape_html_text(value)));
+            }
+            "script" => {
+                script_tags.push_str(&format!(
+                    "<script src=\"{}\"></script>\n",
+                    escape_html_attr(value)
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    let global_block = if is_any {
+        concat!(
+            "<script>\n",
+            "self.GLOBAL = {\n",
+            "  isWindow: function() { return true; },\n",
+            "  isWorker: function() { return false; },\n",
+            "  isShadowRealm: function() { return false; },\n",
+            "};\n",
+            "</script>\n",
+        )
+    } else {
+        ""
+    };
+
+    Some(format!(
+        "<!doctype html>\n\
+         <meta charset=utf-8>\n\
+         {meta_tags}\
+         {global_block}\
+         <script src=\"/resources/testharness.js\"></script>\n\
+         <script src=\"/resources/testharnessreport.js\"></script>\n\
+         {script_tags}\
+         <div id=log></div>\n\
+         <script src=\"/{relative_path}\"></script>\n"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_meta_block() {
+        let js = "// META: title=A <title>\n\
+                  // META: script=/common/utils.js\n\
+                  //META: timeout=long\n\
+                  'use strict';\n\
+                  // META: script=ignored-after-code.js\n";
+        let html = wrapper_html_for_js_test("dom/foo.any.js", js).unwrap();
+        assert!(html.contains("<title>A &lt;title></title>"));
+        assert!(html.contains("<script src=\"/common/utils.js\"></script>"));
+        assert!(html.contains("<meta name=\"timeout\" content=\"long\">"));
+        assert!(!html.contains("ignored-after-code.js"));
+        assert!(html.contains("self.GLOBAL"));
+        assert!(html.contains("<script src=\"/dom/foo.any.js\"></script>"));
+    }
+
+    #[test]
+    fn window_js_has_no_global_block() {
+        let html = wrapper_html_for_js_test("dom/foo.window.js", "test(() => {});").unwrap();
+        assert!(!html.contains("self.GLOBAL"));
+        assert!(html.contains("<script src=\"/dom/foo.window.js\"></script>"));
+    }
+
+    #[test]
+    fn worker_only_any_js_is_excluded() {
+        let js = "// META: global=worker\ntest(() => {});";
+        assert!(wrapper_html_for_js_test("dom/foo.any.js", js).is_none());
+        let js = "// META: global=window,worker\ntest(() => {});";
+        assert!(wrapper_html_for_js_test("dom/foo.any.js", js).is_some());
+    }
+}

--- a/wpt/runner/src/test_runners/js_wrapper.rs
+++ b/wpt/runner/src/test_runners/js_wrapper.rs
@@ -33,16 +33,17 @@ fn globals_include_window(metas: &[(&str, &str)]) -> bool {
     value.split(',').any(|item| item.trim() == "window")
 }
 
-/// Build the wrapper HTML for a `.any.js` or `.window.js` test. Returns `None`
-/// for `.any.js` tests whose `// META: global=` list excludes the `window`
-/// global (worker-only tests), which have no window variant to run.
-pub fn wrapper_html_for_js_test(relative_path: &str, js_source: &str) -> Option<String> {
+/// Whether the runner can run this `.any.js` / `.window.js` test, i.e.
+/// whether it has a window variant. `.any.js` tests whose `// META: global=`
+/// list excludes the `window` global (worker-only tests) cannot be run.
+pub fn js_test_has_window_variant(relative_path: &str, js_source: &str) -> bool {
+    !relative_path.ends_with(".any.js") || globals_include_window(&parse_metas(js_source))
+}
+
+/// Build the wrapper HTML for a `.any.js` or `.window.js` test.
+pub fn wrapper_html_for_js_test(relative_path: &str, js_source: &str) -> String {
     let is_any = relative_path.ends_with(".any.js");
     let metas = parse_metas(js_source);
-
-    if is_any && !globals_include_window(&metas) {
-        return None;
-    }
 
     let mut meta_tags = String::new();
     let mut script_tags = String::new();
@@ -81,7 +82,7 @@ pub fn wrapper_html_for_js_test(relative_path: &str, js_source: &str) -> Option<
         ""
     };
 
-    Some(format!(
+    format!(
         "<!doctype html>\n\
          <meta charset=utf-8>\n\
          {meta_tags}\
@@ -91,7 +92,7 @@ pub fn wrapper_html_for_js_test(relative_path: &str, js_source: &str) -> Option<
          {script_tags}\
          <div id=log></div>\n\
          <script src=\"/{relative_path}\"></script>\n"
-    ))
+    )
 }
 
 #[cfg(test)]
@@ -105,7 +106,7 @@ mod tests {
                   //META: timeout=long\n\
                   'use strict';\n\
                   // META: script=ignored-after-code.js\n";
-        let html = wrapper_html_for_js_test("dom/foo.any.js", js).unwrap();
+        let html = wrapper_html_for_js_test("dom/foo.any.js", js);
         assert!(html.contains("<title>A &lt;title&gt;</title>"));
         assert!(html.contains("<script src=\"/common/utils.js\"></script>"));
         assert!(html.contains("<meta name=\"timeout\" content=\"long\">"));
@@ -116,7 +117,7 @@ mod tests {
 
     #[test]
     fn window_js_has_no_global_block() {
-        let html = wrapper_html_for_js_test("dom/foo.window.js", "test(() => {});").unwrap();
+        let html = wrapper_html_for_js_test("dom/foo.window.js", "test(() => {});");
         assert!(!html.contains("self.GLOBAL"));
         assert!(html.contains("<script src=\"/dom/foo.window.js\"></script>"));
     }
@@ -124,8 +125,9 @@ mod tests {
     #[test]
     fn worker_only_any_js_is_excluded() {
         let js = "// META: global=worker\ntest(() => {});";
-        assert!(wrapper_html_for_js_test("dom/foo.any.js", js).is_none());
+        assert!(!js_test_has_window_variant("dom/foo.any.js", js));
         let js = "// META: global=window,worker\ntest(() => {});";
-        assert!(wrapper_html_for_js_test("dom/foo.any.js", js).is_some());
+        assert!(js_test_has_window_variant("dom/foo.any.js", js));
+        assert!(js_test_has_window_variant("dom/foo.window.js", js));
     }
 }

--- a/wpt/runner/src/test_runners/js_wrapper.rs
+++ b/wpt/runner/src/test_runners/js_wrapper.rs
@@ -24,14 +24,6 @@ fn parse_metas(js_source: &str) -> Vec<(&str, &str)> {
     metas
 }
 
-fn escape_html_text(value: &str) -> String {
-    value.replace('&', "&amp;").replace('<', "&lt;")
-}
-
-fn escape_html_attr(value: &str) -> String {
-    value.replace('&', "&amp;").replace('"', "&quot;")
-}
-
 /// Does the test's `// META: global=` line (or the `.any.js` default of
 /// "window,dedicatedworker") include the `window` global?
 fn globals_include_window(metas: &[(&str, &str)]) -> bool {
@@ -60,12 +52,15 @@ pub fn wrapper_html_for_js_test(relative_path: &str, js_source: &str) -> Option<
                 meta_tags.push_str("<meta name=\"timeout\" content=\"long\">\n");
             }
             "title" => {
-                meta_tags.push_str(&format!("<title>{}</title>\n", escape_html_text(value)));
+                meta_tags.push_str(&format!(
+                    "<title>{}</title>\n",
+                    html_escape::encode_text(value)
+                ));
             }
             "script" => {
                 script_tags.push_str(&format!(
                     "<script src=\"{}\"></script>\n",
-                    escape_html_attr(value)
+                    html_escape::encode_double_quoted_attribute(value)
                 ));
             }
             _ => {}
@@ -111,7 +106,7 @@ mod tests {
                   'use strict';\n\
                   // META: script=ignored-after-code.js\n";
         let html = wrapper_html_for_js_test("dom/foo.any.js", js).unwrap();
-        assert!(html.contains("<title>A &lt;title></title>"));
+        assert!(html.contains("<title>A &lt;title&gt;</title>"));
         assert!(html.contains("<script src=\"/common/utils.js\"></script>"));
         assert!(html.contains("<meta name=\"timeout\" content=\"long\">"));
         assert!(!html.contains("ignored-after-code.js"));

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -24,7 +24,7 @@ mod ref_test;
 pub use attr_test::process_attr_test;
 pub use crash_test::process_crash_test;
 pub use harness_test::process_harness_test;
-pub use js_wrapper::wrapper_html_for_js_test;
+pub use js_wrapper::{js_test_has_window_variant, wrapper_html_for_js_test};
 pub use ref_test::process_ref_test;
 
 static TIMEOUT_QUARANTINE: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
@@ -232,20 +232,21 @@ pub fn process_test_file(
     // wrapper HTML which wptserve would serve and run it as a harness test
     if relative_path.ends_with(".any.js") || relative_path.ends_with(".window.js") {
         flags |= TestFlags::USES_SCRIPT;
-        return match wrapper_html_for_js_test(relative_path, &file_contents) {
-            Some(html) => {
-                let (status, counts, results) = process_harness_test(ctx, &html, relative_path);
-                (TestKind::TestHarness, flags, status, counts, results)
-            }
-            // No window variant (worker-only test): not a runnable test
-            None => (
+
+        // No window variant (worker-only test): not a runnable test
+        if !js_test_has_window_variant(relative_path, &file_contents) {
+            return (
                 TestKind::Unknown,
                 flags,
                 TestStatus::Skip,
                 SubtestCounts::ZERO_OF_ZERO,
                 Vec::new(),
-            ),
-        };
+            );
+        }
+
+        let html = wrapper_html_for_js_test(relative_path, &file_contents);
+        let (status, counts, results) = process_harness_test(ctx, &html, relative_path);
+        return (TestKind::TestHarness, flags, status, counts, results);
     }
 
     // Crash Test

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -18,11 +18,13 @@ mod attr_test;
 mod crash_test;
 mod fuzzy;
 mod harness_test;
+mod js_wrapper;
 mod ref_test;
 
 pub use attr_test::process_attr_test;
 pub use crash_test::process_crash_test;
 pub use harness_test::process_harness_test;
+pub use js_wrapper::wrapper_html_for_js_test;
 pub use ref_test::process_ref_test;
 
 static TIMEOUT_QUARANTINE: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
@@ -224,6 +226,26 @@ pub fn process_test_file(
     }
     if ctx.script_re.is_match(&file_contents) {
         flags |= TestFlags::USES_SCRIPT;
+    }
+
+    // JS-file (`.any.js` / `.window.js`) testharness test: synthesize the
+    // wrapper HTML which wptserve would serve and run it as a harness test
+    if relative_path.ends_with(".any.js") || relative_path.ends_with(".window.js") {
+        flags |= TestFlags::USES_SCRIPT;
+        return match wrapper_html_for_js_test(relative_path, &file_contents) {
+            Some(html) => {
+                let (status, counts, results) = process_harness_test(ctx, &html, relative_path);
+                (TestKind::TestHarness, flags, status, counts, results)
+            }
+            // No window variant (worker-only test): not a runnable test
+            None => (
+                TestKind::Unknown,
+                flags,
+                TestStatus::Skip,
+                SubtestCounts::ZERO_OF_ZERO,
+                Vec::new(),
+            ),
+        };
     }
 
     // Crash Test


### PR DESCRIPTION
## Summary

JS-file testharness tests (`.any.js` / `.window.js`) were never collected by the WPT runner (it only globs html-ish extensions), so entire swaths of the dom/html suites were invisible. Real WPT auto-generates a tiny HTML wrapper page for these (`foo.any.js` is served as `foo.any.html`); this PR synthesizes those wrappers in the runner (new `js_wrapper::wrapper_html_for_js_test`), mirroring `AnyHtmlHandler`/`WindowHandler` in wpt's `tools/serve/serve.py`, and runs them through the existing testharness path:

```text
<!doctype html>
<meta charset=utf-8>
{<title>/<meta timeout> from // META: comments}
{self.GLOBAL = {...} block, .any.js only}
<script src="/resources/testharness.js"></script>
<script src="/resources/testharnessreport.js"></script>
{<script src=...> for each // META: script=...}
<div id=log></div>
<script src="/{path/to/test.any.js}"></script>
```

Details:
- `// META:` comment parsing matches upstream `read_script_metadata`: only the leading run of `// META: key=value` lines is honoured (`title`, `script`, `timeout`, `global`; others ignored).
- `.any.js` tests whose `// META: global=` list excludes `window` (worker-only tests) have no window variant and are skipped (excluded from the report, like other non-runnable files).
- Results are reported under the wrapper URL (`foo.any.html` / `foo.window.html`) to match other engines' wptreports.
- Worker-based variants (`.worker.js`, `.any.worker.html`, etc.) remain unsupported (no Worker support).

On the `dom` suite this raises collected tests from 686 to 749 and passing subtests to 1329 (many of the new tests fail/timeout on missing engine features, which is the point: they're now measured).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/13db5150cbcd480b86567637ec411a82
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/13db5150cbcd480b86567637ec411a82?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**0** newly passing, **0** newly failing (net 0), **6** added tests.

<details>
<summary>Full diff (6 changed tests)</summary>

```diff
+ ADD css/css-highlight-api/historical.window.html
+ ADD css/css-highlight-api/idlharness.window.html
+ ADD css/css-typed-om/stylevalue-subclasses/cssKeywordValue-invalid.any.html
+ ADD css/cssom/cssstyledeclaration-csstext-setter.window.html
+ ADD css/filter-effects/idlharness.any.html
+ ADD css/geometry/idlharness.any.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33439342776).</sub>
<!-- wpt-results-end -->
