### PR TITLE
Upgrade to Taffy `main` (Grid: min-contribution optimizations + floor `AvailableSpace` at 0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=9fa4b458f1a797b93cb2380f1e47c05d02a4fce3#9fa4b458f1a797b93cb2380f1e47c05d02a4fce3"
+source = "git+https://github.com/DioxusLabs/taffy?rev=bbd0d872c4f529fd701454bc8baa47d992ef392b#bbd0d872c4f529fd701454bc8baa47d992ef392b"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,8 +7917,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639627c87f43b9181c811f40a6296409e093a17bc761214cba3c15df74f86b99"
+source = "git+https://github.com/DioxusLabs/taffy?rev=9fa4b458f1a797b93cb2380f1e47c05d02a4fce3#9fa4b458f1a797b93cb2380f1e47c05d02a4fce3"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=bbd0d872c4f529fd701454bc8baa47d992ef392b#bbd0d872c4f529fd701454bc8baa47d992ef392b"
+source = "git+https://github.com/DioxusLabs/taffy?rev=1b918bafcab101dd234ebeb27da0443e24fd9de2#1b918bafcab101dd234ebeb27da0443e24fd9de2"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "9fa4b458f1a797b93cb2380f1e47c05d02a4fce3", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "bbd0d872c4f529fd701454bc8baa47d992ef392b", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "bbd0d872c4f529fd701454bc8baa47d992ef392b", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "1b918bafcab101dd234ebeb27da0443e24fd9de2", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { version = "0.14.0", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "9fa4b458f1a797b93cb2380f1e47c05d02a4fce3", default-features = false, features = [
     "std",
     "flexbox",
     "grid",

--- a/packages/blitz-dom/src/layout/inline.rs
+++ b/packages/blitz-dom/src/layout/inline.rs
@@ -259,8 +259,9 @@ impl BaseDocument {
                 .maybe_set(known_dimensions.width)
                 .maybe_set(node_size.width)
                 .map_definite_value(|size| {
-                    size.maybe_clamp(node_min_size.width, node_max_size.width)
-                        - content_box_inset.horizontal_axis_sum()
+                    (size.maybe_clamp(node_min_size.width, node_max_size.width)
+                        - content_box_inset.horizontal_axis_sum())
+                    .max(0.0)
                 }),
             height: known_dimensions
                 .height
@@ -270,8 +271,9 @@ impl BaseDocument {
                 .maybe_set(known_dimensions.height)
                 .maybe_set(node_size.height)
                 .map_definite_value(|size| {
-                    size.maybe_clamp(node_min_size.height, node_max_size.height)
-                        - content_box_inset.vertical_axis_sum()
+                    (size.maybe_clamp(node_min_size.height, node_max_size.height)
+                        - content_box_inset.vertical_axis_sum())
+                    .max(0.0)
                 }),
         };
 


### PR DESCRIPTION
## Summary

- `taffy` → git `9fa4b458f1a797b93cb2380f1e47c05d02a4fce3` (DioxusLabs/taffy#1177). Taffy's grid intrinsic track sizing no longer measures an item's min-/max-content contribution when none of its spanned tracks can receive it (matches Blink). On Wikipedia's Vector skin (`grid-template-columns: 12.25rem minmax(0, 1fr)`) the old behaviour measured the whole article under `MinContent`, which line-broke ~880 inline layouts at width 0 and then threw the result away.
- `compute_inline_layout_inner`: the definite available size handed to Parley is clamped at 0 after subtracting margins / content-box insets, so a 0-width container with margined children no longer produces `Definite(-17.0)`-style available widths (they only occurred inside the discarded pass above, but negative available width is never meaningful):
  ```rust
  .map_definite_value(|size| {
      (size.maybe_clamp(min, max) - content_box_inset.axis_sum()).max(0.0)
  })
  ```

Obama article, headless `resolve()` at 1280px (`examples/obama_bench` from #832's branch, 3 runs each, medians):

| | first layout | relayout | heap after layout | heap peak |
|---|---:|---:|---:|---:|
| main | 266–270 ms | 145–151 ms | 77.5 MB | 157.3 MB |
| this PR | 235–237 ms | 119–121 ms | 54.4 MB | 110.9 MB |

Zero-width `break_lines` passes 916 → 3, root height unchanged. blitz-dom/blitz-html tests and workspace clippy pass.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/3a0b8cc210c041d8955c841fb2a76a8e
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/3a0b8cc210c041d8955c841fb2a76a8e?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **4** newly passing, **0** newly failing (net +4).

<details>
<summary>Full diff (4 changed tests)</summary>

```diff
+ FAIL => PASS    [1/1]  +1  css/CSS2/floats/floats-wrap-bfc-with-margin-004.html
+ FAIL => PASS    [1/1]  +1  css/CSS2/floats/floats-wrap-bfc-with-margin-005.html
+ FAIL => PASS  [24/24]  +1  css/css-grid/parsing/grid-template-columns-computed-implicit-track.html
+ FAIL => PASS  [24/24]  +1  css/css-grid/parsing/grid-template-rows-computed-implicit-track.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33768692873).</sub>
<!-- wpt-results-end -->
