### PR TITLE
script: fix replaceChild panic when old child is not a child of this node

### DIFF
--- a/packages/blitz-vibey-script/src/dom/node.rs
+++ b/packages/blitz-vibey-script/src/dom/node.rs
@@ -347,17 +347,40 @@ fn remove_child(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsRe
 
 fn replace_child(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let ctx = dom_ctx(context)?;
-    let _parent_id = this_node_id(this)?;
+    let parent_id = this_node_id(this)?;
     let new_id = arg_node_id(args, 0)?;
     let old_id = arg_node_id(args, 1)?;
 
+    {
+        let doc = ctx.doc.borrow();
+        let mut ancestor_id = Some(parent_id);
+        while let Some(id) = ancestor_id {
+            if id == new_id {
+                return Err(super::dom_exception(
+                    context,
+                    "HierarchyRequestError",
+                    "the new child is an inclusive ancestor of this node",
+                ));
+            }
+            ancestor_id = doc.get_node(id).and_then(|node| node.parent);
+        }
+        if doc.get_node(old_id).and_then(|node| node.parent) != Some(parent_id) {
+            return Err(super::dom_exception(
+                context,
+                "NotFoundError",
+                "the node to be replaced is not a child of this node",
+            ));
+        }
+    }
+
     if new_id != old_id {
+        // Inserting a DocumentFragment moves its children
+        let node_ids = insertable_node_ids(&ctx, new_id);
+
         let mut doc = ctx.doc.borrow_mut();
         let mut mutr = doc.mutate();
-        if mutr.node_has_parent(new_id) {
-            mutr.remove_node(new_id);
-        }
-        mutr.insert_nodes_before(old_id, &[new_id]);
+        detach_all(&mut mutr, &node_ids);
+        mutr.insert_nodes_before(old_id, &node_ids);
         mutr.remove_node(old_id);
     }
     Ok(args[1].clone())


### PR DESCRIPTION
## Summary
`dom/nodes/Node-replaceChild.html` crashed with `Option::unwrap() on a None value` in `DocumentMutator::insert_nodes_before` (mutator.rs:646): `replace_child` called `insert_nodes_before(old_id, ...)` unconditionally, and the anchor's `parent.unwrap()` panics when the "old child" has no parent (e.g. `a.replaceChild(b, c)` where `c` was never inserted).

Fix in `replace_child` (blitz-vibey-script), per the DOM spec's replace steps:
- throw `HierarchyRequestError` if the new node is an inclusive ancestor of the context node (spec step 2) — this previously could also create a cycle in the node tree
- throw `NotFoundError` if the old child's parent is not the context node (spec step 3) — this was the panic
- expand DocumentFragments via `insertable_node_ids` (matching `insert_before`/`append_child`)

WPT result goes from CRASH to FAIL 9/29 subtests passing; remaining failures are the unimplemented full pre-insertion validation (node-type checks, document child constraints, doctype handling) which is a larger piece of work. No change to `Node-insertBefore/appendChild/removeChild` results.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/967f095dfc0a48d3b73b3f13a579372b
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/967f095dfc0a48d3b73b3f13a579372b?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33486498904).</sub>
<!-- wpt-results-end -->
