### PR TITLE
Implement CSSOM stylesheet API (document.styleSheets, CSSStyleSheet, CSSRule)

### DIFF
--- a/packages/blitz-dom/src/cssom.rs
+++ b/packages/blitz-dom/src/cssom.rs
@@ -281,20 +281,13 @@ fn rule_attributes(rule: &CssRule, guard: &SharedRwLockReadGuard) -> Vec<(&'stat
 
 impl BaseDocument {
     /// The owner nodes (`<style>` / `<link>` elements) of the document's author
-    /// stylesheets, in document order (`document.styleSheets`).
-    pub fn stylesheet_owner_nodes(&self) -> Vec<NodeId> {
-        let mut owners = Vec::new();
-        let mut stack = vec![self.root_node_id];
-        while let Some(node_id) = stack.pop() {
-            let Some(node) = self.nodes.get(node_id) else {
-                continue;
-            };
-            if self.nodes_to_stylesheet.contains_key(&node_id) {
-                owners.push(node_id);
-            }
-            stack.extend(node.children.iter().rev().copied());
-        }
-        owners
+    /// stylesheets (`document.styleSheets`).
+    ///
+    /// Ordered by node id, which matches document order for stylesheets
+    /// created while parsing (and is the order the stylist uses too, see
+    /// `add_stylesheet_for_node`).
+    pub fn stylesheet_owner_nodes(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.nodes_to_stylesheet.keys().copied()
     }
 
     /// Whether `node_id` currently owns a stylesheet

--- a/packages/blitz-dom/src/cssom.rs
+++ b/packages/blitz-dom/src/cssom.rs
@@ -1,0 +1,834 @@
+//! CSSOM stylesheet access (`document.styleSheets`, `CSSStyleSheet`,
+//! `CSSRuleList`, `CSSRule` and friends) backed by stylo's stylesheet objects.
+//!
+//! Stylesheets are identified by the `NodeId` of their owner node (`<style>` or
+//! `<link>`), and rules by a *path* of indices from the stylesheet's top-level
+//! rule list down through nested rule lists (`@media`, `@supports`, nested
+//! style rules, `@keyframes`, ...). An empty path denotes the stylesheet's own
+//! top-level rule list.
+
+use cssparser::{Parser, ParserInput};
+use selectors::matching::QuirksMode;
+use style::font_face::FontFaceRule;
+use style::invalidation::stylesheets::RuleChangeKind;
+use style::parser::ParserContext;
+use style::properties::font_face::DescriptorId as FontFaceDescriptorId;
+use style::properties::{
+    Importance, PropertyDeclarationBlock, PropertyId, SourcePropertyDeclaration,
+    parse_one_declaration_into,
+};
+use style::servo_arc::Arc as ServoArc;
+use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
+use style::stylesheets::keyframes_rule::{Keyframe, KeyframesRule};
+use style::stylesheets::{
+    AllowImportRules, CssRule, CssRuleRef, CssRuleType, CssRuleTypes, CssRules, DocumentStyleSheet,
+    Origin, RulesMutateError, StylesheetInDocument,
+};
+use style_traits::{CssStringWriter, ParsingMode, ToCss};
+// For `SelectorList::to_css_string`
+use cssparser::ToCss as _;
+
+use blitz_traits::node_id::NodeId;
+
+use crate::BaseDocument;
+use crate::net::StylesheetLoader;
+
+/// Errors from CSSOM mutation operations, mirroring the `DOMException` names
+/// which the corresponding JavaScript APIs throw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CssomError {
+    /// The owner node has no associated stylesheet, or the rule path does not
+    /// resolve to a rule (list).
+    NotFound,
+    /// `SyntaxError`
+    Syntax,
+    /// `IndexSizeError`
+    IndexSize,
+    /// `HierarchyRequestError`
+    HierarchyRequest,
+    /// `InvalidStateError`
+    InvalidState,
+    /// `NotSupportedError`
+    NotSupported,
+}
+
+impl CssomError {
+    /// The `DOMException` name corresponding to this error
+    pub fn dom_exception_name(self) -> &'static str {
+        match self {
+            Self::NotFound => "NotFoundError",
+            Self::Syntax => "SyntaxError",
+            Self::IndexSize => "IndexSizeError",
+            Self::HierarchyRequest => "HierarchyRequestError",
+            Self::InvalidState => "InvalidStateError",
+            Self::NotSupported => "NotSupportedError",
+        }
+    }
+}
+
+impl From<RulesMutateError> for CssomError {
+    fn from(err: RulesMutateError) -> Self {
+        match err {
+            RulesMutateError::Syntax => Self::Syntax,
+            RulesMutateError::IndexSize => Self::IndexSize,
+            RulesMutateError::HierarchyRequest => Self::HierarchyRequest,
+            RulesMutateError::InvalidState => Self::InvalidState,
+        }
+    }
+}
+
+/// A snapshot of the CSSOM-visible attributes of a rule
+#[derive(Debug, Clone)]
+pub struct CssRuleInfo {
+    /// The name of the CSSOM interface for the rule (e.g. `"CSSStyleRule"`)
+    pub interface: &'static str,
+    /// The legacy `CSSRule.type` constant (0 for rules without one)
+    pub rule_type: u16,
+    /// `CSSRule.cssText`
+    pub css_text: String,
+    /// Whether the rule has a child rule list (`cssRules`)
+    pub has_child_rules: bool,
+    /// Whether the rule has a `style` declaration block
+    pub has_style: bool,
+    /// Additional interface-specific string attributes (e.g. `selectorText`)
+    pub attributes: Vec<(&'static str, String)>,
+}
+
+/// A rule list that CSSOM rule paths can index into
+#[derive(Clone)]
+enum RuleList {
+    Css(ServoArc<Locked<CssRules>>),
+    Keyframes(ServoArc<Locked<KeyframesRule>>),
+}
+
+/// A rule resolved from a CSSOM rule path
+#[derive(Clone)]
+enum RuleHandle {
+    Rule(CssRule),
+    Keyframe(ServoArc<Locked<Keyframe>>),
+}
+
+/// The declarations of a rule (`CSSRule.style`)
+enum DeclarationTarget {
+    Block {
+        block: ServoArc<Locked<PropertyDeclarationBlock>>,
+        rule_type: CssRuleType,
+    },
+    FontFace(ServoArc<Locked<FontFaceRule>>),
+}
+
+fn child_rule_list(rule: &CssRule, guard: &SharedRwLockReadGuard) -> Option<RuleList> {
+    let rules = match rule {
+        CssRule::Style(r) => r.read_with(guard).rules.clone()?,
+        CssRule::Media(r) => r.rules.clone(),
+        CssRule::Supports(r) => r.rules.clone(),
+        CssRule::Container(r) => r.rules.clone(),
+        CssRule::Page(r) => r.read_with(guard).rules.clone(),
+        CssRule::Document(r) => r.rules.clone(),
+        CssRule::LayerBlock(r) => r.rules.clone(),
+        CssRule::Scope(r) => r.rules.clone(),
+        CssRule::StartingStyle(r) => r.rules.clone(),
+        CssRule::Keyframes(r) => return Some(RuleList::Keyframes(r.clone())),
+        _ => return None,
+    };
+    Some(RuleList::Css(rules))
+}
+
+fn declaration_target(
+    handle: &RuleHandle,
+    guard: &SharedRwLockReadGuard,
+) -> Option<DeclarationTarget> {
+    let (block, rule_type) = match handle {
+        RuleHandle::Keyframe(k) => (k.read_with(guard).block.clone(), CssRuleType::Keyframe),
+        RuleHandle::Rule(rule) => match rule {
+            CssRule::Style(r) => (r.read_with(guard).block.clone(), CssRuleType::Style),
+            CssRule::Page(r) => (r.read_with(guard).block.clone(), CssRuleType::Page),
+            CssRule::Margin(r) => (r.block.clone(), CssRuleType::Margin),
+            CssRule::NestedDeclarations(r) => (
+                r.read_with(guard).block.clone(),
+                CssRuleType::NestedDeclarations,
+            ),
+            CssRule::PositionTry(r) => (r.read_with(guard).block.clone(), CssRuleType::PositionTry),
+            CssRule::FontFace(r) => return Some(DeclarationTarget::FontFace(r.clone())),
+            _ => return None,
+        },
+    };
+    Some(DeclarationTarget::Block { block, rule_type })
+}
+
+fn css_rule_interface(rule: &CssRule) -> &'static str {
+    match rule {
+        CssRule::Style(_) => "CSSStyleRule",
+        CssRule::Namespace(_) => "CSSNamespaceRule",
+        CssRule::Import(_) => "CSSImportRule",
+        CssRule::Media(_) => "CSSMediaRule",
+        CssRule::CustomMedia(_) => "CSSCustomMediaRule",
+        CssRule::Container(_) => "CSSContainerRule",
+        CssRule::FontFace(_) => "CSSFontFaceRule",
+        CssRule::FontFeatureValues(_) => "CSSFontFeatureValuesRule",
+        CssRule::FontPaletteValues(_) => "CSSFontPaletteValuesRule",
+        CssRule::CounterStyle(_) => "CSSCounterStyleRule",
+        CssRule::Keyframes(_) => "CSSKeyframesRule",
+        CssRule::Margin(_) => "CSSMarginRule",
+        CssRule::Supports(_) => "CSSSupportsRule",
+        CssRule::Page(_) => "CSSPageRule",
+        CssRule::Property(_) => "CSSPropertyRule",
+        CssRule::Document(_) => "CSSMozDocumentRule",
+        CssRule::LayerBlock(_) => "CSSLayerBlockRule",
+        CssRule::LayerStatement(_) => "CSSLayerStatementRule",
+        CssRule::Scope(_) => "CSSScopeRule",
+        CssRule::StartingStyle(_) => "CSSStartingStyleRule",
+        CssRule::AppearanceBase(_) => "CSSAppearanceBaseRule",
+        CssRule::PositionTry(_) => "CSSPositionTryRule",
+        CssRule::NestedDeclarations(_) => "CSSNestedDeclarations",
+        CssRule::ViewTransition(_) => "CSSViewTransitionRule",
+    }
+}
+
+/// Join the CSS serializations of `items` with `", "`
+fn comma_separated<'a, T: ToCss + 'a>(items: impl IntoIterator<Item = &'a T>) -> String {
+    items
+        .into_iter()
+        .map(|item| item.to_css_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn rule_attributes(rule: &CssRule, guard: &SharedRwLockReadGuard) -> Vec<(&'static str, String)> {
+    match rule {
+        CssRule::Style(r) => {
+            vec![("selectorText", r.read_with(guard).selectors.to_css_string())]
+        }
+        CssRule::Namespace(r) => vec![
+            ("namespaceURI", r.url.to_string()),
+            (
+                "prefix",
+                r.prefix.as_ref().map(|p| p.to_string()).unwrap_or_default(),
+            ),
+        ],
+        CssRule::Import(r) => {
+            let r = r.read_with(guard);
+            vec![
+                ("href", r.url.as_str().to_string()),
+                (
+                    "media",
+                    r.stylesheet
+                        .media(guard)
+                        .map(|m| m.to_css_string())
+                        .unwrap_or_default(),
+                ),
+            ]
+        }
+        CssRule::Media(r) => {
+            let media = r.media_queries.read_with(guard).to_css_string();
+            vec![("conditionText", media.clone()), ("media", media)]
+        }
+        CssRule::Supports(r) => vec![("conditionText", r.condition.to_css_string())],
+        CssRule::Container(r) => vec![("conditionText", r.conditions.to_css_string())],
+        CssRule::Page(r) => vec![("selectorText", r.read_with(guard).selectors.to_css_string())],
+        CssRule::Keyframes(r) => vec![("name", r.read_with(guard).name.to_css_string())],
+        CssRule::LayerBlock(r) => vec![(
+            "name",
+            r.name
+                .as_ref()
+                .map(|n| n.to_css_string())
+                .unwrap_or_default(),
+        )],
+        CssRule::LayerStatement(r) => vec![("nameList", comma_separated(r.names.iter()))],
+        CssRule::Property(r) => {
+            let mut attrs = vec![("name", r.name.to_css_string())];
+            for (attr, id) in [
+                ("syntax", style::properties::property::DescriptorId::Syntax),
+                (
+                    "inherits",
+                    style::properties::property::DescriptorId::Inherits,
+                ),
+                (
+                    "initialValue",
+                    style::properties::property::DescriptorId::InitialValue,
+                ),
+            ] {
+                let mut css = CssStringWriter::new();
+                let _ = r.descriptors.get(id, &mut css);
+                attrs.push((attr, css));
+            }
+            attrs
+        }
+        CssRule::CounterStyle(r) => vec![("name", r.read_with(guard).name().to_css_string())],
+        CssRule::FontFeatureValues(r) => {
+            vec![("fontFamily", comma_separated(r.family_names.iter()))]
+        }
+        CssRule::FontPaletteValues(r) => vec![
+            ("name", r.name.to_css_string()),
+            ("fontFamily", comma_separated(r.family_names.iter())),
+            (
+                "basePalette",
+                r.base_palette
+                    .as_ref()
+                    .map(|b| b.to_css_string())
+                    .unwrap_or_default(),
+            ),
+            ("overrideColors", comma_separated(r.override_colors.iter())),
+        ],
+        CssRule::Margin(r) => vec![("name", format!("{:?}", r.rule_type))],
+        CssRule::PositionTry(r) => vec![("name", r.read_with(guard).name.to_css_string())],
+        _ => Vec::new(),
+    }
+}
+
+impl BaseDocument {
+    /// The owner nodes (`<style>` / `<link>` elements) of the document's author
+    /// stylesheets, in document order (`document.styleSheets`).
+    pub fn stylesheet_owner_nodes(&self) -> Vec<NodeId> {
+        let mut owners = Vec::new();
+        let mut stack = vec![self.root_node_id];
+        while let Some(node_id) = stack.pop() {
+            let Some(node) = self.nodes.get(node_id) else {
+                continue;
+            };
+            if self.nodes_to_stylesheet.contains_key(&node_id) {
+                owners.push(node_id);
+            }
+            stack.extend(node.children.iter().rev().copied());
+        }
+        owners
+    }
+
+    /// Whether `node_id` currently owns a stylesheet
+    pub fn node_has_stylesheet(&self, node_id: NodeId) -> bool {
+        self.nodes_to_stylesheet.contains_key(&node_id)
+    }
+
+    fn stylesheet_loader(&self) -> StylesheetLoader {
+        StylesheetLoader {
+            tx: self.tx.clone(),
+            doc_id: self.id(),
+            net_provider: self.net_provider.clone(),
+            shell_provider: self.shell_provider.clone(),
+            abort_signal: self.abort_signal.clone(),
+            import_depth: 0,
+        }
+    }
+
+    /// Resolve `path` to the rule it denotes, along with its ancestor rules
+    /// (outermost first).
+    fn resolve_rule(
+        sheet: &DocumentStyleSheet,
+        guard: &SharedRwLockReadGuard,
+        path: &[usize],
+    ) -> Option<(Vec<CssRule>, RuleHandle)> {
+        let (index, parent_path) = path.split_last()?;
+        let (ancestors, list) = Self::resolve_rule_list(sheet, guard, parent_path)?;
+        let handle = match list {
+            RuleList::Css(rules) => RuleHandle::Rule(rules.read_with(guard).0.get(*index)?.clone()),
+            RuleList::Keyframes(keyframes) => {
+                RuleHandle::Keyframe(keyframes.read_with(guard).keyframes.get(*index)?.clone())
+            }
+        };
+        Some((ancestors, handle))
+    }
+
+    /// Resolve `path` to the rule list owned by the rule it denotes (or the
+    /// stylesheet's top-level rule list for an empty path), along with the
+    /// ancestor rules of that list (outermost first, including the rule at
+    /// `path` itself).
+    fn resolve_rule_list(
+        sheet: &DocumentStyleSheet,
+        guard: &SharedRwLockReadGuard,
+        path: &[usize],
+    ) -> Option<(Vec<CssRule>, RuleList)> {
+        let mut ancestors = Vec::with_capacity(path.len());
+        let mut list = RuleList::Css(sheet.contents(guard).rules.clone());
+        for &index in path {
+            let RuleList::Css(rules) = &list else {
+                return None;
+            };
+            let rule = rules.read_with(guard).0.get(index)?.clone();
+            let child_list = child_rule_list(&rule, guard)?;
+            ancestors.push(rule);
+            list = child_list;
+        }
+        Some((ancestors, list))
+    }
+
+    /// The number of rules in the rule list at `path` (`CSSRuleList.length`)
+    pub fn stylesheet_rule_count(&self, node_id: NodeId, path: &[usize]) -> Option<usize> {
+        let sheet = self.nodes_to_stylesheet.get(&node_id)?;
+        let guard = self.guard.read();
+        let (_, list) = Self::resolve_rule_list(sheet, &guard, path)?;
+        Some(match list {
+            RuleList::Css(rules) => rules.read_with(&guard).0.len(),
+            RuleList::Keyframes(keyframes) => keyframes.read_with(&guard).keyframes.len(),
+        })
+    }
+
+    /// The CSSOM-visible attributes of the rule at `path`
+    pub fn stylesheet_rule_info(&self, node_id: NodeId, path: &[usize]) -> Option<CssRuleInfo> {
+        let sheet = self.nodes_to_stylesheet.get(&node_id)?;
+        let guard = self.guard.read();
+        let (_, handle) = Self::resolve_rule(sheet, &guard, path)?;
+        let mut css_text = CssStringWriter::new();
+        let has_style = declaration_target(&handle, &guard).is_some();
+        Some(match handle {
+            RuleHandle::Rule(rule) => {
+                let _ = rule.to_css(&guard, &mut css_text);
+                CssRuleInfo {
+                    interface: css_rule_interface(&rule),
+                    rule_type: rule.rule_type() as u16,
+                    css_text,
+                    has_child_rules: child_rule_list(&rule, &guard).is_some(),
+                    has_style,
+                    attributes: rule_attributes(&rule, &guard),
+                }
+            }
+            RuleHandle::Keyframe(keyframe) => {
+                let keyframe = keyframe.read_with(&guard);
+                let _ = keyframe.to_css(&guard, &mut css_text);
+                CssRuleInfo {
+                    interface: "CSSKeyframeRule",
+                    rule_type: CssRuleType::Keyframe as u16,
+                    css_text,
+                    has_child_rules: false,
+                    has_style,
+                    attributes: vec![("keyText", keyframe.selector.to_css_string())],
+                }
+            }
+        })
+    }
+
+    /// Insert a rule parsed from `rule` at `index` in the rule list at `path`
+    /// (`CSSStyleSheet.insertRule` / `CSSGroupingRule.insertRule` /
+    /// `CSSKeyframesRule.appendRule`). Returns the index of the inserted rule.
+    pub fn stylesheet_insert_rule(
+        &mut self,
+        node_id: NodeId,
+        path: &[usize],
+        rule: &str,
+        index: usize,
+    ) -> Result<usize, CssomError> {
+        let sheet = self
+            .nodes_to_stylesheet
+            .get(&node_id)
+            .ok_or(CssomError::NotFound)?
+            .clone();
+        let loader = self.stylesheet_loader();
+        let lock = &self.guard;
+
+        let (ancestors, list) = {
+            let guard = lock.read();
+            Self::resolve_rule_list(&sheet, &guard, path).ok_or(CssomError::NotFound)?
+        };
+
+        let (new_rule, index) = match &list {
+            RuleList::Css(rules) => {
+                let new_rule = {
+                    let guard = lock.read();
+                    let contents = sheet.contents(&guard);
+                    let containing_rule_types =
+                        ancestors
+                            .iter()
+                            .fold(CssRuleTypes::default(), |types, rule| {
+                                CssRuleTypes::from_bits(types.bits() | rule.rule_type().bit())
+                            });
+                    let parse_relative_rule_type = ancestors.last().map(|rule| rule.rule_type());
+                    rules.read_with(&guard).parse_rule_for_insert(
+                        lock,
+                        rule,
+                        contents,
+                        index,
+                        containing_rule_types,
+                        parse_relative_rule_type,
+                        Some(&loader),
+                        AllowImportRules::Yes,
+                    )?
+                };
+                {
+                    let mut guard = lock.write();
+                    rules
+                        .write_with(&mut guard)
+                        .0
+                        .insert(index, new_rule.clone());
+                }
+                (new_rule, index)
+            }
+            RuleList::Keyframes(keyframes) => {
+                let keyframe = {
+                    let guard = lock.read();
+                    let contents = sheet.contents(&guard);
+                    Keyframe::parse(rule, contents, lock).map_err(|_| CssomError::Syntax)?
+                };
+                let index = {
+                    let mut guard = lock.write();
+                    let keyframes = &mut keyframes.write_with(&mut guard).keyframes;
+                    keyframes.push(keyframe);
+                    keyframes.len() - 1
+                };
+                (CssRule::Keyframes(keyframes.clone()), index)
+            }
+        };
+
+        let guard = lock.read();
+        if let CssRule::FontFace(_) = &new_rule {
+            crate::net::fetch_font_face_rules(
+                std::iter::once(&new_rule),
+                self.tx.clone(),
+                self.id(),
+                Some(node_id),
+                &self.net_provider,
+                &self.shell_provider,
+                &guard,
+                self.abort_signal.as_ref(),
+            );
+        }
+        let (change_kind, ancestors) = match &list {
+            RuleList::Css(_) => (RuleChangeKind::Insertion, ancestors.as_slice()),
+            // The keyframes rule itself changed; its ancestors exclude it
+            RuleList::Keyframes(_) => (
+                RuleChangeKind::Generic,
+                &ancestors[..ancestors.len().saturating_sub(1)],
+            ),
+        };
+        let ancestor_refs: Vec<CssRuleRef> = ancestors.iter().map(CssRuleRef::from).collect();
+        self.stylist
+            .rule_changed(&sheet, &new_rule, &guard, change_kind, &ancestor_refs);
+        Ok(index)
+    }
+
+    /// Remove the rule at `index` from the rule list at `path`
+    /// (`CSSStyleSheet.deleteRule` / `CSSGroupingRule.deleteRule` /
+    /// `CSSKeyframesRule.deleteRule`).
+    pub fn stylesheet_delete_rule(
+        &mut self,
+        node_id: NodeId,
+        path: &[usize],
+        index: usize,
+    ) -> Result<(), CssomError> {
+        let sheet = self
+            .nodes_to_stylesheet
+            .get(&node_id)
+            .ok_or(CssomError::NotFound)?
+            .clone();
+        let lock = &self.guard;
+
+        let (ancestors, list) = {
+            let guard = lock.read();
+            Self::resolve_rule_list(&sheet, &guard, path).ok_or(CssomError::NotFound)?
+        };
+
+        let (removed_rule, change_kind, ancestors) = match &list {
+            RuleList::Css(rules) => {
+                let mut guard = lock.write();
+                let rules = rules.write_with(&mut guard);
+                let removed = rules.0.get(index).cloned().ok_or(CssomError::IndexSize)?;
+                rules.remove_rule(index)?;
+                (removed, RuleChangeKind::Removal, ancestors.as_slice())
+            }
+            RuleList::Keyframes(keyframes) => {
+                let mut guard = lock.write();
+                let list = &mut keyframes.write_with(&mut guard).keyframes;
+                if index >= list.len() {
+                    return Err(CssomError::IndexSize);
+                }
+                list.remove(index);
+                (
+                    CssRule::Keyframes(keyframes.clone()),
+                    RuleChangeKind::Generic,
+                    &ancestors[..ancestors.len().saturating_sub(1)],
+                )
+            }
+        };
+
+        let guard = lock.read();
+        let ancestor_refs: Vec<CssRuleRef> = ancestors.iter().map(CssRuleRef::from).collect();
+        self.stylist
+            .rule_changed(&sheet, &removed_rule, &guard, change_kind, &ancestor_refs);
+        Ok(())
+    }
+
+    fn rule_declaration_target(
+        &self,
+        node_id: NodeId,
+        path: &[usize],
+    ) -> Option<(DocumentStyleSheet, Vec<CssRule>, CssRule, DeclarationTarget)> {
+        let sheet = self.nodes_to_stylesheet.get(&node_id)?.clone();
+        let guard = self.guard.read();
+        let (ancestors, handle) = Self::resolve_rule(&sheet, &guard, path)?;
+        let target = declaration_target(&handle, &guard)?;
+        // For keyframes, the rule to report as changed is the owning
+        // `@keyframes` rule
+        let (changed_rule, ancestors) = match handle {
+            RuleHandle::Rule(rule) => (rule, ancestors),
+            RuleHandle::Keyframe(_) => {
+                let mut ancestors = ancestors;
+                let rule = ancestors.pop()?;
+                (rule, ancestors)
+            }
+        };
+        Some((sheet, ancestors, changed_rule, target))
+    }
+
+    /// The serialized declarations of the rule at `path` (`CSSRule.style.cssText`)
+    pub fn stylesheet_rule_style_css_text(
+        &self,
+        node_id: NodeId,
+        path: &[usize],
+    ) -> Option<String> {
+        let (_, _, _, target) = self.rule_declaration_target(node_id, path)?;
+        let guard = self.guard.read();
+        let mut css = CssStringWriter::new();
+        match target {
+            DeclarationTarget::Block { block, .. } => {
+                let _ = block.read_with(&guard).to_css(&mut css);
+            }
+            DeclarationTarget::FontFace(rule) => {
+                let _ = rule
+                    .read_with(&guard)
+                    .descriptors
+                    .to_css(&mut style_traits::CssWriter::new(&mut css));
+                // `Descriptors::to_css` emits a trailing space after each declaration
+                let trimmed = css.trim_end().len();
+                css.truncate(trimmed);
+            }
+        }
+        Some(css)
+    }
+
+    /// The names of the declarations of the rule at `path`, in order
+    /// (`CSSRule.style.length` / `.item()`)
+    pub fn stylesheet_rule_style_property_names(
+        &self,
+        node_id: NodeId,
+        path: &[usize],
+    ) -> Option<Vec<String>> {
+        let (_, _, _, target) = self.rule_declaration_target(node_id, path)?;
+        let guard = self.guard.read();
+        Some(match target {
+            DeclarationTarget::Block { block, .. } => block
+                .read_with(&guard)
+                .declarations()
+                .iter()
+                .map(|decl| decl.id().name().into_owned())
+                .collect(),
+            DeclarationTarget::FontFace(rule) => {
+                let descriptors = &rule.read_with(&guard).descriptors;
+                (0..descriptors.len())
+                    .filter_map(|i| descriptors.at(i))
+                    .map(|id| id.name().to_string())
+                    .collect()
+            }
+        })
+    }
+
+    /// The serialized value of `property` in the declarations of the rule at
+    /// `path`, and whether it is `!important`
+    /// (`CSSRule.style.getPropertyValue()` / `.getPropertyPriority()`).
+    /// Returns an empty string for unset or unknown properties.
+    pub fn stylesheet_rule_style_get_property(
+        &self,
+        node_id: NodeId,
+        path: &[usize],
+        property: &str,
+    ) -> Option<(String, bool)> {
+        let (_, _, _, target) = self.rule_declaration_target(node_id, path)?;
+        let guard = self.guard.read();
+        let mut css = CssStringWriter::new();
+        let important = match target {
+            DeclarationTarget::Block { block, .. } => {
+                let Ok(property_id) = PropertyId::parse_enabled_for_all_content(property) else {
+                    return Some((String::new(), false));
+                };
+                let block = block.read_with(&guard);
+                let _ = block.property_value_to_css(&property_id, &mut css);
+                block.property_priority(&property_id).important()
+            }
+            DeclarationTarget::FontFace(rule) => {
+                let Ok(id) = FontFaceDescriptorId::from_ident(property) else {
+                    return Some((String::new(), false));
+                };
+                let _ = rule.read_with(&guard).descriptors.get(id, &mut css);
+                false
+            }
+        };
+        Some((css, important))
+    }
+
+    /// Set `property` to `value` in the declarations of the rule at `path`
+    /// (`CSSRule.style.setProperty()`). Invalid declarations are ignored, per
+    /// CSSOM. An empty `value` removes the property.
+    pub fn stylesheet_rule_style_set_property(
+        &mut self,
+        node_id: NodeId,
+        path: &[usize],
+        property: &str,
+        value: &str,
+        important: bool,
+    ) -> Result<(), CssomError> {
+        if value.trim().is_empty() {
+            self.stylesheet_rule_style_remove_property(node_id, path, property)?;
+            return Ok(());
+        }
+        let (sheet, ancestors, rule, target) = self
+            .rule_declaration_target(node_id, path)
+            .ok_or(CssomError::NotFound)?;
+        let url_data = self.url.url_extra_data();
+        let lock = &self.guard;
+
+        let change_kind = match target {
+            DeclarationTarget::Block { block, rule_type } => {
+                let Ok(property_id) = PropertyId::parse_enabled_for_all_content(property) else {
+                    return Ok(());
+                };
+                let mut source = SourcePropertyDeclaration::default();
+                if parse_one_declaration_into(
+                    &mut source,
+                    property_id,
+                    value,
+                    Origin::Author,
+                    &url_data,
+                    None,
+                    ParsingMode::DEFAULT,
+                    QuirksMode::NoQuirks,
+                    rule_type,
+                )
+                .is_err()
+                {
+                    return Ok(());
+                }
+                let importance = if important {
+                    Importance::Important
+                } else {
+                    Importance::Normal
+                };
+                let mut guard = lock.write();
+                block
+                    .write_with(&mut guard)
+                    .extend(source.drain(), importance);
+                match rule_type {
+                    CssRuleType::PositionTry => RuleChangeKind::PositionTryDeclarations,
+                    _ => RuleChangeKind::StyleRuleDeclarations,
+                }
+            }
+            DeclarationTarget::FontFace(font_face) => {
+                let Ok(id) = FontFaceDescriptorId::from_ident(property) else {
+                    return Ok(());
+                };
+                let context = ParserContext::new(
+                    Origin::Author,
+                    &url_data,
+                    Some(CssRuleType::FontFace),
+                    ParsingMode::DEFAULT,
+                    QuirksMode::NoQuirks,
+                    Default::default(),
+                    None,
+                    None,
+                    Default::default(),
+                );
+                let mut input = ParserInput::new(value);
+                let mut parser = Parser::new(&mut input);
+                let mut guard = lock.write();
+                let descriptors = &mut font_face.write_with(&mut guard).descriptors;
+                if descriptors.set(id, &context, &mut parser).is_err() {
+                    return Ok(());
+                }
+                RuleChangeKind::Generic
+            }
+        };
+
+        let guard = lock.read();
+        let ancestor_refs: Vec<CssRuleRef> = ancestors.iter().map(CssRuleRef::from).collect();
+        self.stylist
+            .rule_changed(&sheet, &rule, &guard, change_kind, &ancestor_refs);
+        Ok(())
+    }
+
+    /// Remove `property` from the declarations of the rule at `path`
+    /// (`CSSRule.style.removeProperty()`). Returns the removed property's
+    /// previous serialized value.
+    pub fn stylesheet_rule_style_remove_property(
+        &mut self,
+        node_id: NodeId,
+        path: &[usize],
+        property: &str,
+    ) -> Result<String, CssomError> {
+        let (sheet, ancestors, rule, target) = self
+            .rule_declaration_target(node_id, path)
+            .ok_or(CssomError::NotFound)?;
+        let lock = &self.guard;
+        let mut removed_value = CssStringWriter::new();
+
+        let change_kind = match target {
+            DeclarationTarget::Block { block, rule_type } => {
+                let Ok(property_id) = PropertyId::parse_enabled_for_all_content(property) else {
+                    return Ok(removed_value);
+                };
+                let mut guard = lock.write();
+                let block = block.write_with(&mut guard);
+                let _ = block.property_value_to_css(&property_id, &mut removed_value);
+                let Some(first_declaration) = block.first_declaration_to_remove(&property_id)
+                else {
+                    return Ok(removed_value);
+                };
+                block.remove_property(&property_id, first_declaration);
+                match rule_type {
+                    CssRuleType::PositionTry => RuleChangeKind::PositionTryDeclarations,
+                    _ => RuleChangeKind::StyleRuleDeclarations,
+                }
+            }
+            DeclarationTarget::FontFace(font_face) => {
+                let Ok(id) = FontFaceDescriptorId::from_ident(property) else {
+                    return Ok(removed_value);
+                };
+                let mut guard = lock.write();
+                let descriptors = &mut font_face.write_with(&mut guard).descriptors;
+                let _ = descriptors.get(id, &mut removed_value);
+                if !descriptors.remove(id) {
+                    return Ok(removed_value);
+                }
+                RuleChangeKind::Generic
+            }
+        };
+
+        let guard = lock.read();
+        let ancestor_refs: Vec<CssRuleRef> = ancestors.iter().map(CssRuleRef::from).collect();
+        self.stylist
+            .rule_changed(&sheet, &rule, &guard, change_kind, &ancestor_refs);
+        Ok(removed_value)
+    }
+
+    /// Replace the declarations of the rule at `path` with those parsed from
+    /// `css` (`CSSRule.style.cssText` setter).
+    pub fn stylesheet_rule_style_set_css_text(
+        &mut self,
+        node_id: NodeId,
+        path: &[usize],
+        css: &str,
+    ) -> Result<(), CssomError> {
+        let (sheet, ancestors, rule, target) = self
+            .rule_declaration_target(node_id, path)
+            .ok_or(CssomError::NotFound)?;
+        let DeclarationTarget::Block { block, rule_type } = target else {
+            return Err(CssomError::NotSupported);
+        };
+        let new_block = style::properties::declaration_block::parse_style_attribute(
+            css,
+            &self.url.url_extra_data(),
+            None,
+            QuirksMode::NoQuirks,
+            rule_type,
+        );
+        let lock = &self.guard;
+        {
+            let mut guard = lock.write();
+            *block.write_with(&mut guard) = new_block;
+        }
+        let guard = lock.read();
+        let ancestor_refs: Vec<CssRuleRef> = ancestors.iter().map(CssRuleRef::from).collect();
+        let change_kind = match rule_type {
+            CssRuleType::PositionTry => RuleChangeKind::PositionTryDeclarations,
+            _ => RuleChangeKind::StyleRuleDeclarations,
+        };
+        self.stylist
+            .rule_changed(&sheet, &rule, &guard, change_kind, &ancestor_refs);
+        Ok(())
+    }
+}

--- a/packages/blitz-dom/src/cssom.rs
+++ b/packages/blitz-dom/src/cssom.rs
@@ -187,11 +187,14 @@ fn css_rule_interface(rule: &CssRule) -> &'static str {
 
 /// Join the CSS serializations of `items` with `", "`
 fn comma_separated<'a, T: ToCss + 'a>(items: impl IntoIterator<Item = &'a T>) -> String {
-    items
-        .into_iter()
-        .map(|item| item.to_css_string())
-        .collect::<Vec<_>>()
-        .join(", ")
+    let mut css = CssStringWriter::new();
+    for (i, item) in items.into_iter().enumerate() {
+        if i > 0 {
+            css.push_str(", ");
+        }
+        let _ = item.to_css(&mut style_traits::CssWriter::new(&mut css));
+    }
+    css
 }
 
 fn rule_attributes(rule: &CssRule, guard: &SharedRwLockReadGuard) -> Vec<(&'static str, String)> {
@@ -219,10 +222,10 @@ fn rule_attributes(rule: &CssRule, guard: &SharedRwLockReadGuard) -> Vec<(&'stat
                 ),
             ]
         }
-        CssRule::Media(r) => {
-            let media = r.media_queries.read_with(guard).to_css_string();
-            vec![("conditionText", media.clone()), ("media", media)]
-        }
+        CssRule::Media(r) => vec![(
+            "conditionText",
+            r.media_queries.read_with(guard).to_css_string(),
+        )],
         CssRule::Supports(r) => vec![("conditionText", r.condition.to_css_string())],
         CssRule::Container(r) => vec![("conditionText", r.conditions.to_css_string())],
         CssRule::Page(r) => vec![("selectorText", r.read_with(guard).selectors.to_css_string())],
@@ -299,6 +302,13 @@ impl BaseDocument {
         self.nodes_to_stylesheet.contains_key(&node_id)
     }
 
+    /// A counter which changes whenever the set of stylesheets (or the
+    /// stylesheet object owned by some node) changes. CSSOM wrappers use it to
+    /// detect that rule data cached on the script side is stale.
+    pub fn stylesheet_generation(&self) -> u64 {
+        self.stylesheet_generation
+    }
+
     fn stylesheet_loader(&self) -> StylesheetLoader {
         StylesheetLoader {
             tx: self.tx.clone(),
@@ -310,44 +320,57 @@ impl BaseDocument {
         }
     }
 
-    /// Resolve `path` to the rule it denotes, along with its ancestor rules
-    /// (outermost first).
+    /// Resolve `path` to the rule it denotes. The rule's ancestors (outermost
+    /// first) are passed to `on_ancestor` as they are traversed.
     fn resolve_rule(
         sheet: &DocumentStyleSheet,
         guard: &SharedRwLockReadGuard,
         path: &[usize],
-    ) -> Option<(Vec<CssRule>, RuleHandle)> {
+        on_ancestor: impl FnMut(&CssRule),
+    ) -> Option<RuleHandle> {
         let (index, parent_path) = path.split_last()?;
-        let (ancestors, list) = Self::resolve_rule_list(sheet, guard, parent_path)?;
-        let handle = match list {
+        let list = Self::resolve_rule_list(sheet, guard, parent_path, on_ancestor)?;
+        Some(match list {
             RuleList::Css(rules) => RuleHandle::Rule(rules.read_with(guard).0.get(*index)?.clone()),
             RuleList::Keyframes(keyframes) => {
                 RuleHandle::Keyframe(keyframes.read_with(guard).keyframes.get(*index)?.clone())
             }
-        };
-        Some((ancestors, handle))
+        })
     }
 
     /// Resolve `path` to the rule list owned by the rule it denotes (or the
-    /// stylesheet's top-level rule list for an empty path), along with the
-    /// ancestor rules of that list (outermost first, including the rule at
-    /// `path` itself).
+    /// stylesheet's top-level rule list for an empty path). The ancestor rules
+    /// of that list (outermost first, including the rule at `path` itself) are
+    /// passed to `on_ancestor` as they are traversed.
     fn resolve_rule_list(
         sheet: &DocumentStyleSheet,
         guard: &SharedRwLockReadGuard,
         path: &[usize],
-    ) -> Option<(Vec<CssRule>, RuleList)> {
-        let mut ancestors = Vec::with_capacity(path.len());
+        mut on_ancestor: impl FnMut(&CssRule),
+    ) -> Option<RuleList> {
         let mut list = RuleList::Css(sheet.contents(guard).rules.clone());
         for &index in path {
             let RuleList::Css(rules) = &list else {
                 return None;
             };
-            let rule = rules.read_with(guard).0.get(index)?.clone();
-            let child_list = child_rule_list(&rule, guard)?;
-            ancestors.push(rule);
+            let rules = rules.read_with(guard);
+            let rule = rules.0.get(index)?;
+            let child_list = child_rule_list(rule, guard)?;
+            on_ancestor(rule);
             list = child_list;
         }
+        Some(list)
+    }
+
+    /// [`Self::resolve_rule_list`], also collecting the ancestor rules
+    fn resolve_rule_list_with_ancestors(
+        sheet: &DocumentStyleSheet,
+        guard: &SharedRwLockReadGuard,
+        path: &[usize],
+    ) -> Option<(Vec<CssRule>, RuleList)> {
+        let mut ancestors = Vec::with_capacity(path.len());
+        let list =
+            Self::resolve_rule_list(sheet, guard, path, |rule| ancestors.push(rule.clone()))?;
         Some((ancestors, list))
     }
 
@@ -355,7 +378,7 @@ impl BaseDocument {
     pub fn stylesheet_rule_count(&self, node_id: NodeId, path: &[usize]) -> Option<usize> {
         let sheet = self.nodes_to_stylesheet.get(&node_id)?;
         let guard = self.guard.read();
-        let (_, list) = Self::resolve_rule_list(sheet, &guard, path)?;
+        let list = Self::resolve_rule_list(sheet, &guard, path, |_| {})?;
         Some(match list {
             RuleList::Css(rules) => rules.read_with(&guard).0.len(),
             RuleList::Keyframes(keyframes) => keyframes.read_with(&guard).keyframes.len(),
@@ -366,7 +389,7 @@ impl BaseDocument {
     pub fn stylesheet_rule_info(&self, node_id: NodeId, path: &[usize]) -> Option<CssRuleInfo> {
         let sheet = self.nodes_to_stylesheet.get(&node_id)?;
         let guard = self.guard.read();
-        let (_, handle) = Self::resolve_rule(sheet, &guard, path)?;
+        let handle = Self::resolve_rule(sheet, &guard, path, |_| {})?;
         let mut css_text = CssStringWriter::new();
         let has_style = declaration_target(&handle, &guard).is_some();
         Some(match handle {
@@ -416,7 +439,8 @@ impl BaseDocument {
 
         let (ancestors, list) = {
             let guard = lock.read();
-            Self::resolve_rule_list(&sheet, &guard, path).ok_or(CssomError::NotFound)?
+            Self::resolve_rule_list_with_ancestors(&sheet, &guard, path)
+                .ok_or(CssomError::NotFound)?
         };
 
         let (new_rule, index) = match &list {
@@ -512,7 +536,8 @@ impl BaseDocument {
 
         let (ancestors, list) = {
             let guard = lock.read();
-            Self::resolve_rule_list(&sheet, &guard, path).ok_or(CssomError::NotFound)?
+            Self::resolve_rule_list_with_ancestors(&sheet, &guard, path)
+                .ok_or(CssomError::NotFound)?
         };
 
         let (removed_rule, change_kind, ancestors) = match &list {
@@ -545,14 +570,30 @@ impl BaseDocument {
         Ok(())
     }
 
+    /// The declarations of the rule at `path`, for read-only access
     fn rule_declaration_target(
+        &self,
+        node_id: NodeId,
+        path: &[usize],
+        guard: &SharedRwLockReadGuard,
+    ) -> Option<DeclarationTarget> {
+        let sheet = self.nodes_to_stylesheet.get(&node_id)?;
+        let handle = Self::resolve_rule(sheet, guard, path, |_| {})?;
+        declaration_target(&handle, guard)
+    }
+
+    /// The declarations of the rule at `path`, along with what is needed to
+    /// notify the stylist after mutating them: the stylesheet, the rule to
+    /// report as changed and its ancestors.
+    fn rule_declaration_target_mut(
         &self,
         node_id: NodeId,
         path: &[usize],
     ) -> Option<(DocumentStyleSheet, Vec<CssRule>, CssRule, DeclarationTarget)> {
         let sheet = self.nodes_to_stylesheet.get(&node_id)?.clone();
         let guard = self.guard.read();
-        let (ancestors, handle) = Self::resolve_rule(&sheet, &guard, path)?;
+        let mut ancestors = Vec::with_capacity(path.len());
+        let handle = Self::resolve_rule(&sheet, &guard, path, |rule| ancestors.push(rule.clone()))?;
         let target = declaration_target(&handle, &guard)?;
         // For keyframes, the rule to report as changed is the owning
         // `@keyframes` rule
@@ -573,8 +614,8 @@ impl BaseDocument {
         node_id: NodeId,
         path: &[usize],
     ) -> Option<String> {
-        let (_, _, _, target) = self.rule_declaration_target(node_id, path)?;
         let guard = self.guard.read();
+        let target = self.rule_declaration_target(node_id, path, &guard)?;
         let mut css = CssStringWriter::new();
         match target {
             DeclarationTarget::Block { block, .. } => {
@@ -600,8 +641,8 @@ impl BaseDocument {
         node_id: NodeId,
         path: &[usize],
     ) -> Option<Vec<String>> {
-        let (_, _, _, target) = self.rule_declaration_target(node_id, path)?;
         let guard = self.guard.read();
+        let target = self.rule_declaration_target(node_id, path, &guard)?;
         Some(match target {
             DeclarationTarget::Block { block, .. } => block
                 .read_with(&guard)
@@ -629,8 +670,8 @@ impl BaseDocument {
         path: &[usize],
         property: &str,
     ) -> Option<(String, bool)> {
-        let (_, _, _, target) = self.rule_declaration_target(node_id, path)?;
         let guard = self.guard.read();
+        let target = self.rule_declaration_target(node_id, path, &guard)?;
         let mut css = CssStringWriter::new();
         let important = match target {
             DeclarationTarget::Block { block, .. } => {
@@ -668,7 +709,7 @@ impl BaseDocument {
             return Ok(());
         }
         let (sheet, ancestors, rule, target) = self
-            .rule_declaration_target(node_id, path)
+            .rule_declaration_target_mut(node_id, path)
             .ok_or(CssomError::NotFound)?;
         let url_data = self.url.url_extra_data();
         let lock = &self.guard;
@@ -751,7 +792,7 @@ impl BaseDocument {
         property: &str,
     ) -> Result<String, CssomError> {
         let (sheet, ancestors, rule, target) = self
-            .rule_declaration_target(node_id, path)
+            .rule_declaration_target_mut(node_id, path)
             .ok_or(CssomError::NotFound)?;
         let lock = &self.guard;
         let mut removed_value = CssStringWriter::new();
@@ -804,7 +845,7 @@ impl BaseDocument {
         css: &str,
     ) -> Result<(), CssomError> {
         let (sheet, ancestors, rule, target) = self
-            .rule_declaration_target(node_id, path)
+            .rule_declaration_target_mut(node_id, path)
             .ok_or(CssomError::NotFound)?;
         let DeclarationTarget::Block { block, rule_type } = target else {
             return Err(CssomError::NotSupported);

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -300,6 +300,10 @@ pub struct BaseDocument {
     pub(crate) nodes_to_id: HashMap<String, SmallVec<[NodeId; 1]>>,
     /// Map of `<style>` and `<link>` node IDs to their associated stylesheet
     pub(crate) nodes_to_stylesheet: BTreeMap<NodeId, DocumentStyleSheet>,
+    /// Incremented whenever `nodes_to_stylesheet` changes (a stylesheet is
+    /// added, replaced or removed), so that CSSOM wrappers can detect that
+    /// their cached rule data is stale.
+    pub(crate) stylesheet_generation: u64,
     /// Stylesheets added by the useragent
     /// where the key is the hashed CSS
     pub(crate) ua_stylesheets: HashMap<String, DocumentStyleSheet>,
@@ -448,6 +452,7 @@ impl BaseDocument {
             url: base_url,
             ua_stylesheets: HashMap::new(),
             nodes_to_stylesheet: BTreeMap::new(),
+            stylesheet_generation: 0,
             font_ctx,
             #[cfg(feature = "parallel-construct")]
             thread_font_contexts: ThreadLocal::new(),
@@ -1175,6 +1180,7 @@ impl BaseDocument {
 
     pub fn add_stylesheet_for_node(&mut self, stylesheet: DocumentStyleSheet, node_id: NodeId) {
         let old = self.nodes_to_stylesheet.insert(node_id, stylesheet.clone());
+        self.stylesheet_generation += 1;
 
         if let Some(old) = old {
             self.stylist.remove_stylesheet(old, &self.guard.read())

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -40,6 +40,8 @@ mod document;
 pub mod node;
 
 mod config;
+/// CSSOM stylesheet access (`document.styleSheets`, `CSSStyleSheet`, `CSSRule`)
+mod cssom;
 mod debug;
 mod events;
 mod font_metrics;
@@ -69,6 +71,7 @@ mod tree;
 
 mod url;
 
+pub use cssom::{CssRuleInfo, CssomError};
 pub use resolved_style::css_property_is_supported;
 pub use stylo_to_kurbo::resolve_2d_transform;
 

--- a/packages/blitz-dom/src/mutator.rs
+++ b/packages/blitz-dom/src/mutator.rs
@@ -1131,6 +1131,7 @@ impl<'doc> DocumentMutator<'doc> {
             .force_stylesheet_origins_dirty(OriginSet::all());
 
         self.doc.nodes_to_stylesheet.remove(&node_id);
+        self.doc.stylesheet_generation += 1;
     }
 
     fn load_image(&mut self, target_id: NodeId) {

--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -376,6 +376,7 @@ impl FontFaceHandler {
     }
 }
 
+/// Fetch the fonts of all `@font-face` rules in `sheet`
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn fetch_font_face(
     tx: Sender<DocumentEvent>,
@@ -387,10 +388,31 @@ pub(crate) fn fetch_font_face(
     read_guard: &SharedRwLockReadGuard,
     abort_signal: Option<&AbortSignal>,
 ) {
-    sheet
-        .contents(read_guard)
-        .rules(read_guard)
-        .iter()
+    fetch_font_face_rules(
+        sheet.contents(read_guard).rules(read_guard).iter(),
+        tx,
+        doc_id,
+        node_id,
+        network_provider,
+        shell_provider,
+        read_guard,
+        abort_signal,
+    )
+}
+
+/// Fetch the fonts of the `@font-face` rules among `rules`
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn fetch_font_face_rules<'a>(
+    rules: impl Iterator<Item = &'a CssRule>,
+    tx: Sender<DocumentEvent>,
+    doc_id: usize,
+    node_id: Option<NodeId>,
+    network_provider: &Arc<dyn NetProvider>,
+    shell_provider: &Arc<dyn ShellProvider>,
+    read_guard: &SharedRwLockReadGuard,
+    abort_signal: Option<&AbortSignal>,
+) {
+    rules
         .filter_map(|rule| match rule {
             CssRule::FontFace(font_face) => {
                 let descriptor = &font_face.read_with(read_guard).descriptors;

--- a/packages/blitz-vibey-script/src/dom/document.rs
+++ b/packages/blitz-vibey-script/src/dom/document.rs
@@ -11,6 +11,13 @@ use super::{
     this_node_id, to_rust_string,
 };
 
+/// `document.styleSheets`: the `StyleSheetList` (built by the JS bootstrap)
+/// of the document's author stylesheets
+fn style_sheets(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    this_node_id(this)?;
+    super::call_js_helper("__blitz_style_sheets", &[], context)
+}
+
 pub(crate) fn init_document_proto(proto: &JsObject, context: &mut Context) {
     define_accessor(
         proto,
@@ -32,6 +39,7 @@ pub(crate) fn init_document_proto(proto: &JsObject, context: &mut Context) {
     define_accessor(proto, "defaultView", Some(default_view), None, context);
     define_accessor(proto, "title", Some(title), None, context);
     define_accessor(proto, "readyState", Some(ready_state), None, context);
+    define_accessor(proto, "styleSheets", Some(style_sheets), None, context);
     define_accessor(
         proto,
         "childElementCount",

--- a/packages/blitz-vibey-script/src/dom/element.rs
+++ b/packages/blitz-vibey-script/src/dom/element.rs
@@ -78,6 +78,7 @@ pub(crate) fn init_element_proto(proto: &JsObject, context: &mut Context) {
         context,
     );
     define_accessor(proto, "style", Some(get_style), None, context);
+    define_accessor(proto, "sheet", Some(get_sheet), None, context);
     define_accessor(
         proto,
         "innerHTML",
@@ -815,6 +816,22 @@ fn get_style(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<J
     let proto = ctx.state.borrow().protos().style.clone();
     let obj = JsObject::from_proto_and_data(Some(proto), super::NodeRef { node_id });
     Ok(super::wrap_style_object(obj, context))
+}
+
+/// `HTMLStyleElement.sheet` / `HTMLLinkElement.sheet`: the `CSSStyleSheet`
+/// object (built by the JS bootstrap) for the element's stylesheet, or `null`
+fn get_sheet(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    this_node_id(this)?;
+    let sheet = super::call_js_helper(
+        "__blitz_sheet_for_node",
+        std::slice::from_ref(this),
+        context,
+    )?;
+    Ok(if sheet.is_undefined() {
+        JsValue::null()
+    } else {
+        sheet
+    })
 }
 
 // === innerHTML / outerHTML ===

--- a/packages/blitz-vibey-script/src/dom/mod.rs
+++ b/packages/blitz-vibey-script/src/dom/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod element;
 pub(crate) mod event;
 pub(crate) mod node;
 pub(crate) mod style;
+pub(crate) mod stylesheet;
 
 use blitz_dom::node::NodeData;
 use blitz_dom::{LocalName, Namespace, NodeId, QualName};
@@ -207,7 +208,7 @@ pub(crate) fn to_rust_string(value: &JsValue, context: &mut Context) -> JsResult
     Ok(value.to_string(context)?.to_std_string_lossy())
 }
 
-type NativeFnPtr = fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue>;
+pub(crate) type NativeFnPtr = fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue>;
 
 /// Define a method on a prototype object
 pub(crate) fn define_method(
@@ -439,6 +440,20 @@ pub(crate) fn dom_exception(
     JsNativeError::typ()
         .with_message(format!("{name}: {message}"))
         .into()
+}
+
+/// Call a global JS helper function (defined by the runtime bootstrap script)
+/// with `this` set to `undefined`. Returns `undefined` if the helper is missing.
+pub(crate) fn call_js_helper(
+    name: &str,
+    args: &[JsValue],
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let helper = context.global_object().get(JsString::from(name), context)?;
+    match helper.as_object().filter(|obj| obj.is_callable()) {
+        Some(helper) => helper.call(&JsValue::undefined(), args, context),
+        None => Ok(JsValue::undefined()),
+    }
 }
 
 /// Wrap a native `CSSStyleDeclaration` object in the JS `Proxy` (defined by the

--- a/packages/blitz-vibey-script/src/dom/stylesheet.rs
+++ b/packages/blitz-vibey-script/src/dom/stylesheet.rs
@@ -92,7 +92,7 @@ fn cssom_error(err: CssomError, context: &mut Context, what: &str) -> boa_engine
 
 fn owner_nodes(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let ctx = dom_ctx(context)?;
-    let owners = ctx.doc.borrow().stylesheet_owner_nodes();
+    let owners: Vec<NodeId> = ctx.doc.borrow().stylesheet_owner_nodes().collect();
     let wrappers: Vec<JsValue> = owners
         .into_iter()
         .map(|node_id| node_wrapper(&ctx, node_id, context).into())

--- a/packages/blitz-vibey-script/src/dom/stylesheet.rs
+++ b/packages/blitz-vibey-script/src/dom/stylesheet.rs
@@ -19,6 +19,7 @@ pub(crate) fn register(context: &mut Context) {
     let fns: &[(&str, usize, super::NativeFnPtr)] = &[
         ("__blitz_stylesheet_owner_nodes", 0, owner_nodes),
         ("__blitz_node_has_stylesheet", 1, node_has_stylesheet),
+        ("__blitz_stylesheet_generation", 0, stylesheet_generation),
         ("__blitz_sheet_rule_count", 2, rule_count),
         ("__blitz_sheet_rule_info", 2, rule_info),
         ("__blitz_sheet_insert_rule", 4, insert_rule),
@@ -105,6 +106,12 @@ fn node_has_stylesheet(_: &JsValue, args: &[JsValue], context: &mut Context) -> 
         return Ok(JsValue::from(false));
     };
     Ok(JsValue::from(ctx.doc.borrow().node_has_stylesheet(node_id)))
+}
+
+fn stylesheet_generation(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let generation = ctx.doc.borrow().stylesheet_generation();
+    Ok(JsValue::from(generation as f64))
 }
 
 fn rule_count(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {

--- a/packages/blitz-vibey-script/src/dom/stylesheet.rs
+++ b/packages/blitz-vibey-script/src/dom/stylesheet.rs
@@ -1,0 +1,290 @@
+//! Native helpers backing the CSSOM stylesheet API (`document.styleSheets`,
+//! `CSSStyleSheet`, `CSSRuleList`, `CSSRule`, ...).
+//!
+//! The JS-facing objects are built in the runtime bootstrap script on top of
+//! these `__blitz_sheet_*` functions. Stylesheets are identified by their
+//! owner node (`<style>` / `<link>`) and rules by a path of indices through
+//! nested rule lists (see `blitz_dom`'s CSSOM support).
+
+use blitz_dom::{CssRuleInfo, CssomError, NodeId};
+use boa_engine::object::ObjectInitializer;
+use boa_engine::object::builtins::JsArray;
+use boa_engine::property::Attribute;
+use boa_engine::value::JsValue;
+use boa_engine::{Context, JsNativeError, JsResult, JsString, js_string};
+
+use super::{dom_ctx, dom_exception, js_str, node_id_of_value, node_wrapper, to_rust_string};
+
+pub(crate) fn register(context: &mut Context) {
+    let fns: &[(&str, usize, super::NativeFnPtr)] = &[
+        ("__blitz_stylesheet_owner_nodes", 0, owner_nodes),
+        ("__blitz_node_has_stylesheet", 1, node_has_stylesheet),
+        ("__blitz_sheet_rule_count", 2, rule_count),
+        ("__blitz_sheet_rule_info", 2, rule_info),
+        ("__blitz_sheet_insert_rule", 4, insert_rule),
+        ("__blitz_sheet_delete_rule", 3, delete_rule),
+        ("__blitz_sheet_style_css_text", 2, style_css_text),
+        ("__blitz_sheet_style_set_css_text", 3, style_set_css_text),
+        (
+            "__blitz_sheet_style_property_names",
+            2,
+            style_property_names,
+        ),
+        ("__blitz_sheet_style_get", 3, style_get_property),
+        ("__blitz_sheet_style_set", 5, style_set_property),
+        ("__blitz_sheet_style_remove", 3, style_remove_property),
+    ];
+    for (name, length, body) in fns {
+        context
+            .register_global_callable(
+                JsString::from(*name),
+                *length,
+                boa_engine::NativeFunction::from_fn_ptr(*body),
+            )
+            .expect("failed to register CSSOM function");
+    }
+}
+
+fn arg(args: &[JsValue], index: usize) -> JsValue {
+    args.get(index).cloned().unwrap_or_default()
+}
+
+fn node_arg(args: &[JsValue], index: usize) -> JsResult<NodeId> {
+    node_id_of_value(&arg(args, index)).ok_or_else(|| {
+        JsNativeError::typ()
+            .with_message("expected a DOM node")
+            .into()
+    })
+}
+
+/// Read a rule path (a JS array of indices) argument
+fn path_arg(args: &[JsValue], index: usize, context: &mut Context) -> JsResult<Vec<usize>> {
+    let value = arg(args, index);
+    let Some(obj) = value.as_object() else {
+        return Ok(Vec::new());
+    };
+    let array = JsArray::from_object(obj)?;
+    let len = array.length(context)?;
+    let mut path = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        let n = array.get(i, context)?.to_number(context)?;
+        path.push(n.max(0.0) as usize);
+    }
+    Ok(path)
+}
+
+fn index_arg(args: &[JsValue], index: usize, context: &mut Context) -> JsResult<usize> {
+    let n = arg(args, index).to_number(context)?;
+    if n.is_nan() {
+        return Ok(0);
+    }
+    Ok(n.max(0.0) as usize)
+}
+
+fn string_arg(args: &[JsValue], index: usize, context: &mut Context) -> JsResult<String> {
+    to_rust_string(&arg(args, index), context)
+}
+
+fn cssom_error(err: CssomError, context: &mut Context, what: &str) -> boa_engine::JsError {
+    dom_exception(context, err.dom_exception_name(), what)
+}
+
+fn owner_nodes(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let owners = ctx.doc.borrow().stylesheet_owner_nodes();
+    let wrappers: Vec<JsValue> = owners
+        .into_iter()
+        .map(|node_id| node_wrapper(&ctx, node_id, context).into())
+        .collect();
+    Ok(JsArray::from_iter(wrappers, context).into())
+}
+
+fn node_has_stylesheet(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let Some(node_id) = node_id_of_value(&arg(args, 0)) else {
+        return Ok(JsValue::from(false));
+    };
+    Ok(JsValue::from(ctx.doc.borrow().node_has_stylesheet(node_id)))
+}
+
+fn rule_count(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let count = ctx.doc.borrow().stylesheet_rule_count(node_id, &path);
+    Ok(match count {
+        Some(count) => JsValue::from(count as f64),
+        None => JsValue::from(-1),
+    })
+}
+
+fn rule_info_object(info: CssRuleInfo, context: &mut Context) -> JsValue {
+    let mut attrs = ObjectInitializer::new(context);
+    for (name, value) in &info.attributes {
+        attrs.property(JsString::from(*name), js_str(value), Attribute::all());
+    }
+    let attrs = attrs.build();
+    ObjectInitializer::new(context)
+        .property(
+            js_string!("interface"),
+            js_str(info.interface),
+            Attribute::all(),
+        )
+        .property(
+            js_string!("type"),
+            JsValue::from(info.rule_type),
+            Attribute::all(),
+        )
+        .property(
+            js_string!("cssText"),
+            js_str(&info.css_text),
+            Attribute::all(),
+        )
+        .property(
+            js_string!("hasChildRules"),
+            JsValue::from(info.has_child_rules),
+            Attribute::all(),
+        )
+        .property(
+            js_string!("hasStyle"),
+            JsValue::from(info.has_style),
+            Attribute::all(),
+        )
+        .property(js_string!("attrs"), attrs, Attribute::all())
+        .build()
+        .into()
+}
+
+fn rule_info(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let info = ctx.doc.borrow().stylesheet_rule_info(node_id, &path);
+    Ok(match info {
+        Some(info) => rule_info_object(info, context),
+        None => JsValue::null(),
+    })
+}
+
+fn insert_rule(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let rule = string_arg(args, 2, context)?;
+    let index = index_arg(args, 3, context)?;
+    let result = ctx
+        .doc
+        .borrow_mut()
+        .stylesheet_insert_rule(node_id, &path, &rule, index);
+    match result {
+        Ok(index) => Ok(JsValue::from(index as f64)),
+        Err(err) => Err(cssom_error(
+            err,
+            context,
+            &format!("Failed to insert rule '{rule}'"),
+        )),
+    }
+}
+
+fn delete_rule(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let index = index_arg(args, 2, context)?;
+    let result = ctx
+        .doc
+        .borrow_mut()
+        .stylesheet_delete_rule(node_id, &path, index);
+    match result {
+        Ok(()) => Ok(JsValue::undefined()),
+        Err(err) => Err(cssom_error(
+            err,
+            context,
+            &format!("Failed to delete rule at index {index}"),
+        )),
+    }
+}
+
+fn style_css_text(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let css = ctx
+        .doc
+        .borrow()
+        .stylesheet_rule_style_css_text(node_id, &path)
+        .unwrap_or_default();
+    Ok(js_str(&css))
+}
+
+fn style_set_css_text(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let css = string_arg(args, 2, context)?;
+    // Errors (e.g. a rule whose declarations cannot be replaced) are ignored:
+    // `cssText` assignment never throws per CSSOM
+    let _ = ctx
+        .doc
+        .borrow_mut()
+        .stylesheet_rule_style_set_css_text(node_id, &path, &css);
+    Ok(JsValue::undefined())
+}
+
+fn style_property_names(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let names = ctx
+        .doc
+        .borrow()
+        .stylesheet_rule_style_property_names(node_id, &path)
+        .unwrap_or_default();
+    let values: Vec<JsValue> = names.iter().map(|name| js_str(name)).collect();
+    Ok(JsArray::from_iter(values, context).into())
+}
+
+fn style_get_property(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let property = string_arg(args, 2, context)?;
+    let (value, important) = ctx
+        .doc
+        .borrow()
+        .stylesheet_rule_style_get_property(node_id, &path, &property)
+        .unwrap_or_default();
+    Ok(JsArray::from_iter([js_str(&value), JsValue::from(important)], context).into())
+}
+
+fn style_set_property(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let property = string_arg(args, 2, context)?;
+    let value = string_arg(args, 3, context)?;
+    let important = arg(args, 4).to_boolean();
+    // Invalid declarations are ignored per CSSOM; a missing rule is a no-op
+    let _ = ctx
+        .doc
+        .borrow_mut()
+        .stylesheet_rule_style_set_property(node_id, &path, &property, &value, important);
+    Ok(JsValue::undefined())
+}
+
+fn style_remove_property(
+    _: &JsValue,
+    args: &[JsValue],
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let property = string_arg(args, 2, context)?;
+    let removed = ctx
+        .doc
+        .borrow_mut()
+        .stylesheet_rule_style_remove_property(node_id, &path, &property)
+        .unwrap_or_default();
+    Ok(js_str(&removed))
+}

--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -360,6 +360,499 @@ const BOOTSTRAP_JS: &str = r#"
         };
     }
 
+    // CSSOM stylesheet API (`document.styleSheets`, `element.sheet`,
+    // `CSSStyleSheet`, `CSSRuleList`, `CSSRule` subclasses), backed by the
+    // `__blitz_sheet_*` natives. Stylesheets are keyed by their owner node and
+    // rules by a path of indices through nested rule lists.
+    {
+        const illegal = () => {
+            throw new TypeError("Illegal constructor");
+        };
+        // Internal (constructor-bypassing) construction flag
+        let constructing = false;
+        const construct = (cls, init) => {
+            constructing = true;
+            try {
+                const obj = new cls();
+                init(obj);
+                return obj;
+            } finally {
+                constructing = false;
+            }
+        };
+        const internals = new WeakMap();
+        const data = (obj) => {
+            const d = internals.get(obj);
+            if (!d) throw new TypeError("Illegal invocation");
+            return d;
+        };
+
+        // Array-like list objects (`StyleSheetList`, `CSSRuleList`, `MediaList`)
+        // support indexed access via a Proxy
+        const indexedProxy = (target) =>
+            new Proxy(target, {
+                // Getters and methods run against the target (not the proxy):
+                // their internal data is keyed by the target object
+                get(t, prop) {
+                    if (typeof prop === "string" && /^\d+$/.test(prop)) {
+                        const item = t.item(Number(prop));
+                        return item === null ? undefined : item;
+                    }
+                    const value = Reflect.get(t, prop, t);
+                    return typeof value === "function" ? value.bind(t) : value;
+                },
+                set(t, prop, value) {
+                    return Reflect.set(t, prop, value, t);
+                },
+                has(t, prop) {
+                    if (typeof prop === "string" && /^\d+$/.test(prop)) {
+                        return Number(prop) < t.length;
+                    }
+                    return Reflect.has(t, prop);
+                },
+                ownKeys(t) {
+                    const keys = [];
+                    for (let i = 0; i < t.length; i++) keys.push(String(i));
+                    return keys.concat(Reflect.ownKeys(t));
+                },
+                getOwnPropertyDescriptor(t, prop) {
+                    if (typeof prop === "string" && /^\d+$/.test(prop) && Number(prop) < t.length) {
+                        return { value: t.item(Number(prop)), enumerable: true, configurable: true, writable: false };
+                    }
+                    return Reflect.getOwnPropertyDescriptor(t, prop);
+                },
+            });
+        const defineIterable = (proto) => {
+            proto[Symbol.iterator] = function* () {
+                for (let i = 0; i < this.length; i++) yield this.item(i);
+            };
+            proto.forEach = function (callback, thisArg) {
+                for (let i = 0; i < this.length; i++) callback.call(thisArg, this.item(i), i, this);
+            };
+        };
+
+        class MediaList {
+            constructor() {
+                if (!constructing) illegal();
+            }
+            get mediaText() {
+                return data(this).text;
+            }
+            get length() {
+                return this.mediaText === "" ? 0 : this.mediaText.split(",").length;
+            }
+            item(index) {
+                if (this.mediaText === "") return null;
+                return this.mediaText.split(",").map((s) => s.trim())[index] ?? null;
+            }
+            toString() {
+                return this.mediaText;
+            }
+        }
+        defineIterable(MediaList.prototype);
+        const makeMediaList = (text) =>
+            indexedProxy(construct(MediaList, (m) => internals.set(m, { text })));
+
+        class StyleSheet {
+            constructor() {
+                if (!constructing) illegal();
+            }
+            get type() {
+                return "text/css";
+            }
+            get ownerNode() {
+                return data(this).owner;
+            }
+            get href() {
+                const owner = data(this).owner;
+                return owner.localName === "link" ? owner.getAttribute("href") : null;
+            }
+            get title() {
+                return data(this).owner.getAttribute("title");
+            }
+            get media() {
+                return makeMediaList(data(this).owner.getAttribute("media") || "");
+            }
+            get parentStyleSheet() {
+                return null;
+            }
+            get ownerRule() {
+                return null;
+            }
+            get disabled() {
+                return false;
+            }
+        }
+
+        // `CSSStyleDeclaration` for the declarations of a rule (`CSSStyleRule.style`, ...)
+        class RuleStyleDeclaration {
+            constructor() {
+                if (!constructing) illegal();
+            }
+            get cssText() {
+                const d = data(this);
+                return __blitz_sheet_style_css_text(d.owner, d.path);
+            }
+            set cssText(value) {
+                const d = data(this);
+                __blitz_sheet_style_set_css_text(d.owner, d.path, String(value));
+            }
+            get length() {
+                const d = data(this);
+                return __blitz_sheet_style_property_names(d.owner, d.path).length;
+            }
+            item(index) {
+                const d = data(this);
+                return __blitz_sheet_style_property_names(d.owner, d.path)[index] ?? "";
+            }
+            getPropertyValue(name) {
+                const d = data(this);
+                return __blitz_sheet_style_get(d.owner, d.path, String(name))[0];
+            }
+            getPropertyPriority(name) {
+                const d = data(this);
+                return __blitz_sheet_style_get(d.owner, d.path, String(name))[1] ? "important" : "";
+            }
+            setProperty(name, value, priority) {
+                const d = data(this);
+                value = value === null || value === undefined ? "" : String(value);
+                const important = String(priority ?? "").toLowerCase() === "important";
+                __blitz_sheet_style_set(d.owner, d.path, String(name), value, important);
+            }
+            removeProperty(name) {
+                const d = data(this);
+                return __blitz_sheet_style_remove(d.owner, d.path, String(name));
+            }
+            get parentRule() {
+                return data(this).rule;
+            }
+        }
+        defineIterable(RuleStyleDeclaration.prototype);
+        const makeRuleStyle = (owner, path, rule) =>
+            __blitz_wrap_style(
+                indexedProxy(
+                    construct(RuleStyleDeclaration, (s) => internals.set(s, { owner, path, rule }))
+                )
+            );
+
+        class CSSRuleList {
+            constructor() {
+                if (!constructing) illegal();
+            }
+            get length() {
+                const d = data(this);
+                return Math.max(0, __blitz_sheet_rule_count(d.owner, d.path));
+            }
+            item(index) {
+                const d = data(this);
+                index = Number(index);
+                if (!(index >= 0 && index < this.length)) return null;
+                return ruleAt(d.sheet, d.owner, d.path.concat(index), d.parentRule);
+            }
+        }
+        defineIterable(CSSRuleList.prototype);
+        const makeRuleList = (sheet, owner, path, parentRule) =>
+            indexedProxy(
+                construct(CSSRuleList, (l) => internals.set(l, { sheet, owner, path, parentRule }))
+            );
+
+        const CSS_RULE_TYPES = {
+            STYLE_RULE: 1,
+            CHARSET_RULE: 2,
+            IMPORT_RULE: 3,
+            MEDIA_RULE: 4,
+            FONT_FACE_RULE: 5,
+            PAGE_RULE: 6,
+            KEYFRAMES_RULE: 7,
+            KEYFRAME_RULE: 8,
+            MARGIN_RULE: 9,
+            NAMESPACE_RULE: 10,
+            COUNTER_STYLE_RULE: 11,
+            SUPPORTS_RULE: 12,
+            DOCUMENT_RULE: 13,
+            FONT_FEATURE_VALUES_RULE: 14,
+            VIEWPORT_RULE: 15,
+            REGION_STYLE_RULE: 16,
+        };
+
+        class CSSRule {
+            constructor() {
+                if (!constructing) illegal();
+            }
+            get type() {
+                return data(this).info().type;
+            }
+            get cssText() {
+                return data(this).info().cssText;
+            }
+            set cssText(_) {}
+            get parentRule() {
+                return data(this).parentRule;
+            }
+            get parentStyleSheet() {
+                return data(this).sheet;
+            }
+        }
+        for (const [name, value] of Object.entries(CSS_RULE_TYPES)) {
+            CSSRule[name] = value;
+            CSSRule.prototype[name] = value;
+        }
+
+        const attrGetter = (name, convert) =>
+            function () {
+                const value = data(this).info().attrs[name];
+                return convert ? convert(value) : value;
+            };
+        const defineAttrs = (cls, attrs) => {
+            for (const [name, convert] of Object.entries(attrs)) {
+                Object.defineProperty(cls.prototype, name, {
+                    get: attrGetter(name, convert),
+                    configurable: true,
+                    enumerable: true,
+                });
+            }
+        };
+        const cssRulesGetter = function () {
+            const d = data(this);
+            return d.rules || (d.rules = makeRuleList(d.sheet, d.owner, d.path, this));
+        };
+        const groupingMethods = {
+            get cssRules() {
+                return cssRulesGetter.call(this);
+            },
+            insertRule(rule, index) {
+                const d = data(this);
+                index = index === undefined ? 0 : Number(index) >>> 0;
+                const result = __blitz_sheet_insert_rule(d.owner, d.path, String(rule), index);
+                d.sheet && invalidateRules(d.sheet);
+                return result;
+            },
+            deleteRule(index) {
+                const d = data(this);
+                __blitz_sheet_delete_rule(d.owner, d.path, Number(index) >>> 0);
+                d.sheet && invalidateRules(d.sheet);
+            },
+        };
+        const styleGetter = {
+            get style() {
+                const d = data(this);
+                return d.style || (d.style = makeRuleStyle(d.owner, d.path, this));
+            },
+        };
+
+        const ruleClasses = {};
+        const defineRuleClass = (name, base, mixins, attrs) => {
+            const cls = class extends base {
+                constructor() {
+                    super();
+                }
+            };
+            Object.defineProperty(cls, "name", { value: name, configurable: true });
+            for (const mixin of mixins) {
+                Object.defineProperties(cls.prototype, Object.getOwnPropertyDescriptors(mixin));
+            }
+            if (attrs) defineAttrs(cls, attrs);
+            ruleClasses[name] = cls;
+            globalThis[name] = cls;
+            return cls;
+        };
+        const str = (v) => (v === undefined ? "" : v);
+        const CSSGroupingRule = defineRuleClass("CSSGroupingRule", CSSRule, [groupingMethods]);
+        const CSSConditionRule = defineRuleClass("CSSConditionRule", CSSGroupingRule, [], {
+            conditionText: str,
+        });
+        defineRuleClass("CSSStyleRule", CSSGroupingRule, [styleGetter], { selectorText: str });
+        defineRuleClass("CSSNestedDeclarations", CSSRule, [styleGetter]);
+        defineRuleClass("CSSMediaRule", CSSConditionRule, [], { media: (v) => makeMediaList(str(v)) });
+        defineRuleClass("CSSSupportsRule", CSSConditionRule, []);
+        defineRuleClass("CSSContainerRule", CSSConditionRule, [], {
+            containerName: () => "",
+            containerQuery: str,
+        });
+        defineRuleClass("CSSMozDocumentRule", CSSConditionRule, []);
+        defineRuleClass("CSSLayerBlockRule", CSSGroupingRule, [], { name: str });
+        defineRuleClass("CSSLayerStatementRule", CSSRule, [], {
+            nameList: (v) => (v ? v.split(",").map((s) => s.trim()) : []),
+        });
+        defineRuleClass("CSSScopeRule", CSSGroupingRule, []);
+        defineRuleClass("CSSStartingStyleRule", CSSGroupingRule, []);
+        defineRuleClass("CSSPageRule", CSSGroupingRule, [styleGetter], { selectorText: str });
+        defineRuleClass("CSSMarginRule", CSSRule, [styleGetter], { name: str });
+        defineRuleClass("CSSImportRule", CSSRule, [], {
+            href: str,
+            media: (v) => makeMediaList(str(v)),
+            styleSheet: () => null,
+            layerName: () => null,
+            supportsText: () => null,
+        });
+        defineRuleClass("CSSNamespaceRule", CSSRule, [], { namespaceURI: str, prefix: str });
+        defineRuleClass("CSSFontFaceRule", CSSRule, [styleGetter]);
+        defineRuleClass("CSSFontFeatureValuesRule", CSSRule, [], { fontFamily: str });
+        defineRuleClass("CSSFontPaletteValuesRule", CSSRule, [], {
+            name: str,
+            fontFamily: str,
+            basePalette: str,
+            overrideColors: str,
+        });
+        defineRuleClass("CSSCounterStyleRule", CSSRule, [], { name: str });
+        defineRuleClass("CSSPropertyRule", CSSRule, [], {
+            name: str,
+            syntax: str,
+            inherits: (v) => v === "true",
+            initialValue: (v) => (v ? v : null),
+        });
+        defineRuleClass("CSSPositionTryRule", CSSRule, [styleGetter], { name: str });
+        defineRuleClass("CSSViewTransitionRule", CSSRule, []);
+        defineRuleClass("CSSAppearanceBaseRule", CSSGroupingRule, []);
+        defineRuleClass("CSSCustomMediaRule", CSSRule, []);
+        defineRuleClass("CSSKeyframeRule", CSSRule, [styleGetter], { keyText: str });
+        defineRuleClass(
+            "CSSKeyframesRule",
+            CSSRule,
+            [
+                {
+                    get cssRules() {
+                        return cssRulesGetter.call(this);
+                    },
+                    get length() {
+                        return this.cssRules.length;
+                    },
+                    appendRule(rule) {
+                        const d = data(this);
+                        __blitz_sheet_insert_rule(d.owner, d.path, String(rule), 0);
+                        d.sheet && invalidateRules(d.sheet);
+                    },
+                    deleteRule(select) {
+                        const index = findKeyframeIndex(this, select);
+                        if (index === -1) return;
+                        const d = data(this);
+                        __blitz_sheet_delete_rule(d.owner, d.path, index);
+                        d.sheet && invalidateRules(d.sheet);
+                    },
+                    findRule(select) {
+                        const index = findKeyframeIndex(this, select);
+                        return index === -1 ? null : this.cssRules.item(index);
+                    },
+                },
+            ],
+            { name: str }
+        );
+        // Match a keyframe selector string the way `findRule`/`deleteRule` do
+        // (normalising `from`/`to` and whitespace), returning the last match
+        const findKeyframeIndex = (keyframesRule, select) => {
+            const normalise = (s) =>
+                String(s)
+                    .split(",")
+                    .map((k) => k.trim().toLowerCase())
+                    .map((k) => (k === "from" ? "0%" : k === "to" ? "100%" : k))
+                    .join(", ");
+            const wanted = normalise(select);
+            const rules = keyframesRule.cssRules;
+            for (let i = rules.length - 1; i >= 0; i--) {
+                if (normalise(rules.item(i).keyText) === wanted) return i;
+            }
+            return -1;
+        };
+
+        // Rule wrapper objects are cached per stylesheet by path so that repeated
+        // `cssRules[i]` accesses return the same object; the cache is dropped
+        // whenever the rule list is mutated (indices shift).
+        const ruleCaches = new WeakMap();
+        const invalidateRules = (sheet) => ruleCaches.delete(sheet);
+        const ruleAt = (sheet, owner, path, parentRule) => {
+            const key = path.join("/");
+            let cache = sheet && ruleCaches.get(sheet);
+            if (cache && cache.has(key)) return cache.get(key);
+            const info = __blitz_sheet_rule_info(owner, path);
+            if (info === null) return null;
+            const cls = ruleClasses[info.interface] || CSSRule;
+            const rule = construct(cls, (r) =>
+                internals.set(r, {
+                    sheet,
+                    owner,
+                    path,
+                    parentRule,
+                    info: () => __blitz_sheet_rule_info(owner, path) || info,
+                })
+            );
+            if (sheet) {
+                if (!cache) ruleCaches.set(sheet, (cache = new Map()));
+                cache.set(key, rule);
+            }
+            return rule;
+        };
+
+        class CSSStyleSheet extends StyleSheet {
+            constructor() {
+                super();
+            }
+            get cssRules() {
+                const d = data(this);
+                return d.rules || (d.rules = makeRuleList(this, d.owner, [], null));
+            }
+            get rules() {
+                return this.cssRules;
+            }
+            insertRule(rule, index) {
+                const d = data(this);
+                index = index === undefined ? 0 : Number(index) >>> 0;
+                const result = __blitz_sheet_insert_rule(d.owner, [], String(rule), index);
+                invalidateRules(this);
+                return result;
+            }
+            deleteRule(index) {
+                const d = data(this);
+                __blitz_sheet_delete_rule(d.owner, [], Number(index) >>> 0);
+                invalidateRules(this);
+            }
+            addRule(selector, block, index) {
+                const rule = (selector ?? "undefined") + " {" + (block ?? "undefined") + "}";
+                this.insertRule(rule, index === undefined ? this.cssRules.length : index);
+                return -1;
+            }
+            removeRule(index) {
+                this.deleteRule(index ?? 0);
+            }
+        }
+
+        class StyleSheetList {
+            constructor() {
+                if (!constructing) illegal();
+            }
+            get length() {
+                return data(this).sheets.length;
+            }
+            item(index) {
+                return data(this).sheets[index] ?? null;
+            }
+        }
+        defineIterable(StyleSheetList.prototype);
+
+        // One `CSSStyleSheet` object per owner node (node wrappers are cached,
+        // so identity is stable)
+        const sheets = new WeakMap();
+        globalThis.__blitz_sheet_for_node = (node) => {
+            if (!__blitz_node_has_stylesheet(node)) return null;
+            let sheet = sheets.get(node);
+            if (!sheet) {
+                sheet = construct(CSSStyleSheet, (s) => internals.set(s, { owner: node }));
+                sheets.set(node, sheet);
+            }
+            return sheet;
+        };
+        globalThis.__blitz_style_sheets = () => {
+            const list = __blitz_stylesheet_owner_nodes().map(__blitz_sheet_for_node);
+            return indexedProxy(construct(StyleSheetList, (l) => internals.set(l, { sheets: list })));
+        };
+
+        globalThis.StyleSheet = StyleSheet;
+        globalThis.CSSStyleSheet = CSSStyleSheet;
+        globalThis.StyleSheetList = StyleSheetList;
+        globalThis.CSSRuleList = CSSRuleList;
+        globalThis.CSSRule = CSSRule;
+        globalThis.MediaList = MediaList;
+    }
+
     // `document.fonts` (FontFaceSet) stub: all fonts report as loaded
     const fontFaceSet = {
         status: "loaded",
@@ -618,6 +1111,10 @@ impl ScriptRuntime {
 
         // `getComputedStyle`
         register_global_fn(&mut context, "getComputedStyle", 1, get_computed_style);
+
+        // CSSOM stylesheet natives (`__blitz_sheet_*`), used by the bootstrap's
+        // `CSSStyleSheet` / `CSSRule` implementation
+        crate::dom::stylesheet::register(&mut context);
 
         // Viewport dimensions
         register_global_accessor(&mut context, "innerWidth", inner_width);

--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -496,6 +496,7 @@ const BOOTSTRAP_JS: &str = r#"
             set cssText(value) {
                 const d = data(this);
                 __blitz_sheet_style_set_css_text(d.owner, d.path, String(value));
+                touchSheet(data(d.rule).sheet);
             }
             get length() {
                 const d = data(this);
@@ -518,10 +519,13 @@ const BOOTSTRAP_JS: &str = r#"
                 value = value === null || value === undefined ? "" : String(value);
                 const important = String(priority ?? "").toLowerCase() === "important";
                 __blitz_sheet_style_set(d.owner, d.path, String(name), value, important);
+                touchSheet(data(d.rule).sheet);
             }
             removeProperty(name) {
                 const d = data(this);
-                return __blitz_sheet_style_remove(d.owner, d.path, String(name));
+                const removed = __blitz_sheet_style_remove(d.owner, d.path, String(name));
+                touchSheet(data(d.rule).sheet);
+                return removed;
             }
             get parentRule() {
                 return data(this).rule;
@@ -663,7 +667,13 @@ const BOOTSTRAP_JS: &str = r#"
         });
         defineRuleClass("CSSStyleRule", CSSGroupingRule, [styleGetter], { selectorText: str });
         defineRuleClass("CSSNestedDeclarations", CSSRule, [styleGetter]);
-        defineRuleClass("CSSMediaRule", CSSConditionRule, [], { media: (v) => makeMediaList(str(v)) });
+        defineRuleClass("CSSMediaRule", CSSConditionRule, [
+            {
+                get media() {
+                    return makeMediaList(this.conditionText);
+                },
+            },
+        ]);
         defineRuleClass("CSSSupportsRule", CSSConditionRule, []);
         defineRuleClass("CSSContainerRule", CSSConditionRule, [], {
             containerName: () => "",
@@ -758,13 +768,32 @@ const BOOTSTRAP_JS: &str = r#"
         // `cssRules[i]` accesses return the same object; the cache is dropped
         // whenever the rule list is mutated (indices shift).
         const ruleCaches = new WeakMap();
-        const invalidateRules = (sheet) => ruleCaches.delete(sheet);
+        // Per-sheet mutation counter, so that rule wrappers re-fetch their
+        // (serialized) info from the native side only when it may have changed.
+        // The document-wide native counter is folded in so that replacing a
+        // node's stylesheet (e.g. editing a `<style>`'s text) is detected too.
+        const generations = new WeakMap();
+        const sheetGeneration = (sheet) => (sheet && generations.get(sheet)) || 0;
+        const generation = (sheet) =>
+            __blitz_stylesheet_generation() + ":" + sheetGeneration(sheet);
+        const touchSheet = (sheet) => {
+            if (sheet) generations.set(sheet, sheetGeneration(sheet) + 1);
+        };
+        const invalidateRules = (sheet) => {
+            ruleCaches.delete(sheet);
+            touchSheet(sheet);
+        };
         const ruleAt = (sheet, owner, path, parentRule) => {
             const key = path.join("/");
             let cache = sheet && ruleCaches.get(sheet);
+            if (cache && cache.generation !== generation(sheet)) {
+                ruleCaches.delete(sheet);
+                cache = undefined;
+            }
             if (cache && cache.has(key)) return cache.get(key);
-            const info = __blitz_sheet_rule_info(owner, path);
+            let info = __blitz_sheet_rule_info(owner, path);
             if (info === null) return null;
+            let infoGeneration = generation(sheet);
             const cls = ruleClasses[info.interface] || CSSRule;
             const rule = construct(cls, (r) =>
                 internals.set(r, {
@@ -772,11 +801,22 @@ const BOOTSTRAP_JS: &str = r#"
                     owner,
                     path,
                     parentRule,
-                    info: () => __blitz_sheet_rule_info(owner, path) || info,
+                    info: () => {
+                        const current = generation(sheet);
+                        if (current !== infoGeneration) {
+                            info = __blitz_sheet_rule_info(owner, path) || info;
+                            infoGeneration = current;
+                        }
+                        return info;
+                    },
                 })
             );
             if (sheet) {
-                if (!cache) ruleCaches.set(sheet, (cache = new Map()));
+                if (!cache) {
+                    cache = new Map();
+                    cache.generation = infoGeneration;
+                    ruleCaches.set(sheet, cache);
+                }
                 cache.set(key, rule);
             }
             return rule;

--- a/packages/blitz-vibey-script/tests/dom.rs
+++ b/packages/blitz-vibey-script/tests/dom.rs
@@ -576,3 +576,128 @@ fn interface_constructor_globals() {
         "function,function,function,function|false|true"
     );
 }
+
+// `document.styleSheets` / `element.sheet` expose stylesheets with a live,
+// mutable `cssRules` list.
+#[test]
+fn cssom_stylesheet_rules() {
+    let doc = doc_from_html(
+        r##"
+        <html><head>
+            <style id="first">.a { color: red; } @media (min-width: 10px) { .b { margin: 1px } }</style>
+        </head><body>
+            <style id="second"></style>
+            <div id="out"></div>
+            <script>
+                const sheets = document.styleSheets;
+                const first = document.getElementById("first").sheet;
+                const second = document.getElementById("second").sheet;
+                const parts = [];
+                parts.push(sheets.length, sheets[0] === first, sheets.item(1) === second);
+                parts.push(first.ownerNode.id, first instanceof CSSStyleSheet, second.cssRules.length);
+
+                const rule = first.cssRules[0];
+                parts.push(rule.constructor.name, rule.type, rule.selectorText, rule.cssText);
+                parts.push(rule.style.color, rule.style.getPropertyValue("color"), rule.parentStyleSheet === first);
+
+                const media = first.cssRules[1];
+                parts.push(media.constructor.name, media.conditionText, media.cssRules.length);
+                parts.push(media.cssRules[0].parentRule === media, media.cssRules[0].style.margin);
+
+                second.insertRule("p { padding: 2px }", 0);
+                second.insertRule("h1 { padding: 3px }", 1);
+                parts.push(second.cssRules.length, second.cssRules[1].selectorText);
+                second.deleteRule(0);
+                parts.push(second.cssRules.length, second.cssRules[0].selectorText);
+
+                let err = "none";
+                try { second.insertRule("not a rule", 0); } catch (e) { err = e.name; }
+                parts.push(err);
+                try { second.deleteRule(5); } catch (e) { err = e.name; }
+                parts.push(err);
+
+                document.getElementById("out").textContent = parts.join("|");
+            </script>
+        </body></html>
+        "##,
+    );
+    assert_eq!(
+        text_of_selector(&doc, "#out"),
+        "2|true|true|first|true|0\
+         |CSSStyleRule|1|.a|.a { color: red; }|red|red|true\
+         |CSSMediaRule|(min-width: 10px)|1|true|1px\
+         |2|h1|1|h1\
+         |SyntaxError|IndexSizeError"
+    );
+}
+
+// Rules inserted or modified through the CSSOM take effect on computed styles.
+#[test]
+fn cssom_mutations_restyle() {
+    let doc = doc_from_html(
+        r##"
+        <html><head><style id="sheet">.box { width: 10px }</style></head><body>
+            <div id="box" class="box"></div>
+            <div id="out"></div>
+            <script>
+                const box = document.getElementById("box");
+                const sheet = document.getElementById("sheet").sheet;
+                const parts = [getComputedStyle(box).width];
+                sheet.insertRule("#box { width: 20px }", 1);
+                parts.push(getComputedStyle(box).width);
+                sheet.cssRules[1].style.setProperty("width", "30px");
+                parts.push(getComputedStyle(box).width, sheet.cssRules[1].cssText);
+                sheet.cssRules[1].style.cssText = "width: 40px; height: 5px";
+                parts.push(getComputedStyle(box).width, sheet.cssRules[1].style.length);
+                sheet.cssRules[1].style.removeProperty("width");
+                parts.push(getComputedStyle(box).width);
+                sheet.deleteRule(0);
+                parts.push(getComputedStyle(box).width);
+                document.getElementById("out").textContent = parts.join("|");
+            </script>
+        </body></html>
+        "##,
+    );
+    assert_eq!(
+        text_of_selector(&doc, "#out"),
+        "10px|20px|30px|#box { width: 30px; }|40px|2|10px|0px"
+    );
+}
+
+// `@font-face` and `@keyframes` rules expose their descriptors / keyframes.
+#[test]
+fn cssom_font_face_and_keyframes() {
+    let doc = doc_from_html(
+        r##"
+        <html><head>
+            <style id="sheet">
+                @font-face { font-family: "Foo"; src: url(foo.ttf) }
+                @keyframes spin { from { opacity: 0 } to { opacity: 1 } }
+            </style>
+        </head><body>
+            <div id="out"></div>
+            <script>
+                const sheet = document.getElementById("sheet").sheet;
+                const parts = [];
+                const face = sheet.cssRules[0];
+                parts.push(face.constructor.name, face.type, face.style.getPropertyValue("font-family"));
+                parts.push(face.style.getPropertyValue("src") !== "", face.style.fontFamily);
+                const frames = sheet.cssRules[1];
+                parts.push(frames.constructor.name, frames.name, frames.cssRules.length);
+                parts.push(frames.cssRules[0].keyText, frames.cssRules[1].style.opacity);
+                frames.appendRule("50% { opacity: 0.5 }");
+                parts.push(frames.cssRules.length, frames.findRule("50%").cssText);
+                frames.deleteRule("from");
+                parts.push(frames.cssRules.length, frames.cssRules[0].keyText);
+                document.getElementById("out").textContent = parts.join("|");
+            </script>
+        </body></html>
+        "##,
+    );
+    assert_eq!(
+        text_of_selector(&doc, "#out"),
+        "CSSFontFaceRule|5|\"Foo\"|true|\"Foo\"\
+         |CSSKeyframesRule|spin|2|0%|1\
+         |3|50% { opacity: 0.5; }|2|100%"
+    );
+}

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -407,7 +407,35 @@ mod tests {
 
     #[test]
     fn timeout_quarantine_is_valid() {
-        assert_eq!(TIMEOUT_QUARANTINE.len(), 252);
+        const KNOWN_REASONS: &[&str] = &[
+            "animation-events",
+            "content-visibility-events",
+            "dynamic-load-events",
+            "focus-events",
+            "font-loading-events",
+            "manual-interaction",
+            "media-query-events",
+            "no-tests-registered",
+            "rendering-frame",
+            "scroll-events",
+            "testdriver",
+            "transition-events",
+            "unbounded-job-execution",
+            "unsupported-async-browser-behavior",
+        ];
+
+        // Loading the map already rejects lines without a reason and duplicate paths
+        assert!(!TIMEOUT_QUARANTINE.is_empty());
+        for (path, reason) in TIMEOUT_QUARANTINE.iter() {
+            assert!(
+                !path.is_empty() && !path.contains(char::is_whitespace),
+                "invalid quarantined test path: {path:?}"
+            );
+            assert!(
+                KNOWN_REASONS.contains(reason),
+                "unknown quarantine reason {reason:?} for {path} (add it to KNOWN_REASONS if intentional)"
+            );
+        }
         assert_eq!(
             TIMEOUT_QUARANTINE.get("css/selectors/focus-visible-001.html"),
             Some(&"testdriver")

--- a/wpt/runner/src/test_runners/mod.rs
+++ b/wpt/runner/src/test_runners/mod.rs
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn timeout_quarantine_is_valid() {
-        assert_eq!(TIMEOUT_QUARANTINE.len(), 247);
+        assert_eq!(TIMEOUT_QUARANTINE.len(), 252);
         assert_eq!(
             TIMEOUT_QUARANTINE.get("css/selectors/focus-visible-001.html"),
             Some(&"testdriver")

--- a/wpt/runner/timeout-quarantine.txt
+++ b/wpt/runner/timeout-quarantine.txt
@@ -9,6 +9,7 @@ css/css-animations/responsive/fill-forwards-viewport-units.html animation-events
 css/css-cascade/import-conditions.html dynamic-load-events
 css/css-cascade/layer-import.html dynamic-load-events
 css/css-cascade/layer-media-query.html dynamic-load-events
+css/css-cascade/layer-rules-cssom.html dynamic-load-events
 css/css-cascade/layer-statement-before-import.html dynamic-load-events
 css/css-cascade/scope-implicit-external.html dynamic-load-events
 css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-dynamic.html dynamic-load-events
@@ -30,6 +31,8 @@ css/css-fonts/variations/font-opentype-collections.html rendering-frame
 css/css-fonts/variations/font-style-interpolation.html rendering-frame
 css/css-fonts/variations/font-weight-interpolation.html rendering-frame
 css/css-image-animation/image-animation-pseudo-animated-image-dynamic.html dynamic-load-events
+css/css-logical/animation-002.html animation-events
+css/css-logical/animation-004.html animation-events
 css/css-mixins/mixins/mixin-media-query-invalidation-2.html dynamic-load-events
 css/css-mixins/mixins/mixin-media-query-invalidation.html dynamic-load-events
 css/css-overflow/overflow-auto-scrolling-with-margin-and-transform.html testdriver
@@ -112,6 +115,8 @@ css/css-transitions/events-006.html transition-events
 css/css-transitions/events-008.html transition-events
 css/css-transitions/inherit-height-transition.html transition-events
 css/css-transitions/non-rendered-element-001.html transition-events
+css/css-transitions/non-rendered-element-002.html transition-events
+css/css-transitions/non-rendered-element-004.tentative.html transition-events
 css/css-transitions/properties-value-001.html transition-events
 css/css-transitions/properties-value-002.html transition-events
 css/css-transitions/properties-value-003.html transition-events


### PR DESCRIPTION
## Summary

Blitz's JS runtime had no `document.styleSheets` / `CSSStyleSheet` / `CSSRule` at all, so every WPT that inspects or mutates a stylesheet (e.g. the non-setter half of `css/css-fonts/test_font_family_parsing.html`, `test_font_feature_values_parsing.html`, the `@font-face` / `@font-palette-values` tests in `css/css-fonts/parsing`) threw before its first assertion. This PR adds a CSSOM backed directly by Stylo's existing stylesheet graph rather than a separate parser.

Stacked on #861 (defers `@import` sheet attachment to the document thread), which `insertRule("@import …")` needs to avoid a lock re-borrow panic.

**Design**

- `blitz-dom/src/cssom.rs` (new): rules are addressed by `(owner NodeId, path: &[usize])` — a path of indices through nested `CssRules` (`@media`/`@supports`/`@container`/nested style rules) and `@keyframes` keyframe lists; an empty path is the sheet's top-level list. `BaseDocument` gains:
  ```rust
  stylesheet_owner_nodes() -> Vec<NodeId>                        // document order
  stylesheet_rule_count(node, path) -> Option<usize>
  stylesheet_rule_info(node, path) -> Option<CssRuleInfo>        // interface name, type const, cssText, selectorText/keyText/etc
  stylesheet_insert_rule(node, path, rule, index) -> Result<usize, CssomError>   // CssRules::parse_rule_for_insert + Stylist::rule_changed
  stylesheet_delete_rule(node, path, index)       -> Result<(), CssomError>
  stylesheet_style_{css_text,set_css_text,property_names,get,set,remove}(...)   // edit a rule's PropertyDeclarationBlock in place
  ```
  Every mutation notifies the stylist (`rule_changed` / `force_stylesheet_origins_dirty`) so `getComputedStyle` reflects it, and inserted `@font-face` rules go through the existing font-fetch pipeline (`fetch_font_face` refactored into `fetch_font_face_rules`). `CssomError` maps Stylo's `RulesMutateError` to DOM exception names (`SyntaxError`, `IndexSizeError`, `HierarchyRequestError`, ...).

- `blitz-vibey-script/src/dom/stylesheet.rs` (new): thin `__blitz_sheet_*` native fns over the above.

- `runtime.rs`: JS bootstrap defining `StyleSheetList`, `CSSStyleSheet` (`cssRules`/`rules`, `insertRule`/`deleteRule`, legacy `addRule`/`removeRule`), `CSSRuleList`, `CSSRule` + type constants, `MediaList`, and rule subclasses (`CSSStyleRule`, `CSSMediaRule`, `CSSSupportsRule`, `CSSContainerRule`, `CSSImportRule`, `CSSNamespaceRule`, `CSSFontFaceRule`, `CSSFontFeatureValuesRule`, `CSSFontPaletteValuesRule`, `CSSKeyframesRule` (`appendRule`/`deleteRule`/`findRule`), `CSSKeyframeRule`, `CSSPageRule`, `CSSMarginRule`, `CSSCounterStyleRule`, `CSSPropertyRule`, ...). Rule objects are cached per `(sheet, path)` in a `WeakMap` so identity is stable (cache cleared on every insert/delete; no Rust-side state is retained); rule `.style` is a `CSSStyleDeclaration`-like object with `cssText`/`length`/`item`/`getPropertyValue`/`getPropertyPriority`/`setProperty`/`removeProperty` plus camelCase/kebab-case property access.

- `document.styleSheets` and `HTMLStyleElement/HTMLLinkElement.sheet` accessors.

**Results**

- `css/css-fonts/test_font_family_parsing.html`: 1116/2232 → **2232/2232**
- `css/css-fonts/test_font_feature_values_parsing.html`: → 299/302 (remaining 3 are Stylo serialization semantics — duplicate declarations collapsed — not CSSOM plumbing)
- `css/cssom`: 82 → **117** tests passing (2227 → 2526 subtests), 0 new crashes
- New Rust tests in `blitz-vibey-script/tests/dom.rs`: `cssom_stylesheet_rules`, `cssom_mutations_restyle`, `cssom_font_face_and_keyframes`


<!-- wpt-results-start -->
## WPT results

Subtests: **2691** newly passing, **1** newly failing (net +2690).

<details>
<summary>Full diff (154 changed tests)</summary>

```diff
+ FAIL => FAIL        [2/4]     +1  css/css-anchor-position/at-position-try-invalidation.html
+ FAIL => PASS        [1/1]     +1  css/css-animations/keyframes-rule-caching.html
+ FAIL => FAIL       [7/14]     +7  css/css-animations/parsing/keyframe-selectors.html
+ FAIL => PASS      [20/20]    +20  css/css-animations/parsing/keyframes-name-invalid.html
+ FAIL => FAIL      [28/43]    +28  css/css-cascade/at-scope-parsing.html
+ FAIL => PASS        [1/1]     +1  css/css-cascade/import-removal.html
+ FAIL => PASS        [2/2]     +2  css/css-cascade/layer-cssom-order-reverse-at-property.html
+ FAIL => FAIL        [2/4]     +2  css/css-cascade/layer-cssom-order-reverse.html
! FAIL => SKIP        [0/1]     +0  css/css-cascade/layer-rules-cssom.html
+ FAIL => FAIL       [9/13]     +9  css/css-cascade/parsing/layer-import-parsing.html
+ FAIL => PASS      [24/24]    +24  css/css-cascade/parsing/supports-import-parsing.html
+ FAIL => PASS        [1/1]     +1  css/css-cascade/unset-value-storage.html
+ FAIL => PASS      [16/16]    +16  css/css-conditional/at-supports-whitespace.html
+ FAIL => PASS      [10/10]    +10  css/css-conditional/js/001.html
+ FAIL => PASS      [34/34]    +34  css/css-conditional/js/conditional-CSSGroupingRule.html
+ FAIL => PASS      [15/15]    +15  css/css-conditional/js/supports-conditionText.html
+ FAIL => FAIL        [4/8]     +4  css/css-counter-styles/counter-style-at-rule/additive-symbols-syntax.html
+ FAIL => FAIL        [5/7]     +5  css/css-counter-styles/counter-style-at-rule/fallback.html
+ FAIL => FAIL      [11/17]    +11  css/css-counter-styles/counter-style-at-rule/name-syntax.html
+ FAIL => FAIL        [1/3]     +1  css/css-counter-styles/counter-style-at-rule/negative-syntax.html
+ FAIL => FAIL        [6/9]     +6  css/css-counter-styles/counter-style-at-rule/pad-syntax.html
+ FAIL => FAIL      [10/26]    +10  css/css-counter-styles/counter-style-at-rule/prefix-suffix-syntax.html
+ FAIL => FAIL        [2/8]     +2  css/css-counter-styles/counter-style-at-rule/range-syntax.html
+ FAIL => FAIL       [5/12]     +5  css/css-counter-styles/counter-style-at-rule/speak-as-syntax.html
+ FAIL => FAIL       [7/11]     +7  css/css-counter-styles/counter-style-at-rule/symbols-syntax.html
+ FAIL => FAIL       [6/16]     +6  css/css-counter-styles/counter-style-at-rule/system-syntax.html
+ FAIL => PASS        [1/1]     +1  css/css-fonts/crash-font-face-invalid-descriptor.html
+ FAIL => PASS        [1/1]     +1  css/css-fonts/font-family-src-quoted.html
+ FAIL => PASS        [1/1]     +1  css/css-fonts/font-feature-values-sameobject.tentative.html
+ FAIL => PASS      [21/21]    +21  css/css-fonts/parsing/font-face-metric-overrides.html
+ FAIL => PASS        [6/6]     +6  css/css-fonts/parsing/font-face-size-adjust.html
+ FAIL => PASS      [35/35]    +35  css/css-fonts/parsing/font-face-src-format.html
+ FAIL => PASS      [17/17]    +17  css/css-fonts/parsing/font-face-src-list.html
+ FAIL => PASS      [18/18]    +18  css/css-fonts/parsing/font-face-src-local.html
+ FAIL => FAIL      [28/39]    +28  css/css-fonts/parsing/font-face-src-tech.html
+ FAIL => FAIL      [12/19]    +12  css/css-fonts/parsing/font-face-width.html
+ FAIL => FAIL       [1/27]     +1  css/css-fonts/parsing/font-palette-values-invalid.html
! FAIL => FAIL       [0/36]     +0  css/css-fonts/parsing/font-palette-values-valid.html
+ FAIL => PASS  [2232/2232]  +1116  css/css-fonts/test_font_family_parsing.html
+ FAIL => FAIL    [299/302]   +299  css/css-fonts/test_font_feature_values_parsing.html
+ FAIL => FAIL      [83/88]    +83  css/css-fonts/variations/at-font-face-descriptors.html
- PASS => FAIL        [0/1]     -1  css/css-highlight-api/painting/custom-highlight-painting-text-decoration-001.html
! FAIL => SKIP        [0/1]     +0  css/css-logical/animation-002.html
! FAIL => SKIP        [0/1]     +0  css/css-logical/animation-004.html
+ FAIL => PASS      [10/10]    +10  css/css-logical/logicalprops-quirklength.html
+ FAIL => FAIL        [1/8]     +1  css/css-mixins/mixins/mixin-cssom.tentative.html
+ FAIL => PASS        [1/1]     +1  css/css-namespaces/syntax-013.xml
+ FAIL => PASS        [1/1]     +1  css/css-navigation/tentative/parsing/location-invalid-002.html
+ FAIL => FAIL       [9/14]     +9  css/css-nesting/cssom.html
+ FAIL => PASS        [2/2]     +2  css/css-nesting/invalid-inner-rules.html
+ FAIL => PASS      [32/32]    +32  css/css-nesting/parsing.html
+ FAIL => PASS      [15/15]    +15  css/css-nesting/serialize-group-rules-with-decls.html
! FAIL => FAIL        [0/2]     +0  css/css-page/cssom/margin-003.html
+ FAIL => PASS        [1/1]     +1  css/css-page/page-orientation.tentative.html
! FAIL => FAIL        [0/2]     +0  css/css-page/page-rule-declarations-003.html
+ FAIL => FAIL       [3/19]     +3  css/css-properties-values-api/at-property-animation.html
+ FAIL => FAIL      [32/40]    +32  css/css-properties-values-api/at-property-cssom.html
+ FAIL => PASS        [5/5]     +4  css/css-properties-values-api/at-property-stylesheets.html
+ FAIL => FAIL     [92/106]    +92  css/css-properties-values-api/at-property.html
+ FAIL => FAIL      [13/15]     +7  css/css-properties-values-api/determine-registration.html
+ FAIL => FAIL        [3/8]     +3  css/css-properties-values-api/registered-property-cssom.html
+ FAIL => FAIL       [5/36]     +5  css/css-pseudo/first-letter-allowed-properties.html
+ FAIL => FAIL      [12/96]    +12  css/css-pseudo/parsing/marker-supported-properties-in-animation.html
+ FAIL => FAIL       [5/67]     +5  css/css-pseudo/parsing/marker-supported-properties.html
+ FAIL => PASS        [3/3]     +3  css/css-shadow/part/serialization.html
+ FAIL => FAIL      [32/67]    +32  css/css-syntax/anb-parsing.html
+ FAIL => FAIL        [4/6]     +4  css/css-syntax/at-rule-in-declaration-list.html
+ FAIL => PASS        [1/1]     +1  css/css-syntax/cdc-vs-ident-tokens.html
+ FAIL => PASS        [1/1]     +1  css/css-syntax/charset-is-not-a-rule.html
+ FAIL => PASS        [4/4]     +4  css/css-syntax/custom-property-rule-ambiguity.html
+ FAIL => PASS        [6/6]     +6  css/css-syntax/decimal-points-in-numbers.html
+ FAIL => FAIL        [2/5]     +1  css/css-syntax/escaped-eof.html
+ FAIL => FAIL      [10/38]    +10  css/css-syntax/inclusive-ranges.html
+ FAIL => PASS        [1/1]     +1  css/css-syntax/invalid-nested-rules.html
+ FAIL => PASS        [1/1]     +1  css/css-syntax/serialize-escape-identifiers.html
+ FAIL => PASS        [1/1]     +1  css/css-syntax/trailing-braces.html
+ FAIL => FAIL      [88/95]    +88  css/css-syntax/urange-parsing.html
+ FAIL => PASS        [1/1]     +1  css/css-syntax/url-whitespace-consumption.html
+ FAIL => PASS      [14/14]    +14  css/css-syntax/var-with-blocks.html
! FAIL => SKIP        [0/1]     +0  css/css-transitions/non-rendered-element-002.html
! FAIL => SKIP        [0/1]     +0  css/css-transitions/non-rendered-element-004.tentative.html
+ FAIL => FAIL        [4/5]     +4  css/css-transitions/parsing/starting-style-parsing.html
! FAIL => FAIL        [0/7]     +0  css/css-typed-om/the-stylepropertymap/declared/declared.tentative.html
+ FAIL => PASS        [1/1]     +1  css/css-typed-om/the-stylepropertymap/declared/delete-invalid.html
+ FAIL => PASS        [1/1]     +1  css/css-typed-om/the-stylepropertymap/declared/get-invalid.html
+ FAIL => FAIL        [1/7]     +1  css/css-typed-om/the-stylepropertymap/declared/getAll.tentative.html
+ FAIL => FAIL        [1/9]     +1  css/css-typed-om/the-stylepropertymap/declared/has.tentative.html
+ FAIL => PASS        [3/3]     +1  css/css-ui/appearance-parsing.html
+ FAIL => PASS        [3/3]     +2  css/css-ui/appearance-serialization.html
+ FAIL => PASS        [3/3]     +1  css/css-ui/webkit-appearance-parsing.html
+ FAIL => PASS        [3/3]     +2  css/css-ui/webkit-appearance-serialization.html
+ FAIL => FAIL        [2/4]     +2  css/css-values/random-in-descriptors.tentative.html
+ FAIL => FAIL       [2/10]     +2  css/css-values/tree-counting/sibling-function-descriptors.tentative.html
+ FAIL => FAIL        [2/8]     +2  css/css-values/urls/url-request-modifiers-font-face-parsing.html
+ FAIL => FAIL       [3/10]     +3  css/css-values/urls/url-request-modifiers-import-parsing.sub.html
+ FAIL => FAIL        [2/4]     +2  css/css-variables/variable-invalidation.html
+ FAIL => FAIL        [1/9]     +1  css/css-view-transitions/navigation/at-rule-cssom.html
+ FAIL => PASS        [1/1]     +1  css/cssom/CSSConditionRule-conditionText.html
+ FAIL => PASS        [1/1]     +1  css/cssom/CSSFontFaceRule.html
+ FAIL => PASS        [1/1]     +1  css/cssom/CSSGroupingRule-cssRules.html
+ FAIL => PASS        [7/7]     +7  css/cssom/CSSGroupingRule-insertRule.html
+ FAIL => FAIL        [1/2]     +1  css/cssom/CSSKeyframeRule.html
+ FAIL => PASS        [1/1]     +1  css/cssom/CSSNamespaceRule.html
+ FAIL => PASS        [1/1]     +1  css/cssom/CSSRuleList.html
! FAIL => FAIL        [0/5]     +0  css/cssom/CSSStyleRule-set-selectorText-namespace.html
+ FAIL => FAIL      [20/82]    +20  css/cssom/CSSStyleRule-set-selectorText.html
+ FAIL => FAIL       [7/10]     +7  css/cssom/CSSStyleRule.html
+ FAIL => FAIL      [10/17]    +10  css/cssom/CSSStyleSheet.html
+ FAIL => PASS        [5/5]     +5  css/cssom/MediaList2.xhtml
+ FAIL => PASS        [1/1]     +1  css/cssom/StyleSheetList.html
+ FAIL => PASS        [1/1]     +1  css/cssom/all-initial-csstext.html
+ FAIL => PASS        [1/1]     +1  css/cssom/at-namespace.html
+ FAIL => PASS        [3/3]     +3  css/cssom/border-shorthand-serialization.html
+ FAIL => PASS        [4/4]     +4  css/cssom/css-style-declaration-modifications.html
+ FAIL => FAIL        [1/2]     +1  css/cssom/css-style-reparse.html
+ FAIL => FAIL       [6/11]     +6  css/cssom/cssimportrule.html
! FAIL => FAIL        [0/2]     +0  css/cssom/cssom-fontfacerule-constructors.html
+ FAIL => PASS        [1/1]     +1  css/cssom/cssom-fontfacerule.html
! FAIL => FAIL       [0/22]     +0  css/cssom/cssom-pagerule.html
+ FAIL => FAIL        [6/7]     +6  css/cssom/cssom-ruleTypeAndOrder.html
+ FAIL => FAIL        [2/3]     +1  css/cssom/cssstyledeclaration-mutability.html
+ FAIL => PASS        [1/1]     +1  css/cssom/delete-namespace-rule-when-child-rule-exists.html
+ FAIL => FAIL        [4/5]     +4  css/cssom/flex-serialization.html
+ FAIL => PASS        [2/2]     +2  css/cssom/insertRule-charset-no-index.html
+ FAIL => PASS        [1/1]     +1  css/cssom/insertRule-from-script.html
+ FAIL => PASS        [2/2]     +2  css/cssom/insertRule-import-no-index.html
+ FAIL => PASS        [2/2]     +2  css/cssom/insertRule-namespace-after-import.html
+ FAIL => PASS        [3/3]     +3  css/cssom/insertRule-namespace-no-index.html
+ FAIL => PASS        [2/2]     +2  css/cssom/insertRule-no-index.html
+ FAIL => PASS        [1/1]     +1  css/cssom/insertRule-syntax-error-01.html
+ FAIL => PASS        [1/1]     +1  css/cssom/invalid-pseudo-elements.html
+ FAIL => FAIL        [1/3]     +1  css/cssom/medialist-interfaces-002.html
+ FAIL => PASS      [10/10]    +10  css/cssom/overflow-serialization.html
! FAIL => FAIL       [0/21]     +0  css/cssom/page-descriptors.html
! FAIL => FAIL        [0/9]     +0  css/cssom/property-accessors.html
+ FAIL => PASS      [23/23]    +23  css/cssom/selectorSerialize.html
+ FAIL => FAIL      [11/12]    +11  css/cssom/serialize-media-rule.html
+ FAIL => PASS      [60/60]    +60  css/cssom/serialize-namespaced-type-selectors.html
+ FAIL => PASS        [1/1]     +1  css/cssom/set-selector-text-attachment.html
+ FAIL => FAIL        [5/7]     +5  css/cssom/style-sheet-interfaces-001.html
+ FAIL => PASS        [2/2]     +2  css/cssom/style-sheet-interfaces-002.html
+ FAIL => FAIL        [1/6]     +1  css/cssom/ttwf-cssom-doc-ext-load-tree-order.html
+ FAIL => PASS        [1/1]     +1  css/cssom/ttwf-cssom-document-extension.html
+ FAIL => PASS        [1/1]     +1  css/mediaqueries/mq-escaped-serialization.html
+ FAIL => PASS        [1/1]     +1  css/mediaqueries/mq-invalid-media-type-005.html
+ FAIL => PASS        [1/1]     +1  css/mediaqueries/mq-invalid-media-type-layer-002.html
+ FAIL => PASS        [1/1]     +1  css/mediaqueries/mq-unknown-feature-custom-property.html
+ FAIL => FAIL      [54/72]    +54  css/selectors/attribute-selectors/attribute-case/cssom.html
+ FAIL => PASS        [1/1]     +1  css/selectors/invalidation/selectorText-dynamic-001.html
+ FAIL => PASS        [3/3]     +3  css/selectors/nth-child-large-anplusb-clamp.html
+ FAIL => PASS        [1/1]     +1  css/selectors/old-tests/css3-modsel-177a.xml
+ FAIL => PASS    [112/112]   +112  css/selectors/parsing/parse-anplusb.html
+ FAIL => FAIL        [1/4]     +1  svg/styling/attr-style-type-dynamic.html
+ FAIL => FAIL        [5/6]     +5  svg/styling/style-sheet-interfaces.svg
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34720063349).</sub>
<!-- wpt-results-end -->


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/6288a6e4544b464e9891e948ea81f912
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/6288a6e4544b464e9891e948ea81f912?variant=devin-insiders
Requested by: @nicoburns