### PR TITLE
Send `@import`ed stylesheets around the regular resource loading flow

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -1272,6 +1272,14 @@ impl BaseDocument {
                 let node_id = res.node_id.unwrap();
                 self.add_stylesheet_for_node(css, node_id);
             }
+            Resource::ImportedCss(import_rule, sheet) => {
+                let mut guard = self.guard.write();
+                import_rule.write_with(&mut guard).stylesheet =
+                    style::stylesheets::import_rule::ImportSheet::Sheet(sheet);
+                drop(guard);
+                self.stylist
+                    .force_stylesheet_origins_dirty(style::stylesheets::OriginSet::all());
+            }
             Resource::Image(_kind, width, height, image_data) => {
                 // Create the ImageData and cache it
                 let image = ImageData::Raster(RasterImageData::new(width, height, image_data));

--- a/packages/blitz-dom/src/net.rs
+++ b/packages/blitz-dom/src/net.rs
@@ -60,6 +60,8 @@ pub enum Resource {
     #[cfg(feature = "svg")]
     Svg(ImageType, crate::node::SvgImageData),
     Css(DocumentStyleSheet),
+    /// Stylesheet loaded for an `@import` rule, to be attached to the rule on the document thread
+    ImportedCss(ServoArc<Locked<ImportRule>>, ServoArc<Stylesheet>),
     Font(Bytes, FontFaceOverrides),
     /// HTML fetched for an `<iframe>` element's `src`
     DocumentSrc(String),
@@ -288,11 +290,8 @@ impl NetHandler for ResourceHandler<NestedStylesheetHandler> {
             self.data.loader.abort_signal.as_ref(),
         );
 
-        let mut guard = self.data.lock.write();
-        self.data.import_rule.write_with(&mut guard).stylesheet = ImportSheet::Sheet(sheet);
-        drop(guard);
-
-        self.respond(resolved_url, Ok(Resource::None))
+        let import_rule = self.data.import_rule.clone();
+        self.respond(resolved_url, Ok(Resource::ImportedCss(import_rule, sheet)))
     }
 }
 


### PR DESCRIPTION
## Summary

`NestedStylesheetHandler::bytes` (the handler for an `@import`ed stylesheet) took a `SharedRwLock` **write** guard to set `ImportRule::stylesheet` directly inside the net callback. With a synchronous `NetProvider` (e.g. the WPT runner), that callback runs while the *parsing* code path still holds a read guard on the same lock, so it panicked with `already immutably borrowed` (`AtomicRefCell`). With async providers it's a latent cross-thread race with any reader (layout/style resolution).

Fix: hand the loaded sheet back to the document instead of mutating in place:

```rust
// net.rs
pub enum Resource {
    ...
+   ImportedCss(ServoArc<Locked<ImportRule>>, ServoArc<Stylesheet>),
}
// NestedStylesheetHandler::bytes
-   self.data.import_rule.write_with(&mut lock.write()).stylesheet = ImportSheet::Sheet(sheet);
-   self.respond(url, Ok(Resource::None))
+   self.respond(url, Ok(Resource::ImportedCss(self.data.import_rule.clone(), sheet)))

// document.rs  BaseDocument::load_resource
+   Resource::ImportedCss(import_rule, sheet) => {
+       import_rule.write_with(&mut self.guard.write()).stylesheet = ImportSheet::Sheet(sheet);
+       self.stylist.force_stylesheet_origins_dirty(OriginSet::all());
+   }
```

The write now happens on the document thread with no other guard held, and the stylist is explicitly invalidated once the import resolves (previously it relied on incidental invalidation).

Split out of #860 (CSSOM `insertRule("@import …")` is what surfaced the panic); that PR is stacked on top of this one.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/6288a6e4544b464e9891e948ea81f912
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/6288a6e4544b464e9891e948ea81f912?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

No changes in test results compared to `main`.

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34717227807).</sub>
<!-- wpt-results-end -->
