### PR TITLE
ci: report WPT subtest changes in the PR description

### DIFF
--- a/.github/scripts/test_wpt_diff_to_pr.py
+++ b/.github/scripts/test_wpt_diff_to_pr.py
@@ -53,11 +53,11 @@ class FormatLinesTest(unittest.TestCase):
         self.assertEqual(
             format_lines(Diff(ENTRIES)),
             [
-                "+ ADD            [  4/    6] (  +4) /css/added.html",
-                "+ FAIL => OK     [477/23423] (+244) /css/big.html",
-                "- OK => TIMEOUT  [  0/    1] ( -10) /css/regressed.html",
-                "- REM            [  2/    3] (  -2) /css/removed.html",
-                "! FAIL => FAIL   [  9/   10] (  +6) /css/subtests-only.html",
+                "+ ADD            [  4/    6]    +4  /css/added.html",
+                "+ FAIL => OK     [477/23423]  +244  /css/big.html",
+                "- OK => TIMEOUT  [  0/    1]   -10  /css/regressed.html",
+                "- REM            [  2/    3]    -2  /css/removed.html",
+                "! FAIL => FAIL   [  9/   10]    +6  /css/subtests-only.html",
             ],
         )
 

--- a/.github/scripts/test_wpt_diff_to_pr.py
+++ b/.github/scripts/test_wpt_diff_to_pr.py
@@ -53,11 +53,11 @@ class FormatLinesTest(unittest.TestCase):
         self.assertEqual(
             format_lines(Diff(ENTRIES)),
             [
-                "+ ADD            [  4/    6]    +4  /css/added.html",
+                "+ ADD                  [4/6]    +4  /css/added.html",
                 "+ FAIL => OK     [477/23423]  +244  /css/big.html",
-                "- OK => TIMEOUT  [  0/    1]   -10  /css/regressed.html",
-                "- REM            [  2/    3]    -2  /css/removed.html",
-                "! FAIL => FAIL   [  9/   10]    +6  /css/subtests-only.html",
+                "- OK => TIMEOUT        [0/1]   -10  /css/regressed.html",
+                "- REM                  [2/3]    -2  /css/removed.html",
+                "! FAIL => FAIL        [9/10]    +6  /css/subtests-only.html",
             ],
         )
 

--- a/.github/scripts/test_wpt_diff_to_pr.py
+++ b/.github/scripts/test_wpt_diff_to_pr.py
@@ -67,9 +67,10 @@ class RenderTest(unittest.TestCase):
         section = render(Diff(ENTRIES), run_url=None)
         self.assertIn(
             "Subtests: **254** newly passing, **12** newly failing (net +242). "
-            "Tests: **1** added, **1** removed.",
+            "Tests: **1** added, **1** removed. Timeouts: **+1**.",
             section,
         )
+        self.assertNotIn("Crashes", section)
         self.assertIn("<summary>Full diff (5 changed tests)</summary>", section)
 
     def test_no_changes(self):

--- a/.github/scripts/test_wpt_diff_to_pr.py
+++ b/.github/scripts/test_wpt_diff_to_pr.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Tests for wpt_diff_to_pr.py. Run with `python3 -m unittest discover .github/scripts`."""
+
+import unittest
+
+from wpt_diff_to_pr import Diff, format_lines, render, splice
+
+ENTRIES = [
+    {
+        "kind": "changed",
+        "test": "/css/big.html",
+        "before": "FAIL",
+        "after": "OK",
+        "counts_before": {"pass": 233, "total": 23423},
+        "counts_after": {"pass": 477, "total": 23423},
+        "subtests": [],
+    },
+    {
+        "kind": "changed",
+        "test": "/css/subtests-only.html",
+        "before": "FAIL",
+        "after": "FAIL",
+        "counts_before": {"pass": 3, "total": 10},
+        "counts_after": {"pass": 9, "total": 10},
+        "subtests": [],
+    },
+    {
+        "kind": "changed",
+        "test": "/css/regressed.html",
+        "before": "OK",
+        "after": "TIMEOUT",
+        "counts_before": {"pass": 10, "total": 10},
+        "counts_after": {"pass": 0, "total": 1},
+        "subtests": [],
+    },
+    {
+        "kind": "added",
+        "test": "/css/added.html",
+        "status": "OK",
+        "counts": {"pass": 4, "total": 6},
+    },
+    {
+        "kind": "removed",
+        "test": "/css/removed.html",
+        "status": "FAIL",
+        "counts": {"pass": 2, "total": 3},
+    },
+]
+
+
+class FormatLinesTest(unittest.TestCase):
+    def test_sorted_aligned_and_marked(self):
+        self.assertEqual(
+            format_lines(Diff(ENTRIES)),
+            [
+                "+ ADD            [  4/    6] (  +4) /css/added.html",
+                "+ FAIL => OK     [477/23423] (+244) /css/big.html",
+                "- OK => TIMEOUT  [  0/    1] ( -10) /css/regressed.html",
+                "- REM            [  2/    3] (  -2) /css/removed.html",
+                "! FAIL => FAIL   [  9/   10] (  +6) /css/subtests-only.html",
+            ],
+        )
+
+
+class RenderTest(unittest.TestCase):
+    def test_headline_counts_tests_and_subtests(self):
+        section = render(Diff(ENTRIES), run_url=None)
+        self.assertIn(
+            "**1** newly passing, **1** newly failing (net +0), **1** other change, "
+            "**1** added test, **1** removed test. "
+            "Subtests: **+242** net (+254, -12).",
+            section,
+        )
+        self.assertIn("<summary>Full diff (5 changed tests)</summary>", section)
+
+    def test_no_changes(self):
+        section = render(Diff([]), run_url="https://example.com/run")
+        self.assertIn("No changes in test results compared to `main`.", section)
+        self.assertNotIn("```diff", section)
+        self.assertIn("https://example.com/run", section)
+
+
+class SpliceTest(unittest.TestCase):
+    def test_replaces_existing_section(self):
+        section = render(Diff([]), run_url=None)
+        body = splice("Original body.", section)
+        self.assertEqual(splice(body, section), body)
+        self.assertTrue(body.startswith("Original body."))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_wpt_diff_to_pr.py
+++ b/.github/scripts/test_wpt_diff_to_pr.py
@@ -63,12 +63,11 @@ class FormatLinesTest(unittest.TestCase):
 
 
 class RenderTest(unittest.TestCase):
-    def test_headline_counts_tests_and_subtests(self):
+    def test_headline_counts_subtests(self):
         section = render(Diff(ENTRIES), run_url=None)
         self.assertIn(
-            "**1** newly passing, **1** newly failing (net +0), **1** other change, "
-            "**1** added test, **1** removed test. "
-            "Subtests: **+242** net (+254, -12).",
+            "Subtests: **254** newly passing, **12** newly failing (net +242). "
+            "Tests: **1** added, **1** removed.",
             section,
         )
         self.assertIn("<summary>Full diff (5 changed tests)</summary>", section)

--- a/.github/scripts/wpt_diff_to_pr.py
+++ b/.github/scripts/wpt_diff_to_pr.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Summarise the output of `wpt diff` and publish it into the PR description.
+"""Summarise the output of `wpt diff --format json` and publish it into the PR description.
 
 The section is delimited by HTML comment markers so that re-runs of the
 workflow replace the previous results instead of appending a new section.
@@ -8,7 +8,6 @@ workflow replace the previous results instead of appending a new section.
 import argparse
 import json
 import os
-import re
 import subprocess
 import sys
 
@@ -18,86 +17,111 @@ END_MARKER = "<!-- wpt-results-end -->"
 PASSING_STATUSES = {"PASS", "OK"}
 MAX_DIFF_LINES = 400
 
-CHANGE_RE = re.compile(r"^(\w+) => (\w+) (.*)$")
-ADD_REM_RE = re.compile(r"^(ADD|REM)\s+(.*)$")
+
+class Change:
+    """A single changed test, in the shape rendered into the PR description."""
+
+    def __init__(self, entry):
+        self.test = entry["test"]
+        self.kind = entry["kind"]
+
+        if self.kind == "added":
+            self.status = "ADD"
+            self.counts = entry["counts"]
+            self.delta = self.counts["pass"]
+        elif self.kind == "removed":
+            self.status = "REM"
+            self.counts = entry["counts"]
+            self.delta = -self.counts["pass"]
+        else:
+            before, after = entry["before"], entry["after"]
+            self.status = f"{before} => {after}"
+            self.counts = entry["counts_after"]
+            self.delta = self.counts["pass"] - entry["counts_before"]["pass"]
+
+        self.newly_passing = self.kind == "changed" and (
+            entry["before"] not in PASSING_STATUSES and entry["after"] in PASSING_STATUSES
+        )
+        self.newly_failing = self.kind == "changed" and (
+            entry["before"] in PASSING_STATUSES and entry["after"] not in PASSING_STATUSES
+        )
+
+    @property
+    def marker(self):
+        if self.newly_passing or self.kind == "added":
+            return "+"
+        if self.newly_failing or self.kind == "removed":
+            return "-"
+        return "!"
 
 
 class Diff:
-    def __init__(self):
-        self.newly_passing = []
-        self.newly_failing = []
-        self.other_changes = []
-        self.added = []
-        self.removed = []
+    def __init__(self, entries):
+        self.changes = sorted((Change(entry) for entry in entries), key=lambda c: c.test)
 
     @property
     def is_empty(self):
-        return not (
-            self.newly_passing
-            or self.newly_failing
-            or self.other_changes
-            or self.added
-            or self.removed
-        )
+        return not self.changes
 
+    def count(self, predicate):
+        return sum(1 for change in self.changes if predicate(change))
 
-def parse_diff(text):
-    diff = Diff()
-    for line in text.splitlines():
-        line = line.rstrip()
-        if not line or line.startswith("=====") or line.startswith("Done in "):
-            continue
+    @property
+    def subtests_gained(self):
+        return sum(change.delta for change in self.changes if change.delta > 0)
 
-        match = ADD_REM_RE.match(line)
-        if match:
-            kind, test = match.groups()
-            (diff.added if kind == "ADD" else diff.removed).append(test)
-            continue
-
-        match = CHANGE_RE.match(line)
-        if match:
-            before, after, test = match.groups()
-            entry = (before, after, test)
-            if before.upper() not in PASSING_STATUSES and after.upper() in PASSING_STATUSES:
-                diff.newly_passing.append(entry)
-            elif before.upper() in PASSING_STATUSES and after.upper() not in PASSING_STATUSES:
-                diff.newly_failing.append(entry)
-            else:
-                diff.other_changes.append(entry)
-
-    return diff
+    @property
+    def subtests_lost(self):
+        return -sum(change.delta for change in self.changes if change.delta < 0)
 
 
 def format_lines(diff):
-    """Render the changes as diff-syntax lines sorted by test name."""
-    lines = []
-    for marker, entries in [("+", diff.newly_passing), ("-", diff.newly_failing), ("!", diff.other_changes)]:
-        for before, after, test in entries:
-            lines.append((test, f"{marker} {before} => {after} {test}"))
-    lines.extend((test, f"+ ADD {test}") for test in diff.added)
-    lines.extend((test, f"- REM {test}") for test in diff.removed)
-    lines.sort()
-    return [line for _, line in lines]
+    """Render the changes as diff-syntax lines, aligned into columns."""
+    status_width = max(len(change.status) for change in diff.changes)
+    pass_width = max(len(str(change.counts["pass"])) for change in diff.changes)
+    total_width = max(len(str(change.counts["total"])) for change in diff.changes)
+    delta_width = max(len(f"{change.delta:+}") for change in diff.changes)
+
+    return [
+        "{} {:<{}}  [{:>{}}/{:>{}}] ({:>{}}) {}".format(
+            change.marker,
+            change.status,
+            status_width,
+            change.counts["pass"],
+            pass_width,
+            change.counts["total"],
+            total_width,
+            f"{change.delta:+}",
+            delta_width,
+            change.test,
+        )
+        for change in diff.changes
+    ]
 
 
 def render(diff, run_url):
-    net = len(diff.newly_passing) - len(diff.newly_failing)
     if diff.is_empty:
         headline = "No changes in test results compared to `main`."
     else:
-        sign = "+" if net > 0 else ""
+        newly_passing = diff.count(lambda c: c.newly_passing)
+        newly_failing = diff.count(lambda c: c.newly_failing)
+        net = newly_passing - newly_failing
         parts = [
-            f"**{len(diff.newly_passing)}** newly passing",
-            f"**{len(diff.newly_failing)}** newly failing (net {sign}{net})",
+            f"**{newly_passing}** newly passing",
+            f"**{newly_failing}** newly failing (net {net:+})",
         ]
         for count, label in [
-            (len(diff.other_changes), "other status change"),
-            (len(diff.added), "added test"),
-            (len(diff.removed), "removed test"),
+            (diff.count(lambda c: c.kind == "changed" and not (c.newly_passing or c.newly_failing)), "other change"),
+            (diff.count(lambda c: c.kind == "added"), "added test"),
+            (diff.count(lambda c: c.kind == "removed"), "removed test"),
         ]:
             if count:
                 parts.append(f"**{count}** {label}{'s' if count != 1 else ''}")
-        headline = ", ".join(parts) + "."
+        gained, lost = diff.subtests_gained, diff.subtests_lost
+        headline = (
+            ", ".join(parts)
+            + f". Subtests: **{gained - lost:+}** net (+{gained}, -{lost})."
+        )
 
     out = [START_MARKER, "## WPT results", "", headline, ""]
 
@@ -155,7 +179,7 @@ def main():
     args = parser.parse_args()
 
     with open(args.diff_file, encoding="utf-8") as file:
-        diff = parse_diff(file.read())
+        diff = Diff(json.load(file))
 
     section = render(diff, args.run_url)
 

--- a/.github/scripts/wpt_diff_to_pr.py
+++ b/.github/scripts/wpt_diff_to_pr.py
@@ -26,24 +26,26 @@ class Change:
         self.kind = entry["kind"]
 
         if self.kind == "added":
+            self.before, self.after = None, entry["status"]
             self.status = "ADD"
             self.counts = entry["counts"]
             self.delta = self.counts["pass"]
         elif self.kind == "removed":
+            self.before, self.after = entry["status"], None
             self.status = "REM"
             self.counts = entry["counts"]
             self.delta = -self.counts["pass"]
         else:
-            before, after = entry["before"], entry["after"]
-            self.status = f"{before} => {after}"
+            self.before, self.after = entry["before"], entry["after"]
+            self.status = f"{self.before} => {self.after}"
             self.counts = entry["counts_after"]
             self.delta = self.counts["pass"] - entry["counts_before"]["pass"]
 
         self.newly_passing = self.kind == "changed" and (
-            entry["before"] not in PASSING_STATUSES and entry["after"] in PASSING_STATUSES
+            self.before not in PASSING_STATUSES and self.after in PASSING_STATUSES
         )
         self.newly_failing = self.kind == "changed" and (
-            entry["before"] in PASSING_STATUSES and entry["after"] not in PASSING_STATUSES
+            self.before in PASSING_STATUSES and self.after not in PASSING_STATUSES
         )
 
     @property
@@ -73,6 +75,12 @@ class Diff:
     @property
     def subtests_lost(self):
         return -sum(change.delta for change in self.changes if change.delta < 0)
+
+    def status_delta(self, status):
+        """The change in the number of tests with the given status."""
+        return self.count(lambda c: c.after == status) - self.count(
+            lambda c: c.before == status
+        )
 
 
 def format_lines(diff):
@@ -117,6 +125,10 @@ def render(diff, run_url):
                 parts.append(f"**{count}** {label}")
         if parts:
             headline += " Tests: " + ", ".join(parts) + "."
+        for status, label in [("CRASH", "Crashes"), ("TIMEOUT", "Timeouts")]:
+            delta = diff.status_delta(status)
+            if delta:
+                headline += f" {label}: **{delta:+}**."
 
     out = [START_MARKER, "## WPT results", "", headline, ""]
 

--- a/.github/scripts/wpt_diff_to_pr.py
+++ b/.github/scripts/wpt_diff_to_pr.py
@@ -103,25 +103,20 @@ def render(diff, run_url):
     if diff.is_empty:
         headline = "No changes in test results compared to `main`."
     else:
-        newly_passing = diff.count(lambda c: c.newly_passing)
-        newly_failing = diff.count(lambda c: c.newly_failing)
-        net = newly_passing - newly_failing
-        parts = [
-            f"**{newly_passing}** newly passing",
-            f"**{newly_failing}** newly failing (net {net:+})",
-        ]
-        for count, label in [
-            (diff.count(lambda c: c.kind == "changed" and not (c.newly_passing or c.newly_failing)), "other change"),
-            (diff.count(lambda c: c.kind == "added"), "added test"),
-            (diff.count(lambda c: c.kind == "removed"), "removed test"),
-        ]:
-            if count:
-                parts.append(f"**{count}** {label}{'s' if count != 1 else ''}")
         gained, lost = diff.subtests_gained, diff.subtests_lost
         headline = (
-            ", ".join(parts)
-            + f". Subtests: **{gained - lost:+}** net (+{gained}, -{lost})."
+            f"Subtests: **{gained}** newly passing, **{lost}** newly failing "
+            f"(net {gained - lost:+})."
         )
+        parts = []
+        for count, label in [
+            (diff.count(lambda c: c.kind == "added"), "added"),
+            (diff.count(lambda c: c.kind == "removed"), "removed"),
+        ]:
+            if count:
+                parts.append(f"**{count}** {label}")
+        if parts:
+            headline += " Tests: " + ", ".join(parts) + "."
 
     out = [START_MARKER, "## WPT results", "", headline, ""]
 

--- a/.github/scripts/wpt_diff_to_pr.py
+++ b/.github/scripts/wpt_diff_to_pr.py
@@ -83,7 +83,7 @@ def format_lines(diff):
     delta_width = max(len(f"{change.delta:+}") for change in diff.changes)
 
     return [
-        "{} {:<{}}  [{:>{}}/{:>{}}] ({:>{}}) {}".format(
+        "{} {:<{}}  [{:>{}}/{:>{}}]  {:>{}}  {}".format(
             change.marker,
             change.status,
             status_width,

--- a/.github/scripts/wpt_diff_to_pr.py
+++ b/.github/scripts/wpt_diff_to_pr.py
@@ -85,20 +85,21 @@ class Diff:
 
 def format_lines(diff):
     """Render the changes as diff-syntax lines, aligned into columns."""
+
+    def counts_of(change):
+        return "[{}/{}]".format(change.counts["pass"], change.counts["total"])
+
     status_width = max(len(change.status) for change in diff.changes)
-    pass_width = max(len(str(change.counts["pass"])) for change in diff.changes)
-    total_width = max(len(str(change.counts["total"])) for change in diff.changes)
+    counts_width = max(len(counts_of(change)) for change in diff.changes)
     delta_width = max(len(f"{change.delta:+}") for change in diff.changes)
 
     return [
-        "{} {:<{}}  [{:>{}}/{:>{}}]  {:>{}}  {}".format(
+        "{} {:<{}}  {:>{}}  {:>{}}  {}".format(
             change.marker,
             change.status,
             status_width,
-            change.counts["pass"],
-            pass_width,
-            change.counts["total"],
-            total_width,
+            counts_of(change),
+            counts_width,
             f"{change.delta:+}",
             delta_width,
             change.test,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,13 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
       - run: cargo clippy --workspace -- -D warnings
 
+  ci-scripts:
+    name: "Test CI scripts"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 -m unittest discover -s .github/scripts
+
   doc:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/wpt-post-results.yml
+++ b/.github/workflows/wpt-post-results.yml
@@ -46,4 +46,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pull-request.outputs.number }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
-        run: python3 ./.github/scripts/wpt_diff_to_pr.py ./wpt/output/wptdiff.txt
+        run: python3 ./.github/scripts/wpt_diff_to_pr.py ./wpt/output/wptdiff.json

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -57,7 +57,7 @@ jobs:
           cp ./wpt/output/wptreport.json ./sites/gh-pages/wptreport.json
           cp ./wpt/output/wptreport.json.zst ./sites/gh-pages/wptreport.json.zst
       - name: Install wpt cli
-        run: cargo install wpt@0.0.13
+        run: cargo install wpt@0.0.14
       - name: Generate scores.json
         run: |
           wpt calc-scores --in ./sites/gh-pages/wptreport.json --out ./sites/gh-pages/wptscores.json
@@ -65,18 +65,22 @@ jobs:
       - name: Fetch main-branch results
         run: curl https://dioxuslabs.github.io/blitz/wptreport.json -o ./wpt/output/main-wptreport.json
       - name: Diff WPT results
-        run: wpt diff ./wpt/output/main-wptreport.json ./wpt/output/wptreport.json | tee ./wpt/output/wptdiff.txt
+        run: |
+          wpt diff ./wpt/output/main-wptreport.json ./wpt/output/wptreport.json | tee ./wpt/output/wptdiff.txt
+          wpt diff --format json ./wpt/output/main-wptreport.json ./wpt/output/wptreport.json > ./wpt/output/wptdiff.json
       - name: Render results in step summary
         if: github.event_name == 'pull_request'
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: python3 ./.github/scripts/wpt_diff_to_pr.py --dry-run ./wpt/output/wptdiff.txt
+        run: python3 ./.github/scripts/wpt_diff_to_pr.py --dry-run ./wpt/output/wptdiff.json
       - name: Upload WPT diff
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: wpt-diff
-          path: ./wpt/output/wptdiff.txt
+          path: |
+            ./wpt/output/wptdiff.txt
+            ./wpt/output/wptdiff.json
       - name: Setup Github Pages
         if: github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v6


### PR DESCRIPTION
## Summary

The WPT results section on PRs only tracked test-level status, so a change that flipped a hundred subtests inside tests that stayed `FAIL` reported "No changes in test results compared to `main`". The workflow now consumes `wpt diff --format json` (added in nicoburns/wpt-rs#9, released as `wpt@0.0.14`) and `wpt_diff_to_pr.py` parses that instead of regexing the text output.

The headline is now about subtests, since test statuses barely move between runs; crash/timeout deltas are appended only when non-zero. Each row carries the new subtest counts and the change in passing subtests:

```
Subtests: **254** newly passing, **12** newly failing (net +242). Tests: **1** added, **1** removed. Timeouts: **+1**.

+ ADD                  [4/6]    +4  /css/added.html
+ FAIL => OK     [477/23423]  +244  /css/big.html
- OK => TIMEOUT        [0/1]   -10  /css/regressed.html
- REM                  [2/3]    -2  /css/removed.html
! FAIL => FAIL        [9/10]    +6  /css/subtests-only.html
```

Tests whose subtests moved without a status change get the `!` marker. Crash/timeout deltas are derived from the diff (tests whose status moved in or out of `CRASH`/`TIMEOUT`), not from run totals, which the JSON doesn't carry.

The workflow writes both `wptdiff.txt` (human-readable, also in the step log) and `wptdiff.json` into the `wpt-diff` artifact. Keeping the text file matters for the transition: `wpt-post-results.yml` runs the script from the *default branch*, so until this lands that job is still the old text-parsing version reading `wptdiff.txt`.

Also adds `.github/scripts/test_wpt_diff_to_pr.py` plus a `ci-scripts` job running `python3 -m unittest discover -s .github/scripts`, since this script's output is otherwise only exercised on PRs that happen to change WPT results.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/bf0aad28e9904602b6150ec9e9b16dad
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/bf0aad28e9904602b6150ec9e9b16dad?variant=devin-insiders
Requested by: @nicoburns