### PR TITLE
hit test: keep embedded boxes in border-box coordinates

### DIFF
--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1376,14 +1376,20 @@ impl Node {
             *scrollbar = Some(sb);
         }
 
-        if self.flags.is_inline_root() {
-            let content_box_offset = taffy::Point {
+        // Text clusters and callers of the returned coordinates work in the
+        // inline root's content box, but embedded boxes store border-box
+        // relative locations like every other child; apply the offset only
+        // where content-box coordinates are wanted, or atomic inlines in a
+        // padded inline root are hit one padding down and right of where
+        // they are painted.
+        let content_box_offset = if self.flags.is_inline_root() {
+            taffy::Point {
                 x: self.final_layout().padding.left + self.final_layout().border.left,
                 y: self.final_layout().padding.top + self.final_layout().border.top,
-            };
-            x -= content_box_offset.x;
-            y -= content_box_offset.y;
-        }
+            }
+        } else {
+            taffy::Point { x: 0.0, y: 0.0 }
+        };
 
         // Positive z_index hoisted children
         if matches_hoisted_content {
@@ -1426,6 +1432,8 @@ impl Node {
 
         // Inline children
         if self.flags.is_inline_root() {
+            let x = x - content_box_offset.x;
+            let y = y - content_box_offset.y;
             let element_data = &self.element_data().unwrap();
             if let Some(ild) = element_data.inline_layout_data.as_ref() {
                 let layout = &ild.layout;
@@ -1456,8 +1464,8 @@ impl Node {
         if matches_self && !pointer_events_none {
             return Some(HitResult {
                 node_id: self.id,
-                x,
-                y,
+                x: x - content_box_offset.x,
+                y: y - content_box_offset.y,
                 is_text: false,
             });
         }

--- a/tests/blitz-tests/tests/hit_inline_embedded_box.rs
+++ b/tests/blitz-tests/tests/hit_inline_embedded_box.rs
@@ -1,0 +1,71 @@
+//! Hit testing atomic inline boxes inside a padded inline root.
+//!
+//! Text clusters are hit in the inline root's content box, but embedded
+//! boxes store border-box relative locations like every other child. The
+//! hit test subtracted the content-box offset before descending into the
+//! children, so an atomic inline in a padded inline root was hit one
+//! padding down and right of where it is painted: a search field built as
+//! an inline-flex box inside a padded container missed clicks into its
+//! upper half.
+
+use blitz_test_harness::{Harness, HarnessOptions};
+
+fn harness() -> Harness {
+    Harness::from_html_with(
+        "<html><head><style>\
+         body { margin: 0; font-size: 14px; line-height: 20px }\
+         #pad { padding: 10px }\
+         #box { display: inline-flex; width: 200px; height: 32px }\
+         #box input { width: 100%; margin: 6px }\
+         </style></head><body>\
+         <div id=pad><div id=box><input id=field></div>after</div>\
+         </body></html>",
+        HarnessOptions {
+            width: 600,
+            height: 400,
+            ..Default::default()
+        },
+    )
+}
+
+fn hit_id(harness: &Harness, x: f32, y: f32) -> String {
+    let node_id = harness.hit_node(x, y);
+    let doc = harness.base();
+    doc.get_node(node_id)
+        .and_then(|n| n.data.downcast_element())
+        .and_then(|el| el.id.as_ref().map(|id| id.to_string()))
+        .unwrap_or_default()
+}
+
+/// The whole painted rect of the embedded box hits it, top-left corner
+/// included, not just the part below and right of one padding's worth.
+#[test]
+fn an_embedded_box_is_hit_where_it_is_painted() {
+    let harness = harness();
+    let rect = harness.layout_rect("#box");
+
+    // near the top-left corner, inside the box but within one padding of
+    // its edges - the region the double-subtraction pushed out of the box
+    assert_eq!(hit_id(&harness, rect.x + 2.0, rect.y + 2.0), "box");
+    // dead center hits the input (margin 6 inside the box)
+    assert_eq!(
+        hit_id(
+            &harness,
+            rect.x + rect.width / 2.0,
+            rect.y + rect.height / 2.0
+        ),
+        "field"
+    );
+    // just outside the top-left corner hits the padded container
+    assert_eq!(hit_id(&harness, rect.x - 2.0, rect.y - 2.0), "pad");
+    // just past the bottom-right corner, where the shifted hit region
+    // used to sit
+    assert_eq!(
+        hit_id(
+            &harness,
+            rect.x + rect.width + 2.0,
+            rect.y + rect.height + 2.0
+        ),
+        "pad"
+    );
+}


### PR DESCRIPTION
The inline-root branch subtracted the content-box offset from the point before descending into the children, for the text clusters whose parley coordinates are content-box relative. Embedded boxes store border-box relative locations like every other child, so an atomic inline inside a padded inline root was hit one padding down and right of where it is painted: a search field built as an inline-flex box inside a padded container missed clicks into its upper half and focused nothing.

Subtract the offset only where content-box coordinates are wanted, the cluster query and the returned hit coordinates.

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34338031838).</sub>
<!-- wpt-results-end -->
