### PR TITLE
Apply EXIF orientation to decoded images; render image documents in iframes

### DIFF
--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -1,4 +1,5 @@
 use blitz_traits::node_id::NodeId;
+use image::{DynamicImage, ImageDecoder as _, ImageReader, metadata::Orientation};
 use selectors::context::QuirksMode;
 use std::sync::atomic::Ordering as Ao;
 use std::{
@@ -522,9 +523,22 @@ pub(crate) struct DocumentSrcHandler;
 
 impl NetHandler for ResourceHandler<DocumentSrcHandler> {
     fn bytes(self: Box<Self>, resolved_url: String, bytes: Bytes) {
-        let html = String::from_utf8_lossy(&bytes).into_owned();
+        let html = if image::guess_format(&bytes).is_ok() {
+            image_document_html(&resolved_url)
+        } else {
+            String::from_utf8_lossy(&bytes).into_owned()
+        };
         self.respond(resolved_url, Ok(Resource::DocumentSrc(html)));
     }
+}
+
+/// Synthesize an HTML document that displays a raster image, for when an
+/// embedded document's URL points directly at an image rather than HTML.
+fn image_document_html(url: &str) -> String {
+    let src = html_escape::encode_double_quoted_attribute(url);
+    format!(
+        "<!DOCTYPE html><html><head><style>body{{margin:0}}img{{display:block}}</style></head><body><img src=\"{src}\"></body></html>"
+    )
 }
 
 pub struct ImageHandler {
@@ -545,11 +559,7 @@ impl NetHandler for ResourceHandler<ImageHandler> {
 
 impl ImageHandler {
     fn parse(&self, bytes: Bytes) -> Result<Resource, String> {
-        let image_err = match image::ImageReader::new(Cursor::new(&bytes))
-            .with_guessed_format()
-            .expect("IO errors impossible with Cursor")
-            .decode()
-        {
+        let image_err = match decode_raster_image(&bytes) {
             Ok(image) => {
                 let width = image.width();
                 let height = image.height();
@@ -580,6 +590,21 @@ impl ImageHandler {
             bytes.len()
         ))
     }
+}
+
+/// Decode a raster image, applying any EXIF orientation it carries.
+///
+/// This corresponds to the initial value of the CSS `image-orientation`
+/// property (`from-image`). `image-orientation: none` is not supported.
+fn decode_raster_image(bytes: &[u8]) -> image::ImageResult<DynamicImage> {
+    let mut decoder = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .expect("IO errors impossible with Cursor")
+        .into_decoder()?;
+    let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
+    let mut image = DynamicImage::from_decoder(decoder)?;
+    image.apply_orientation(orientation);
+    Ok(image)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Two small changes in `blitz-dom/src/net.rs` that take `css/css-images/image-orientation` WPT from 14/34 to 21/34 passing.

**EXIF orientation (`image-orientation: from-image`, the initial value).** `ImageHandler::parse` previously used `ImageReader::decode()`, which discards the decoder's orientation metadata, so JPEGs/PNGs with EXIF rotation/flip rendered un-rotated. Now:

```rust
let mut decoder = ImageReader::new(..).with_guessed_format()?.into_decoder()?;
let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
let mut image = DynamicImage::from_decoder(decoder)?;
image.apply_orientation(orientation);
```

The transform is baked in at decode time (width/height in `Resource::Image` are post-rotation), so everything downstream (`<img>`, `background-image`, `border-image`, `list-style-image`, `mask-image`, `content:`) picks it up for free.

**Image documents in `<iframe>`.** `DocumentSrcHandler` treated every response as HTML, so an iframe whose `src` is a JPEG rendered the raw bytes as text. If `image::guess_format` recognises the bytes, we now synthesise a minimal `<img src="{url}">` document instead (the image is then fetched via the normal image path, so it gets EXIF handling too).

### Remaining failures (13) — not addressed here

- **10 need `image-orientation: none`**: `background-image`, `none`, `none-content-images`, `*-dynamic2`, `*-computed-style`, `none-cross-origin*`. Stylo declares `image-orientation` with `engine = "gecko"` in `properties/longhands.toml`, so the property isn't generated for the Servo build and can't be parsed by Blitz at all. Supporting it needs an upstream Stylo change plus keeping the un-oriented pixels around (or applying the orientation as a paint-time transform instead of at decode). The `cross-origin` variants additionally need multi-origin serving and `<canvas>`.
- **`exif-png.html`**: EXIF stored in a legacy compressed `zTXt` "Raw profile type exif" chunk. No browser passes this on wpt.fyi either.
- **`background-properties(-border-radius)`**: renders visually identical, but JPEG decode noise between the EXIF file and the pre-rotated reference file gives 406 differing pixels (max diff 2) vs the fuzzy budget of 313/331. Chrome/Edge also fail one or both of these.

Side finding: `new URL(img.src)` throws "relative URL without a base" in the cross-origin tests — the `HTMLImageElement.src` getter returns the raw attribute rather than the resolved absolute URL.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/67f3ef53d8b744548190d4a3dfa8f9dc
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/67f3ef53d8b744548190d4a3dfa8f9dc?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

**11** newly passing, **4** newly failing (net +7).

<details>
<summary>Full diff (15 changed tests)</summary>

```diff
+ Fail => Pass css/css-images/image-orientation/image-orientation-background-position.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-default.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-exif-png-2.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-exif-png-3.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-from-image-composited-dynamic1.html
- Pass => Fail css/css-images/image-orientation/image-orientation-from-image-composited-dynamic2.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-from-image-composited.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-from-image-content-images.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-from-image-dynamic1.html
- Pass => Fail css/css-images/image-orientation/image-orientation-from-image-dynamic2.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-from-image-embedded-content.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-from-image.html
- Pass => Fail css/css-images/image-orientation/image-orientation-none-content-images.html
+ Fail => Pass css/css-images/image-orientation/image-orientation-none-image-document.html
- Pass => Fail css/css-images/image-orientation/image-orientation-none.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33572066424).</sub>
<!-- wpt-results-end -->
