### PR TITLE
element: count boolean attributes by presence, not by parsed value

### DIFF
--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -511,7 +511,8 @@ fn collect_layout_children_with_wrap(
                 el.attr_parsed(local_name!("start"))
                     .map(|start: usize| start - 1)
                     .unwrap_or(0),
-                el.attr_parsed(local_name!("reversed")).unwrap_or(false),
+                // reversed is a boolean attribute: its presence is what counts
+                el.has_attr(local_name!("reversed")),
             )
         } else {
             (1, false)

--- a/packages/blitz-dom/src/node/element.rs
+++ b/packages/blitz-dom/src/node/element.rs
@@ -625,7 +625,9 @@ impl ElementData {
     }
 
     pub fn flush_is_focussable(&mut self) {
-        let disabled: bool = self.attr_parsed(local_name!("disabled")).unwrap_or(false);
+        // disabled is a boolean attribute: its presence is what counts. Parsing the value
+        // would read the spec-conformant empty form (`<input disabled>`) as not disabled.
+        let disabled: bool = self.has_attr(local_name!("disabled"));
         let tabindex: Option<i32> = self.attr_parsed(local_name!("tabindex"));
         let contains_sub_document: bool = self.sub_doc_data().is_some();
 

--- a/tests/blitz-tests/tests/focusability_updates.rs
+++ b/tests/blitz-tests/tests/focusability_updates.rs
@@ -56,10 +56,8 @@ fn removing_it_takes_the_focusability_away_again() {
     assert!(!doc.get_node(node).unwrap().is_focussable());
 }
 
-/// Disabling an element takes it out of both.
-///
-/// Note the value: blitz reads `disabled` as a parsed boolean rather than
-/// treating the bare attribute as disabling, so `""` would not count.
+/// Disabling an element takes it out of both. `disabled` is a boolean
+/// attribute, so setting it to the spec-conformant empty value counts.
 #[test]
 fn disabling_it_takes_it_out_of_both() {
     let mut doc = make_doc("<html><body><button id=t>press</button></body></html>");
@@ -69,8 +67,16 @@ fn disabling_it_takes_it_out_of_both() {
     doc.mutate().set_attribute(
         node,
         QualName::new(None, ns!(), local_name!("disabled")),
-        "true",
+        "",
     );
 
+    assert!(!doc.get_node(node).unwrap().is_focussable());
+}
+
+/// The bare attribute form a page usually writes.
+#[test]
+fn an_element_born_with_a_bare_disabled_attribute_is_not_focusable() {
+    let doc = make_doc("<html><body><button id=t disabled>press</button></body></html>");
+    let node = node_id(&doc, "#t");
     assert!(!doc.get_node(node).unwrap().is_focussable());
 }

--- a/tests/blitz-tests/tests/reversed_list.rs
+++ b/tests/blitz-tests/tests/reversed_list.rs
@@ -1,0 +1,27 @@
+//! `reversed` is a boolean attribute: its bare form must reverse an ordered
+//! list's numbering. Parsing its value would read `<ol reversed>` as not
+//! reversed, since the empty string is not a boolean literal.
+
+use blitz_dom::node::Marker;
+use blitz_test_harness::Harness;
+
+fn marker(harness: &Harness, selector: &str) -> String {
+    let node_id = harness.node(selector);
+    let doc = harness.base();
+    let element = doc.get_node(node_id).unwrap().element_data().unwrap();
+    match &element.list_item_data.as_ref().unwrap().marker {
+        Marker::String(s) => s.clone(),
+        Marker::Char(c) => c.to_string(),
+    }
+}
+
+#[test]
+fn a_bare_reversed_attribute_reverses_the_numbering() {
+    let harness = Harness::from_html(
+        "<html><body>\
+         <ol reversed><li id=first>a</li><li>b</li><li id=last>c</li></ol>\
+         </body></html>",
+    );
+    assert_eq!(marker(&harness, "#first"), "3. ");
+    assert_eq!(marker(&harness, "#last"), "1. ");
+}


### PR DESCRIPTION
Focusability read the disabled attribute through a bool parse, which only accepts the literal "true": the spec-conformant empty form that pages usually write, a bare disabled, parsed to nothing and left the element focusable and in the tab order. The ol element's reversed attribute had the same reading and never reversed a list's numbering. HTML boolean attributes count by presence, whatever their value.

<!-- wpt-results-start -->
## WPT results

Subtests: **0** newly passing, **18** newly failing (net -18).

<details>
<summary>Full diff (18 changed tests)</summary>

```diff
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-style-ol-ordinal-reversed.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-001.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-002.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-003.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-004.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-005.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-010.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-012.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-013.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-014.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-015.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-016.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-018.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-019.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-020.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-022.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-024.html
- PASS => FAIL  [0/1]  -1  css/css-lists/li-value-reversed-025.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34333946503).</sub>
<!-- wpt-results-end -->
