### PR TITLE
cssom: enumerable getComputedStyle() declarations; computed values for non-atomic inlines

### DIFF
--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -72,7 +72,7 @@ mod tree;
 mod url;
 
 pub use cssom::{CssRuleInfo, CssomError};
-pub use resolved_style::css_property_is_supported;
+pub use resolved_style::{css_property_is_supported, resolved_style_property_names};
 pub use stylo_to_kurbo::resolve_2d_transform;
 
 pub mod net;

--- a/packages/blitz-dom/src/resolved_style.rs
+++ b/packages/blitz-dom/src/resolved_style.rs
@@ -12,8 +12,8 @@ use style::computed_values::position::T as Position;
 use style::parser::ParserContext;
 use style::properties::declaration_block::{Importance, parse_style_attribute};
 use style::properties::{
-    ComputedValues, PropertyDeclaration, PropertyDeclarationBlock, PropertyId, ShorthandId,
-    SourcePropertyDeclaration, parse_one_declaration_into,
+    ComputedValues, NonCustomPropertyId, PropertyDeclaration, PropertyDeclarationBlock, PropertyId,
+    ShorthandId, SourcePropertyDeclaration, parse_one_declaration_into,
 };
 use style::stylesheets::supports_rule::parse_condition_or_declaration;
 use style::stylesheets::{CssRuleType, Origin};
@@ -21,12 +21,14 @@ use style::values::computed::LengthPercentage;
 use style::values::computed::length::CSSPixelLength;
 use style::values::generics::position::{Inset as GenericInset, PreferredRatio};
 use style::values::resolved;
-use style::values::specified::box_::DisplayInside;
+use style::values::specified::box_::{DisplayInside, DisplayOutside};
 use style_traits::{CssStringWriter, ParsingMode, ToCss};
 
 use blitz_traits::node_id::NodeId;
 
 use crate::BaseDocument;
+use crate::layout::replaced::is_replaced_element;
+use crate::local_name;
 
 /// Serialize a used length (in CSS pixels) the way stylo serializes computed lengths
 fn format_px(px: f32) -> String {
@@ -96,6 +98,22 @@ pub fn css_property_is_supported(name: &str) -> bool {
         PropertyId::parse_enabled_for_all_content(name),
         Ok(property_id) if !matches!(property_id, PropertyId::Custom(_))
     )
+}
+
+/// The names of the properties exposed by the `CSSStyleDeclaration` returned
+/// from `getComputedStyle()` (its indexed properties): every enabled longhand,
+/// sorted alphabetically.
+pub fn resolved_style_property_names() -> &'static [&'static str] {
+    static NAMES: std::sync::OnceLock<Vec<&'static str>> = std::sync::OnceLock::new();
+    NAMES.get_or_init(|| {
+        let mut names: Vec<&'static str> = NonCustomPropertyId::iter()
+            .filter_map(|id| id.as_longhand())
+            .map(|longhand| longhand.name())
+            .filter(|name| PropertyId::parse_enabled_for_all_content(name).is_ok())
+            .collect();
+        names.sort_unstable();
+        names
+    })
 }
 
 impl BaseDocument {
@@ -280,8 +298,22 @@ impl BaseDocument {
         };
 
         let display = styles.clone_display();
-        let has_layout_box =
+        // Non-atomic inline elements are laid out as style spans within their
+        // inline root's text layout rather than as boxes of their own, so their
+        // layout-dependent properties resolve to computed (not used) values.
+        let is_non_atomic_inline = display.outside() == DisplayOutside::Inline
+            && display.inside() == DisplayInside::Flow
+            && !node.flags.is_inline_root()
+            && node.element_data().is_none_or(|data| {
+                let tag = &data.name.local;
+                !(is_replaced_element(tag)
+                    || *tag == local_name!("input")
+                    || *tag == local_name!("textarea")
+                    || *tag == local_name!("button"))
+            });
+        let generates_box =
             node.flags.is_in_document() && !display.is_none() && stored_styles.is_some();
+        let has_layout_box = generates_box && !is_non_atomic_inline;
 
         // Layout-dependent "used value" special cases
         match property_name {
@@ -467,7 +499,7 @@ impl BaseDocument {
                 let has_aspect_ratio =
                     !matches!(pos_styles.aspect_ratio.ratio, PreferredRatio::None);
                 let preserves_auto =
-                    has_layout_box && (has_aspect_ratio || self.is_flex_or_grid_item(node_id));
+                    generates_box && (has_aspect_ratio || self.is_flex_or_grid_item(node_id));
                 if is_auto && !preserves_auto {
                     return format_px(0.0);
                 }

--- a/packages/blitz-vibey-script/src/dom/style.rs
+++ b/packages/blitz-vibey-script/src/dom/style.rs
@@ -25,6 +25,8 @@ pub(crate) fn init_style_proto(proto: &JsObject, context: &mut Context) {
 /// `getComputedStyle()`. Property reads return *resolved* values.
 pub(crate) fn init_computed_style_proto(proto: &JsObject, context: &mut Context) {
     define_accessor(proto, "cssText", Some(get_empty_string), None, context);
+    define_accessor(proto, "length", Some(get_resolved_length), None, context);
+    define_method(proto, "item", 1, get_resolved_item, context);
     define_method(proto, "setProperty", 2, noop, context);
     define_method(proto, "removeProperty", 1, noop, context);
     define_method(
@@ -42,6 +44,26 @@ fn get_empty_string(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsV
 
 fn noop(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
     Ok(JsValue::undefined())
+}
+
+fn get_resolved_length(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    Ok(JsValue::from(
+        blitz_dom::resolved_style_property_names().len() as u32,
+    ))
+}
+
+fn get_resolved_item(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let index = args
+        .first()
+        .unwrap_or(&JsValue::undefined())
+        .to_number(context)?;
+    let names = blitz_dom::resolved_style_property_names();
+    let name = if index >= 0.0 && index < names.len() as f64 {
+        names[index as usize]
+    } else {
+        ""
+    };
+    Ok(js_str(name))
 }
 
 fn get_resolved_property_value(

--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -262,9 +262,24 @@ const BOOTSTRAP_JS: &str = r#"
     // via indexed access) property names
     const isCssPropName = (prop) =>
         typeof prop === "string" && /^-?[a-zA-Z][a-zA-Z0-9-]*$/.test(prop);
+    // Declarations exposing `length`/`item()` (e.g. `getComputedStyle()`) also
+    // support indexed access (`style[0]`) and iteration.
+    const isIndex = (prop) => typeof prop === "string" && /^\d+$/.test(prop);
+    const isIndexed = (target) => typeof target.item === "function";
+    const styleIterator = function* () {
+        for (let i = 0; i < this.length; i++) yield this.item(i);
+    };
     globalThis.__blitz_wrap_style = function (native) {
         return new Proxy(native, {
             get(target, prop) {
+                if (isIndexed(target)) {
+                    if (isIndex(prop)) {
+                        return Number(prop) < target.length ? target.item(Number(prop)) : undefined;
+                    }
+                    if (prop === Symbol.iterator && !(prop in target)) {
+                        return styleIterator.bind(target);
+                    }
+                }
                 if (isCssPropName(prop) && !(prop in target)) {
                     return target.getPropertyValue(toKebab(prop));
                 }
@@ -285,9 +300,34 @@ const BOOTSTRAP_JS: &str = r#"
             // property (used by WPT's computed-value test helpers)
             has(target, prop) {
                 if (Reflect.has(target, prop)) return true;
+                if (isIndexed(target)) {
+                    if (isIndex(prop)) return Number(prop) < target.length;
+                    if (prop === Symbol.iterator) return true;
+                }
                 return (
                     isCssPropName(prop) && __blitz_css_property_supported(toKebab(prop))
                 );
+            },
+            ownKeys(target) {
+                const keys = [];
+                if (isIndexed(target)) {
+                    for (let i = 0; i < target.length; i++) keys.push(String(i));
+                }
+                for (const key of Reflect.ownKeys(target)) {
+                    if (!keys.includes(key)) keys.push(key);
+                }
+                return keys;
+            },
+            getOwnPropertyDescriptor(target, prop) {
+                if (isIndexed(target) && isIndex(prop) && Number(prop) < target.length) {
+                    return {
+                        value: target.item(Number(prop)),
+                        enumerable: true,
+                        configurable: true,
+                        writable: false,
+                    };
+                }
+                return Reflect.getOwnPropertyDescriptor(target, prop);
             },
         });
     };


### PR DESCRIPTION
## Summary

`css/css-cascade/all-prop-revert-layer.html` (and siblings) failed before running a single subtest with `TypeError: value with type object is not iterable` at `for (let property of cs)`: the `CSSStyleDeclaration` returned by `getComputedStyle()` had no `length`/`item()`/indexed access/`Symbol.iterator`.

**Enumeration.** New `blitz_dom::resolved_style_property_names()` returns every enabled longhand (via `NonCustomPropertyId::iter()` filtered by `PropertyId::parse_enabled_for_all_content`), sorted alphabetically, cached in a `OnceLock`. The computed-style proto gains native `length` and `item(i)`, and the `__blitz_wrap_style` Proxy now provides `style[i]`, `Symbol.iterator`, `in`, `ownKeys`/`getOwnPropertyDescriptor` for any wrapped declaration that exposes `item()` (`element.style` is unchanged since it has no `item`).

**Non-atomic inlines resolve to computed values.** With enumeration working, 5 subtests still failed because `height`/`margin-*` on the `display: inline` `<foo-bar>` target returned `0px`: those properties were read as used values from `final_layout()`, but non-atomic inline elements are laid out as Parley style spans, not Taffy boxes, so their layout is all zeros. `resolved_style_value` now splits the old `has_layout_box` into

```rust
let generates_box = in_document && !display.is_none() && stored_styles.is_some();
let has_layout_box = generates_box && !is_non_atomic_inline;
```

where `is_non_atomic_inline` = `inline`/`flow` display, not an inline root, and not a replaced/`input`/`textarea`/`button` element (same set `construct.rs` gives its own box). The used-value branches (`width`/`height`, `margin-*`, `top`/`right`/`bottom`/`left`, `transform`) use `has_layout_box`; the `min-width: auto → 0px when no box is generated` rule keeps `generates_box`, since inline elements do generate a box.

**WPT** (`css/css-cascade css/cssom css/cssom-view css/css-display`): 4311 → 4816 subtests passing. Newly passing tests: `all-prop-revert-layer.html` (268/268), `all-prop-revert-layer-noop.html`, `all-prop-revert-noop.html`, `cssom/cssstyledeclaration-csstext-all-shorthand.html`, `cssom/getComputedStyle-getter-v-properties.tentative.html`, `cssom/getComputedStyle-logical-enumeration.html`, `cssom/serialize-all-longhands.html` (computed style), plus the `CSSStyleDeclaration.length`/`item` idlharness subtests.

One subtest flips PASS → FAIL: `getComputedStyle-pseudo.html` / "Prefixed ::-webkit-file-upload-button". It only passed by accident before (`style.length` fell through the camelCase proxy to `getPropertyValue("length")` → `""`, and `"" == 0`). It genuinely requires `getComputedStyle(el, pseudo)` to return an empty declaration for unknown pseudo-elements, which Blitz doesn't model yet (the pseudo argument is ignored entirely).

Not addressed: `css/css-cascade/all-prop-initial-xml.html` needs `Blob`, `URL.createObjectURL`, iframe `contentDocument`/`contentWindow` and XML document parsing.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/17006eed19e3472c9252fdb27d4d7f72
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/17006eed19e3472c9252fdb27d4d7f72?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **604** newly passing, **3** newly failing (net +601).

<details>
<summary>Full diff (19 changed tests)</summary>

```diff
+ FAIL => PASS  [114/114]  +114  css/css-cascade/all-prop-revert-layer-noop.html
+ FAIL => PASS  [268/268]  +268  css/css-cascade/all-prop-revert-layer.html
+ FAIL => PASS  [114/114]  +114  css/css-cascade/all-prop-revert-noop.html
- PASS => FAIL      [0/1]    -1  css/css-transforms/2d-transform-inline-js.html
- PASS => FAIL      [0/1]    -1  css/css-ui/compute-kind-widget-no-fallback-props-001.html
+ FAIL => PASS      [1/1]    +1  css/css-values/lh-unit-004.html
+ FAIL => FAIL   [66/109]   +66  css/css-viewport/zoom/explicit-inherit/all-length-properties.html
+ FAIL => FAIL    [74/88]    +8  css/css-viewport/zoom/svg-computed-style.html
+ FAIL => PASS      [6/6]    +1  css/cssom/cssstyledeclaration-csstext-all-shorthand.html
+ FAIL => PASS    [10/10]    +4  css/cssom/getComputedStyle-getter-v-properties.tentative.html
+ FAIL => PASS      [1/1]    +1  css/cssom/getComputedStyle-logical-enumeration.html
+ FAIL => FAIL      [1/3]    +1  css/cssom/getComputedStyle-pseudo-picker-icon.html
- FAIL => FAIL     [1/28]    -1  css/cssom/getComputedStyle-pseudo.html
+ FAIL => FAIL  [223/497]    +2  css/cssom/idlharness.html
+ FAIL => FAIL      [1/2]    +1  css/cssom/serialize-all-longhands.html
+ FAIL => FAIL      [2/4]    +1  svg/extensibility/foreignObject/properties.svg
+ FAIL => FAIL    [15/34]    +8  svg/geometry/parsing/height-computed.svg
+ FAIL => FAIL    [10/14]    +6  svg/geometry/parsing/sizing-properties-computed.svg
+ FAIL => FAIL    [15/34]    +8  svg/geometry/parsing/width-computed.svg
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34723471219).</sub>
<!-- wpt-results-end -->
