### PR TITLE
Copy-on-write style attribute blocks that are in the rule tree

### DIFF
--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -1334,6 +1334,7 @@ impl Drop for ViewportMut<'_> {
 #[cfg(test)]
 mod test {
     use style::media_queries::MediaType;
+    use style::servo_arc::Arc as ServoArc;
     use style_dom::ElementState;
 
     use std::sync::{
@@ -1712,5 +1713,85 @@ mod test {
                 .x,
             120.0
         );
+    }
+
+    #[test]
+    fn style_property_mutation_copies_blocks_in_rule_tree() {
+        let mut document = BaseDocument::new(DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        });
+        let root_id = document.root_node().id;
+
+        let div_id = {
+            let mut mutator = document.mutate();
+            let div_id = mutator.create_element(qual_name!("div"), vec![]);
+            mutator.set_style_property(div_id, "width", "100px");
+            mutator.set_style_property(div_id, "height", "50px");
+            mutator.append_children(root_id, &[div_id]);
+            div_id
+        };
+
+        let style_block = |document: &BaseDocument| {
+            document
+                .get_node(div_id)
+                .unwrap()
+                .element_data()
+                .unwrap()
+                .style_attribute
+                .clone()
+                .unwrap()
+        };
+
+        let before_resolve = style_block(&document);
+        {
+            let mut mutator = document.mutate();
+            mutator.set_style_property(div_id, "height", "60px");
+        }
+        // Not yet in the rule tree: mutated in place.
+        assert!(ServoArc::ptr_eq(&before_resolve, &style_block(&document)));
+
+        document.resolve(0.0);
+        let in_rule_tree = style_block(&document);
+        assert!(
+            in_rule_tree
+                .read_with(&document.guard.read())
+                .immutable
+                .load(Ordering::Relaxed)
+        );
+
+        {
+            let mut mutator = document.mutate();
+            mutator.set_style_property(div_id, "width", "200px");
+        }
+        let after_set = style_block(&document);
+        assert!(!ServoArc::ptr_eq(&in_rule_tree, &after_set));
+        {
+            let guard = document.guard.read();
+            let old = in_rule_tree.read_with(&guard);
+            let new = after_set.read_with(&guard);
+            assert_eq!(old.declarations().len(), 2);
+            assert_eq!(new.declarations().len(), 2);
+            assert_ne!(old, new);
+        }
+
+        document.resolve(0.0);
+        assert_eq!(
+            document.get_node(div_id).unwrap().final_layout().size.width,
+            200.0
+        );
+
+        let in_rule_tree = style_block(&document);
+        {
+            let mut mutator = document.mutate();
+            mutator.remove_style_property(div_id, "height");
+        }
+        let after_remove = style_block(&document);
+        assert!(!ServoArc::ptr_eq(&in_rule_tree, &after_remove));
+        {
+            let guard = document.guard.read();
+            assert_eq!(in_rule_tree.read_with(&guard).declarations().len(), 2);
+            assert_eq!(after_remove.read_with(&guard).declarations().len(), 1);
+        }
     }
 }

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -708,7 +708,7 @@ impl ElementData {
             return false;
         };
 
-        self.mutable_style_attribute(guard)
+        self.style_attr_mut(guard)
             .write_with(&mut guard.write())
             .extend(source_property_declaration.drain(), Importance::Normal);
 
@@ -718,7 +718,7 @@ impl ElementData {
     // Copy-on-write: once Stylo has put this block in the rule tree it may be
     // shared with other elements' styles (mirrors Gecko's
     // nsDOMCSSDeclaration::EnsureBlockMutable).
-    fn mutable_style_attribute(
+    fn style_attr_mut(
         &mut self,
         guard: &SharedRwLock,
     ) -> &ServoArc<Locked<PropertyDeclarationBlock>> {
@@ -765,7 +765,7 @@ impl ElementData {
         if self.style_attribute.is_none() {
             return false;
         }
-        let style = self.mutable_style_attribute(guard);
+        let style = self.style_attr_mut(guard);
         let mut guard = guard.write();
         let style = style.write_with(&mut guard);
         if let Some(index) = style.first_declaration_to_remove(&property_id) {

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -708,16 +708,35 @@ impl ElementData {
             return false;
         };
 
-        if self.style_attribute.is_none() {
-            self.style_attribute = Some(ServoArc::new(guard.wrap(PropertyDeclarationBlock::new())));
-        }
-        self.style_attribute
-            .as_mut()
-            .unwrap()
+        self.mutable_style_attribute(guard)
             .write_with(&mut guard.write())
             .extend(source_property_declaration.drain(), Importance::Normal);
 
         true
+    }
+
+    // Copy-on-write: once Stylo has put this block in the rule tree it may be
+    // shared with other elements' styles (mirrors Gecko's
+    // nsDOMCSSDeclaration::EnsureBlockMutable).
+    fn mutable_style_attribute(
+        &mut self,
+        guard: &SharedRwLock,
+    ) -> &ServoArc<Locked<PropertyDeclarationBlock>> {
+        let cloned = match &self.style_attribute {
+            None => Some(PropertyDeclarationBlock::new()),
+            Some(arc) => {
+                let read = guard.read();
+                let block = arc.read_with(&read);
+                block
+                    .immutable
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    .then(|| block.clone())
+            }
+        };
+        if let Some(block) = cloned {
+            self.style_attribute = Some(ServoArc::new(guard.wrap(block)));
+        }
+        self.style_attribute.as_ref().unwrap()
     }
 
     pub fn remove_style_property(
@@ -743,13 +762,15 @@ impl ElementData {
             return false;
         };
 
-        if let Some(style) = &mut self.style_attribute {
-            let mut guard = guard.write();
-            let style = style.write_with(&mut guard);
-            if let Some(index) = style.first_declaration_to_remove(&property_id) {
-                style.remove_property(&property_id, index);
-                return true;
-            }
+        if self.style_attribute.is_none() {
+            return false;
+        }
+        let style = self.mutable_style_attribute(guard);
+        let mut guard = guard.write();
+        let style = style.write_with(&mut guard);
+        if let Some(index) = style.first_declaration_to_remove(&property_id) {
+            style.remove_property(&property_id, index);
+            return true;
         }
 
         false

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -708,7 +708,7 @@ impl ElementData {
             return false;
         };
 
-        self.style_attr_mut(guard)
+        self.mutable_style_attribute(guard)
             .write_with(&mut guard.write())
             .extend(source_property_declaration.drain(), Importance::Normal);
 
@@ -718,7 +718,7 @@ impl ElementData {
     // Copy-on-write: once Stylo has put this block in the rule tree it may be
     // shared with other elements' styles (mirrors Gecko's
     // nsDOMCSSDeclaration::EnsureBlockMutable).
-    fn style_attr_mut(
+    fn mutable_style_attribute(
         &mut self,
         guard: &SharedRwLock,
     ) -> &ServoArc<Locked<PropertyDeclarationBlock>> {
@@ -765,7 +765,7 @@ impl ElementData {
         if self.style_attribute.is_none() {
             return false;
         }
-        let style = self.style_attr_mut(guard);
+        let style = self.mutable_style_attribute(guard);
         let mut guard = guard.write();
         let style = style.write_with(&mut guard);
         if let Some(index) = style.first_declaration_to_remove(&property_id) {


### PR DESCRIPTION
## Summary

`ElementData::set_style_property` / `remove_style_property` mutated the element's `style_attribute` `PropertyDeclarationBlock` in place. Once Stylo has cascaded the element, that block is referenced by a `RuleNode` in the rule tree (`StyleSource::mark_in_rule_tree` sets `PropertyDeclarationBlock::immutable`), so in-place mutation silently changes the rule node that existing `ComputedValues` (and potentially style-sharing-cache hits) were built from.

This mirrors Gecko's `nsDOMCSSDeclaration::EnsureBlockMutable`: if `Servo_DeclarationBlock_IsImmutable(block)` then `Servo_DeclarationBlock_Clone(block)` (which reads under the shared lock and wraps `block.clone()` in a fresh `Arc<Locked<_>>`; `Clone for PropertyDeclarationBlock` resets `immutable` to `false`), otherwise mutate the same block. Gecko runs this for both `ModifyDeclaration` (setProperty) and `RemoveProperty`, and then swaps the element's inline style to the new block — same as what `mutable_style_attribute` does here:

```rust
fn mutable_style_attribute(&mut self, guard) -> &ServoArc<Locked<PropertyDeclarationBlock>> {
    // None                 -> new empty block
    // Some(block) immutable -> clone into a fresh Arc (drops the shared one)
    // Some(block) mutable   -> reuse as-is
}
```

`remove_style_property` keeps its early `return false` when there is no style attribute, so it never allocates an empty block (matches Gecko's `Operation::RemoveProperty` path returning "nothing to remove").

Added a unit test that asserts the block is mutated in place before the first `resolve()`, is flagged `immutable` after, and that both set and remove then produce a distinct `Arc` while leaving the original block's declarations untouched. The test fails on `main` at the first `!ptr_eq` assertion.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/71044201392448b7bd505edfa9413a1b
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/71044201392448b7bd505edfa9413a1b?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33661117235).</sub>
<!-- wpt-results-end -->
