### PR TITLE
wpt: use wpt-runner-types crate for META and fuzzy parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10130,8 +10130,14 @@ dependencies = [
  "terminal-link",
  "thread_local",
  "url",
+ "wpt-runner-types",
  "wptreport",
 ]
+
+[[package]]
+name = "wpt-runner-types"
+version = "0.0.13"
+source = "git+https://github.com/nicoburns/wpt-rs?rev=961f8b905f22b9aa592979625614dccf3a0d3223#961f8b905f22b9aa592979625614dccf3a0d3223"
 
 [[package]]
 name = "wptreport"

--- a/wpt/runner/Cargo.toml
+++ b/wpt/runner/Cargo.toml
@@ -46,5 +46,6 @@ atomic_float = "1"
 supports-hyperlinks = "3.1.0"
 terminal-link = "0.1.0"
 wptreport = { version = "0.0.5", default-features = false }
+wpt-runner-types = { git = "https://github.com/nicoburns/wpt-rs", rev = "961f8b905f22b9aa592979625614dccf3a0d3223" }
 os_info = "3.10.0"
 serde_json = "1.0.140"

--- a/wpt/runner/src/test_runners/fuzzy.rs
+++ b/wpt/runner/src/test_runners/fuzzy.rs
@@ -1,52 +1,19 @@
-//! Parsing of `<meta name=fuzzy>` tags, which specify tolerances for reftest image
+//! Extraction of `<meta name=fuzzy>` tags, which specify tolerances for reftest image
 //! comparison. See <https://web-platform-tests.org/writing-tests/reftests.html#fuzzy-matching>
 //!
-//! The `content` attribute has the form `[ <ref-name> ":" ] <fuzzy-value>` where
-//! `<fuzzy-value>` is `maxDifference=<range>;totalPixels=<range>` (the key names are
-//! optional, in which case the ranges are positional) and `<range>` is either a single
-//! number or `<min>-<max>`.
+//! The content values are parsed by the `wpt-runner-types` crate; this module scrapes
+//! them out of the test's HTML and implements the image comparison.
 
 use regex::Regex;
 use std::sync::LazyLock;
+
+pub use wpt_runner_types::fuzzy::{FuzzySpec, tolerance_for_reference};
 
 static META_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"<meta\s[^>]*>"#).unwrap());
 static NAME_FUZZY_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"name\s*=\s*['"]?fuzzy['"]?"#).unwrap());
 static CONTENT_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"content\s*=\s*(?:['"]([^'"]*)['"]|([^\s'">]+))"#).unwrap());
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct FuzzyRange {
-    pub min: u64,
-    pub max: u64,
-}
-
-impl FuzzyRange {
-    fn parse(s: &str) -> Option<Self> {
-        let s = s.trim();
-        let (min, max) = match s.split_once('-') {
-            Some((min, max)) => (min.trim().parse().ok()?, max.trim().parse().ok()?),
-            None => {
-                let value = s.parse().ok()?;
-                (value, value)
-            }
-        };
-        (min <= max).then_some(Self { min, max })
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct FuzzyTolerance {
-    pub max_difference: FuzzyRange,
-    pub total_pixels: FuzzyRange,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FuzzySpec {
-    /// Reference file this tolerance applies to (`None` = all references)
-    pub reference: Option<String>,
-    pub tolerance: FuzzyTolerance,
-}
 
 /// Parses all `<meta name=fuzzy>` tags in the document
 pub fn parse_fuzzy_metas(html: &str) -> Vec<FuzzySpec> {
@@ -60,53 +27,9 @@ pub fn parse_fuzzy_metas(html: &str) -> Vec<FuzzySpec> {
             let content = CONTENT_RE
                 .captures(tag)
                 .and_then(|c| c.get(1).or(c.get(2)))?;
-            parse_fuzzy_content(content.as_str())
+            content.as_str().parse().ok()
         })
         .collect()
-}
-
-fn parse_fuzzy_content(content: &str) -> Option<FuzzySpec> {
-    let content = content.trim();
-    let (reference, value) = match content.split_once(':') {
-        Some((prefix, rest)) if !prefix.contains('=') => (Some(prefix.trim().to_string()), rest),
-        _ => (None, content),
-    };
-
-    let mut max_difference = None;
-    let mut total_pixels = None;
-    for (index, part) in value.split(';').enumerate() {
-        let part = part.trim();
-        if let Some(range) = part.strip_prefix("maxDifference=") {
-            max_difference = FuzzyRange::parse(range);
-        } else if let Some(range) = part.strip_prefix("totalPixels=") {
-            total_pixels = FuzzyRange::parse(range);
-        } else if index == 0 {
-            max_difference = FuzzyRange::parse(part);
-        } else {
-            total_pixels = FuzzyRange::parse(part);
-        }
-    }
-
-    Some(FuzzySpec {
-        reference,
-        tolerance: FuzzyTolerance {
-            max_difference: max_difference?,
-            total_pixels: total_pixels?,
-        },
-    })
-}
-
-/// Finds the tolerance applicable to `ref_file`: a spec naming that reference takes
-/// precedence over an unnamed one.
-pub fn tolerance_for_reference<'a>(
-    specs: &'a [FuzzySpec],
-    ref_file: &str,
-) -> Option<&'a FuzzyTolerance> {
-    specs
-        .iter()
-        .find(|spec| spec.reference.as_deref() == Some(ref_file))
-        .or_else(|| specs.iter().find(|spec| spec.reference.is_none()))
-        .map(|spec| &spec.tolerance)
 }
 
 /// Compares two RGBA buffers, returning the maximum per-channel difference and the
@@ -139,46 +62,6 @@ pub fn fuzzy_buffer_diff(test_buffer: &[u8], ref_buffer: &[u8]) -> (u64, u64) {
 mod tests {
     use super::*;
 
-    fn range(min: u64, max: u64) -> FuzzyRange {
-        FuzzyRange { min, max }
-    }
-
-    #[test]
-    fn parse_named_ranges() {
-        let spec = parse_fuzzy_content("maxDifference=0-2;totalPixels=0-40").unwrap();
-        assert_eq!(spec.reference, None);
-        assert_eq!(spec.tolerance.max_difference, range(0, 2));
-        assert_eq!(spec.tolerance.total_pixels, range(0, 40));
-    }
-
-    #[test]
-    fn parse_named_ranges_with_space() {
-        let spec = parse_fuzzy_content("maxDifference=0-99; totalPixels=0-410").unwrap();
-        assert_eq!(spec.tolerance.max_difference, range(0, 99));
-        assert_eq!(spec.tolerance.total_pixels, range(0, 410));
-    }
-
-    #[test]
-    fn parse_positional_ranges() {
-        let spec = parse_fuzzy_content("2;40").unwrap();
-        assert_eq!(spec.tolerance.max_difference, range(2, 2));
-        assert_eq!(spec.tolerance.total_pixels, range(40, 40));
-    }
-
-    #[test]
-    fn parse_per_reference() {
-        let spec = parse_fuzzy_content("ref.html:maxDifference=0-2;totalPixels=0-40").unwrap();
-        assert_eq!(spec.reference.as_deref(), Some("ref.html"));
-        assert_eq!(spec.tolerance.max_difference, range(0, 2));
-        assert_eq!(spec.tolerance.total_pixels, range(0, 40));
-    }
-
-    #[test]
-    fn parse_invalid() {
-        assert_eq!(parse_fuzzy_content("garbage"), None);
-        assert_eq!(parse_fuzzy_content("maxDifference=0-2"), None);
-    }
-
     #[test]
     fn parse_metas_from_html() {
         let html = r#"
@@ -189,41 +72,9 @@ mod tests {
         let specs = parse_fuzzy_metas(html);
         assert_eq!(specs.len(), 2);
         assert_eq!(specs[0].reference, None);
+        assert_eq!(specs[0].tolerance.max_difference.max, 5);
         assert_eq!(specs[1].reference.as_deref(), Some("ref.html"));
-        assert_eq!(specs[1].tolerance.max_difference, range(1, 1));
-    }
-
-    #[test]
-    fn tolerance_selection() {
-        let specs = vec![
-            FuzzySpec {
-                reference: None,
-                tolerance: FuzzyTolerance {
-                    max_difference: range(0, 1),
-                    total_pixels: range(0, 1),
-                },
-            },
-            FuzzySpec {
-                reference: Some("ref.html".to_string()),
-                tolerance: FuzzyTolerance {
-                    max_difference: range(0, 2),
-                    total_pixels: range(0, 2),
-                },
-            },
-        ];
-        assert_eq!(
-            tolerance_for_reference(&specs, "ref.html")
-                .unwrap()
-                .max_difference,
-            range(0, 2)
-        );
-        assert_eq!(
-            tolerance_for_reference(&specs, "other.html")
-                .unwrap()
-                .max_difference,
-            range(0, 1)
-        );
-        assert_eq!(tolerance_for_reference(&[], "ref.html"), None);
+        assert_eq!(specs[1].tolerance.max_difference.max, 1);
     }
 
     #[test]

--- a/wpt/runner/src/test_runners/js_wrapper.rs
+++ b/wpt/runner/src/test_runners/js_wrapper.rs
@@ -2,66 +2,45 @@
 //! JS-file tests (`.any.js` and `.window.js`), mirroring `AnyHtmlHandler` and
 //! `WindowHandler` in wpt's `tools/serve/serve.py`. This lets the runner
 //! execute these tests through the regular testharness path without a server.
+//!
+//! The `// META:` comment block is parsed by the `wpt-runner-types` crate.
 
-/// The maximum set of `// META:` directives at the top of a JS test file,
-/// in file order. Parsing stops at the first non-META line (matching
-/// upstream's `read_script_metadata`).
-fn parse_metas(js_source: &str) -> Vec<(&str, &str)> {
-    let mut metas = Vec::new();
-    for line in js_source.lines() {
-        let Some(rest) = line.strip_prefix("//") else {
-            break;
-        };
-        let rest = rest.trim_start();
-        let Some(rest) = rest.strip_prefix("META:") else {
-            break;
-        };
-        let Some((key, value)) = rest.trim_start().split_once('=') else {
-            break;
-        };
-        metas.push((key, value));
-    }
-    metas
-}
-
-/// Does the test's `// META: global=` line (or the `.any.js` default of
-/// "window,dedicatedworker") include the `window` global?
-fn globals_include_window(metas: &[(&str, &str)]) -> bool {
-    let Some((_, value)) = metas.iter().find(|(key, _)| *key == "global") else {
-        return true;
-    };
-    value.split(',').any(|item| item.trim() == "window")
-}
+use wpt_runner_types::script_metadata::{
+    GlobalScope, ScriptMetadata, ScriptMetadataExt as _, Timeout, parse_script_metadata,
+};
 
 /// Whether the runner can run this `.any.js` / `.window.js` test, i.e.
 /// whether it has a window variant. `.any.js` tests whose `// META: global=`
 /// list excludes the `window` global (worker-only tests) cannot be run.
 pub fn js_test_has_window_variant(relative_path: &str, js_source: &str) -> bool {
-    !relative_path.ends_with(".any.js") || globals_include_window(&parse_metas(js_source))
+    !relative_path.ends_with(".any.js")
+        || parse_script_metadata(js_source)
+            .global_scopes()
+            .contains(&GlobalScope::Window)
 }
 
 /// Build the wrapper HTML for a `.any.js` or `.window.js` test.
 pub fn wrapper_html_for_js_test(relative_path: &str, js_source: &str) -> String {
     let is_any = relative_path.ends_with(".any.js");
-    let metas = parse_metas(js_source);
+    let metas = parse_script_metadata(js_source);
 
     let mut meta_tags = String::new();
     let mut script_tags = String::new();
-    for (key, value) in &metas {
-        match *key {
-            "timeout" if *value == "long" => {
+    for meta in &metas {
+        match meta {
+            ScriptMetadata::Timeout(Timeout::Long) => {
                 meta_tags.push_str("<meta name=\"timeout\" content=\"long\">\n");
             }
-            "title" => {
+            ScriptMetadata::Title(title) => {
                 meta_tags.push_str(&format!(
                     "<title>{}</title>\n",
-                    html_escape::encode_text(value)
+                    html_escape::encode_text(title)
                 ));
             }
-            "script" => {
+            ScriptMetadata::Script(src) => {
                 script_tags.push_str(&format!(
                     "<script src=\"{}\"></script>\n",
-                    html_escape::encode_double_quoted_attribute(value)
+                    html_escape::encode_double_quoted_attribute(src)
                 ));
             }
             _ => {}


### PR DESCRIPTION
## Summary

Switches the WPT runner to the new `wpt-runner-types` crate (nicoburns/wpt-rs#4), which upstreams the `// META:` comment parsing and reftest fuzziness parsing with more rigour:

- `js_wrapper.rs` now consumes `parse_script_metadata()` / `ScriptMetadata` (typed directives incl. `global` as `GlobalScope` with upstream's full keyword set and `worker`/`shadowrealm` longhand expansion). `js_test_has_window_variant` is now `global_scopes().contains(&GlobalScope::Window)` — note this also matches upstream's default of `{window, dedicatedworker}` when no `global=` is present.
- `fuzzy.rs` keeps only the HTML `<meta name=fuzzy>` scraping and the RGBA buffer diff; the content-value parsing (`FuzzySpec: FromStr` with structured errors, `tolerance_for_reference`) moves upstream. The new parser is stricter (rejects unknown/duplicate properties and wrong part counts like upstream's manifest code) and additionally supports named args in either order.

Draft until nicoburns/wpt-rs#4 merges and `wpt-runner-types` is published — currently pinned as a git dependency (`rev = 961f8b9`); should be switched to a crates.io version before merging.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/13db5150cbcd480b86567637ec411a82
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/13db5150cbcd480b86567637ec411a82?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33441965560).</sub>
<!-- wpt-results-end -->
