### PR TITLE
Fix OOM (signal 9) in WPT html suite: bound @import recursion, cache ES modules

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1157,6 +1157,7 @@ impl BaseDocument {
                 net_provider: self.net_provider.clone(),
                 shell_provider: self.shell_provider.clone(),
                 abort_signal: self.abort_signal.clone(),
+                import_depth: 0,
             }),
             None,
             QuirksMode::NoQuirks,

--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -159,6 +159,7 @@ impl NetHandler for ResourceHandler<StylesheetHandler> {
                 net_provider: self.data.net_provider.clone(),
                 shell_provider: self.shell_provider.clone(),
                 abort_signal: self.data.abort_signal.clone(),
+                import_depth: 0,
             }),
             None, // error_reporter
             QuirksMode::NoQuirks,
@@ -172,6 +173,12 @@ impl NetHandler for ResourceHandler<StylesheetHandler> {
     }
 }
 
+/// Maximum depth of nested `@import` rules. Imports nested deeper than this
+/// are refused, preventing unbounded recursion (e.g. a stylesheet whose
+/// resolved `@import` URL yields another stylesheet importing in turn, with
+/// the URL growing geometrically at each level).
+const MAX_IMPORT_DEPTH: usize = 16;
+
 #[derive(Clone)]
 pub(crate) struct StylesheetLoader {
     pub(crate) tx: Sender<DocumentEvent>,
@@ -179,6 +186,9 @@ pub(crate) struct StylesheetLoader {
     pub(crate) net_provider: Arc<dyn NetProvider>,
     pub(crate) shell_provider: Arc<dyn ShellProvider>,
     pub(crate) abort_signal: Option<AbortSignal>,
+    /// Depth of `@import` nesting for the stylesheet this loader is parsing
+    /// (0 for a top-level stylesheet)
+    pub(crate) import_depth: usize,
 }
 impl ServoStylesheetLoader for StylesheetLoader {
     fn request_stylesheet(
@@ -190,7 +200,7 @@ impl ServoStylesheetLoader for StylesheetLoader {
         supports: Option<ImportSupportsCondition>,
         layer: ImportLayer,
     ) -> ServoArc<Locked<ImportRule>> {
-        if !supports.as_ref().is_none_or(|s| s.enabled) {
+        if self.import_depth >= MAX_IMPORT_DEPTH || !supports.as_ref().is_none_or(|s| s.enabled) {
             return ServoArc::new(lock.wrap(ImportRule {
                 url,
                 stylesheet: ImportSheet::new_refused(),
@@ -220,7 +230,10 @@ impl ServoStylesheetLoader for StylesheetLoader {
                 self.shell_provider.clone(),
                 NestedStylesheetHandler {
                     url: url.clone(),
-                    loader: self.clone(),
+                    loader: StylesheetLoader {
+                        import_depth: self.import_depth + 1,
+                        ..self.clone()
+                    },
                     lock: lock.clone(),
                     media,
                     import_rule: import.clone(),

--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -2,6 +2,7 @@
 //! dispatches events / timers into JavaScript.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -412,6 +413,10 @@ fn report_js_error(ctx: &DomCtx, what: &str, error: &boa_engine::JsError) {
 struct BlitzModuleLoader {
     fetcher: Rc<RefCell<Box<dyn ScriptFetcher>>>,
     base_url: Option<Url>,
+    /// Modules already fetched and parsed, keyed by resolved URL. Serving
+    /// repeat imports from here breaks import cycles (e.g. `a.js` importing
+    /// `b.js` which imports `a.js`), which would otherwise load forever.
+    modules: RefCell<HashMap<Url, Module>>,
 }
 
 impl BlitzModuleLoader {
@@ -425,6 +430,14 @@ impl BlitzModuleLoader {
             .and_then(|path| Url::parse(path).ok());
         let base = referrer_url.or_else(|| self.base_url.clone())?;
         base.join(specifier).ok()
+    }
+
+    fn get(&self, url: &Url) -> Option<Module> {
+        self.modules.borrow().get(url).cloned()
+    }
+
+    fn insert(&self, url: Url, module: Module) {
+        self.modules.borrow_mut().insert(url, module);
     }
 }
 
@@ -444,13 +457,18 @@ impl ModuleLoader for BlitzModuleLoader {
                         .with_message(format!("could not resolve module specifier {specifier:?}")),
                 )
             })?;
+        if let Some(module) = self.get(&url) {
+            return Ok(module);
+        }
         let code = self.fetcher.borrow().fetch(&url).map_err(|error| {
             JsError::from(
                 JsNativeError::typ().with_message(format!("failed to fetch module {url}: {error}")),
             )
         })?;
         let source = Source::from_reader(code.as_bytes(), Some(Path::new(url.as_str())));
-        Module::parse(source, None, &mut context.borrow_mut())
+        let module = Module::parse(source, None, &mut context.borrow_mut())?;
+        self.insert(url, module.clone());
+        Ok(module)
     }
 }
 
@@ -481,6 +499,7 @@ impl Logger for LogCrateLogger {
 pub(crate) struct ScriptRuntime {
     pub context: Context,
     pub ctx: DomCtx,
+    module_loader: Rc<BlitzModuleLoader>,
 }
 
 impl ScriptRuntime {
@@ -492,9 +511,10 @@ impl ScriptRuntime {
         let module_loader = Rc::new(BlitzModuleLoader {
             fetcher,
             base_url: base_url.cloned(),
+            modules: RefCell::new(HashMap::new()),
         });
         let mut context = Context::builder()
-            .module_loader(module_loader)
+            .module_loader(module_loader.clone())
             .build()
             .expect("failed to build JS context");
         let ctx = DomCtx::new(doc);
@@ -621,7 +641,11 @@ impl ScriptRuntime {
             .build();
         register_global(&mut context, "CSS", css_namespace.into());
 
-        let mut runtime = Self { context, ctx };
+        let mut runtime = Self {
+            context,
+            ctx,
+            module_loader,
+        };
 
         // Small JS bootstrap for APIs that are easiest to define in JS
         runtime.eval_internal(BOOTSTRAP_JS, "<blitz-bootstrap>");
@@ -667,6 +691,13 @@ impl ScriptRuntime {
                 return;
             }
         };
+        // Register the module so that imports resolving to this URL (including
+        // circular ones) reuse it rather than re-fetching
+        if let Some(url) = url
+            && self.module_loader.get(url).is_none()
+        {
+            self.module_loader.insert(url.clone(), module.clone());
+        }
 
         let promise = module.load_link_evaluate(&mut self.context);
         self.run_jobs(&description);


### PR DESCRIPTION
## Summary

`just wpt html` was killed by the kernel OOM killer (~31GB RSS). Two unbounded-recursion bugs, each triggered by a WPT test:

1. **CSS `@import` recursion** — `html/links/stylesheet/quirk-origin-check-recursive-import.html` uses `<link rel="stylesheet" href="data:/,@import url('x/');">`. The `data:/,` prefix makes the data URL hierarchical, so each `@import url('x/…')` resolves relative to it into a *new* data URL whose body is again a stylesheet containing an `@import`, with the URL roughly doubling per level. `StylesheetLoader::request_stylesheet` fetched/parsed synchronously with no bound, exploding to gigabytes within ~25 levels. Fix: `StylesheetLoader` now carries an `import_depth` (incremented for each `NestedStylesheetHandler`) and refuses imports (`ImportSheet::new_refused()`) past `MAX_IMPORT_DEPTH = 16`.

2. **Cyclic ES module imports** — `html/semantics/scripting-1/the-script-element/module/choice-of-error-*.html` have `a.js ⇄ b.js` import cycles. `BlitzModuleLoader::load_imported_module` re-fetched and re-parsed on every request, so a cycle looped forever. Fix: the loader now keeps a `modules: RefCell<HashMap<Url, Module>>` registry (same approach as boa's `SimpleModuleLoader`) — repeat imports return the cached `Module`, breaking cycles. `eval_module` also registers top-level modules by URL so imports back into the root script reuse it.

Verified: full `./target/release/wpt html` now completes (9420 tests found) in ~2 min under a 16GB `ulimit -v` cap; previously it was OOM-killed at ~31GB (`dmesg`: `Out of memory: Killed process (wpt)`).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/12bc7e0411fd4ae99b12765885c0f474
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/12bc7e0411fd4ae99b12765885c0f474?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33439861648).</sub>
<!-- wpt-results-end -->
