### PR TITLE
script: make `element.style` assignable; enable `sibling-index()`/`sibling-count()`

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -399,6 +399,7 @@ impl BaseDocument {
         style_config::set_pref!("layout.columns.enabled", true);
         style_config::set_pref!("layout.css.basic-shape-shape.enabled", true);
         style_config::set_pref!("layout.css.attr.enabled", true);
+        style_config::set_pref!("layout.css.tree-counting-functions.enabled", true);
         style_config::set_pref!("layout.threads", -1);
 
         let viewport = config.viewport.unwrap_or_default();

--- a/packages/blitz-vibey-script/src/dom/element.rs
+++ b/packages/blitz-vibey-script/src/dom/element.rs
@@ -77,7 +77,14 @@ pub(crate) fn init_element_proto(proto: &JsObject, context: &mut Context) {
         Some(set_autofocus),
         context,
     );
-    define_accessor(proto, "style", Some(get_style), None, context);
+    // `style` is `[PutForwards=cssText]`: assignment sets `style.cssText`
+    define_accessor(
+        proto,
+        "style",
+        Some(get_style),
+        Some(super::style::set_css_text),
+        context,
+    );
     define_accessor(proto, "sheet", Some(get_sheet), None, context);
     define_accessor(
         proto,

--- a/packages/blitz-vibey-script/src/dom/style.rs
+++ b/packages/blitz-vibey-script/src/dom/style.rs
@@ -87,7 +87,11 @@ fn get_css_text(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResul
     Ok(js_str(&css))
 }
 
-fn set_css_text(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+pub(crate) fn set_css_text(
+    this: &JsValue,
+    args: &[JsValue],
+    context: &mut Context,
+) -> JsResult<JsValue> {
     let ctx = dom_ctx(context)?;
     let node_id = this_node_id(this)?;
     let css = to_rust_string(args.first().unwrap_or(&JsValue::undefined()), context)?;


### PR DESCRIPTION
## Summary

`css/css-values/acos-asin-atan-atan2-computed.html` (and the whole family of tests using `css/support/numeric-testcommon.js`) was failing with a single uncaught error:

```
TypeError: cannot set non-writable property: style
```

`numeric-testcommon.js` resets the target with `testEl.style = ""`. The `style` accessor on the element prototype was defined getter-only, so assignment threw. Per CSSOM, `style` is `[PutForwards=cssText]`, so assigning to it must set `style.cssText`. Since the `style` object and the element share the same `NodeRef` `this`, the existing `set_css_text` is reused directly as the `style` setter:

```rust
define_accessor(proto, "style", Some(get_style), Some(style::set_css_text), context);
```

With that fixed, 47/52 subtests pass. Four of the remaining five used `sibling-index()`, which Stylo already implements but gates behind `layout.css.tree-counting-functions.enabled`; this PR turns that pref on alongside the existing `attr()` pref in `BaseDocument::new`.

The one still-failing subtest is `calc(1px * pow(tan(atan2(50%, 1px)), 1))` in `flex-basis`, which Stylo rejects at parse time (mixed `%`/`px` inside `atan2`) — a Stylo limitation, out of scope here.

**WPT `css/css-values`:** 3824 → 5370 subtests passing (261 → 279 whole tests), 0 regressions.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/3bcdae8a18a74fa0b3003a2ad7fff7c5
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/3bcdae8a18a74fa0b3003a2ad7fff7c5?variant=devin-insiders
Requested by: @nicoburns