### PR TITLE
Reland #866: root clientWidth/Height, CSS.registerProperty; enable progress()

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -400,6 +400,7 @@ impl BaseDocument {
         style_config::set_pref!("layout.css.basic-shape-shape.enabled", true);
         style_config::set_pref!("layout.css.attr.enabled", true);
         style_config::set_pref!("layout.css.tree-counting-functions.enabled", true);
+        style_config::set_pref!("layout.css.progress-function.enabled", true);
         style_config::set_pref!("layout.threads", -1);
 
         let viewport = config.viewport.unwrap_or_default();

--- a/packages/blitz-dom/src/lib.rs
+++ b/packages/blitz-dom/src/lib.rs
@@ -114,6 +114,7 @@ pub fn dom_node_id(id: taffy::NodeId) -> NodeId {
 pub use style::Atom;
 pub use style::invalidation::element::restyle_hints::RestyleHint;
 pub use style::media_queries::MediaType;
+pub use style::stylist::RegisterCustomPropertyResult;
 pub type SelectorList = selectors::SelectorList<style::selector_parser::SelectorImpl>;
 pub use events::{EventDriver, EventHandler, NoopEventHandler};
 pub use html::{DummyHtmlParserProvider, HtmlParserProvider};

--- a/packages/blitz-dom/src/resolved_style.rs
+++ b/packages/blitz-dom/src/resolved_style.rs
@@ -16,7 +16,8 @@ use style::properties::{
     SourcePropertyDeclaration, parse_one_declaration_into,
 };
 use style::stylesheets::supports_rule::parse_condition_or_declaration;
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::{CssRuleType, Origin, OriginSet};
+use style::stylist::RegisterCustomPropertyResult;
 use style::values::computed::LengthPercentage;
 use style::values::computed::length::CSSPixelLength;
 use style::values::generics::position::{Inset as GenericInset, PreferredRatio};
@@ -251,6 +252,27 @@ impl BaseDocument {
             Default::default(),
         );
         condition.eval(&context)
+    }
+
+    /// Register a custom property via script (`CSS.registerProperty()`).
+    /// On success all styles are invalidated so that declarations of the
+    /// property are re-parsed against the new registration.
+    pub fn register_custom_property(
+        &mut self,
+        name: &str,
+        syntax: &str,
+        inherits: bool,
+        initial_value: Option<&str>,
+    ) -> RegisterCustomPropertyResult {
+        let url_data = self.url.url_extra_data();
+        let result =
+            self.stylist
+                .register_custom_property(&url_data, name, syntax, inherits, initial_value);
+        if matches!(result, RegisterCustomPropertyResult::SuccessfullyRegistered) {
+            self.stylist
+                .force_stylesheet_origins_dirty(OriginSet::all());
+        }
+        result
     }
 
     /// Compute the resolved value of a CSS property for the given node, as exposed

--- a/packages/blitz-vibey-script/src/dom/element.rs
+++ b/packages/blitz-vibey-script/src/dom/element.rs
@@ -962,12 +962,51 @@ fn offset_top(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<
     layout_value(this, context, |node| node.offset_top_left().y.round())
 }
 
+/// `clientWidth`/`clientHeight`. For the root element (in no-quirks mode, which
+/// is all Blitz supports) these are the viewport dimensions minus scrollbars.
+fn client_size(
+    this: &JsValue,
+    context: &mut Context,
+    axis: impl FnOnce(&blitz_dom::Node) -> f32,
+    viewport_axis: impl FnOnce(&blitz_dom::Node, (f32, f32)) -> f32,
+) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = this_node_id(this)?;
+    let mut doc = ctx.doc.borrow_mut();
+    doc.resolve(0.0);
+    let Some(node) = doc.get_node(node_id) else {
+        return Ok(JsValue::from(0.0));
+    };
+    let value = if node_id == doc.root_element().id {
+        let viewport = doc.viewport();
+        let scale = viewport.scale();
+        let size = (
+            viewport.window_size.0 as f32 / scale,
+            viewport.window_size.1 as f32 / scale,
+        );
+        viewport_axis(node, size)
+    } else {
+        axis(node)
+    };
+    Ok(JsValue::from(value.round() as f64))
+}
+
 fn client_width(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-    layout_value(this, context, |node| node.client_width().round())
+    client_size(
+        this,
+        context,
+        |node| node.client_width(),
+        |node, (w, _)| w - node.final_layout().scrollbar_size.width,
+    )
 }
 
 fn client_height(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-    layout_value(this, context, |node| node.client_height().round())
+    client_size(
+        this,
+        context,
+        |node| node.client_height(),
+        |node, (_, h)| h - node.final_layout().scrollbar_size.height,
+    )
 }
 
 fn scroll_width(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {

--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -1295,6 +1295,11 @@ impl ScriptRuntime {
                 js_string!("supports"),
                 1,
             )
+            .function(
+                NativeFunction::from_fn_ptr(css_register_property),
+                js_string!("registerProperty"),
+                1,
+            )
             .build();
         register_global(&mut context, "CSS", css_namespace.into());
 
@@ -2064,6 +2069,69 @@ fn css_supports(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
         ctx.doc.borrow().css_supports_condition(&condition)
     };
     Ok(JsValue::from(supported))
+}
+
+/// `CSS.registerProperty({ name, syntax = "*", inherits, initialValue })`
+/// <https://drafts.css-houdini.org/css-properties-values-api-1/#the-registerproperty-function>
+fn css_register_property(
+    _: &JsValue,
+    args: &[JsValue],
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    use blitz_dom::RegisterCustomPropertyResult as Result_;
+
+    let ctx = dom_ctx(context)?;
+    let Some(descriptor) = args.first().and_then(JsValue::as_object) else {
+        return Err(JsNativeError::typ()
+            .with_message("CSS.registerProperty: argument must be a PropertyDefinition dictionary")
+            .into());
+    };
+    let get = |key: &str, context: &mut Context| -> JsResult<Option<String>> {
+        let value = descriptor.get(js_string!(key), context)?;
+        if value.is_undefined() {
+            return Ok(None);
+        }
+        Ok(Some(to_rust_string(&value, context)?))
+    };
+    let Some(name) = get("name", context)? else {
+        return Err(JsNativeError::typ()
+            .with_message("CSS.registerProperty: 'name' is required")
+            .into());
+    };
+    let inherits = descriptor.get(js_string!("inherits"), context)?;
+    if inherits.is_undefined() {
+        return Err(JsNativeError::typ()
+            .with_message("CSS.registerProperty: 'inherits' is required")
+            .into());
+    }
+    let inherits = inherits.to_boolean();
+    let syntax = get("syntax", context)?.unwrap_or_else(|| "*".to_string());
+    let initial_value = get("initialValue", context)?;
+
+    let result = ctx.doc.borrow_mut().register_custom_property(
+        &name,
+        &syntax,
+        inherits,
+        initial_value.as_deref(),
+    );
+    let error = match result {
+        Result_::SuccessfullyRegistered => return Ok(JsValue::undefined()),
+        Result_::InvalidName => JsNativeError::syntax().with_message(format!(
+            "CSS.registerProperty: '{name}' is not a valid custom property name"
+        )),
+        Result_::AlreadyRegistered => JsNativeError::error().with_message(format!(
+            "CSS.registerProperty: '{name}' is already registered"
+        )),
+        Result_::InvalidSyntax => JsNativeError::syntax()
+            .with_message(format!("CSS.registerProperty: invalid syntax '{syntax}'")),
+        Result_::NoInitialValue => JsNativeError::syntax().with_message(
+            "CSS.registerProperty: 'initialValue' is required for non-universal syntax",
+        ),
+        Result_::InvalidInitialValue | Result_::InitialValueNotComputationallyIndependent => {
+            JsNativeError::syntax().with_message("CSS.registerProperty: invalid 'initialValue'")
+        }
+    };
+    Err(error.into())
 }
 
 fn get_computed_style(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {


### PR DESCRIPTION
## Summary

#866 was stacked on #865's branch (`devin/1789249057-style-putforwards`) and was merged into *that branch* at 21:56 UTC — seven minutes after #865 had already been squash-merged into `main` (6eedc389, 21:49 UTC). Its commit therefore never reached `main`, which is why `css/css-properties-values-api/register-property-syntax-parsing.html` still fails 0/246 with `CSS.registerProperty` "not a callable function".

This is a clean cherry-pick of a2791565 onto `main` (no conflicts, no other changes). See #866 for the full description: root-element `clientWidth/Height` = viewport size, `BaseDocument::register_custom_property` + JS `CSS.registerProperty` binding, and the `layout.css.progress-function.enabled` pref.

Local WPT: `css/css-properties-values-api` 21 → 34 whole tests passing, 206 → 517 subtests; `register-property-syntax-parsing.html` 0/246 → 128/246.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ebb74f23fcae452a886fd774a6719ebb
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/ebb74f23fcae452a886fd774a6719ebb?variant=devin-insiders
Requested by: @nicoburns