### PR TITLE
resolved_style: overconstrained relative insets resolve to the computed value

### DIFF
--- a/packages/blitz-dom/src/resolved_style.rs
+++ b/packages/blitz-dom/src/resolved_style.rs
@@ -347,9 +347,10 @@ impl BaseDocument {
                     .map(|parent| *parent.final_layout());
 
                 match position {
-                    // Used value: the relative offset. The non-`auto` side of
-                    // each axis wins (`top`/`left` take precedence when both
-                    // are set) and the opposite side resolves to its negation.
+                    // Used value: the relative offset. An `auto` side resolves
+                    // to the negation of the opposite side. When both sides
+                    // are set the axis is overconstrained and each side
+                    // resolves to its computed value instead.
                     Position::Relative => {
                         let (cb_width, cb_height) = parent_layout
                             .map(|pl| {
@@ -381,15 +382,30 @@ impl BaseDocument {
                                 resolve_inset(&pos_styles.right, basis),
                             )
                         };
-                        let used_start = match (start, end) {
-                            (Some(start), _) => start,
-                            (None, Some(end)) => -end,
+                        let is_start = matches!(property_name, "top" | "left");
+                        let used = match (start, end) {
+                            (Some(start), Some(end)) => {
+                                if is_start {
+                                    start
+                                } else {
+                                    end
+                                }
+                            }
+                            (Some(start), None) => {
+                                if is_start {
+                                    start
+                                } else {
+                                    -start
+                                }
+                            }
+                            (None, Some(end)) => {
+                                if is_start {
+                                    -end
+                                } else {
+                                    end
+                                }
+                            }
                             (None, None) => 0.0,
-                        };
-                        let used = if matches!(property_name, "top" | "left") {
-                            used_start
-                        } else {
-                            -used_start
                         };
                         return format_px(used);
                     }


### PR DESCRIPTION
## Summary

`getComputedStyle().top/right/bottom/left` on a `position: relative` box returned `-top`/`-left` for `bottom`/`right` whenever both sides of an axis were specified (e.g. `top: 1px; bottom: 3px` → `bottom: -1px`). That is the *used* value, but per [CSSOM resolved value](https://drafts.csswg.org/cssom/#resolved-value-special-case-property-like-top) an inset only resolves to the used value when it is *not over-constrained*; both sides set on a relpos box is over-constrained, so each side must resolve to its own computed value (`bottom: 3px`).

```
(Some(start), Some(end)) => is_start ? start : end   // new: computed value
(Some(start), None)      => is_start ? start : -start
(None, Some(end))        => is_start ? -end  : end
(None, None)             => 0
```

WPT `css/cssom/getComputedStyle-insets-relative.html`: 108/252 → 252/252. No other `css/cssom` test changed.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/73b31f38267044d2a1f175b866bc8855
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/73b31f38267044d2a1f175b866bc8855?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **153** newly passing, **0** newly failing (net +153).

<details>
<summary>Full diff (2 changed tests)</summary>

```diff
+ FAIL => FAIL    [12/44]    +9  css/css-logical/logical-box-inset.html
+ FAIL => PASS  [252/252]  +144  css/cssom/getComputedStyle-insets-relative.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34721476700).</sub>
<!-- wpt-results-end -->
