### PR TITLE
ci: install libfontconfig directly instead of via the apt cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,7 @@ jobs:
         with:
           toolchain: 1.91
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libfontconfig-dev
-          version: 1.0
+      - run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
       - run: cargo build --workspace
 
   build-features-default:
@@ -45,10 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libfontconfig-dev
-          version: 1.0
+      - run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
       - run: cargo build --workspace
 
   test-features-default:
@@ -58,10 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libfontconfig-dev
-          version: 1.0
+      - run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
       - run: cargo test --workspace
 
   build-counter:
@@ -71,10 +62,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libfontconfig-dev
-          version: 1.0
+      - run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
       - run: cargo build -p counter
 
   # wasm_hello is a standalone workspace; seven_guis and todomvc are workspace
@@ -117,10 +105,7 @@ jobs:
           toolchain: stable
           components: clippy
       - run: perl -pi.bak -e 's/opt-level = 2/opt-level = 0/g' Cargo.toml
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libfontconfig-dev
-          version: 1.0
+      - run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
       - run: cargo clippy --workspace -- -D warnings
 
   doc:


### PR DESCRIPTION
## Summary

Every ubuntu CI job that installs `libfontconfig-dev` through `awalsh128/cache-apt-pkgs-action` has been failing repo-wide since ~17:45 UTC today (Clippy, Test/Build [default features], MSRV Build, Build counter example — on `support-setting-hidden-flag`, `darft/vibey-script` and #824 alike; main was last green at 08:41).

The cause is on the cache side, not in any PR: the action reports a hit for its key and "restores" it, but the restored directory is empty, so nothing is installed and the build script fails:

```
Cache hit for: cache-apt-pkgs_1faeca06bfabb6bec22666215b3571dc
cat: /home/runner/cache-apt-pkgs/manifest_all.log: No such file or directory
...
error: failed to run custom build command for `yeslogic-fontconfig-sys v6.0.1`
  Package 'fontconfig', required by 'virtual:world', not found
```

The same run at 03:04 UTC restored that identical key with its manifests intact, so the entry has since been evicted/truncated while the key still resolves. The jobs asking for `libfontconfig1-dev` use a different key and still pass.

Fix: install it directly in those five jobs, which takes a few seconds and removes the cache as a failure mode:

```diff
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libfontconfig-dev
-          version: 1.0
+      - run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
```

(`libfontconfig-dev` is a virtual package on 24.04; `libfontconfig1-dev` is the real one, matching the jobs that already use it.)


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f2f594019316461cae0fcda15b660ece
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/f2f594019316461cae0fcda15b660ece?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33563075405).</sub>
<!-- wpt-results-end -->
