### PR TITLE
ci: use +/- markers for same-status tests with subtest changes

### DIFF
--- a/.github/scripts/test_wpt_diff_to_pr.py
+++ b/.github/scripts/test_wpt_diff_to_pr.py
@@ -57,7 +57,7 @@ class FormatLinesTest(unittest.TestCase):
                 "+ FAIL => OK     [477/23423]  +244  /css/big.html",
                 "- OK => TIMEOUT        [0/1]   -10  /css/regressed.html",
                 "- REM                  [2/3]    -2  /css/removed.html",
-                "! FAIL => FAIL        [9/10]    +6  /css/subtests-only.html",
+                "+ FAIL => FAIL        [9/10]    +6  /css/subtests-only.html",
             ],
         )
 

--- a/.github/scripts/wpt_diff_to_pr.py
+++ b/.github/scripts/wpt_diff_to_pr.py
@@ -54,6 +54,11 @@ class Change:
             return "+"
         if self.newly_failing or self.kind == "removed":
             return "-"
+        if self.before == self.after:
+            if self.delta > 0:
+                return "+"
+            if self.delta < 0:
+                return "-"
         return "!"
 
 


### PR DESCRIPTION
## Summary
In the PR WPT report, tests whose overall status is unchanged (e.g. `FAIL => FAIL`) but whose subtest pass count moved now get `+` (net subtests gained) or `-` (net subtests lost) instead of `!`. `!` is kept for genuine status changes that aren't newly passing/failing (e.g. `FAIL => TIMEOUT`).

`Change.marker` in `.github/scripts/wpt_diff_to_pr.py`:
```
if before == after: return "+" if delta > 0 else "-" if delta < 0 else "!"
```

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/39337eec52f84165809b03b6a5bf0d54
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/39337eec52f84165809b03b6a5bf0d54?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33657836705).</sub>
<!-- wpt-results-end -->
