### PR TITLE
script: add a minimal `fetch()` (Response/Headers) and a `Window` interface; unblocks css idlharness tests

### DIFF
--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -78,6 +78,105 @@ const BOOTSTRAP_JS: &str = r#"
         };
     }
 
+    // `fetch()`: a minimal Fetch API on top of the synchronous `__blitz_fetch_sync`
+    // native (which goes through the document's ScriptFetcher). Bodies are
+    // text-only; `Headers` is a simple case-insensitive map.
+    if (typeof globalThis.fetch !== "function") {
+        class Headers {
+            #map = new Map();
+            constructor(init) {
+                if (init instanceof Headers) {
+                    for (const [k, v] of init) this.append(k, v);
+                } else if (Array.isArray(init)) {
+                    for (const [k, v] of init) this.append(k, v);
+                } else if (init && typeof init === "object") {
+                    for (const k of Object.keys(init)) this.append(k, init[k]);
+                }
+            }
+            append(name, value) {
+                const key = String(name).toLowerCase();
+                const existing = this.#map.get(key);
+                this.#map.set(key, existing === undefined ? String(value) : existing + ", " + value);
+            }
+            set(name, value) { this.#map.set(String(name).toLowerCase(), String(value)); }
+            get(name) { return this.#map.get(String(name).toLowerCase()) ?? null; }
+            has(name) { return this.#map.has(String(name).toLowerCase()); }
+            delete(name) { this.#map.delete(String(name).toLowerCase()); }
+            forEach(cb, thisArg) { for (const [k, v] of this) cb.call(thisArg, v, k, this); }
+            *entries() { yield* [...this.#map.entries()].sort((a, b) => (a[0] < b[0] ? -1 : 1)); }
+            *keys() { for (const [k] of this.entries()) yield k; }
+            *values() { for (const [, v] of this.entries()) yield v; }
+            [Symbol.iterator]() { return this.entries(); }
+        }
+
+        class Response {
+            #body;
+            #bodyUsed = false;
+            constructor(body = null, init = {}) {
+                this.#body = body === null || body === undefined ? "" : String(body);
+                const status = init.status === undefined ? 200 : Number(init.status);
+                if (!Number.isInteger(status) || status < 200 || status > 599) {
+                    throw new RangeError("The status provided (" + status + ") is outside the range [200, 599].");
+                }
+                Object.defineProperties(this, {
+                    status: { value: status, enumerable: true },
+                    statusText: { value: init.statusText === undefined ? "" : String(init.statusText), enumerable: true },
+                    headers: { value: new Headers(init.headers), enumerable: true },
+                    url: { value: init.url === undefined ? "" : String(init.url), enumerable: true },
+                    type: { value: "basic", enumerable: true },
+                    redirected: { value: false, enumerable: true },
+                });
+            }
+            get ok() { return this.status >= 200 && this.status <= 299; }
+            get bodyUsed() { return this.#bodyUsed; }
+            #consume() {
+                if (this.#bodyUsed) {
+                    return Promise.reject(new TypeError("body stream already read"));
+                }
+                this.#bodyUsed = true;
+                return Promise.resolve(this.#body);
+            }
+            text() { return this.#consume(); }
+            json() { return this.#consume().then((text) => JSON.parse(text)); }
+            arrayBuffer() { return this.#consume().then((text) => new TextEncoder().encode(text).buffer); }
+            clone() {
+                if (this.#bodyUsed) throw new TypeError("Response body is already used");
+                return new Response(this.#body, {
+                    status: this.status, statusText: this.statusText, headers: this.headers, url: this.url,
+                });
+            }
+        }
+
+        globalThis.Headers = Headers;
+        globalThis.Response = Response;
+        globalThis.fetch = function fetch(input, init) {
+            return new Promise((resolve, reject) => {
+                let url;
+                try {
+                    url = input && typeof input === "object" && "url" in input ? String(input.url) : String(input);
+                } catch (e) {
+                    reject(e);
+                    return;
+                }
+                const method = String(init?.method ?? "GET").toUpperCase();
+                if (method !== "GET" && method !== "HEAD") {
+                    reject(new TypeError("fetch: only GET and HEAD requests are supported"));
+                    return;
+                }
+                try {
+                    const [status, resolvedUrl, text] = __blitz_fetch_sync(url);
+                    resolve(new Response(method === "HEAD" ? "" : text, {
+                        status,
+                        statusText: status === 200 ? "OK" : status === 404 ? "Not Found" : "",
+                        url: resolvedUrl,
+                    }));
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        };
+    }
+
     if (typeof globalThis.DOMException !== "function") {
         const DOM_EXCEPTION_CODES = {
             IndexSizeError: 1,
@@ -1042,11 +1141,16 @@ impl ScriptRuntime {
         fetcher: Rc<RefCell<Box<dyn ScriptFetcher>>>,
     ) -> Self {
         let module_loader = Rc::new(BlitzModuleLoader {
-            fetcher,
+            fetcher: Rc::clone(&fetcher),
             base_url: base_url.cloned(),
             modules: RefCell::new(HashMap::new()),
         });
         let ctx = DomCtx::new(doc);
+        {
+            let mut state = ctx.state.borrow_mut();
+            state.base_url = base_url.cloned();
+            state.fetcher = Some(fetcher);
+        }
         // Share the runtime's clock with boa so that `Date` observes the same
         // (possibly virtual) time as timers
         let clock = ctx.state.borrow().clock.clone();
@@ -1140,6 +1244,9 @@ impl ScriptRuntime {
 
         // Embedder message channel (see `ScriptDocument::take_messages`)
         register_global_fn(&mut context, "__blitz_send_message", 1, send_message);
+
+        // Synchronous resource fetch backing the bootstrap's `fetch()`
+        register_global_fn(&mut context, "__blitz_fetch_sync", 1, fetch_sync);
 
         // CSS property support check, used by the style Proxy's `has` trap
         register_global_fn(
@@ -1971,6 +2078,57 @@ fn send_message(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
         .to_std_string_lossy();
     ctx.state.borrow_mut().outbound_messages.push(message);
     Ok(JsValue::undefined())
+}
+
+/// `__blitz_fetch_sync(url)`: resolve `url` against the document base URL and
+/// fetch it via the document's [`ScriptFetcher`]. Returns `[status, url, text]`:
+/// a missing resource yields a 404 (like an HTTP server would), any other
+/// failure throws a `TypeError` (a network error, in `fetch()` terms).
+fn fetch_sync(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    use boa_engine::object::builtins::JsArray;
+
+    let ctx = dom_ctx(context)?;
+    let input = args
+        .first()
+        .unwrap_or(&JsValue::undefined())
+        .to_string(context)?
+        .to_std_string_lossy();
+
+    let (base_url, fetcher) = {
+        let state = ctx.state.borrow();
+        (state.base_url.clone(), state.fetcher.clone())
+    };
+    let url = match &base_url {
+        Some(base) => base.join(&input),
+        None => Url::parse(&input),
+    }
+    .map_err(|_| JsNativeError::typ().with_message(format!("Failed to parse URL from {input}")))?;
+    let fetcher =
+        fetcher.ok_or_else(|| JsNativeError::typ().with_message("fetch is unavailable"))?;
+
+    let (status, text) = match fetcher.borrow().fetch(&url) {
+        Ok(text) => (200, text),
+        Err(crate::fetch::FetchError::Io(error))
+            if error.kind() == std::io::ErrorKind::NotFound =>
+        {
+            (404, String::new())
+        }
+        Err(error) => {
+            return Err(JsNativeError::typ()
+                .with_message(format!("Failed to fetch {url}: {error}"))
+                .into());
+        }
+    };
+
+    Ok(JsArray::from_iter(
+        [
+            JsValue::from(status),
+            JsString::from(url.as_str()).into(),
+            JsString::from(text).into(),
+        ],
+        context,
+    )
+    .into())
 }
 
 fn clear_timer(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {

--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -319,6 +319,15 @@ const BOOTSTRAP_JS: &str = r#"
     // probes throw "right-hand side of 'instanceof' is not an object". All
     // blitz-vibey-script elements share a single prototype, so tag-specific
     // interfaces cannot be truthfully modelled: these always answer false.
+    // `Window`: the global object's interface (`window instanceof Window`).
+    // Feature-detection code (and WPT's idlharness) uses `'Window' in self`
+    // to tell a window global from a worker or ShadowRealm global.
+    if (typeof globalThis.Window === "undefined") {
+        const windowProto = Object.create(Object.getPrototypeOf(globalThis));
+        Object.setPrototypeOf(globalThis, windowProto);
+        globalThis.Window = makeInterface("Window", windowProto);
+    }
+
     for (const name of [
         "EventTarget", "CharacterData", "Text", "Comment", "DocumentFragment",
         "HTMLInputElement", "HTMLTextAreaElement", "HTMLSelectElement",

--- a/packages/blitz-vibey-script/src/state.rs
+++ b/packages/blitz-vibey-script/src/state.rs
@@ -8,8 +8,10 @@ use std::rc::Rc;
 use blitz_dom::{BaseDocument, NodeId};
 use boa_engine::object::JsObject;
 use boa_engine::{Finalize, JsData, Trace};
+use url::Url;
 
 use crate::clock::ScriptClock;
+use crate::fetch::ScriptFetcher;
 use crate::timers::TimerQueue;
 
 /// Prototype objects for the DOM wrapper classes
@@ -86,6 +88,10 @@ pub(crate) struct RuntimeState {
     /// listeners, timer callbacks and promise jobs). Drained with
     /// [`ScriptDocument::take_js_errors`](crate::ScriptDocument::take_js_errors).
     pub uncaught_errors: Vec<String>,
+    /// The document base URL, against which `fetch()` URLs are resolved
+    pub base_url: Option<Url>,
+    /// Fetcher backing `fetch()` (shared with `<script src>` and module loading)
+    pub fetcher: Option<Rc<RefCell<Box<dyn ScriptFetcher>>>>,
 }
 
 /// Maximum number of errors stored in [`RuntimeState::uncaught_errors`] between

--- a/packages/blitz-vibey-script/tests/dom.rs
+++ b/packages/blitz-vibey-script/tests/dom.rs
@@ -701,3 +701,53 @@ fn cssom_font_face_and_keyframes() {
          |3|50% { opacity: 0.5; }|2|100%"
     );
 }
+
+#[test]
+fn fetch_via_script_fetcher() {
+    use blitz_vibey_script::{FetchError, ScriptFetcher};
+    use url::Url;
+
+    struct MapFetcher;
+    impl ScriptFetcher for MapFetcher {
+        fn fetch(&self, url: &Url) -> Result<String, FetchError> {
+            match url.path() {
+                "/data.json" => Ok(r#"{"answer": 42}"#.to_string()),
+                _ => Err(FetchError::Io(std::io::Error::from(
+                    std::io::ErrorKind::NotFound,
+                ))),
+            }
+        }
+    }
+
+    let mut doc = ScriptDocument::from_html(
+        r#"
+        <html><body>
+            <div id="out"></div>
+            <div id="missing"></div>
+            <script>
+                fetch("/data.json")
+                    .then((r) => { if (!r.ok) throw new Error("not ok"); return r.json(); })
+                    .then((json) => {
+                        document.getElementById("out").textContent = String(json.answer);
+                    });
+                fetch("missing.txt").then((r) => {
+                    document.getElementById("missing").textContent =
+                        r.status + " " + r.ok + " " + r.url;
+                });
+            </script>
+        </body></html>
+        "#,
+        DocumentConfig {
+            base_url: Some("http://example.test/dir/page.html".to_string()),
+            ..Default::default()
+        },
+    )
+    .with_fetcher(MapFetcher);
+    doc.execute_scripts();
+    assert_eq!(doc.take_js_errors(), Vec::<String>::new());
+    assert_eq!(text_of_selector(&doc, "#out"), "42");
+    assert_eq!(
+        text_of_selector(&doc, "#missing"),
+        "404 false http://example.test/dir/missing.txt"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #867. After that fix, all 24 `css/**/idlharness*` WPT tests still failed at `idl_test setup` with `fetch is not defined`: `idlharness.js` loads WebIDL via `fetch('/interfaces/<spec>.idl')`, and blitz-vibey-script had no `fetch` global.

### `fetch()`

- Native `__blitz_fetch_sync(url)`: resolves `url` against the document base URL and reads it through the document's existing `ScriptFetcher` (the same one used for `<script src>` and ES module imports — so the WPT runner's `WptScriptFetcher` serves `/interfaces/*.idl` from `WPT_DIR` with no runner changes). `FetchError::Io(NotFound)` → status 404; any other error → `TypeError` rejection (network error). `RuntimeState` now holds the `base_url` and a shared handle to the fetcher for this.
- JS bootstrap: `fetch(input, init)` (GET/HEAD only; accepts a string, `URL`, or anything with `.url`), returning a Promise of a text-bodied `Response` (`ok`, `status`, `statusText`, `url`, `headers`, `bodyUsed`, `text()`, `json()`, `arrayBuffer()`, `clone()`), plus a simple case-insensitive `Headers`.

Deliberately not using boa_runtime's `FetchExtension`, which would bring its own HTTP client rather than going through the embedder's fetcher (see the existing comment in `ScriptRuntime::new`).

### `Window` interface

With `fetch` working, idlharness ran but classified Blitz's global as a **ShadowRealm** (`exposed_in()` in idlharness.js: no `'Window' in self`, and `Object.getPrototypeOf(self) === Object.prototype`), so it treated every `[Exposed=Window]` interface as *not* exposed: "interface object exists" subtests passed vacuously, all member checks were skipped, and interfaces Blitz *does* define (`CSSStyleSheet`, `CSSRule`, ...) failed for existing at all. The bootstrap now inserts a `Window.prototype` object into the global's prototype chain and exposes `Window` (`window instanceof Window === true`), so idlharness (and feature-detection code using `'Window' in self`) sees a window global.

### WPT impact (`css/**/idlharness*`, local run of the 22 affected directories)

Subtest run counts now match Chrome's (3258 vs 3259). Pass counts, Blitz vs Chrome:

| test | Blitz | Chrome |
|---|---|---|
| css-anchor-position | 7/86 | 86/86 |
| css-animations | 58/98 | 98/98 |
| css-cascade | 20/33 | 34/34 |
| css-conditional | 30/45 | 41/45 |
| css-conditional/container-queries | 7/28 | 21/28 |
| css-counter-styles | 9/37 | 37/37 |
| css-font-loading | 13/143 | 95/143 |
| css-fonts | 23/97 | 40/97 |
| css-highlight-api | 7/33 | 33/33 |
| css-images | 5/6 | 5/6 |
| css-masking | 9/41 | 41/41 |
| css-paint-api | 19/20 | 19/20 |
| css-parser-api | 5/71 | 5/71 |
| css-properties-values-api | 10/16 | 16/16 |
| css-pseudo | 8/29 | 19/29 |
| css-shadow | 8/12 | 12/12 |
| css-transitions | 26/64 | 64/64 |
| css-transitions (idlharness-2) | 7/19 | 17/19 |
| css-typed-om | 26/544 | 485/544 |
| css-view-transitions | 22/66 | 66/66 |
| cssom-view | 153/417 | 412/417 |
| cssom | 221/497 | 440/497 |
| filter-effects | 27/484 | 474/484 |
| geometry | 2/372 | 369/372 |
| **total** | **722/3258** | 3259 |

Across the 22 directories overall: subtests passed 25352 → 26074, tests passed/failed unchanged (1815/4223) — no regressions.

Test: `fetch_via_script_fetcher` in `packages/blitz-vibey-script/tests/dom.rs`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/eb89080a7e364cb3b94ba086b42d31d8
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/eb89080a7e364cb3b94ba086b42d31d8?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **778** newly passing, **0** newly failing (net +778).

<details>
<summary>Full diff (25 changed tests)</summary>

```diff
+ FAIL => FAIL     [7/86]    +7  css/css-anchor-position/idlharness.html
+ FAIL => FAIL    [58/98]   +58  css/css-animations/idlharness.html
+ FAIL => FAIL    [20/33]   +20  css/css-cascade/idlharness.html
+ FAIL => FAIL     [7/28]    +7  css/css-conditional/container-queries/idlharness.html
+ FAIL => FAIL    [30/45]   +30  css/css-conditional/idlharness.html
+ FAIL => FAIL     [9/37]    +9  css/css-counter-styles/idlharness.html
+ FAIL => FAIL   [13/143]   +13  css/css-font-loading/idlharness.https.html
+ FAIL => FAIL    [23/97]   +23  css/css-fonts/idlharness.html
+ FAIL => FAIL     [7/33]    +7  css/css-highlight-api/idlharness.window.html
+ FAIL => FAIL      [5/6]    +5  css/css-images/idlharness.html
+ FAIL => FAIL     [9/41]    +9  css/css-masking/idlharness.html
+ FAIL => FAIL    [19/20]   +19  css/css-paint-api/idlharness.html
+ FAIL => FAIL     [5/71]    +5  css/css-parser-api/idlharness.html
+ FAIL => FAIL    [10/16]   +10  css/css-properties-values-api/idlharness.html
+ FAIL => FAIL     [8/29]    +8  css/css-pseudo/idlharness.html
+ FAIL => FAIL     [8/12]    +8  css/css-shadow/idlharness.html
+ FAIL => FAIL     [7/19]    +7  css/css-transitions/idlharness-2.html
+ FAIL => FAIL    [26/64]   +26  css/css-transitions/idlharness.html
+ FAIL => FAIL   [26/544]   +26  css/css-typed-om/idlharness.html
+ FAIL => FAIL    [22/66]   +22  css/css-view-transitions/idlharness.html
+ FAIL => FAIL  [153/417]  +153  css/cssom-view/idlharness.html
+ FAIL => FAIL  [221/497]  +221  css/cssom/idlharness.html
+ FAIL => FAIL   [27/484]   +27  css/filter-effects/idlharness.any.html
+ FAIL => FAIL    [2/372]    +2  css/geometry/idlharness.any.html
+ FAIL => FAIL  [56/1705]   +56  svg/idlharness.window.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34721898497).</sub>
<!-- wpt-results-end -->
