### PR TITLE
wpt: run reference-named files which are themselves tests

### DIFF
--- a/wpt/runner/src/main.rs
+++ b/wpt/runner/src/main.rs
@@ -181,13 +181,42 @@ fn has_suffix_with_test_extension(path_str: &str, suffix: &str) -> bool {
         .any(|ext| path_str.ends_with(&format!("{suffix}.{ext}")))
 }
 
+/// Matches file stems which the upstream WPT manifest classifies as reference files:
+/// `foo-ref`, `foo-notref`, `foo-ref2`, `foo_ref-a`, `ref-foo`, ...
+static REFERENCE_NAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(^|[\-_])(not)?ref[0-9]*([\-_]|$)").unwrap());
+
+/// Reference-named files are still tests in the upstream WPT manifest if their content makes them
+/// a reftest (`<link rel=match|mismatch>`, see RFC #15) or a testharness test.
+static REFERENCE_IS_TEST_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"<(?:[A-Za-z_][\w.\-]*:)?link\s[^>]*rel\s*=\s*['"]?(match|mismatch)['"]?[^>]*>|/resources/testharness\.js"#,
+    )
+    .unwrap()
+});
+
+/// Is the path a reference file (by upstream WPT naming rules) which is *not* also a test?
+fn is_non_test_reference(p: &Path) -> bool {
+    let stem = p
+        .file_stem()
+        .map(|s| s.to_string_lossy())
+        .unwrap_or_default();
+    let is_ref_name = path_contains_directory(p, "reference") || REFERENCE_NAME_RE.is_match(&stem);
+    if !is_ref_name {
+        return false;
+    }
+    // Only reference-named files are sniffed, so the extra read is limited to a
+    // small fraction of the tree.
+    match fs::read_to_string(p) {
+        Ok(contents) => !REFERENCE_IS_TEST_RE.is_match(&contents),
+        Err(_) => true,
+    }
+}
+
 fn filter_path(p: &Path) -> bool {
     // let is_tentative = path_buf.ends_with("tentative.html");
     let path_str = p.to_string_lossy();
-    let is_ref = has_suffix_with_test_extension(&path_str, "-ref")
-        || path_contains_directory(p, "reference");
-    // Negative references for mismatch reftests
-    let is_notref = has_suffix_with_test_extension(&path_str, "-notref");
+    let is_ref = is_non_test_reference(p);
     // Manual tests require human interaction/verification and cannot be run automatically
     let is_manual = has_suffix_with_test_extension(&path_str, "-manual");
     // `support`, `tools` and `resources` directories contain helper files, not tests
@@ -202,7 +231,7 @@ fn filter_path(p: &Path) -> bool {
 
     let is_dir = p.is_dir();
 
-    !(is_ref | is_notref | is_manual | is_support_file | is_blocked | is_dir)
+    !(is_ref | is_manual | is_support_file | is_blocked | is_dir)
 }
 
 fn collect_tests(wpt_dir: &Path) -> Vec<PathBuf> {
@@ -440,6 +469,14 @@ fn main() {
     }
     let test_paths = collect_tests(&wpt_dir);
     let count = test_paths.len();
+
+    // `--list` prints the selected test files (relative to WPT_DIR) without running them
+    if env::args().any(|arg| arg == "--list") {
+        for path in &test_paths {
+            println!("{}", path.strip_prefix(&wpt_dir).unwrap_or(path).display());
+        }
+        return;
+    }
 
     let cargo_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let out_dir = cargo_dir.parent().unwrap().join("output");


### PR DESCRIPTION
## Summary

Upstream WPT (RFC #15, [reftest graph simplification](https://github.com/web-platform-tests/rfcs/blob/master/rfcs/reftest_simplification.md)) does not chain reftests: a reference's own `<link rel=match|mismatch>` is ignored, and instead every file containing such links is a test in its own right — *including* files named `*-ref.html`, `*-notref.html` or living under `reference/`. `filter_path` dropped all reference-named files unconditionally, so ~113 upstream reftests (mostly `css/CSS2`, `css/css-text`, `css/css-pseudo`) and 15 reference-named testharness tests were never run.

`filter_path` now mirrors the manifest's `SourceFile` rules:

```rust
// upstream `reference_file_re`, applied to the file stem
REFERENCE_NAME_RE = (^|[-_])(not)?ref[0-9]*([-_]|$)

fn is_non_test_reference(p) -> bool {
    let is_ref_name = path_contains_directory(p, "reference") || REFERENCE_NAME_RE.is_match(stem);
    is_ref_name && !contents.matches(<link rel=match|mismatch> | /resources/testharness.js)
}
```

Only reference-named files are sniffed, so the extra reads are a small fraction of the tree.

Also adds a `--list` flag which prints the selected test files (relative to `WPT_DIR`) and exits, for checking selection without running anything.

### Verification

Compared `wpt full --list` against a freshly generated upstream `MANIFEST.json`, restricted to reference-named files: all 128 that upstream classifies as `reftest`/`testharness` are selected, with 0 missing and 0 extras.

Net change vs `main`: +97 files newly selected; −65 reference-named files (e.g. `foo-ref2.html`, `foo_ref.html`) which used to be enumerated but always ended up `TestKind::Unknown` → skipped are no longer enumerated.

Expectation files are not regenerated here; the new tests will show up as new rows on the next CI run.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9998c85cd56947688bda80b87fcbeb1e
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/9998c85cd56947688bda80b87fcbeb1e?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **27** newly passing, **0** newly failing (net +27). Tests: **85** added.

<details>
<summary>Full diff (85 changed tests)</summary>

```diff
+ ADD  [1/1]  +1  css/CSS2/floats/float-nowrap-3-ref.html
+ ADD  [1/1]  +1  css/CSS2/floats/floats-placement-vertical-004-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-append-002-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-append-002-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-001-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-001-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-002-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-002-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-003-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-003-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-004-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-004-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-006-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-006-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-007-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-007-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-008-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-008-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-009-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-009-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-010-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-010-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-011-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-011-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-012-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-012-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-013-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-013-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-014-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-014-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-015-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-015-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-016-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-insert-016-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-001-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-001-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-003-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-003-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-004-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-004-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-005-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-005-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-006-nosplit-ref.xht
+ ADD  [0/1]  +0  css/CSS2/normal-flow/block-in-inline-remove-006-ref.xht
+ ADD  [1/1]  +1  css/CSS2/text/text-indent-114-ref.xht
+ ADD  [0/1]  +0  css/CSS2/visuren/remove-from-split-inline-1-ref.html
+ ADD  [0/1]  +0  css/CSS2/visuren/remove-from-split-inline-3-ref.html
+ ADD  [0/1]  +0  css/CSS2/visuren/remove-from-split-inline-4-ref.html
+ ADD  [0/1]  +0  css/CSS2/visuren/remove-from-split-inline-5-ref.html
+ ADD  [0/1]  +0  css/CSS2/visuren/remove-from-split-inline-6-ref.html
+ ADD  [1/1]  +1  css/css-fonts/font-size-zero-1-ref.html
+ ADD  [0/1]  +0  css/css-grid/grid-lanes/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-007-ref.html
+ ADD  [0/1]  +0  css/css-pseudo/first-letter-opacity-001-ref.html
+ ADD  [0/1]  +0  css/css-pseudo/first-line-opacity-001-ref.html
+ ADD  [1/1]  +1  css/css-pseudo/marker-font-variant-numeric-default-ref.html
+ ADD  [1/1]  +1  css/css-pseudo/marker-font-variant-numeric-normal-ref.html
+ ADD  [0/1]  +0  css/css-pseudo/marker-unicode-bidi-default-ref.html
+ ADD  [0/1]  +0  css/css-pseudo/marker-unicode-bidi-normal-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-000-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-001-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-002-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-003-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-008-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-009-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-010-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-011-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-012-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-014-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-016-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-020-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-021-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-022-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-023-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-024-ref.html
+ ADD  [1/1]  +1  css/css-text/shaping/reference/shaping-025-ref.html
+ ADD  [1/1]  +1  css/css-transforms/2d-rotate-notref.html
+ ADD  [1/1]  +1  css/css-transforms/2d-rotate-ref.html
+ ADD  [0/1]  +0  css/css-transforms/transform3d-perspective-origin-ref.html
+ ADD  [0/1]  +0  css/css-transforms/transform3d-rotatex-ref.html
+ ADD  [0/1]  +0  css/css-ui/appearance-invalidate-author-styling-001-ref.html
+ ADD  [0/1]  +0  css/css-writing-modes/astral-bidi/adlam-anti-ref.html
+ ADD  [0/1]  +0  css/css-writing-modes/astral-bidi/cypriot-anti-ref.html
+ ADD  [1/1]  +1  css/reference/pass_if_filler_text_match_bold.xht
+ ADD  [0/1]  +0  css/reference/pass_if_filler_text_match_smallcaps.xht
+ ADD  [1/1]  +1  css/reference/pass_if_filler_text_underlined.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/33778044281).</sub>
<!-- wpt-results-end -->
