### PR TITLE
Fix atomic-inline baseline export, empty line boxes and root decoration baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "fontique"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ff838004f1912240ec1bfe488e106bd2cb8a9c70#ff838004f1912240ec1bfe488e106bd2cb8a9c70"
+source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -5932,12 +5932,12 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ff838004f1912240ec1bfe488e106bd2cb8a9c70#ff838004f1912240ec1bfe488e106bd2cb8a9c70"
+source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
 
 [[package]]
 name = "parley"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ff838004f1912240ec1bfe488e106bd2cb8a9c70#ff838004f1912240ec1bfe488e106bd2cb8a9c70"
+source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
 dependencies = [
  "fontique",
  "hashbrown 0.17.1",
@@ -5951,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "parley_data"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ff838004f1912240ec1bfe488e106bd2cb8a9c70#ff838004f1912240ec1bfe488e106bd2cb8a9c70"
+source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
 dependencies = [
  "icu_properties",
 ]
@@ -5959,7 +5959,7 @@ dependencies = [
 [[package]]
 name = "parley_engine"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ff838004f1912240ec1bfe488e106bd2cb8a9c70#ff838004f1912240ec1bfe488e106bd2cb8a9c70"
+source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
 dependencies = [
  "fontique",
  "harfrust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "fontique"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
+source = "git+https://github.com/DioxusLabs/parley?rev=62c35980d58afa6e13fc1caa148fa346c086f530#62c35980d58afa6e13fc1caa148fa346c086f530"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -5932,12 +5932,12 @@ dependencies = [
 [[package]]
 name = "parlance"
 version = "0.1.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
+source = "git+https://github.com/DioxusLabs/parley?rev=62c35980d58afa6e13fc1caa148fa346c086f530#62c35980d58afa6e13fc1caa148fa346c086f530"
 
 [[package]]
 name = "parley"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
+source = "git+https://github.com/DioxusLabs/parley?rev=62c35980d58afa6e13fc1caa148fa346c086f530#62c35980d58afa6e13fc1caa148fa346c086f530"
 dependencies = [
  "fontique",
  "hashbrown 0.17.1",
@@ -5951,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "parley_data"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
+source = "git+https://github.com/DioxusLabs/parley?rev=62c35980d58afa6e13fc1caa148fa346c086f530#62c35980d58afa6e13fc1caa148fa346c086f530"
 dependencies = [
  "icu_properties",
 ]
@@ -5959,7 +5959,7 @@ dependencies = [
 [[package]]
 name = "parley_engine"
 version = "0.11.0"
-source = "git+https://github.com/DioxusLabs/parley?rev=ac4c61c33c5bbc63303570b336b4e27cfa0cdd83#ac4c61c33c5bbc63303570b336b4e27cfa0cdd83"
+source = "git+https://github.com/DioxusLabs/parley?rev=62c35980d58afa6e13fc1caa148fa346c086f530#62c35980d58afa6e13fc1caa148fa346c086f530"
 dependencies = [
  "fontique",
  "harfrust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ taffy = { version = "0.14.0", default-features = false, features = [
     "calc",
     "detailed_layout_info",
 ] }
-parley = { git = "https://github.com/DioxusLabs/parley", rev = "ff838004f1912240ec1bfe488e106bd2cb8a9c70", default-features = false, features = ["std"] }
+parley = { git = "https://github.com/DioxusLabs/parley", rev = "ac4c61c33c5bbc63303570b336b4e27cfa0cdd83", default-features = false, features = ["std"] }
 skrifa = { version = "0.44", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ taffy = { version = "0.14.0", default-features = false, features = [
     "calc",
     "detailed_layout_info",
 ] }
-parley = { git = "https://github.com/DioxusLabs/parley", rev = "ac4c61c33c5bbc63303570b336b4e27cfa0cdd83", default-features = false, features = ["std"] }
+parley = { git = "https://github.com/DioxusLabs/parley", rev = "62c35980d58afa6e13fc1caa148fa346c086f530", default-features = false, features = ["std"] }
 skrifa = { version = "0.44", default-features = false, features = [
     "std",
 ] } # Should match parley and vello versions

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -1,7 +1,10 @@
 use blitz_traits::node_id::NodeId;
 use parley::{AlignmentOptions, IndentOptions};
-use style::values::specified::box_::DisplayOutside;
-use style::values::{computed::CSSPixelLength, generics::text::GenericTextIndent};
+use style::values::specified::box_::{DisplayInside, DisplayOutside};
+use style::values::{
+    computed::{CSSPixelLength, Contain},
+    generics::text::GenericTextIndent,
+};
 use taffy::{
     AvailableSpace, BlockContext, BlockFormattingContext, BoxSizing, CollapsibleMarginSet,
     CoreStyle as _, Direction, LayoutInput, LayoutOutput, LayoutPartialTree as _, MaybeMath as _,
@@ -306,11 +309,22 @@ impl BaseDocument {
 
             let is_absolute = style.position() == Position::Absolute;
             // The baseline of an inline-block is the baseline of its last in-flow line box,
-            // unless it has no line boxes or its `overflow` is not `visible`, in which case
-            // it is the bottom margin edge (CSS 2 §10.8.1).
+            // unless it has no line boxes or it is a block-axis scroll container, in which
+            // case it is the bottom margin edge (CSS 2 §10.8.1, css-align-3 §9.1
+            // `baseline-source: auto`; `overflow: clip` is not a scroll container). Other
+            // atomic inlines (flex, grid, table) export a baseline regardless of `overflow`,
+            // clamped to their border box if they are scroll containers (css-align-3 §9.1).
+            // A layout-contained box is treated as having no baseline (css-contain-1 §3.3).
             let overflow = style.overflow();
-            let has_visible_overflow =
-                overflow.x == Overflow::Visible && overflow.y == Overflow::Visible;
+            let box_style = style.style.get_box();
+            let is_flow = matches!(
+                box_style.display.inside(),
+                DisplayInside::Flow | DisplayInside::FlowRoot
+            );
+            let is_scroll_container = !matches!(overflow.y, Overflow::Visible | Overflow::Clip);
+            let is_block_axis_scroll_container = is_flow && is_scroll_container;
+            let contain_layout = box_style.clone_contain().contains(Contain::LAYOUT);
+            let exports_baseline = !is_block_axis_scroll_container && !contain_layout;
             drop(style);
 
             if is_absolute || is_floated {
@@ -320,17 +334,31 @@ impl BaseDocument {
             } else {
                 let output = self.compute_child_layout(taffy::NodeId::from(ibox.id), child_inputs);
                 ibox.width = (margin.left + margin.right + output.size.width) * scale;
-                // Vertical margins adjust the space the box reserves in the line, but the
-                // reserved space cannot be negative.
-                ibox.height = (margin.top + margin.bottom + output.size.height).max(0.0) * scale;
-                ibox.baseline = if has_visible_overflow {
+                ibox.baseline = if exports_baseline {
                     output
                         .baselines
                         .last
                         .or(output.baselines.first)
-                        .map(|baseline| (margin.top + baseline) * scale)
+                        .map(|baseline| {
+                            let baseline = if is_scroll_container {
+                                baseline.clamp(0.0, output.size.height)
+                            } else {
+                                baseline
+                            };
+                            (margin.top + baseline) * scale
+                        })
                 } else {
                     None
+                };
+                // Vertical margins adjust the space the box reserves in the line. A box with a
+                // baseline splits that space into ascent (`margin.top + baseline`) and descent
+                // (`margin.bottom + height - baseline`), either of which may be negative. A box
+                // without a baseline sits on the baseline and cannot reserve negative space.
+                let margin_box_height = margin.top + margin.bottom + output.size.height;
+                ibox.height = if ibox.baseline.is_some() {
+                    margin_box_height * scale
+                } else {
+                    margin_box_height.max(0.0) * scale
                 };
             }
         }
@@ -668,8 +696,18 @@ impl BaseDocument {
             },
         );
 
+        // Parley lays out empty text as a single strut-height line (text-editor semantics),
+        // but a line box containing no text, inline boxes or other in-flow content is a
+        // zero-height line box in CSS (CSS2 §9.4.2).
+        let has_inline_content =
+            !inline_layout.text.is_empty() || !inline_layout.layout.inline_boxes().is_empty();
+
         #[allow(unused_mut)]
-        let mut height = inline_layout.layout.height();
+        let mut height = if has_inline_content {
+            inline_layout.layout.height()
+        } else {
+            0.0
+        };
 
         // HACK. TODO: fix in Parley.
         //
@@ -829,13 +867,18 @@ impl BaseDocument {
                         layout.size = size;
                         layout.location.x =
                             (ibox.x / scale) + margin.left + container_pb.left + inset_offset.x;
-                        // A negative `margin-top` shrinks the space the box reserves in the
+                        // A box with a baseline is positioned by it, so its border box always
+                        // sits `margin.top` below the margin box (`ibox.y`). Without a baseline
+                        // a negative `margin-top` shrinks the space the box reserves in the
                         // line but does not move the box itself, which stays anchored to the
                         // bottom of the reserved space.
-                        layout.location.y = (ibox.y / scale)
-                            + margin.top.max(0.0)
-                            + container_pb.top
-                            + inset_offset.y;
+                        let margin_top = if ibox.baseline.is_some() {
+                            margin.top
+                        } else {
+                            margin.top.max(0.0)
+                        };
+                        layout.location.y =
+                            (ibox.y / scale) + margin_top + container_pb.top + inset_offset.y;
                         layout.padding = padding; //.map(|p| p / scale);
                         layout.border = border; //.map(|p| p / scale);
                     }
@@ -851,8 +894,12 @@ impl BaseDocument {
 
         let line_baseline =
             |line: parley::Line<'_, _>| (line.metrics().baseline / scale) + container_pb.top;
-        let first_baseline = inline_layout.layout.lines().next().map(line_baseline);
-        let last_baseline = inline_layout.layout.lines().last().map(line_baseline);
+        let first_baseline = has_inline_content
+            .then(|| inline_layout.layout.lines().next().map(line_baseline))
+            .flatten();
+        let last_baseline = has_inline_content
+            .then(|| inline_layout.layout.lines().last().map(line_baseline))
+            .flatten();
 
         // Put layout back
         self.nodes[node_id]

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -206,7 +206,8 @@ fn resolve_decoration_entry(doc: &BaseDocument, node_id: NodeId) -> DecorationSt
 /// decorating box (its own text), falling back to the first run it covers.
 #[derive(Clone)]
 struct DecorationRunGeometry {
-    /// The line's baseline (shared by every run on the line).
+    /// The baseline the decoration is positioned from (the run's own, `vertical-align`
+    /// shifted, baseline).
     baseline: f32,
     ascent: f32,
     descent: f32,
@@ -391,15 +392,29 @@ fn flush_line_decorations(
     scale: f64,
     deco_boxes: &[LineDecoration],
     win_ascent_ratios: &mut WinAscentCache,
+    inline_root_id: NodeId,
+    line_baseline: f32,
 ) {
     // Draw innermost boxes first so ancestors' decorations paint on top, matching the
     // per-run drawing order this replaced (`stack.iter().rev()`).
     for acc in deco_boxes.iter().rev() {
         let deco = &acc.deco;
         // Prefer the decorating box's own font; fall back to the first run it covers.
-        let Some(geom) = acc.own.as_ref().or(acc.first.as_ref()) else {
-            continue;
+        let geom = match (&acc.own, &acc.first) {
+            (Some(own), _) => own.clone(),
+            (None, Some(first)) => {
+                let mut geom = first.clone();
+                // A descendant run's baseline may be shifted by `vertical-align`, but the
+                // decoration is positioned from the decorating box's own baseline. For the
+                // inline root that is the line's baseline.
+                if acc.node_id == inline_root_id {
+                    geom.baseline = line_baseline;
+                }
+                geom
+            }
+            (None, None) => continue,
         };
+        let geom = &geom;
         let width = acc.max_x - acc.min_x;
         if width <= 0.0 {
             continue;
@@ -696,7 +711,15 @@ pub(crate) fn stroke_text<'a>(
             }
         }
 
-        flush_line_decorations(scene, transform, scale, deco_boxes, win_ascent_ratios);
+        flush_line_decorations(
+            scene,
+            transform,
+            scale,
+            deco_boxes,
+            win_ascent_ratios,
+            inline_root_id,
+            line.metrics().baseline,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes for regressions in the WPT diff of #832 that are actual bugs in the `vertical-align` mapping (full triage report is posted as a comment on #832). Repins parley to DioxusLabs/parley#22 (`ac4c61c33c5bbc63303570b336b4e27cfa0cdd83`).

`blitz-dom/src/layout/inline.rs` — atomic inline `InlineBox` construction:
- Baseline export now follows css-align-3 §9.1 / CSS2 §10.8.1 instead of "any non-visible overflow ⇒ no baseline":
  ```
  is_block_axis_scroll_container = display.inside ∈ {Flow, FlowRoot} && overflow.y ∉ {Visible, Clip}
  exports_baseline = !is_block_axis_scroll_container && !contain(LAYOUT)
  baseline = last.or(first).map(|b| if is_scroll_container { b.clamp(0, height) } else { b })
  ```
  i.e. only *inline-block* scroll containers synthesize from the bottom margin edge; inline-flex/grid/table keep their content baseline, clamped to the border box when scrollable; `contain: layout` boxes export none. Fixes `baseline-of-scrollable-1a`, `contain-layout-baseline-001/005`, keeps `flex-baseline-overflow-hidden` passing.
- A box *with* a baseline may reserve negative line space (negative vertical margins) and is positioned at `ibox.y + margin.top` (not `margin.top.max(0)`); the `.max(0)` clamp only applies to baseline-less boxes. Fixes `flexbox_inline`.
- An inline root with no text and no inline boxes is a zero-height line box and exports no baselines (Parley lays out empty text as one strut-height line). Fixes `empty-span-size-002`.

`blitz-paint/src/text.rs` — when the inline root has `text-decoration` but no run of its own, `flush_line_decorations` fell back to the first descendant run's geometry, including its `vertical-align`-shifted baseline. It now uses the line baseline for the root. Fixes `text-decoration-va-length-001`.

Full `css/` WPT run vs #832 head: 18 tests FAIL⇒PASS, 1 new failure (`css-contain/contain-size-064`: a size-contained grid with an `&nbsp;` `::after` now has a non-zero NBSP min-content width — pre-existing missing `contain: size` support in Taffy, exposed by the Parley NBSP fix).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/5c4401ef6292427a952400c36ae85272
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/5c4401ef6292427a952400c36ae85272?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **311** newly passing, **45** newly failing (net +266).

<details>
<summary>Full diff (259 changed tests)</summary>

```diff
+ FAIL => PASS    [1/1]   +1  css/CSS2/abspos/between-float-and-text.html
+ FAIL => PASS    [1/1]   +1  css/CSS2/backgrounds/background-position-applies-to-007.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/backgrounds/background-position-applies-to-009.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/backgrounds/background-position-applies-to-012.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/backgrounds/background-position-applies-to-013.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/backgrounds/background-position-applies-to-014.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/bidi-text/bidi-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/box-display/containing-block-030.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c414-flt-fit-004.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c43-rpl-ibx-000.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c44-ln-box-000.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c44-ln-box-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c534-bgre-000.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c534-bgre-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c534-bgreps-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c534-bgreps-002.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c534-bgreps-003.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c534-bgreps-004.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c534-bgreps-005.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c536-bgpos-000.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c536-bgpos-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c547-indent-000.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c5502-mrgn-r-000.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c5504-mrgn-l-000.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c5505-mrgn-000.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c5511-brdr-tw-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c5513-brdr-bw-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c5515-brdr-w-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c5525-fltwidth-003.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/css1/c61-rel-len-000.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/floats-clear/clear-003.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/floats-clear/clear-inline-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/floats-clear/floats-007.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/floats-clear/floats-038.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/floats-clear/floats-040.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/floats-clear/floats-124.xht
- PASS => FAIL    [0/1]   -1  css/CSS2/floats-clear/floats-149.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/floats-clear/margin-collapse-clear-014.xht
- PASS => FAIL    [0/1]   -1  css/CSS2/fonts/font-family-applies-to-005.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/fonts/font-family-rule-005.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/fonts/font-size-124.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/generated-content/content-174.xht
- PASS => FAIL    [0/1]   -1  css/CSS2/linebox/baseline-block-with-overflow-001.html
+ FAIL => FAIL   [7/13]   +5  css/CSS2/linebox/inline-negative-margin-001.html
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-breaking-font-size-zero-001.html
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-127.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-002.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-003.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-004.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-007.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-008.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-009.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-012.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-013.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/line-height-applies-to-014.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-007.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-008.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-019.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-020.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-031.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-032.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-043.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-044.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-055.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-056.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-067.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-068.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-079.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-080.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-091.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-092.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-103.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-104.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-122.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/linebox/vertical-align-applies-to-008.xht
+ FAIL => PASS  [20/20]  +16  css/CSS2/linebox/vertical-align-top-bottom-001.html
+ FAIL => PASS    [1/1]   +1  css/CSS2/margin-padding-clear/padding-applies-to-017.xht
- PASS => FAIL    [0/1]   -1  css/CSS2/normal-flow/inline-block-zorder-002.xht
- PASS => FAIL    [0/1]   -1  css/CSS2/normal-flow/inline-table-zorder-001.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/normal-flow/max-height-036.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/normal-flow/max-height-047.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/normal-flow/min-height-036.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/normal-flow/min-height-047.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/positioning/absolute-non-replaced-max-height-002.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/positioning/absolute-non-replaced-max-height-009.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/positioning/abspos-011.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/positioning/abspos-012.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/selectors/first-line-pseudo-014.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/selectors/first-line-pseudo-015.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/tables/table-anonymous-objects-171.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/text/text-indent-011.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/text/white-space-007.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/text/white-space-normal-003.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/values/units-003.xht
+ FAIL => PASS    [1/1]   +1  css/CSS2/visudet/content-height-001.html
+ FAIL => PASS    [1/1]   +1  css/CSS2/visudet/content-height-002.html
+ FAIL => PASS    [1/1]   +1  css/CSS2/visudet/content-height-003.html
- PASS => FAIL    [0/1]   -1  css/CSS2/visudet/line-height-204.html
- PASS => FAIL    [0/1]   -1  css/css-align/baseline-of-scrollable-1b.html
- FAIL => FAIL    [0/2]   -1  css/css-align/baseline-of-single-axis-scroll-container.html
+ FAIL => PASS    [7/7]   +5  css/css-align/baseline-rules/synthesized-baseline-flexbox-001.html
+ FAIL => PASS    [7/7]   +5  css/css-align/baseline-rules/synthesized-baseline-grid-001.html
+ FAIL => PASS    [3/3]   +3  css/css-align/baseline-rules/synthesized-baseline-inline-block-001.html
+ FAIL => PASS    [1/1]   +1  css/css-backgrounds/box-shadow-outset-without-border-radius-001.html
+ FAIL => PASS    [1/1]   +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-081a-print.html
+ FAIL => PASS    [1/1]   +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-081b-print.html
+ FAIL => PASS    [1/1]   +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-081c-print.html
+ FAIL => PASS    [1/1]   +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-081d-print.html
- PASS => FAIL    [0/1]   -1  css/css-break/ruby-003.html
- PASS => FAIL    [0/1]   -1  css/css-contain/contain-animation-001.html
+ FAIL => PASS    [1/1]   +1  css/css-contain/contain-content-004.html
+ FAIL => PASS    [1/1]   +1  css/css-contain/contain-layout-cell-002.html
+ FAIL => PASS    [1/1]   +1  css/css-contain/contain-layout-ink-overflow-013.html
+ FAIL => PASS    [1/1]   +1  css/css-contain/contain-layout-ink-overflow-015.html
+ FAIL => PASS    [1/1]   +1  css/css-contain/contain-paint-022.html
+ FAIL => PASS    [1/1]   +1  css/css-contain/contain-paint-023.html
- PASS => FAIL    [0/1]   -1  css/css-contain/contain-size-064.html
- PASS => FAIL    [0/1]   -1  css/css-contain/contain-size-flexbox-002.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flex-direction-row-reverse.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-align-self-horiz-001-block.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-align-self-vert-003.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-baseline-align-self-baseline-vert-001.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-baseline-multi-item-vert-001a.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-baseline-multi-item-vert-001b.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-baseline-multi-line-horiz-001.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-baseline-multi-line-horiz-002.html
- PASS => FAIL    [0/1]   -1  css/css-flexbox/flexbox-baseline-multi-line-vert-002.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-basic-canvas-vert-001.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-basic-canvas-vert-001v.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-basic-iframe-vert-001.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-basic-img-vert-001.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-basic-textarea-vert-001.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-basic-video-vert-001.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-justify-content-horiz-002.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexbox-justify-content-horiz-004.xhtml
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/flexible-box-float.html
+ FAIL => PASS    [1/1]   +1  css/css-fonts/font-size-zero-2.html
+ FAIL => PASS    [1/1]   +1  css/css-fonts/font-variant-emoji-005.html
- PASS => FAIL    [0/1]   -1  css/css-fonts/small-caps-letter-spacing-002.html
+ FAIL => PASS    [1/1]   +1  css/css-fonts/variations/font-weight-metrics.html
+ FAIL => FAIL    [7/9]   +1  css/css-grid/alignment/grid-align-baseline.html
- PASS => FAIL    [0/1]   -1  css/css-grid/alignment/grid-baseline-001.html
- PASS => FAIL    [0/1]   -1  css/css-grid/alignment/grid-baseline-002.html
+ FAIL => FAIL  [16/18]  +16  css/css-grid/alignment/grid-baseline-004.html
+ FAIL => FAIL   [3/11]   +3  css/css-grid/alignment/grid-container-baseline-001.html
- PASS => FAIL    [0/1]   -1  css/css-grid/alignment/grid-inline-baseline.html
+ FAIL => PASS    [1/1]   +1  css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-001.html
+ FAIL => PASS    [1/1]   +1  css/css-grid/alignment/self-baseline/grid-self-baseline-horiz-003.html
+ FAIL => PASS    [1/1]   +1  css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-lr-001.html
+ FAIL => PASS    [1/1]   +1  css/css-grid/alignment/self-baseline/grid-self-baseline-vertical-rl-001.html
- PASS => FAIL    [0/1]   -1  css/css-grid/grid-items/grid-inline-items-002.html
+ FAIL => PASS    [1/1]   +1  css/css-grid/grid-items/grid-layout-z-order-a.html
+ FAIL => PASS    [1/1]   +1  css/css-grid/grid-items/grid-layout-z-order-b.html
- PASS => FAIL    [0/1]   -1  css/css-highlight-api/painting/custom-highlight-painting-inheritance-001.html
- PASS => FAIL    [0/1]   -1  css/css-highlight-api/painting/custom-highlight-painting-inheritance-002.html
+ FAIL => PASS    [1/1]   +1  css/css-images/image-orientation/image-orientation-none-cross-origin.html
+ FAIL => PASS    [1/1]   +1  css/css-inline/baseline-shift/baseline-shift-bottom.html
+ FAIL => PASS    [1/1]   +1  css/css-inline/baseline-shift/baseline-shift-center.html
+ FAIL => PASS    [1/1]   +1  css/css-inline/baseline-shift/baseline-shift-top.html
+ FAIL => FAIL  [15/22]  +15  css/css-inline/baseline-source/baseline-source-first-001.html
+ FAIL => FAIL   [9/12]   +9  css/css-inline/baseline-source/baseline-source-first-textarea-001.tentative.html
+ FAIL => FAIL  [10/22]  +10  css/css-inline/baseline-source/baseline-source-last-001.html
+ FAIL => PASS  [12/12]  +12  css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html
- PASS => FAIL    [0/1]   -1  css/css-inline/dominant-baseline/dominant-baseline-mixed-writing-modes-002.html
- PASS => FAIL    [0/1]   -1  css/css-lists/list-and-block-in-inline.html
+ FAIL => PASS    [1/1]   +1  css/css-multicol/multicol-width-negative-001.xht
+ FAIL => PASS    [1/1]   +1  css/css-page/monolithic-overflow-014-print.html
- PASS => FAIL    [0/1]   -1  css/css-ruby/br-clear-all-000.html
- PASS => FAIL    [0/1]   -1  css/css-ruby/empty-ruby-base-container.html
- PASS => FAIL    [0/1]   -1  css/css-ruby/empty-ruby-text-container-abs.html
- PASS => FAIL    [0/1]   -1  css/css-ruby/empty-ruby-text-container-float.html
- PASS => FAIL    [0/1]   -1  css/css-ruby/ruby-base-container-abs.html
- PASS => FAIL    [0/1]   -1  css/css-ruby/ruby-base-container-float.html
- PASS => FAIL    [0/1]   -1  css/css-ruby/ruby-overhang-spaces-022.html
- PASS => FAIL    [0/1]   -1  css/css-sizing/intrinsic-percent-replaced-008.html
- PASS => FAIL    [0/1]   -1  css/css-sizing/intrinsic-percent-replaced-dynamic-008.html
+ FAIL => FAIL   [7/15]   +5  css/css-tables/tentative/baseline-table.html
+ FAIL => PASS    [1/1]   +1  css/css-text-decor/text-decoration-inset-003.html
+ FAIL => PASS    [1/1]   +1  css/css-text-decor/text-decoration-inset-008.html
- PASS => FAIL    [0/1]   -1  css/css-text-decor/text-decoration-skip-spaces-001.html
- PASS => FAIL    [0/1]   -1  css/css-text/hanging-punctuation/hanging-punctuation-first-002.html
+ FAIL => PASS    [1/1]   +1  css/css-text/line-breaking/line-breaking-atomic-002.html
+ FAIL => PASS    [1/1]   +1  css/css-text/line-breaking/line-breaking-atomic-009.html
+ FAIL => PASS    [1/1]   +1  css/css-text/overflow-wrap/overflow-wrap-min-content-size-002.html
+ FAIL => PASS    [1/1]   +1  css/css-text/shaping/shaping-002.html
+ FAIL => PASS    [1/1]   +1  css/css-text/shaping/shaping-003.html
+ FAIL => PASS    [1/1]   +1  css/css-text/shaping/shaping-008.html
+ FAIL => PASS    [1/1]   +1  css/css-text/shaping/shaping-017.html
+ FAIL => PASS    [1/1]   +1  css/css-text/shaping/shaping-018.html
+ FAIL => PASS    [1/1]   +1  css/css-text/shaping/shaping-021.html
+ FAIL => PASS    [1/1]   +1  css/css-text/shaping/shaping-024.html
+ FAIL => PASS    [1/1]   +1  css/css-text/text-align/text-align-match-parent-05.html
+ FAIL => PASS    [1/1]   +1  css/css-text/text-encoding/shaping-join-003.html
+ FAIL => PASS    [1/1]   +1  css/css-text/text-encoding/shaping-tatweel-003.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/control-chars-00B.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/control-chars-085.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/full-width-leading-spaces-002.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/full-width-leading-spaces-003.html
- PASS => FAIL    [0/1]   -1  css/css-text/white-space/full-width-leading-spaces-004.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/full-width-leading-spaces-005.html
- PASS => FAIL    [0/1]   -1  css/css-text/white-space/hanging-whitespace-002.tentative.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/pre-wrap-014.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-006.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-007.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-009.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-012.html
- PASS => FAIL    [0/1]   -1  css/css-text/white-space/trailing-ideographic-space-013.html
- PASS => FAIL    [0/1]   -1  css/css-text/white-space/trailing-ideographic-space-014.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-017.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-019.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-020.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-022.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-023.html
+ FAIL => PASS    [1/1]   +1  css/css-text/white-space/trailing-ideographic-space-025.html
- PASS => FAIL    [0/1]   -1  css/css-text/white-space/white-space-zero-fontsize-001.html
+ FAIL => PASS    [1/1]   +1  css/css-text/word-break/word-break-break-all-008.html
- FAIL => FAIL   [2/12]   -3  css/css-transforms/3d-point-mapping-2-transforminterop.html
+ FAIL => PASS    [1/1]   +1  css/css-ui/text-overflow-023.html
+ FAIL => PASS    [1/1]   +1  css/css-values/ch-unit-001.html
- FAIL => FAIL    [2/8]   -2  css/css-values/lh-rlh-on-root-001.html
+ FAIL => PASS    [1/1]   +1  css/css-values/lh-unit-001.html
+ FAIL => PASS    [1/1]   +1  css/css-values/lh-unit-002.html
- PASS => FAIL    [0/1]   -1  css/css-viewport/zoom/vertical-align.html
- PASS => FAIL    [0/1]   -1  css/css-writing-modes/abs-pos-with-replaced-child.html
+ FAIL => PASS    [1/1]   +1  css/css-writing-modes/baseline-with-orthogonal-flow-001.html
+ FAIL => PASS    [1/1]   +1  css/css-writing-modes/text-combine-upright-decorations-001.html
+ FAIL => PASS    [1/1]   +1  css/css-writing-modes/text-combine-upright-shadow.html
+ FAIL => FAIL   [5/11]   +2  css/cssom-view/elementFromPoint.html
+ FAIL => FAIL    [5/9]   +2  css/cssom-view/elementsFromPoint.html
+ FAIL => PASS    [1/1]   +1  css/filter-effects/effect-reference-after-001.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-021.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-022.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-024.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-025.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-026.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-027.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-028.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-029.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-030.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-031.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-032.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-034.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-035.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-036.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-041.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-042.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-044.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-045.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-046.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-047.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-048.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-049.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-050.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-051.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-052.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-054.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-055.html
+ FAIL => PASS    [1/1]   +1  css/selectors/i18n/css3-selectors-lang-056.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33711300906).</sub>
<!-- wpt-results-end -->
