### PR TITLE
tables: implement fixed table layout column sizing

### DIFF
--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -58,6 +58,48 @@ pub struct TableCell {
     style: taffy::Style<Atom>,
 }
 
+/// Tracks the current column position while walking the table's cells, so that
+/// cells are assigned the same columns Taffy's dense auto-placement will give them
+/// (skipping columns still occupied by rowspan cells from earlier rows).
+#[derive(Debug, Default)]
+struct ColumnCursor {
+    /// The column the next cell in the current row will be placed in
+    col: u16,
+    /// The total number of columns seen so far
+    num_columns: u16,
+    /// For each column, the number of further rows it is occupied by a rowspan cell
+    rowspans: Vec<u16>,
+}
+
+impl ColumnCursor {
+    fn start_row(&mut self) {
+        self.col = 0;
+        for remaining in self.rowspans.iter_mut() {
+            *remaining = remaining.saturating_sub(1);
+        }
+    }
+
+    /// Advance past occupied columns, returning the column of the next cell
+    fn next_free(&mut self) -> u16 {
+        while self.rowspans.get(self.col as usize).is_some_and(|r| *r > 0) {
+            self.col += 1;
+        }
+        self.col
+    }
+
+    fn place(&mut self, colspan: u16, rowspan: u16) {
+        let end = self.col + colspan;
+        if self.rowspans.len() < end as usize {
+            self.rowspans.resize(end as usize, 0);
+        }
+        for remaining in &mut self.rowspans[self.col as usize..end as usize] {
+            *remaining = rowspan - 1;
+        }
+        self.col = end;
+        self.num_columns = self.num_columns.max(end);
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TableColumn {
     pub node_id: NodeId,
@@ -117,7 +159,7 @@ pub(crate) fn build_table_context(
     let mut cells: Vec<TableCell> = Vec::new();
     let mut rows: Vec<TableRow> = Vec::new();
     let mut row = 0u16;
-    let mut col = 0u16;
+    let mut cursor = ColumnCursor::default();
 
     let root_node = &mut doc.nodes[table_root_node_id];
 
@@ -154,35 +196,56 @@ pub(crate) fn build_table_context(
     for child_id in children.iter().copied() {
         collect_columns(doc, child_id, &mut columns, &mut column_sizes);
     }
-    // Column widths only take effect in the fixed table layout algorithm
+    // Percentage column widths only take effect in the fixed table layout algorithm
     if !is_fixed {
-        column_sizes.clear();
+        for column in column_sizes.iter_mut() {
+            if column.max.into_raw().tag() == taffy::CompactLength::PERCENT_TAG {
+                *column = style_helpers::auto();
+            }
+        }
     }
     let mut first_cell_border: Option<ServoArc<Border>> = None;
     // Percentage widths set on first-row cells: (column index, percentage, padding + border)
     let mut percent_columns: Vec<(u16, f32, f32)> = Vec::new();
     let mut calc_values: Vec<LengthPercentage> = Vec::new();
-    for child_id in children.iter().copied() {
-        collect_table_cells(
-            doc,
-            child_id,
-            is_fixed,
-            border_collapse,
-            &mut row,
-            &mut col,
-            &mut cells,
-            &mut rows,
-            &mut column_sizes,
-            &mut first_cell_border,
-            &mut percent_columns,
-        );
+    // Header row groups are laid out before other rows, and footer row groups after
+    let row_group_order = |doc: &BaseDocument, child_id: NodeId| -> u8 {
+        let display = doc.nodes[child_id]
+            .primary_styles()
+            .map(|s| s.clone_display());
+        match display.map(|d| d.inside()) {
+            Some(DisplayInside::TableHeaderGroup) => 0,
+            Some(DisplayInside::TableFooterGroup) => 2,
+            _ => 1,
+        }
+    };
+    for order in 0..3 {
+        for child_id in children.iter().copied() {
+            if row_group_order(doc, child_id) != order {
+                continue;
+            }
+            collect_table_cells(
+                doc,
+                child_id,
+                is_fixed,
+                border_collapse,
+                &mut row,
+                &mut cursor,
+                &mut cells,
+                &mut rows,
+                &mut column_sizes,
+                &mut first_cell_border,
+                &mut percent_columns,
+            );
+        }
     }
     let remaining_column = if is_fixed {
         style_helpers::minmax(style_helpers::length(0.0), style_helpers::fr(1.0))
     } else {
         style_helpers::auto()
     };
-    column_sizes.resize(col as usize, remaining_column);
+    let num_columns = cursor.num_columns.max(column_sizes.len() as u16);
+    column_sizes.resize(num_columns as usize, remaining_column);
     if is_fixed {
         // In the fixed table layout algorithm, percentage column widths resolve against
         // the table's content width minus the horizontal border-spacing between columns,
@@ -193,7 +256,7 @@ pub(crate) fn build_table_context(
             BorderCollapse::Separate => border_spacing.width.px(),
             BorderCollapse::Collapse => 0.0,
         };
-        let inner_spacing = spacing_x * col.saturating_sub(1) as f32;
+        let inner_spacing = spacing_x * num_columns.saturating_sub(1) as f32;
         let mut percent_track = |percent: f32, extra: f32| -> TrackSizingFunction {
             let extra = extra - percent * inner_spacing;
             if extra == 0.0 {
@@ -336,13 +399,13 @@ fn collect_columns(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn collect_table_cells(
+fn collect_table_cells(
     doc: &mut BaseDocument,
     node_id: NodeId,
     is_fixed: bool,
     border_collapse: BorderCollapse,
     row: &mut u16,
-    col: &mut u16,
+    cursor: &mut ColumnCursor,
     cells: &mut Vec<TableCell>,
     rows: &mut Vec<TableRow>,
     columns: &mut Vec<TrackSizingFunction>,
@@ -381,7 +444,7 @@ pub(crate) fn collect_table_cells(
                     is_fixed,
                     border_collapse,
                     row,
-                    col,
+                    cursor,
                     cells,
                     rows,
                     columns,
@@ -394,7 +457,7 @@ pub(crate) fn collect_table_cells(
         DisplayInside::TableRow => {
             node.remove_damage(CONSTRUCT_DESCENDENT | CONSTRUCT_FC | CONSTRUCT_BOX);
             *row += 1;
-            *col = 0;
+            cursor.start_row();
 
             rows.push(TableRow {
                 node_id,
@@ -409,7 +472,7 @@ pub(crate) fn collect_table_cells(
                     is_fixed,
                     border_collapse,
                     row,
-                    col,
+                    cursor,
                     cells,
                     rows,
                     columns,
@@ -432,6 +495,7 @@ pub(crate) fn collect_table_cells(
                 .map(|v| v.clamp(1, 65534))
                 .unwrap_or(1);
             let mut style = stylo_taffy::to_taffy_style(stylo_style);
+            let col = cursor.next_free();
 
             if first_cell_border.is_none() {
                 *first_cell_border = Some(stylo_style.clone_border());
@@ -444,8 +508,9 @@ pub(crate) fn collect_table_cells(
                 style.min_size.width = style_helpers::length(0.0);
             }
 
-            let col_needs_width = (*col as usize) >= columns.len()
-                || (is_fixed && colspan == 1 && columns[*col as usize].max.is_auto());
+            // Column widths from `<col>` elements take precedence over cell widths
+            let col_needs_width =
+                (col as usize) >= columns.len() || columns[col as usize].max.is_auto();
             if *row == 1 && col_needs_width {
                 let column = match style.size.width.tag() {
                     taffy::CompactLength::LENGTH_TAG => {
@@ -472,7 +537,7 @@ pub(crate) fn collect_table_cells(
                                 taffy::BoxSizing::BorderBox => 0.0,
                             };
                             // Resolved in `build_table_context` once the column count is known
-                            percent_columns.push((*col, style.size.width.value(), extra));
+                            percent_columns.push((col, style.size.width.value(), extra));
                             style_helpers::percent(style.size.width.value())
                         } else {
                             style_helpers::auto()
@@ -484,9 +549,10 @@ pub(crate) fn collect_table_cells(
                     // Taffy resolves it against the table's inner width.
                     _ => style.size.width.into(),
                 };
-                if (*col as usize) < columns.len() {
-                    columns[*col as usize] = column;
+                if (col as usize) < columns.len() {
+                    columns[col as usize] = column;
                 } else {
+                    columns.resize(col as usize, style_helpers::auto());
                     columns.push(column);
                 }
             }
@@ -516,7 +582,7 @@ pub(crate) fn collect_table_cells(
             style.size.width = style_helpers::auto();
             cells.push(TableCell { node_id, style });
 
-            *col += colspan;
+            cursor.place(colspan, rowspan);
         }
         DisplayInside::Flow
         | DisplayInside::FlowRoot

--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -29,7 +29,8 @@ pub struct TableTreeWrapper<'doc> {
     pub(crate) ctx: Arc<TableContext>,
 }
 
-#[derive(Debug, Clone)]
+// Deliberately not `Clone`: `style` may hold raw pointers into `calc_values`.
+#[derive(Debug)]
 pub struct TableContext {
     pub style: taffy::Style<Atom>,
     pub cells: Vec<TableCell>,

--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -5,11 +5,16 @@ use atomic_refcell::AtomicRefCell;
 use markup5ever::local_name;
 use style::properties::style_structs::Border;
 use style::servo_arc::Arc as ServoArc;
+use style::values::computed::length_percentage::{
+    CalcLengthPercentage, CalcNode, ComputedLeaf, Unpacked as UnpackedLengthPercentage,
+};
+use style::values::computed::{Length, LengthPercentage, Percentage};
 use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style::{
     Atom, computed_values::border_collapse::T as BorderCollapse,
     computed_values::table_layout::T as TableLayout, values::computed::BorderStyle,
 };
+use style_traits::values::specified::AllowedNumericType;
 use taffy::{
     DetailedGridInfo, LayoutPartialTree as _, ResolveOrZero, TrackSizingFunction, style_helpers,
 };
@@ -29,9 +34,14 @@ pub struct TableContext {
     pub style: taffy::Style<Atom>,
     pub cells: Vec<TableCell>,
     pub rows: Vec<TableRow>,
+    pub columns: Vec<TableColumn>,
     pub computed_grid_info: AtomicRefCell<Option<DetailedGridInfo<Atom>>>,
     pub border_style: Option<ServoArc<Border>>,
     pub border_collapse: BorderCollapse,
+    /// Backing storage for `calc()` track sizes synthesised by the table layout code.
+    /// Taffy stores calc values as raw pointers, so these must outlive the `style`.
+    #[allow(dead_code)]
+    calc_values: Vec<LengthPercentage>,
 }
 
 // #[derive(Debug, Clone, Eq, PartialEq)]
@@ -45,6 +55,11 @@ pub struct TableCell {
     // kind: TableItemKind,
     node_id: NodeId,
     style: taffy::Style<Atom>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TableColumn {
+    pub node_id: NodeId,
 }
 
 #[derive(Debug, Clone)]
@@ -63,6 +78,35 @@ fn side_width(width: app_units::Au, style: BorderStyle) -> f32 {
     } else {
         width.to_f32_px()
     }
+}
+
+/// Build a `calc(<percent> + <length>)` track sizing function. The calc value is
+/// boxed and stored in `calc_values` so that the raw pointer Taffy holds stays valid.
+fn percent_plus_length(
+    calc_values: &mut Vec<LengthPercentage>,
+    percent: f32,
+    length: f32,
+) -> TrackSizingFunction {
+    let node = CalcNode::Sum(
+        vec![
+            CalcNode::Leaf(ComputedLeaf::Percentage(Percentage(percent))),
+            CalcNode::Leaf(ComputedLeaf::Length(Length::new(length))),
+        ]
+        .into(),
+    );
+    let value = LengthPercentage::new_calc(node, AllowedNumericType::NonNegative);
+    let dim = match value.unpack() {
+        UnpackedLengthPercentage::Calc(calc) => {
+            let ptr = calc as *const CalcLengthPercentage as *const ();
+            // SAFETY: the pointer targets the heap allocation owned by `value`, which
+            // is kept alive by `calc_values` for as long as the TableContext exists.
+            unsafe { taffy::Dimension::from_raw(taffy::CompactLength::calc(ptr)) }
+        }
+        UnpackedLengthPercentage::Length(len) => style_helpers::length(len.px()),
+        UnpackedLengthPercentage::Percentage(p) => style_helpers::percent(p.0),
+    };
+    calc_values.push(value);
+    dim.into()
 }
 
 pub(crate) fn build_table_context(
@@ -93,8 +137,9 @@ pub(crate) fn build_table_context(
     style.grid_auto_columns = Vec::new();
     style.grid_auto_rows = Vec::new();
 
+    // The fixed table layout algorithm only applies when the table has a non-auto width
     let is_fixed = match stylo_styles.clone_table_layout() {
-        TableLayout::Fixed => true,
+        TableLayout::Fixed => !style.size.width.is_auto(),
         TableLayout::Auto => false,
     };
 
@@ -103,8 +148,19 @@ pub(crate) fn build_table_context(
 
     drop(stylo_styles);
 
+    let mut columns: Vec<TableColumn> = Vec::new();
     let mut column_sizes: Vec<taffy::TrackSizingFunction> = Vec::new();
+    for child_id in children.iter().copied() {
+        collect_columns(doc, child_id, &mut columns, &mut column_sizes);
+    }
+    // Column widths only take effect in the fixed table layout algorithm
+    if !is_fixed {
+        column_sizes.clear();
+    }
     let mut first_cell_border: Option<ServoArc<Border>> = None;
+    // Percentage widths set on first-row cells: (column index, percentage, padding + border)
+    let mut percent_columns: Vec<(u16, f32, f32)> = Vec::new();
+    let mut calc_values: Vec<LengthPercentage> = Vec::new();
     for child_id in children.iter().copied() {
         collect_table_cells(
             doc,
@@ -117,9 +173,51 @@ pub(crate) fn build_table_context(
             &mut rows,
             &mut column_sizes,
             &mut first_cell_border,
+            &mut percent_columns,
         );
     }
-    column_sizes.resize(col as usize, style_helpers::auto());
+    let remaining_column = if is_fixed {
+        style_helpers::minmax(style_helpers::length(0.0), style_helpers::fr(1.0))
+    } else {
+        style_helpers::auto()
+    };
+    column_sizes.resize(col as usize, remaining_column);
+    if is_fixed {
+        // In the fixed table layout algorithm, percentage column widths resolve against
+        // the table's content width minus the horizontal border-spacing between columns,
+        // whereas Taffy resolves percentage tracks against the container's inner width
+        // (from which only the outer border-spacing has been removed via padding). Fold
+        // the inner border-spacing into the percentage using `calc(N% - N * spacing)`.
+        let spacing_x = match border_collapse {
+            BorderCollapse::Separate => border_spacing.width.px(),
+            BorderCollapse::Collapse => 0.0,
+        };
+        let inner_spacing = spacing_x * col.saturating_sub(1) as f32;
+        let mut percent_track = |percent: f32, extra: f32| -> TrackSizingFunction {
+            let extra = extra - percent * inner_spacing;
+            if extra == 0.0 {
+                style_helpers::percent(percent)
+            } else {
+                percent_plus_length(&mut calc_values, percent, extra)
+            }
+        };
+
+        for column in column_sizes.iter_mut() {
+            if column.max.is_auto() {
+                *column = remaining_column;
+            } else if column.max.into_raw().tag() == taffy::CompactLength::PERCENT_TAG {
+                *column = percent_track(column.max.into_raw().value(), 0.0);
+            }
+        }
+
+        // Percentage widths on cells apply to the cell's content box, so the
+        // cell's horizontal padding and border must be added to the column width.
+        for (col_idx, percent, extra) in percent_columns {
+            if let Some(column) = column_sizes.get_mut(col_idx as usize) {
+                *column = percent_track(percent, extra);
+            }
+        }
+    }
 
     style.grid_template_columns = column_sizes.into_iter().map(|dim| dim.into()).collect();
     style.grid_template_rows = vec![style_helpers::auto(); row as usize];
@@ -177,12 +275,63 @@ pub(crate) fn build_table_context(
             style,
             cells,
             rows,
+            columns,
             computed_grid_info: AtomicRefCell::new(None),
             border_collapse,
             border_style: first_cell_border,
+            calc_values,
         },
         layout_children,
     )
+}
+
+/// Collect `<col>` elements (and `display: table-column` elements) along with their
+/// widths, which take precedence over cell widths in the fixed table layout algorithm.
+/// Columns without a specified width are recorded as `auto`.
+fn collect_columns(
+    doc: &mut BaseDocument,
+    node_id: NodeId,
+    columns: &mut Vec<TableColumn>,
+    column_sizes: &mut Vec<TrackSizingFunction>,
+) {
+    let node = &doc.nodes[node_id];
+    if !node.is_element() {
+        return;
+    }
+    let Some(display) = node.primary_styles().map(|s| s.clone_display()) else {
+        return;
+    };
+
+    match display.inside() {
+        DisplayInside::TableColumnGroup => {
+            let children = std::mem::take(&mut doc.nodes[node_id].children);
+            for child_id in children.iter().copied() {
+                collect_columns(doc, child_id, columns, column_sizes);
+            }
+            doc.nodes[node_id].children = children;
+        }
+        DisplayInside::TableColumn => {
+            let style = stylo_taffy::to_taffy_style(&node.primary_styles().unwrap());
+            let span: u16 = node
+                .attr(local_name!("span"))
+                .and_then(|val| val.parse::<u16>().ok())
+                .map(|v| v.max(1))
+                .unwrap_or(1);
+            let column = match style.size.width.tag() {
+                taffy::CompactLength::LENGTH_TAG => style_helpers::length(style.size.width.value()),
+                taffy::CompactLength::PERCENT_TAG => {
+                    style_helpers::percent(style.size.width.value())
+                }
+                // Browsers treat calc() widths on columns as auto
+                _ => style_helpers::auto(),
+            };
+            for _ in 0..span {
+                columns.push(TableColumn { node_id });
+                column_sizes.push(column);
+            }
+        }
+        _ => {}
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -197,6 +346,7 @@ pub(crate) fn collect_table_cells(
     rows: &mut Vec<TableRow>,
     columns: &mut Vec<TrackSizingFunction>,
     first_cell_border: &mut Option<ServoArc<Border>>,
+    percent_columns: &mut Vec<(u16, f32, f32)>,
 ) {
     let node = &mut doc.nodes[node_id];
 
@@ -235,6 +385,7 @@ pub(crate) fn collect_table_cells(
                     rows,
                     columns,
                     first_cell_border,
+                    percent_columns,
                 );
             }
             doc.nodes[node_id].children = children;
@@ -262,6 +413,7 @@ pub(crate) fn collect_table_cells(
                     rows,
                     columns,
                     first_cell_border,
+                    percent_columns,
                 );
             }
             doc.nodes[node_id].children = children;
@@ -284,7 +436,16 @@ pub(crate) fn collect_table_cells(
                 *first_cell_border = Some(stylo_style.clone_border());
             }
 
-            if *row == 1 {
+            // In the fixed table layout algorithm the widths of columns are not
+            // affected by cell contents, so cells must not impose a min-content
+            // floor on their tracks.
+            if is_fixed {
+                style.min_size.width = style_helpers::length(0.0);
+            }
+
+            let col_needs_width = (*col as usize) >= columns.len()
+                || (is_fixed && colspan == 1 && columns[*col as usize].max.is_auto());
+            if *row == 1 && col_needs_width {
                 let column = match style.size.width.tag() {
                     taffy::CompactLength::LENGTH_TAG => {
                         let len = style.size.width.value();
@@ -299,6 +460,18 @@ pub(crate) fn collect_table_cells(
                     }
                     taffy::CompactLength::PERCENT_TAG => {
                         if is_fixed {
+                            let extra = match style.box_sizing {
+                                taffy::BoxSizing::ContentBox => {
+                                    let padding =
+                                        style.padding.resolve_or_zero(None, resolve_calc_value);
+                                    let border =
+                                        style.border.resolve_or_zero(None, resolve_calc_value);
+                                    padding.left + padding.right + border.left + border.right
+                                }
+                                taffy::BoxSizing::BorderBox => 0.0,
+                            };
+                            // Resolved in `build_table_context` once the column count is known
+                            percent_columns.push((*col, style.size.width.value(), extra));
                             style_helpers::percent(style.size.width.value())
                         } else {
                             style_helpers::auto()
@@ -310,7 +483,11 @@ pub(crate) fn collect_table_cells(
                     // Taffy resolves it against the table's inner width.
                     _ => style.size.width.into(),
                 };
-                columns.push(column);
+                if (*col as usize) < columns.len() {
+                    columns[*col as usize] = column;
+                } else {
+                    columns.push(column);
+                }
             }
 
             // Zero-out cell borders is BorderCollapse is Collapse

--- a/packages/blitz-dom/src/layout/table.rs
+++ b/packages/blitz-dom/src/layout/table.rs
@@ -244,6 +244,16 @@ pub(crate) fn build_table_context(
     } else {
         style_helpers::auto()
     };
+    // Trailing `<col>` columns which contain no cells and have no definite width
+    // (i.e. would be zero-width) are dropped, so they don't add border-spacing.
+    while column_sizes.len() > cursor.num_columns as usize
+        && column_sizes
+            .last()
+            .is_some_and(|c| c.min.into_raw().tag() == taffy::CompactLength::AUTO_TAG)
+    {
+        column_sizes.pop();
+        columns.pop();
+    }
     let num_columns = cursor.num_columns.max(column_sizes.len() as u16);
     column_sizes.resize(num_columns as usize, remaining_column);
     if is_fixed {
@@ -381,13 +391,32 @@ fn collect_columns(
                 .and_then(|val| val.parse::<u16>().ok())
                 .map(|v| v.max(1))
                 .unwrap_or(1);
-            let column = match style.size.width.tag() {
-                taffy::CompactLength::LENGTH_TAG => style_helpers::length(style.size.width.value()),
+            let column: TrackSizingFunction = match style.size.width.tag() {
+                taffy::CompactLength::LENGTH_TAG => {
+                    // A definite `max-width` clamps the column width; a zero width is treated as auto
+                    let mut width = style.size.width.value();
+                    if style.max_size.width.into_raw().tag() == taffy::CompactLength::LENGTH_TAG {
+                        width = width.min(style.max_size.width.into_raw().value());
+                    }
+                    if width > 0.0 {
+                        style_helpers::length(width)
+                    } else {
+                        style_helpers::auto()
+                    }
+                }
                 taffy::CompactLength::PERCENT_TAG => {
                     style_helpers::percent(style.size.width.value())
                 }
                 // Browsers treat calc() widths on columns as auto
                 _ => style_helpers::auto(),
+            };
+            // A definite `min-width` on a column acts as a floor on its width
+            let column = match style.min_size.width.into_raw().tag() {
+                taffy::CompactLength::LENGTH_TAG if column.max.is_auto() => style_helpers::minmax(
+                    style_helpers::length(style.min_size.width.into_raw().value()),
+                    style_helpers::auto(),
+                ),
+                _ => column,
             };
             for _ in 0..span {
                 columns.push(TableColumn { node_id });
@@ -512,7 +541,7 @@ fn collect_table_cells(
             let col_needs_width =
                 (col as usize) >= columns.len() || columns[col as usize].max.is_auto();
             if *row == 1 && col_needs_width {
-                let column = match style.size.width.tag() {
+                let column: TrackSizingFunction = match style.size.width.tag() {
                     taffy::CompactLength::LENGTH_TAG => {
                         let len = style.size.width.value();
                         let padding = style.padding.resolve_or_zero(None, resolve_calc_value);
@@ -550,7 +579,9 @@ fn collect_table_cells(
                     _ => style.size.width.into(),
                 };
                 if (col as usize) < columns.len() {
-                    columns[col as usize] = column;
+                    if !column.max.is_auto() {
+                        columns[col as usize] = column;
+                    }
                 } else {
                     columns.resize(col as usize, style_helpers::auto());
                     columns.push(column);

--- a/packages/blitz-paint/src/render/background.rs
+++ b/packages/blitz-paint/src/render/background.rs
@@ -232,6 +232,36 @@ impl ElementCx<'_, '_> {
 
         let rows = PhysicalTracks::from_tracks(&grid_info.rows);
         let row_origin = rows.origin();
+        let inner_height = rows.span() as f64;
+
+        // Column backgrounds are painted beneath row backgrounds. Track positions are
+        // in logical order, matching the order in which columns were collected.
+        for (column, col_position) in table.columns.iter().zip(&grid_info.columns.positions) {
+            let col_node = &self.context.dom.get_node(column.node_id).unwrap();
+            let Some(style) = col_node.primary_styles() else {
+                continue;
+            };
+
+            let y = row_origin as f64;
+            let shape = Rect::new(
+                col_position.start as f64,
+                y,
+                col_position.end as f64,
+                y + inner_height,
+            )
+            .scale_from_origin(self.scale);
+
+            let current_color = style.clone_color();
+            let background_color = &style.get_background().background_color;
+            let bg_color = background_color
+                .resolve_to_absolute(&current_color)
+                .as_srgb_color();
+
+            if bg_color != Color::TRANSPARENT {
+                scene.fill(Fill::NonZero, self.transform, bg_color, None, &shape);
+            }
+        }
+
         for (row, row_position) in table.rows.iter().zip(rows.iter()) {
             let row_node = &self.context.dom.get_node(row.node_id).unwrap();
             let Some(style) = row_node.primary_styles() else {


### PR DESCRIPTION
## Summary

`table-layout: fixed` previously only differed from `auto` by keeping percentage cell widths. Tables are emulated as a CSS grid, so unspecified columns were `auto` tracks whose base size is the cells' min-content (padding + border + content) – but the fixed algorithm must ignore contents and split the remaining space equally. This PR implements the CSS 2.1 §17.5.2.1 column pass in `build_table_context` (only when the table has a non-`auto` width, per spec):

- **Remaining columns**: `auto` → `minmax(0, 1fr)`; cells get `min_size.width = 0` so their min-content contribution no longer widens tracks or overflows the table.
- **`<col>` / `<colgroup>`**: new `collect_columns` records `TableColumn { node_id }` + a track size (`length` / `percent`; `calc()` is treated as `auto` like browsers), honouring `span`. First-row cell widths only fill columns whose `<col>` is `auto`. `draw_table_row_backgrounds` now also paints `<col>` backgrounds (beneath row backgrounds).
- **Percentages**: a cell's percentage applies to its content box, so its horizontal padding/border is added; and column percentages resolve against the table content width *minus inner border-spacing*, whereas Taffy resolves against the inner width. Both are folded into a single track via `percent_plus_length` which synthesises `calc(P% + (extra − P·(cols−1)·spacing))`. The stylo `LengthPercentage` values backing those calc pointers are kept alive in `TableContext::calc_values`.

Collapsed-border handling is untouched (still the first-cell-border approximation), so `fixed-table-layout-003e*/003f*` and `029–031` remain failing – that's a separate, larger job.

## WPT

`css/CSS2/tables`: +17 passes (`fixed-table-layout-003a01–06`, `003d01–06`, `017–020`, `026`, `table-visual-layout-018`), no regressions.
`css/css-tables`: +1 (`fixed-layout-1`), no regressions.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/84a08f9c92c44905bb0567640e0942a8
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/84a08f9c92c44905bb0567640e0942a8?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **58** newly passing, **1** newly failing (net +57).

<details>
<summary>Full diff (44 changed tests)</summary>

```diff
+ FAIL => PASS    [1/1]  +1  css/CSS2/backgrounds/background-applies-to-006.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/backgrounds/background-color-applies-to-006.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/bidi-text/direction-applies-to-006.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/bidi-text/direction-applies-to-013.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/bidi-text/direction-applies-to-014.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/borders/border-conflict-style-105.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/box-display/display-010.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/margin-padding-clear/margin-collapse-131.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/normal-flow/max-height-applies-to-006.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/normal-flow/max-width-applies-to-006.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/normal-flow/min-width-applies-to-006.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/normal-flow/width-applies-to-006.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/selectors/default-attribute-selector-003.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003a01.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003a02.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003a03.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003a04.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003a05.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003a06.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003d01.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003d02.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003d03.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003d04.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003d05.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-003d06.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-017.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-018.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-019.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-020.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/fixed-table-layout-026.xht
+ FAIL => PASS    [1/1]  +1  css/CSS2/tables/table-visual-layout-018.xht
+ FAIL => FAIL   [4/13]  +1  css/css-tables/column-track-merging.html
+ FAIL => PASS    [5/5]  +1  css/css-tables/fixed-layout-1.html
+ FAIL => FAIL    [2/4]  +2  css/css-tables/height-distribution/computing-row-measure-1.html
+ FAIL => FAIL    [5/6]  +2  css/css-tables/html5-table-formatting-1.html
+ FAIL => FAIL   [6/12]  +6  css/css-tables/html5-table-formatting-2.html
- PASS => FAIL    [0/1]  -1  css/css-tables/paint/col-paint-vrl-rtl.html
+ FAIL => FAIL    [2/6]  +1  css/css-tables/tentative/colgroup-col.html
+ FAIL => FAIL   [5/31]  +1  css/css-tables/tentative/colspan-redistribution.html
+ FAIL => FAIL  [13/33]  +3  css/css-tables/tentative/column-widths.html
+ FAIL => FAIL   [1/15]  +1  css/css-tables/tentative/table-width-redistribution-fixed-padding.html
+ FAIL => FAIL  [10/26]  +6  css/css-tables/tentative/table-width-redistribution-fixed.html
+ FAIL => FAIL   [8/14]  +2  css/css-tables/tentative/td-box-sizing-001.html
+ FAIL => PASS    [1/1]  +1  css/css-tables/width-distribution/computing-column-measure-2.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34537625067).</sub>
<!-- wpt-results-end -->
