### PR TITLE
wpt: mirror wptserve's /resources/WebIDLParser.js rewrite

### DIFF
--- a/wpt/runner/src/test_runners/harness_test.rs
+++ b/wpt/runner/src/test_runners/harness_test.rs
@@ -95,12 +95,16 @@ impl WptScriptFetcher {
 
 impl ScriptFetcher for WptScriptFetcher {
     fn fetch(&self, url: &Url) -> Result<String, FetchError> {
-        let path = url.path();
+        let mut path = url.path();
         if path.ends_with("/resources/testharnessreport.js") {
             return Ok(TESTHARNESSREPORT_JS.to_string());
         }
         if path.ends_with("/resources/testdriver-vendor.js") {
             return Ok(TESTDRIVER_VENDOR_JS.to_string());
+        }
+        // wptserve rewrites this URL (see `rewrites` in tools/serve/serve.py)
+        if path == "/resources/WebIDLParser.js" {
+            path = "/resources/webidl2/lib/webidl2.js";
         }
         let relative_path = path.strip_prefix('/').unwrap_or(path);
         std::fs::read_to_string(self.wpt_dir.join(relative_path)).map_err(FetchError::Io)


### PR DESCRIPTION
## Summary

All 24 `idlharness*` tests under `css/` currently fail in the WPT runner before any subtest runs, with:

```
failed to fetch script http://dummy.local/resources/WebIDLParser.js: No such file or directory
```

`/resources/WebIDLParser.js` does not exist on disk in the WPT checkout — wptserve serves it via a URL rewrite (`tools/serve/serve.py`: `rewrites = [("GET", "/resources/WebIDLParser.js", "/resources/webidl2/lib/webidl2.js")]`). `WptScriptFetcher` reads scripts straight from `WPT_DIR`, so it never saw the alias. This PR applies the same rewrite in `WptScriptFetcher::fetch`.

With this, the harness gets as far as `idl_test setup`, which then fails with `fetch is not defined` on every one of those 24 tests — `idlharness.js` loads the `.idl` files via `fetch('/interfaces/<spec>.idl')`, and Blitz's script runtime has no `fetch` global yet. That is the real remaining blocker and is out of scope here.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/eb89080a7e364cb3b94ba086b42d31d8
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/eb89080a7e364cb3b94ba086b42d31d8?variant=devin-insiders
Requested by: @nicoburns