### PR TITLE
box shadow: pull an inset shadow in by its spread radius

### DIFF
--- a/packages/blitz-paint/src/render/box_shadow.rs
+++ b/packages/blitz-paint/src/render/box_shadow.rs
@@ -122,9 +122,12 @@ impl ElementCx<'_, '_> {
                 None,
                 None,
             );
+            // The unshadowed area is the padding box shrunk by the spread radius
+            let spread = shadow.spread.px() as f64 * self.scale;
+            let hole = self.frame.padding_box.inflate(-spread, -spread);
             scene.draw_box_shadow(
                 transform,
-                self.frame.border_box,
+                hole,
                 Color::WHITE,
                 radius,
                 shadow.base.blur.px() as f64 * self.scale,


### PR DESCRIPTION
The inset path filled the padding box with the shadow colour and then punched the border box back out, which covers the fill whole, and it never read the spread radius at all. So an inset shadow was visible only where an offset shifted the punched-out shape, and the usual way to draw an inner ring - inset 0 0 0 2px, no offset and no blur - painted nothing: a calendar marking today that way showed no ring.

Punch out the padding box pulled in by the spread instead, which is also the box a browser measures an inset shadow from: with a border, the ring starts inside it. The expected pixels in the test come from Chromium rendering the same four boxes.

<!-- wpt-results-start -->
## WPT results

Subtests: **4** newly passing, **0** newly failing (net +4).

<details>
<summary>Full diff (4 changed tests)</summary>

```diff
+ FAIL => PASS  [1/1]  +1  css/css-backgrounds/box-shadow-inset-without-border-radius.html
+ FAIL => PASS  [1/1]  +1  css/css-borders/border-shape/border-shape-combined-shadow.html
+ FAIL => PASS  [1/1]  +1  css/css-borders/border-shape/border-shape-inset-shadow-blur.html
+ FAIL => PASS  [1/1]  +1  css/css-borders/border-shape/border-shape-inset-shadow-negative-spread.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34337403016).</sub>
<!-- wpt-results-end -->
