### PR TITLE
wpt: quarantine atomics-wait-async (unbounded job execution hang)

### DIFF
--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn timeout_quarantine_is_valid() {
-        assert_eq!(TIMEOUT_QUARANTINE.len(), 259);
+        assert_eq!(TIMEOUT_QUARANTINE.len(), 260);
         assert_eq!(
             TIMEOUT_QUARANTINE.get("css/selectors/focus-visible-001.html"),
             Some(&"testdriver")

--- a/wpt/runner/timeout-quarantine.txt
+++ b/wpt/runner/timeout-quarantine.txt
@@ -257,3 +257,4 @@ css/css-backgrounds/animations/box-shadow-interpolation.html harness-timeout
 css/css-fonts/discrete-no-interpolation.html harness-timeout
 css/css-grid/animation/grid-template-rows-interpolation.html harness-timeout
 css/css-masking/animations/clip-path-interpolation-shape.html harness-timeout
+html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/atomics-wait-async.https.any.js unbounded-job-execution


### PR DESCRIPTION
## Summary
`html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/atomics-wait-async.https.any.js` spins forever at 100% CPU inside `boa_engine`'s `SimpleJobExecutor::run_jobs` (via `ScriptRuntime::run_jobs` / `execute_scripts`). The runner's 10s `HARNESS_TIMEOUT` backstop only applies while pumping timers, so it cannot interrupt synchronous script/job execution — this single test wedges the entire `html` suite run indefinitely.

Adds it to `timeout-quarantine.txt` with reason `unbounded-job-execution` (quarantine keys are the `.any.js` relative path; verified the runner now reports SKIP for it), and bumps the quarantine-count assertion 259 → 260.

Longer-term fix would be bounding job execution (e.g. a deadline in the `run_jobs` loop or boa `RuntimeLimits`) so runaway scripts become harness errors instead of hangs.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/a6e55feaf521433193da567e85ee93b6
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/a6e55feaf521433193da567e85ee93b6?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33447136794).</sub>
<!-- wpt-results-end -->
