### PR TITLE
getComputedStyle: style display:none subtrees lazily; resolve min-size auto to 0px outside flex/grid items

### DIFF
--- a/packages/blitz-dom/src/resolved_style.rs
+++ b/packages/blitz-dom/src/resolved_style.rs
@@ -19,7 +19,7 @@ use style::stylesheets::supports_rule::parse_condition_or_declaration;
 use style::stylesheets::{CssRuleType, Origin};
 use style::values::computed::LengthPercentage;
 use style::values::computed::length::CSSPixelLength;
-use style::values::generics::position::Inset as GenericInset;
+use style::values::generics::position::{Inset as GenericInset, PreferredRatio};
 use style::values::resolved;
 use style::values::specified::box_::DisplayInside;
 use style_traits::{CssStringWriter, ParsingMode, ToCss};
@@ -264,12 +264,24 @@ impl BaseDocument {
         let Some(node) = self.get_node(node_id) else {
             return String::new();
         };
-        let Some(styles) = node.primary_styles() else {
-            return String::new();
+        // Elements inside a `display: none` subtree are skipped by the style
+        // traversal, so their style has to be computed on demand.
+        let undisplayed_styles;
+        let stored_styles = node.primary_styles();
+        let styles: &ComputedValues = match &stored_styles {
+            Some(styles) => styles,
+            None => match self.resolve_undisplayed_style(node_id) {
+                Some(styles) => {
+                    undisplayed_styles = styles;
+                    &undisplayed_styles
+                }
+                None => return String::new(),
+            },
         };
 
         let display = styles.clone_display();
-        let has_layout_box = node.flags.is_in_document() && !display.is_none();
+        let has_layout_box =
+            node.flags.is_in_document() && !display.is_none() && stored_styles.is_some();
 
         // Layout-dependent "used value" special cases
         match property_name {
@@ -426,6 +438,24 @@ impl BaseDocument {
                     _ => {}
                 }
             }
+            // `min-width: auto` / `min-height: auto` resolve to `auto` only for
+            // boxes with a preferred aspect ratio and for flex and grid items;
+            // otherwise (including when no box is generated) they resolve to `0px`
+            "min-width" | "min-height" => {
+                let pos_styles = styles.get_position();
+                let is_auto = if property_name == "min-width" {
+                    pos_styles.min_width.is_auto()
+                } else {
+                    pos_styles.min_height.is_auto()
+                };
+                let has_aspect_ratio =
+                    !matches!(pos_styles.aspect_ratio.ratio, PreferredRatio::None);
+                let preserves_auto =
+                    has_layout_box && (has_aspect_ratio || self.is_flex_or_grid_item(node_id));
+                if is_auto && !preserves_auto {
+                    return format_px(0.0);
+                }
+            }
             "transform" if has_layout_box => {
                 let transform = &styles.get_box().transform;
                 if !transform.0.is_empty() {
@@ -455,9 +485,28 @@ impl BaseDocument {
         };
         match property_id.as_shorthand() {
             // Serialize shorthands from the resolved values of their longhands
-            Ok(shorthand) => serialize_resolved_shorthand(&styles, shorthand),
+            Ok(shorthand) => serialize_resolved_shorthand(styles, shorthand),
             Err(declaration_id) => styles.computed_value_to_string(declaration_id),
         }
+    }
+
+    /// Whether the node's box is a flex or grid item, i.e. its nearest ancestor
+    /// that generates a box (skipping `display: contents` ancestors) is a flex
+    /// or grid container.
+    fn is_flex_or_grid_item(&self, node_id: NodeId) -> bool {
+        let mut parent_id = self.get_node(node_id).and_then(|node| node.parent);
+        while let Some(parent) = parent_id.and_then(|id| self.get_node(id)) {
+            let Some(parent_styles) = parent.primary_styles() else {
+                return false;
+            };
+            let display = parent_styles.clone_display();
+            if display.is_contents() {
+                parent_id = parent.parent;
+                continue;
+            }
+            return matches!(display.inside(), DisplayInside::Flex | DisplayInside::Grid);
+        }
+        false
     }
 }
 

--- a/packages/blitz-dom/src/stylo.rs
+++ b/packages/blitz-dom/src/stylo.rs
@@ -41,7 +41,7 @@ use style::{
     Atom,
     context::{
         QuirksMode, RegisteredSpeculativePainter, RegisteredSpeculativePainters,
-        SharedStyleContext, StyleContext,
+        SharedStyleContext, StyleContext, ThreadLocalStyleContext,
     },
     dom::{LayoutIterator, NodeInfo, OpaqueNode, TDocument, TElement, TNode, TShadowRoot},
     global_style_data::GLOBAL_STYLE_DATA,
@@ -49,8 +49,9 @@ use style::{
     selector_parser::{NonTSPseudoClass, SelectorImpl},
     servo_arc::{Arc, ArcBorrow},
     shared_lock::{Locked, SharedRwLock, StylesheetGuards},
+    stylist::RuleInclusion,
     thread_state::ThreadState,
-    traversal::{DomTraversal, PerLevelTraversalData},
+    traversal::{DomTraversal, PerLevelTraversalData, resolve_style},
     traversal_flags::TraversalFlags,
     values::{AtomIdent, GenericAtomIdent},
 };
@@ -181,6 +182,50 @@ impl crate::document::BaseDocument {
         self.stylist.rule_tree().maybe_gc();
 
         style::thread_state::exit(ThreadState::LAYOUT);
+    }
+
+    /// Compute the style of an element which the regular style traversal
+    /// skipped because it lives inside a `display: none` subtree.
+    ///
+    /// The style traversal culls `display: none` subtrees, so such elements
+    /// never have styles stored on them, but `getComputedStyle()` must still
+    /// return their computed values. This resolves the style on demand
+    /// (styling any unstyled ancestors along the way) without storing it on the
+    /// node. Returns `None` for non-elements and elements outside the document.
+    pub fn resolve_undisplayed_style(&self, node_id: NodeId) -> Option<Arc<ComputedValues>> {
+        let node = self.nodes.get(node_id)?;
+        if !node.is_element() || !node.flags.is_in_document() {
+            return None;
+        }
+
+        style::thread_state::enter(ThreadState::LAYOUT);
+
+        let guard = &self.guard;
+        let guards = StylesheetGuards {
+            author: &guard.read(),
+            ua_or_user: &guard.read(),
+        };
+        let shared = SharedStyleContext {
+            traversal_flags: TraversalFlags::empty(),
+            stylist: &self.stylist,
+            options: GLOBAL_STYLE_DATA.options.clone(),
+            guards,
+            visited_styles_enabled: false,
+            animations: self.animations.clone(),
+            current_time_for_animations: 0.0,
+            snapshot_map: &self.snapshots,
+            registered_speculative_painters: &RegisteredPaintersImpl,
+        };
+        let mut thread_local = ThreadLocalStyleContext::new();
+        let mut context = StyleContext {
+            shared: &shared,
+            thread_local: &mut thread_local,
+        };
+        let styles = resolve_style(&mut context, node, RuleInclusion::All, None, None);
+
+        style::thread_state::exit(ThreadState::LAYOUT);
+
+        Some(styles.primary().clone())
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the two failing subtests of `css/css-flexbox/getcomputedstyle/flexbox_computedstyle_min-auto-size.html`, which had two distinct root causes:

1. **Elements inside a `display: none` subtree had no computed style at all** (`getComputedStyle(el).minWidth === ""`). Stylo's traversal culls `display: none` subtrees (`clear_descendant_data`), so those nodes never get an `ElementData`, and `resolved_style_value` bailed out with an empty string. New `BaseDocument::resolve_undisplayed_style(node_id)` (in `stylo.rs`) builds a throwaway `SharedStyleContext`/`ThreadLocalStyleContext` and calls `style::traversal::resolve_style(.., RuleInclusion::All, None, None)`, which styles the unstyled ancestor chain and the element on demand. This mirrors what Servo does in its resolved-style query for `display: none` descendants. The result is *not* stored on the node, so it can't go stale or interfere with the traversal's invariants.

2. **`min-width: auto` / `min-height: auto` serialised as `auto` unconditionally.** Per css-sizing / CSSOM, the resolved value is only `auto` for flex items, grid items, and boxes with a preferred `aspect-ratio`; otherwise – including when no box is generated – it is `0px`. Stylo just serialises the computed keyword (Gecko does this conversion in `nsComputedDOMStyle`), so `resolved_style_value` now does the same:

   ```rust
   "min-width" | "min-height" => {
       let preserves_auto = has_layout_box
           && (aspect_ratio.ratio != PreferredRatio::None || self.is_flex_or_grid_item(node_id));
       if is_auto && !preserves_auto { return "0px" }
   }
   ```
   `is_flex_or_grid_item` walks up through `display: contents` parents to the nearest box-generating ancestor and checks for `DisplayInside::Flex | Grid`. `has_layout_box` is now also false when the style came from the lazy path (the element is in a `display: none` subtree so generates no box).

WPT before/after on `css-flexbox css-grid css-sizing cssom css-display css-position css-box css-values css-align css-tables css-overflow`: 14 subtests FAIL→PASS (5 tests now fully passing: the flexbox test, `css-grid/grid-items/grid-item-min-auto-size-001`, `cssom/getComputedStyle-display-none-00{2,3}`, `cssom/getComputedStyle-resolved-min-size-auto`), no regressions.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/5352ce9c1f9b4d078bb62af1235dfd2d
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/5352ce9c1f9b4d078bb62af1235dfd2d?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **56** newly passing, **0** newly failing (net +56).

<details>
<summary>Full diff (10 changed tests)</summary>

```diff
+ FAIL => PASS    [1/1]   +1  css/CSS2/floats/computed-float-position-absolute.html
+ FAIL => FAIL  [28/62]  +28  css/css-color/system-color-consistency.html
+ FAIL => PASS  [21/21]  +12  css/css-color/system-color-support.html
+ FAIL => PASS    [4/4]   +2  css/css-flexbox/getcomputedstyle/flexbox_computedstyle_min-auto-size.html
+ FAIL => PASS    [4/4]   +2  css/css-grid/grid-items/grid-item-min-auto-size-001.html
+ FAIL => PASS    [1/1]   +1  css/css-pseudo/before-in-display-none-thcrash.html
+ FAIL => FAIL    [1/2]   +1  css/cssom/getComputedStyle-display-none-001.html
+ FAIL => PASS    [1/1]   +1  css/cssom/getComputedStyle-display-none-002.html
+ FAIL => PASS    [1/1]   +1  css/cssom/getComputedStyle-display-none-003.html
+ FAIL => PASS  [16/16]   +7  css/cssom/getComputedStyle-resolved-min-size-auto.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34523535851).</sub>
<!-- wpt-results-end -->
