### PR TITLE
script: root `clientWidth/Height`, `CSS.registerProperty`; enable `progress()`

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -400,6 +400,7 @@ impl BaseDocument {
         style_config::set_pref!("layout.css.basic-shape-shape.enabled", true);
         style_config::set_pref!("layout.css.attr.enabled", true);
         style_config::set_pref!("layout.css.tree-counting-functions.enabled", true);
+        style_config::set_pref!("layout.css.progress-function.enabled", true);
         style_config::set_pref!("layout.threads", -1);
 
         let viewport = config.viewport.unwrap_or_default();

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -114,6 +114,7 @@ pub fn dom_node_id(id: taffy::NodeId) -> NodeId {
 pub use style::Atom;
 pub use style::invalidation::element::restyle_hints::RestyleHint;
 pub use style::media_queries::MediaType;
+pub use style::stylist::RegisterCustomPropertyResult;
 pub type SelectorList = selectors::SelectorList<style::selector_parser::SelectorImpl>;
 pub use events::{EventDriver, EventHandler, NoopEventHandler};
 pub use html::{DummyHtmlParserProvider, HtmlParserProvider};

--- a/packages/blitz-dom/src/resolved_style.rs
+++ b/packages/blitz-dom/src/resolved_style.rs
@@ -16,7 +16,8 @@ use style::properties::{
     SourcePropertyDeclaration, parse_one_declaration_into,
 };
 use style::stylesheets::supports_rule::parse_condition_or_declaration;
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::{CssRuleType, Origin, OriginSet};
+use style::stylist::RegisterCustomPropertyResult;
 use style::values::computed::LengthPercentage;
 use style::values::computed::length::CSSPixelLength;
 use style::values::generics::position::{Inset as GenericInset, PreferredRatio};
@@ -251,6 +252,27 @@ impl BaseDocument {
             Default::default(),
         );
         condition.eval(&context)
+    }
+
+    /// Register a custom property via script (`CSS.registerProperty()`).
+    /// On success all styles are invalidated so that declarations of the
+    /// property are re-parsed against the new registration.
+    pub fn register_custom_property(
+        &mut self,
+        name: &str,
+        syntax: &str,
+        inherits: bool,
+        initial_value: Option<&str>,
+    ) -> RegisterCustomPropertyResult {
+        let url_data = self.url.url_extra_data();
+        let result =
+            self.stylist
+                .register_custom_property(&url_data, name, syntax, inherits, initial_value);
+        if matches!(result, RegisterCustomPropertyResult::SuccessfullyRegistered) {
+            self.stylist
+                .force_stylesheet_origins_dirty(OriginSet::all());
+        }
+        result
     }
 
     /// Compute the resolved value of a CSS property for the given node, as exposed

--- a/packages/blitz-vibey-script/src/dom/element.rs
+++ b/packages/blitz-vibey-script/src/dom/element.rs
@@ -962,12 +962,51 @@ fn offset_top(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<
     layout_value(this, context, |node| node.offset_top_left().y.round())
 }
 
+/// `clientWidth`/`clientHeight`. For the root element (in no-quirks mode, which
+/// is all Blitz supports) these are the viewport dimensions minus scrollbars.
+fn client_size(
+    this: &JsValue,
+    context: &mut Context,
+    axis: impl FnOnce(&blitz_dom::Node) -> f32,
+    viewport_axis: impl FnOnce(&blitz_dom::Node, (f32, f32)) -> f32,
+) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = this_node_id(this)?;
+    let mut doc = ctx.doc.borrow_mut();
+    doc.resolve(0.0);
+    let Some(node) = doc.get_node(node_id) else {
+        return Ok(JsValue::from(0.0));
+    };
+    let value = if node_id == doc.root_element().id {
+        let viewport = doc.viewport();
+        let scale = viewport.scale();
+        let size = (
+            viewport.window_size.0 as f32 / scale,
+            viewport.window_size.1 as f32 / scale,
+        );
+        viewport_axis(node, size)
+    } else {
+        axis(node)
+    };
+    Ok(JsValue::from(value.round() as f64))
+}
+
 fn client_width(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-    layout_value(this, context, |node| node.client_width().round())
+    client_size(
+        this,
+        context,
+        |node| node.client_width(),
+        |node, (w, _)| w - node.final_layout().scrollbar_size.width,
+    )
 }
 
 fn client_height(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-    layout_value(this, context, |node| node.client_height().round())
+    client_size(
+        this,
+        context,
+        |node| node.client_height(),
+        |node, (_, h)| h - node.final_layout().scrollbar_size.height,
+    )
 }
 
 fn scroll_width(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {

--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -1179,6 +1179,11 @@ impl ScriptRuntime {
                 js_string!("supports"),
                 1,
             )
+            .function(
+                NativeFunction::from_fn_ptr(css_register_property),
+                js_string!("registerProperty"),
+                1,
+            )
             .build();
         register_global(&mut context, "CSS", css_namespace.into());
 
@@ -1948,6 +1953,69 @@ fn css_supports(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
         ctx.doc.borrow().css_supports_condition(&condition)
     };
     Ok(JsValue::from(supported))
+}
+
+/// `CSS.registerProperty({ name, syntax = "*", inherits, initialValue })`
+/// <https://drafts.css-houdini.org/css-properties-values-api-1/#the-registerproperty-function>
+fn css_register_property(
+    _: &JsValue,
+    args: &[JsValue],
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    use blitz_dom::RegisterCustomPropertyResult as Result_;
+
+    let ctx = dom_ctx(context)?;
+    let Some(descriptor) = args.first().and_then(JsValue::as_object) else {
+        return Err(JsNativeError::typ()
+            .with_message("CSS.registerProperty: argument must be a PropertyDefinition dictionary")
+            .into());
+    };
+    let get = |key: &str, context: &mut Context| -> JsResult<Option<String>> {
+        let value = descriptor.get(js_string!(key), context)?;
+        if value.is_undefined() {
+            return Ok(None);
+        }
+        Ok(Some(to_rust_string(&value, context)?))
+    };
+    let Some(name) = get("name", context)? else {
+        return Err(JsNativeError::typ()
+            .with_message("CSS.registerProperty: 'name' is required")
+            .into());
+    };
+    let inherits = descriptor.get(js_string!("inherits"), context)?;
+    if inherits.is_undefined() {
+        return Err(JsNativeError::typ()
+            .with_message("CSS.registerProperty: 'inherits' is required")
+            .into());
+    }
+    let inherits = inherits.to_boolean();
+    let syntax = get("syntax", context)?.unwrap_or_else(|| "*".to_string());
+    let initial_value = get("initialValue", context)?;
+
+    let result = ctx.doc.borrow_mut().register_custom_property(
+        &name,
+        &syntax,
+        inherits,
+        initial_value.as_deref(),
+    );
+    let error = match result {
+        Result_::SuccessfullyRegistered => return Ok(JsValue::undefined()),
+        Result_::InvalidName => JsNativeError::syntax().with_message(format!(
+            "CSS.registerProperty: '{name}' is not a valid custom property name"
+        )),
+        Result_::AlreadyRegistered => JsNativeError::error().with_message(format!(
+            "CSS.registerProperty: '{name}' is already registered"
+        )),
+        Result_::InvalidSyntax => JsNativeError::syntax()
+            .with_message(format!("CSS.registerProperty: invalid syntax '{syntax}'")),
+        Result_::NoInitialValue => JsNativeError::syntax().with_message(
+            "CSS.registerProperty: 'initialValue' is required for non-universal syntax",
+        ),
+        Result_::InvalidInitialValue | Result_::InitialValueNotComputationallyIndependent => {
+            JsNativeError::syntax().with_message("CSS.registerProperty: invalid 'initialValue'")
+        }
+    };
+    Err(error.into())
 }
 
 fn get_computed_style(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {


### PR DESCRIPTION
## Summary

Stacked on #865 (which fixes the `element.style = ""` setter that aborted all the `numeric-testcommon.js` math tests). This PR closes the remaining high-subtest-count `css/css-values` gaps where Servo passes and Blitz fails. Three independent root causes:

1. **`documentElement.clientWidth/Height` returned the root element's box instead of the viewport.** Per CSSOM-View, on the root element (no-quirks) these are the viewport dimensions minus scrollbars. `viewport-units-css2-001` computes its expected `vh`/`vmin` values from them.

2. **`CSS.registerProperty` was missing** (`attr-cycle.html`, `attr-security.html` and most of `css-properties-values-api/` aborted on it). Added `BaseDocument::register_custom_property` wrapping Stylo's `Stylist::register_custom_property` (+ `force_stylesheet_origins_dirty` so existing declarations re-parse against the new registration), and the JS binding mapping `RegisterCustomPropertyResult` to `SyntaxError`/`Error` exceptions.

3. **`progress()` was pref-gated off** (`layout.css.progress-function.enabled`), same situation as `attr()` in #864.

### WPT deltas (local run vs #865's branch, no regressions)

| dir | subtests passed | whole tests |
|---|---|---|
| css/css-values | 5235 → **5435** | 279 → 282 |
| css/css-properties-values-api | 206 → **494** | 21 → 34 |
| css/cssom, cssom-view, css-variables | unchanged | unchanged |

Now matching Servo: `progress-serialize` 68/68, `viewport-units-css2-001` 160/160, `attr-cycle` 37/37, `registered-property-computation` 75/75, `registered-properties-inheritance` 8/8, `var-reference-registered-properties-cycles` 5/5.

### Remaining Servo-pass / Blitz-fail in css-values with high counts
- `viewport-units-{compute,invalidation,keyframes,media-queries}` (34/24/24/26): need `iframe.contentDocument` / `contentWindow`.
- `attr-security.html` 29/32: `url()` inside `image-set()`/comma lists isn't attr()-taint-rejected.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/645c604c89a24f289ea3535a9e0acab6
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/645c604c89a24f289ea3535a9e0acab6?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **2383** newly passing, **45** newly failing (net +2338).

<details>
<summary>Full diff (156 changed tests)</summary>

```diff
! FAIL => FAIL        [0/4]    +0  css/css-anchor-position/anchor-query-custom-property-registration.html
+ FAIL => FAIL        [4/7]    +4  css/css-animations/animation-important-001.html
+ FAIL => PASS        [1/1]    +1  css/css-backgrounds/background-color-body-propagation-003.html
+ FAIL => FAIL       [6/11]    +6  css/css-backgrounds/parsing/background-shorthand-serialization.html
+ FAIL => FAIL      [20/22]   +19  css/css-borders/border-width-rounding.tentative.html
+ FAIL => PASS        [4/4]    +3  css/css-cascade/layer-vs-inline-style.html
+ FAIL => FAIL  [1124/1169]    +1  css/css-color/parsing/color-computed-relative-color.html
+ FAIL => PASS        [1/1]    +1  css/css-color/relative-color-with-zoom.html
+ FAIL => PASS        [1/1]    +1  css/css-contain/content-visibility/content-visibility-036.html
+ FAIL => PASS        [1/1]    +1  css/css-contain/content-visibility/content-visibility-042.html
+ FAIL => PASS        [4/4]    +4  css/css-flexbox/flex-shorthand-calc.html
+ FAIL => FAIL    [163/174]  +159  css/css-fonts/font-shorthand-serialization-prevention.html
+ FAIL => FAIL      [42/43]   +14  css/css-fonts/variations/font-style-parsing.html
+ FAIL => FAIL      [34/35]    +1  css/css-grid/parsing/grid-area-computed.html
+ FAIL => PASS      [60/60]    +1  css/css-grid/parsing/grid-area-valid.html
+ FAIL => FAIL      [54/72]   +18  css/css-images/animation/image-slice-interpolation-math-functions-tentative.html
+ FAIL => PASS        [1/1]    +1  css/css-images/conic-gradient-color-with-sibling-index.html
+ FAIL => PASS    [144/144]    +2  css/css-images/image-set/image-set-parsing.html
+ FAIL => PASS        [1/1]    +1  css/css-images/linear-gradient-sibling-index.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-stylemap.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-001.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-002.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-003.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-004.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-005.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-006.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-007.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-008.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-009.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-010.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-011.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-012.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-013.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-014.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-015.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-016.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-017.https.html
+ FAIL => PASS        [1/1]    +1  css/css-paint-api/registered-property-value-018.https.html
- FAIL => FAIL        [0/3]    -1  css/css-position/sticky/position-sticky-margins.html
- FAIL => FAIL        [0/5]    -2  css/css-position/sticky/position-sticky-nested-bottom.html
- FAIL => FAIL        [0/5]    -1  css/css-position/sticky/position-sticky-nested-left.html
- FAIL => FAIL        [0/5]    -2  css/css-position/sticky/position-sticky-nested-right.html
- FAIL => FAIL        [0/5]    -1  css/css-position/sticky/position-sticky-nested-top.html
- FAIL => FAIL        [1/3]    -1  css/css-position/sticky/position-sticky-overflow-padding.html
- FAIL => FAIL        [0/3]    -1  css/css-position/sticky/position-sticky-right.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-angle-comma-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-angle-space-list.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-angle.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-color-comma-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-color-space-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-color.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-integer-comma-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-integer-space-list.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-integer.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-length-comma-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-length-percentage-comma-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-length-percentage-space-list.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-length-percentage.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-length-space-list.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-length.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-number-comma-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-number-space-list.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-number.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-percentage-comma-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-percentage-space-list.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-percentage.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-resolution-comma-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-resolution-space-list.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-resolution.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-time-comma-list.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-time-space-list.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-time.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-transform-function.html
! FAIL => FAIL        [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html
! FAIL => FAIL        [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-transform-list-single-values.html
! FAIL => FAIL        [0/2]    +0  css/css-properties-values-api/animation/custom-property-animation-transform-none.tentative.html
! FAIL => FAIL        [0/3]    +0  css/css-properties-values-api/animation/custom-property-animation-with-zoom.html
+ FAIL => PASS        [1/1]    +1  css/css-properties-values-api/animation/registered-neutral-keyframe.html
+ FAIL => FAIL     [95/106]    +3  css/css-properties-values-api/at-property.html
+ FAIL => PASS        [3/3]    +3  css/css-properties-values-api/conditional-rules.html
+ FAIL => PASS      [15/15]    +2  css/css-properties-values-api/determine-registration.html
- FAIL => FAIL      [35/95]   -32  css/css-properties-values-api/font-property-unit-cycles.tentative.html
+ FAIL => PASS        [5/5]    +5  css/css-properties-values-api/invalid-at-computed-value-time.html
+ FAIL => PASS        [2/2]    +2  css/css-properties-values-api/property-cascade.html
+ FAIL => PASS        [6/6]    +6  css/css-properties-values-api/register-property-sign-mixed-lengths.html
+ FAIL => FAIL    [128/246]  +128  css/css-properties-values-api/register-property-syntax-parsing.html
+ FAIL => FAIL        [3/6]    +2  css/css-properties-values-api/register-property.html
+ FAIL => PASS        [8/8]    +8  css/css-properties-values-api/registered-properties-inheritance.html
+ FAIL => PASS        [2/2]    +2  css/css-properties-values-api/registered-property-change-style-001.html
+ FAIL => PASS        [1/1]    +1  css/css-properties-values-api/registered-property-computation-color-005.html
+ FAIL => PASS      [75/75]   +75  css/css-properties-values-api/registered-property-computation.html
+ FAIL => PASS        [8/8]    +5  css/css-properties-values-api/registered-property-cssom.html
+ FAIL => FAIL        [2/4]    +2  css/css-properties-values-api/registered-property-revert.html
+ FAIL => PASS        [1/1]    +1  css/css-properties-values-api/resolved-color-value.html
+ FAIL => PASS        [3/3]    +2  css/css-properties-values-api/self-utils.html
+ FAIL => FAIL      [24/27]   +24  css/css-properties-values-api/unit-cycles.html
! FAIL => FAIL       [0/18]    +0  css/css-properties-values-api/url-resolution.html
+ FAIL => PASS        [1/1]    +1  css/css-properties-values-api/var-reference-registered-properties-002.html
+ FAIL => PASS        [5/5]    +5  css/css-properties-values-api/var-reference-registered-properties-cycles.html
+ FAIL => FAIL      [15/16]   +15  css/css-properties-values-api/var-reference-registered-properties.html
+ FAIL => PASS        [1/1]    +1  css/css-pseudo/highlight-cascade/highlight-cascade-010.html
+ FAIL => PASS        [1/1]    +1  css/css-tables/abspos-container-change-dynamic-001.html
- PASS => FAIL        [0/1]    -1  css/css-text/text-group-align/text-group-align-left-vlr.html
- PASS => FAIL        [0/1]    -1  css/css-text/text-group-align/text-group-align-left.html
- PASS => FAIL        [0/1]    -1  css/css-text/text-group-align/text-group-align-start-vlr.html
- PASS => FAIL        [0/1]    -1  css/css-text/text-group-align/text-group-align-start.html
+ FAIL => FAIL      [36/48]   +18  css/css-transforms/animation/rotate-interpolation-math-functions-tentative.html
+ FAIL => FAIL      [36/48]   +18  css/css-transforms/animation/scale-animation-math-functions-tentative.html
+ FAIL => PASS      [11/11]   +11  css/css-transforms/transform-with-sign-function.html
+ FAIL => FAIL        [5/7]    +5  css/css-transforms/transforms-support-calc.html
+ FAIL => PASS        [4/4]    +1  css/css-ui/cursor-calc-hotspot.html
+ FAIL => PASS      [12/12]   +11  css/css-ui/outline-width-rounding.tentative.html
+ FAIL => FAIL      [51/52]   +51  css/css-values/acos-asin-atan-atan2-computed.html
+ FAIL => PASS      [37/37]   +37  css/css-values/attr-cycle.html
+ FAIL => FAIL      [29/32]   +29  css/css-values/attr-security.html
! FAIL => FAIL       [0/53]    +0  css/css-values/calc-mix-computed.tentative.html
+ FAIL => PASS      [21/21]   +21  css/css-values/exp-log-compute.html
+ FAIL => PASS      [53/53]   +53  css/css-values/hypot-pow-sqrt-computed.html
+ FAIL => PASS        [8/8]    +4  css/css-values/lh-rlh-on-root-001.html
+ FAIL => PASS      [32/32]   +32  css/css-values/minmax-angle-computed.html
+ FAIL => PASS      [10/10]   +10  css/css-values/minmax-integer-computed.html
+ FAIL => PASS      [80/80]   +80  css/css-values/minmax-length-computed.html
+ FAIL => PASS      [50/50]   +50  css/css-values/minmax-length-percent-computed.html
+ FAIL => PASS      [14/14]   +14  css/css-values/minmax-number-computed.html
+ FAIL => PASS      [14/14]   +14  css/css-values/minmax-percentage-computed.html
+ FAIL => PASS      [24/24]   +24  css/css-values/minmax-time-computed.html
+ FAIL => FAIL      [34/36]   +34  css/css-values/progress-computed.html
+ FAIL => PASS      [68/68]   +60  css/css-values/progress-serialize.html
+ FAIL => PASS    [191/191]  +191  css/css-values/round-function.html
+ FAIL => PASS    [243/243]  +243  css/css-values/round-mod-rem-computed.html
+ FAIL => PASS    [162/162]  +162  css/css-values/signed-zero.html
+ FAIL => FAIL    [227/233]  +227  css/css-values/signs-abs-computed.html
+ FAIL => PASS      [32/32]   +32  css/css-values/sin-cos-tan-computed.html
+ FAIL => PASS    [270/270]  +270  css/css-values/sin-cos-tan-serialize.html
+ FAIL => PASS      [47/47]   +34  css/css-values/tree-counting/calc-sibling-function-parsing.html
+ FAIL => FAIL        [5/7]    +5  css/css-values/tree-counting/calc-sibling-function.html
+ FAIL => FAIL       [2/12]    +2  css/css-values/tree-counting/sibling-function-invalidation.html
+ FAIL => FAIL        [1/2]    +1  css/css-values/tree-counting/sibling-index-keyframe-font-style-dynamic.html
+ FAIL => FAIL        [1/2]    +1  css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic.html
+ FAIL => FAIL        [1/2]    +1  css/css-values/tree-counting/sibling-index-keyframe-length-value-dynamic.html
+ FAIL => FAIL      [10/20]   +10  css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.html
+ FAIL => FAIL        [1/2]    +1  css/css-values/tree-counting/sibling-index-keyframe-rotate-dynamic.html
+ FAIL => FAIL        [1/2]    +1  css/css-values/tree-counting/sibling-index-keyframe-scale-dynamic.html
+ FAIL => FAIL        [1/2]    +1  css/css-values/tree-counting/sibling-index-keyframe-transform-dynamic.html
+ FAIL => FAIL        [1/2]    +1  css/css-values/tree-counting/sibling-index-keyframe-value-dynamic.html
+ FAIL => FAIL        [2/3]    +2  css/css-values/tree-counting/sibling-index-linear-gradient-gcs.html
+ FAIL => PASS        [1/1]    +1  css/css-values/tree-counting/trig-functions-in-gradient-position.html
+ FAIL => PASS        [4/4]    +4  css/css-values/tree-counting/trig-functions-with-runtime-angle-arguments.html
+ FAIL => FAIL       [3/39]    +3  css/css-values/typed_arithmetic.html
+ FAIL => PASS    [160/160]   +40  css/css-values/viewport-units-css2-001.html
+ FAIL => PASS      [11/11]   +11  css/css-variables/variable-cycles.html
+ FAIL => FAIL        [2/6]    +2  css/css-viewport/zoom/line-height-computed.html
+ FAIL => PASS        [2/2]    +2  css/css-viewport/zoom/zoom-with-sign-function.html
+ FAIL => PASS        [3/3]    +3  css/filter-effects/filter-sign-function.html
+ FAIL => FAIL        [1/5]    +1  css/motion/offset-supports-calc.html
+ FAIL => PASS      [11/11]    +2  css/selectors/attribute-selectors/style-attribute-selector.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34720965955).</sub>
<!-- wpt-results-end -->
