### PR TITLE
transforms: keep a rotate about the z axis in the plane

### DIFF
--- a/packages/blitz-dom/src/stylo_to_kurbo.rs
+++ b/packages/blitz-dom/src/stylo_to_kurbo.rs
@@ -37,6 +37,11 @@ pub fn resolve_2d_transform(
     let rotate = match &box_styles.rotate {
         Rotate::None => None,
         Rotate::Rotate(angle) => Some(angle.radians64()),
+        // A rotation about the z axis stays in the plane; the sign of the
+        // axis component decides the direction, its magnitude cancels out.
+        Rotate::Rotate3D(x, y, z, angle) if *x == 0.0 && *y == 0.0 && *z != 0.0 => {
+            Some(angle.radians64() * z.signum() as f64)
+        }
         // TODO: support 3D transforms
         Rotate::Rotate3D(_, _, _, _) => None,
     };

--- a/tests/blitz-tests/tests/rotate_z_axis.rs
+++ b/tests/blitz-tests/tests/rotate_z_axis.rs
@@ -1,0 +1,63 @@
+//! The `rotate` property's axis form is a planar rotation when the axis is z,
+//! the same one `rotate: <angle>` gives, and has to be applied like it.
+//!
+//! <https://drafts.csswg.org/css-transforms-2/#individual-transforms>
+//!
+//! Every axis form was dropped as 3d, so `rotate: z 90deg` did nothing while
+//! `rotate: 90deg` worked. Only an axis that leaves the plane needs the 3d
+//! support that is still missing.
+
+use blitz_test_harness::Harness;
+
+fn transform_coeffs(harness: &Harness, selector: &str) -> Option<[f64; 6]> {
+    let node_id = harness.node(selector);
+    harness
+        .base()
+        .get_node(node_id)
+        .unwrap()
+        .transform()
+        .as_deref()
+        .map(|affine| affine.as_coeffs())
+}
+
+fn page() -> Harness {
+    Harness::from_html(
+        r#"<html><body style="margin:0">
+            <div id="plain" style="width:20px; height:20px; rotate: 90deg"></div>
+            <div id="z" style="width:20px; height:20px; rotate: z 90deg"></div>
+            <div id="vector" style="width:20px; height:20px; rotate: 0 0 1 90deg"></div>
+            <div id="negative" style="width:20px; height:20px; rotate: 0 0 -1 90deg"></div>
+            <div id="reverse" style="width:20px; height:20px; rotate: -90deg"></div>
+            <div id="x" style="width:20px; height:20px; rotate: x 90deg"></div>
+        </body></html>"#,
+    )
+}
+
+#[test]
+fn a_z_axis_rotate_matches_the_plain_angle() {
+    let harness = page();
+    let plain = transform_coeffs(&harness, "#plain").expect("rotate: <angle> must apply");
+    assert_eq!(
+        transform_coeffs(&harness, "#z"),
+        Some(plain),
+        "rotate: z <angle>"
+    );
+    assert_eq!(
+        transform_coeffs(&harness, "#vector"),
+        Some(plain),
+        "rotate: 0 0 1 <angle>"
+    );
+}
+
+#[test]
+fn the_sign_of_the_axis_turns_the_rotation_around() {
+    let harness = page();
+    let reverse = transform_coeffs(&harness, "#reverse").expect("rotate: <angle> must apply");
+    assert_eq!(transform_coeffs(&harness, "#negative"), Some(reverse));
+}
+
+#[test]
+fn a_rotation_leaving_the_plane_is_still_dropped() {
+    let harness = page();
+    assert_eq!(transform_coeffs(&harness, "#x"), None);
+}


### PR DESCRIPTION
The rotate property's axis form was dropped whenever an axis was given, although rotating about z is the same planar rotation as the plain angle form: `rotate: z 90deg` did nothing while `rotate: 90deg` worked. Only an axis that leaves the plane needs the 3D support that is still missing; the sign of the z component decides the direction and its magnitude cancels out.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34335625450).</sub>
<!-- wpt-results-end -->
