### PR TITLE
wpt: run SVG reftests that declare references with <html:link>

### DIFF
--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -163,6 +163,9 @@ const BLOCKED_TESTS: &[&str] = &[
     "css/css-sizing/aspect-ratio/zero-or-infinity-006.html",
     "css/css-sizing/aspect-ratio/zero-or-infinity-009.html",
     "css/css-sizing/aspect-ratio/zero-or-infinity-010.html",
+    // Stack overflow: usvg's clipPath conversion recurses forever on
+    // clip-paths that reference each other in a cycle
+    "css/css-masking/clip-path-svg-content/clip-path-recursion-001.svg",
 ];
 
 fn path_contains_directory(path: &Path, dir_name: &str) -> bool {
@@ -503,7 +506,9 @@ fn main() {
                         ColorScheme::Light,
                     );
                     let net_provider = Arc::new(WptNetProvider::new(&wpt_dir));
-                    let link_re = Regex::new(r#"<link\s[^>]*>"#).unwrap();
+                    // SVG reftests declare their references with a namespace
+                    // prefix (`<html:link rel="match">`)
+                    let link_re = Regex::new(r#"<(?:[A-Za-z_][\w.\-]*:)?link\s[^>]*>"#).unwrap();
                     let rel_re = Regex::new(r#"rel\s*=\s*['"]?(match|mismatch)['"]?"#).unwrap();
                     let href_re =
                         Regex::new(r#"href\s*=\s*(?:['"]([^'"]+)['"]|([^\s'">]+))"#).unwrap();


### PR DESCRIPTION
## Summary

SVG reftests in WPT declare their reference with a namespaced tag, since `link` isn't an SVG element:

```xml
<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
  <html:link rel="match" href="reference/clip-path-square-hole-001-ref.svg" />
```

The runner's reference-link regex was `<link\s[^>]*>`, so it never matched those, and every such file fell through `process_test_file` to `TestKind::Unknown` / `SKIP` — silently dropped from `wptreport.json`. Allowing an optional namespace prefix (`<(?:[A-Za-z_][\w.\-]*:)?link\s[^>]*>`) makes them run as the reftests they are: **123 SVG reftests now reported in `css` (13 PASS, 110 FAIL), up from 0**.

One of the newly-enabled tests aborts the whole run, so it's added to `BLOCKED_TESTS`: `clip-path-recursion-001.svg` builds a cycle of `clipPath`s that reference each other, and usvg 0.48's `parser::clippath::convert` → `converter::convert_group` → `convert_clip_path_elements` recurses through the cycle until the stack overflows (a stack overflow aborts the process, so it takes the rest of the suite with it). Worth an upstream resvg report; `clip-path-recursion-002.svg` is unaffected and runs.

Full `css` run before/after: 33,165 → 33,278 tests run, 184,191 → 184,304 subtests, no new crashes and no timeouts.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f2f594019316461cae0fcda15b660ece
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/f2f594019316461cae0fcda15b660ece?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**0** newly passing, **0** newly failing (net 0), **114** added tests.

<details>
<summary>Full diff (114 changed tests)</summary>

```diff
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-nested-twice.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-005.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-006.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-007.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-008.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-009.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip-rule-010.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-clip.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-clip-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-clip-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-clip-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-clip-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-invisible.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-syling.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-use-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-use-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-use-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-use-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-use-005.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-use-006.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-content-use-007.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-css-transform-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-css-transform-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-css-transform-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-css-transform-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-dom-child-changes.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-dom-clippathunits.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-dom-href.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-dom-id.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-inset-stroke-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-inset-stroke-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-invalid-reference.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-invalid.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-negative-scale.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-no-content-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-no-content-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-no-content-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-no-content-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-no-content-005.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-objectboundingbox-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-objectboundingbox-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-objectboundingbox-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-objectboundingbox-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-g-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-g-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-g-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-g-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-g-005.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-marker-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-marker-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-marker-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-svg-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-svg-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-svg-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-svg-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-svg-005.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-use-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-on-use-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-precision-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-recursion-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-circle-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-circle-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-circle-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-circle-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-circle-005.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-ellipse-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-ellipse-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-inset-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-inset-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-polygon-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-polygon-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-shape-polygon-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-text-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-text-002.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-text-003.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-text-004.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-text-005.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-userspaceonuse-001.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-with-opacity.svg
+ ADD css/css-masking/clip-path-svg-content/clip-path-with-transform.svg
+ ADD css/css-masking/clip-path-svg-content/mask-and-nested-clip-path.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-001.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-002.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-003.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-004.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-005.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-006.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-007.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-008.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-009.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-010.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-panning-001.svg
+ ADD css/css-masking/clip-path-svg-content/mask-nested-clip-path-panning-002.svg
+ ADD css/css-masking/clip-path-svg-content/mask-objectboundingbox-content-clip-transform.svg
+ ADD css/css-masking/clip-path-svg-content/mask-objectboundingbox-content-clip.svg
+ ADD css/css-masking/clip-path-svg-content/mask-userspaceonuse-content-clip-transform.svg
+ ADD css/css-masking/clip-path-svg-content/mask-userspaceonuse-content-clip.svg
+ ADD css/css-masking/mask-svg-content/mask-empty-container-with-filter.svg
+ ADD css/css-masking/mask-svg-content/mask-invalid-reference.svg
+ ADD css/css-masking/mask-svg-content/mask-negative-scale.svg
+ ADD css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default.svg
+ ADD css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse.svg
+ ADD css/css-masking/mask-svg-content/mask-text-001.svg
+ ADD css/css-masking/mask-svg-content/mask-type-001.svg
+ ADD css/css-masking/mask-svg-content/mask-type-002.svg
+ ADD css/css-masking/mask-svg-content/mask-type-003.svg
+ ADD css/css-masking/mask-svg-content/mask-with-filter-clipped-to-region.svg
+ ADD css/css-masking/mask-svg-content/mask-with-filter.svg
+ ADD css/css-masking/mask-svg-content/mask-with-rotation.svg
+ ADD css/css-writing-modes/wm-propagation-svg-root-scrollbar.svg
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33568482098).</sub>
<!-- wpt-results-end -->
