### PR TITLE
script: implement `HTMLHyperlinkElementUtils` on `<a>`/`<area>`

### DIFF
--- a/packages/blitz-vibey-script/src/dom/element.rs
+++ b/packages/blitz-vibey-script/src/dom/element.rs
@@ -206,7 +206,7 @@ pub(crate) fn init_element_proto(proto: &JsObject, context: &mut Context) {
 
 // === Attribute helpers ===
 
-fn read_attr(ctx: &DomCtx, node_id: NodeId, name: &str) -> Option<String> {
+pub(crate) fn read_attr(ctx: &DomCtx, node_id: NodeId, name: &str) -> Option<String> {
     let doc = ctx.doc.borrow();
     let node = doc.get_node(node_id)?;
     let element = node.element_data()?;
@@ -217,7 +217,7 @@ fn read_attr(ctx: &DomCtx, node_id: NodeId, name: &str) -> Option<String> {
         .map(|attr| attr.value.clone())
 }
 
-fn write_attr(ctx: &DomCtx, node_id: NodeId, name: &str, value: &str) {
+pub(crate) fn write_attr(ctx: &DomCtx, node_id: NodeId, name: &str, value: &str) {
     let mut doc = ctx.doc.borrow_mut();
     doc.mutate().set_attribute(node_id, attr_name(name), value);
 }

--- a/packages/blitz-vibey-script/src/dom/hyperlink.rs
+++ b/packages/blitz-vibey-script/src/dom/hyperlink.rs
@@ -1,0 +1,208 @@
+//! `HTMLHyperlinkElementUtils`: `href` and the URL-decomposition accessors
+//! (`protocol`, `host`, `pathname`, ...) on `<a>` and `<area>` elements,
+//! resolved against the document base URL and reflected into the `href`
+//! attribute on assignment. `<link>` and `<base>` reflect `href` only.
+
+use blitz_dom::NodeId;
+use boa_engine::object::JsObject;
+use boa_engine::value::JsValue;
+use boa_engine::{Context, JsResult};
+use url::Url;
+
+use super::element::{read_attr, write_attr};
+use super::{define_accessor, dom_ctx, js_str, this_node_id, to_rust_string};
+use crate::state::DomCtx;
+
+pub(crate) fn init_hyperlink_accessors(proto: &JsObject, context: &mut Context) {
+    define_accessor(proto, "href", Some(get_href), Some(set_href), context);
+    macro_rules! component {
+        ($name:literal, $get:ident, $set:ident, $component:expr) => {
+            fn $get(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+                component_getter($component, this, context)
+            }
+            fn $set(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+                component_setter($component, this, args, context)
+            }
+            define_accessor(proto, $name, Some($get), Some($set), context);
+        };
+    }
+    component!("origin", get_origin, set_origin, Component::Origin);
+    component!("protocol", get_protocol, set_protocol, Component::Protocol);
+    component!("username", get_username, set_username, Component::Username);
+    component!("password", get_password, set_password, Component::Password);
+    component!("host", get_host, set_host, Component::Host);
+    component!("hostname", get_hostname, set_hostname, Component::Hostname);
+    component!("port", get_port, set_port, Component::Port);
+    component!("pathname", get_pathname, set_pathname, Component::Pathname);
+    component!("search", get_search, set_search, Component::Search);
+    component!("hash", get_hash, set_hash, Component::Hash);
+}
+
+#[derive(Clone, Copy)]
+enum Component {
+    Origin,
+    Protocol,
+    Username,
+    Password,
+    Host,
+    Hostname,
+    Port,
+    Pathname,
+    Search,
+    Hash,
+}
+
+fn local_name(ctx: &DomCtx, node_id: NodeId) -> Option<String> {
+    let doc = ctx.doc.borrow();
+    let element = doc.get_node(node_id)?.element_data()?;
+    Some(element.name.local.to_string())
+}
+
+fn is_hyperlink(ctx: &DomCtx, node_id: NodeId) -> bool {
+    matches!(local_name(ctx, node_id).as_deref(), Some("a" | "area"))
+}
+
+fn reflects_href(ctx: &DomCtx, node_id: NodeId) -> bool {
+    matches!(
+        local_name(ctx, node_id).as_deref(),
+        Some("a" | "area" | "link" | "base")
+    )
+}
+
+/// The element's `href` attribute resolved against the document base URL, or
+/// `None` if the attribute is missing or does not parse
+fn resolved_url(ctx: &DomCtx, node_id: NodeId) -> Option<Url> {
+    let href = read_attr(ctx, node_id, "href")?;
+    let base_url = ctx.state.borrow().base_url.clone();
+    match base_url {
+        Some(base) => base.join(&href).ok(),
+        None => Url::parse(&href).ok(),
+    }
+}
+
+fn get_href(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = this_node_id(this)?;
+    if !reflects_href(&ctx, node_id) {
+        return Ok(JsValue::undefined());
+    }
+    let Some(href) = read_attr(&ctx, node_id, "href") else {
+        return Ok(js_str(""));
+    };
+    let href = resolved_url(&ctx, node_id)
+        .map(|url| url.to_string())
+        .unwrap_or(href);
+    Ok(js_str(&href))
+}
+
+fn set_href(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = this_node_id(this)?;
+    let value = to_rust_string(args.first().unwrap_or(&JsValue::undefined()), context)?;
+    write_attr(&ctx, node_id, "href", &value);
+    Ok(JsValue::undefined())
+}
+
+fn component_getter(
+    component: Component,
+    this: &JsValue,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = this_node_id(this)?;
+    if !is_hyperlink(&ctx, node_id) {
+        return Ok(JsValue::undefined());
+    }
+    let Some(url) = resolved_url(&ctx, node_id) else {
+        let value = match component {
+            Component::Protocol => ":",
+            _ => "",
+        };
+        return Ok(js_str(value));
+    };
+    let value = match component {
+        Component::Origin => url.origin().ascii_serialization(),
+        Component::Protocol => format!("{}:", url.scheme()),
+        Component::Username => url.username().to_string(),
+        Component::Password => url.password().unwrap_or_default().to_string(),
+        Component::Host => match (url.host_str(), url.port()) {
+            (Some(host), Some(port)) => format!("{host}:{port}"),
+            (Some(host), None) => host.to_string(),
+            (None, _) => String::new(),
+        },
+        Component::Hostname => url.host_str().unwrap_or_default().to_string(),
+        Component::Port => url.port().map(|p| p.to_string()).unwrap_or_default(),
+        Component::Pathname => url.path().to_string(),
+        Component::Search => match url.query() {
+            Some(query) if !query.is_empty() => format!("?{query}"),
+            _ => String::new(),
+        },
+        Component::Hash => match url.fragment() {
+            Some(fragment) if !fragment.is_empty() => format!("#{fragment}"),
+            _ => String::new(),
+        },
+    };
+    Ok(js_str(&value))
+}
+
+fn component_setter(
+    component: Component,
+    this: &JsValue,
+    args: &[JsValue],
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = this_node_id(this)?;
+    let value = to_rust_string(args.first().unwrap_or(&JsValue::undefined()), context)?;
+    if !is_hyperlink(&ctx, node_id) {
+        return Ok(JsValue::undefined());
+    }
+    let Some(mut url) = resolved_url(&ctx, node_id) else {
+        return Ok(JsValue::undefined());
+    };
+    let value = value.as_str();
+    let ok = match component {
+        Component::Origin => true,
+        Component::Protocol => url
+            .set_scheme(value.strip_suffix(':').unwrap_or(value))
+            .is_ok(),
+        Component::Username => url.set_username(value).is_ok(),
+        Component::Password => url
+            .set_password((!value.is_empty()).then_some(value))
+            .is_ok(),
+        Component::Host => match value.rsplit_once(':') {
+            Some((host, port)) if !host.is_empty() && !host.ends_with(']') => {
+                url.set_host(Some(host)).is_ok() && url.set_port(port.parse().ok()).is_ok()
+            }
+            _ => url.set_host(Some(value)).is_ok(),
+        },
+        Component::Hostname => url.set_host(Some(value)).is_ok(),
+        Component::Port => url
+            .set_port(if value.is_empty() {
+                None
+            } else {
+                value.parse().ok()
+            })
+            .is_ok(),
+        Component::Pathname => {
+            if !url.cannot_be_a_base() {
+                url.set_path(value);
+            }
+            true
+        }
+        Component::Search => {
+            let query = value.strip_prefix('?').unwrap_or(value);
+            url.set_query((!query.is_empty()).then_some(query));
+            true
+        }
+        Component::Hash => {
+            let fragment = value.strip_prefix('#').unwrap_or(value);
+            url.set_fragment((!fragment.is_empty()).then_some(fragment));
+            true
+        }
+    };
+    if ok {
+        write_attr(&ctx, node_id, "href", url.as_str());
+    }
+    Ok(JsValue::undefined())
+}

--- a/packages/blitz-vibey-script/src/dom/mod.rs
+++ b/packages/blitz-vibey-script/src/dom/mod.rs
@@ -9,6 +9,7 @@
 pub(crate) mod document;
 pub(crate) mod element;
 pub(crate) mod event;
+pub(crate) mod hyperlink;
 pub(crate) mod node;
 pub(crate) mod style;
 pub(crate) mod stylesheet;
@@ -348,6 +349,7 @@ pub(crate) fn init_protos(ctx: &DomCtx, context: &mut Context) {
     let element_proto = JsObject::with_object_proto(context.intrinsics());
     element_proto.set_prototype(Some(node_proto.clone()));
     element::init_element_proto(&element_proto, context);
+    hyperlink::init_hyperlink_accessors(&element_proto, context);
 
     let character_data_proto = JsObject::with_object_proto(context.intrinsics());
     character_data_proto.set_prototype(Some(node_proto.clone()));


### PR DESCRIPTION
## Summary

`css/css-masking/animations/clip-path-interpolation-001.html` reported 0 subtests because WPT's `interpolation-testcommon.js` `sanitizeUrls()` does

```js
anchor.href = url;
anchor.pathname = '...' + anchor.pathname.substring(...)
```

and blitz-vibey-script had no `href`/`pathname` on anchors (`href` was an expando, `pathname` was `undefined` → uncaught `TypeError` in the sync top-level script, killing the whole test).

New `dom/hyperlink.rs` adds the `HTMLHyperlinkElementUtils` accessors to the shared element prototype:

- `href`: reflected on `<a>/<area>/<link>/<base>`; getter returns the attribute resolved against `RuntimeState::base_url` (raw attribute if unparsable, `""` if absent), setter writes the attribute.
- `origin, protocol, username, password, host, hostname, port, pathname, search, hash`: `<a>/<area>` only. Getters decompose the resolved URL (`""` / `":"` when unparsable); setters mutate the `url::Url` and write it back to `href` (no-op when the URL is unparsable, `pathname` no-op for cannot-be-a-base URLs).
- Other elements return `undefined` for all of these.

`read_attr`/`write_attr` in `element.rs` become `pub(crate)` for reuse.

WPT deltas (no regressions in css-animations, css-transitions, dom):
- `css-masking/animations/clip-path-interpolation-001`: 0/1 → 292/414 (rest are `Element.animate` missing + Stylo not parsing `polygon(round ...)`)
- `css-masking/clip-path/animations/clip-path-interpolation-discrete`: 0/1 → 126/168
- `css-masking/animations/mask-image-interpolation`: 53 → 341; `mask-no-interpolation`: 9 → 35
- `css-backgrounds/animations/background-image-interpolation`: 30 → 132; `border-image-source-interpolation`: 88 → 245
- `html/semantics/links`: 11 → 145 (all `*-url-getter-setter.window.html`, `htmlanchorelement_getter`, `htmlanchorelement_attribute-getter-setter` fully pass)


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/fc77d1364a06490f967f0b3fab7cdcd4
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/fc77d1364a06490f967f0b3fab7cdcd4?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **2400** newly passing, **4** newly failing (net +2396).

<details>
<summary>Full diff (123 changed tests)</summary>

```diff
! FAIL => FAIL      [0/4]    +0  css/css-anchor-position/anchor-query-custom-property-registration.html
+ FAIL => FAIL      [4/7]    +4  css/css-animations/animation-important-001.html
+ FAIL => FAIL  [132/288]  +102  css/css-backgrounds/animations/background-image-interpolation.html
+ FAIL => FAIL  [245/294]  +157  css/css-backgrounds/animations/border-image-source-interpolation.html
+ FAIL => PASS  [114/114]  +114  css/css-cascade/all-prop-revert-layer-noop.html
+ FAIL => PASS  [268/268]  +268  css/css-cascade/all-prop-revert-layer.html
+ FAIL => PASS  [114/114]  +114  css/css-cascade/all-prop-revert-noop.html
+ FAIL => FAIL    [54/72]   +18  css/css-images/animation/image-slice-interpolation-math-functions-tentative.html
+ FAIL => FAIL  [131/234]  +104  css/css-lists/animations/list-style-image-interpolation.html
+ FAIL => FAIL  [292/414]  +292  css/css-masking/animations/clip-path-interpolation-001.html
+ FAIL => FAIL  [341/408]  +288  css/css-masking/animations/mask-image-interpolation.html
+ FAIL => FAIL    [35/42]   +26  css/css-masking/animations/mask-no-interpolation.html
+ FAIL => FAIL  [126/168]  +126  css/css-masking/clip-path/animations/clip-path-interpolation-discrete.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-stylemap.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-001.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-002.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-003.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-004.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-005.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-006.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-007.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-008.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-009.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-010.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-011.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-012.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-013.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-014.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-015.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-016.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-017.https.html
+ FAIL => PASS      [1/1]    +1  css/css-paint-api/registered-property-value-018.https.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-angle-comma-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-angle-space-list.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-angle.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-color-comma-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-color-space-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-color.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-integer-comma-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-integer-space-list.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-integer.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-length-comma-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-length-percentage-comma-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-length-percentage-space-list.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-length-percentage.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-length-space-list.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-length.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-number-comma-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-number-space-list.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-number.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-percentage-comma-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-percentage-space-list.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-percentage.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-resolution-comma-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-resolution-space-list.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-resolution.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-time-comma-list.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-time-space-list.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-time.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-transform-function.html
! FAIL => FAIL      [0/6]    +0  css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html
! FAIL => FAIL      [0/5]    +0  css/css-properties-values-api/animation/custom-property-animation-transform-list-single-values.html
! FAIL => FAIL      [0/2]    +0  css/css-properties-values-api/animation/custom-property-animation-transform-none.tentative.html
! FAIL => FAIL      [0/3]    +0  css/css-properties-values-api/animation/custom-property-animation-with-zoom.html
+ FAIL => PASS      [1/1]    +1  css/css-properties-values-api/animation/registered-neutral-keyframe.html
+ FAIL => PASS      [3/3]    +3  css/css-properties-values-api/conditional-rules.html
+ FAIL => PASS    [15/15]    +2  css/css-properties-values-api/determine-registration.html
+ FAIL => PASS      [5/5]    +5  css/css-properties-values-api/invalid-at-computed-value-time.html
+ FAIL => PASS      [2/2]    +2  css/css-properties-values-api/property-cascade.html
+ FAIL => PASS      [6/6]    +6  css/css-properties-values-api/register-property-sign-mixed-lengths.html
+ FAIL => FAIL  [128/246]  +128  css/css-properties-values-api/register-property-syntax-parsing.html
+ FAIL => FAIL      [3/6]    +2  css/css-properties-values-api/register-property.html
+ FAIL => PASS      [8/8]    +8  css/css-properties-values-api/registered-properties-inheritance.html
+ FAIL => PASS      [2/2]    +2  css/css-properties-values-api/registered-property-change-style-001.html
+ FAIL => PASS    [75/75]   +75  css/css-properties-values-api/registered-property-computation.html
+ FAIL => PASS      [8/8]    +5  css/css-properties-values-api/registered-property-cssom.html
+ FAIL => FAIL      [2/4]    +2  css/css-properties-values-api/registered-property-revert.html
+ FAIL => PASS      [3/3]    +2  css/css-properties-values-api/self-utils.html
+ FAIL => FAIL    [24/27]   +24  css/css-properties-values-api/unit-cycles.html
! FAIL => FAIL     [0/18]    +0  css/css-properties-values-api/url-resolution.html
+ FAIL => PASS      [1/1]    +1  css/css-properties-values-api/var-reference-registered-properties-002.html
+ FAIL => PASS      [5/5]    +5  css/css-properties-values-api/var-reference-registered-properties-cycles.html
+ FAIL => FAIL    [15/16]   +15  css/css-properties-values-api/var-reference-registered-properties.html
+ FAIL => PASS      [1/1]    +1  css/css-pseudo/highlight-cascade/highlight-cascade-010.html
+ FAIL => PASS      [1/1]    +1  css/css-text/line-breaking/line-breaking-024.html
+ FAIL => PASS      [1/1]    +1  css/css-text/line-breaking/line-breaking-025.html
+ FAIL => PASS      [1/1]    +1  css/css-text/line-breaking/line-breaking-026.html
+ FAIL => PASS      [1/1]    +1  css/css-text/line-breaking/line-breaking-027.html
- PASS => FAIL      [0/1]    -1  css/css-text/word-break/word-break-manual-001.html
+ FAIL => PASS      [1/1]    +1  css/css-text/word-break/word-break-normal-002.html
+ FAIL => PASS      [1/1]    +1  css/css-text/word-break/word-break-normal-003.html
+ FAIL => PASS      [1/1]    +1  css/css-text/word-break/word-break-normal-km-000.html
+ FAIL => PASS      [1/1]    +1  css/css-text/word-break/word-break-normal-lo-000.html
+ FAIL => PASS      [1/1]    +1  css/css-text/word-break/word-break-normal-my-000.html
+ FAIL => PASS      [1/1]    +1  css/css-text/word-break/word-break-normal-th-001.html
- PASS => FAIL      [0/1]    -1  css/css-transforms/2d-transform-inline-js.html
+ FAIL => FAIL    [36/48]   +18  css/css-transforms/animation/rotate-interpolation-math-functions-tentative.html
+ FAIL => FAIL    [36/48]   +18  css/css-transforms/animation/scale-animation-math-functions-tentative.html
- PASS => FAIL      [0/1]    -1  css/css-ui/compute-kind-widget-no-fallback-props-001.html
+ FAIL => PASS    [37/37]   +37  css/css-values/attr-cycle.html
+ FAIL => FAIL    [29/32]   +29  css/css-values/attr-security.html
+ FAIL => PASS      [1/1]    +1  css/css-values/lh-unit-004.html
+ FAIL => FAIL    [34/36]   +34  css/css-values/progress-computed.html
+ FAIL => PASS    [68/68]   +60  css/css-values/progress-serialize.html
+ FAIL => PASS      [3/3]    +3  css/css-values/urls/resolve-relative-to-stylesheet.html
+ FAIL => PASS  [160/160]   +40  css/css-values/viewport-units-css2-001.html
+ FAIL => FAIL   [66/109]   +66  css/css-viewport/zoom/explicit-inherit/all-length-properties.html
+ FAIL => FAIL    [74/88]    +8  css/css-viewport/zoom/svg-computed-style.html
+ FAIL => PASS      [6/6]    +1  css/cssom/cssstyledeclaration-csstext-all-shorthand.html
+ FAIL => PASS    [10/10]    +4  css/cssom/getComputedStyle-getter-v-properties.tentative.html
+ FAIL => PASS      [1/1]    +1  css/cssom/getComputedStyle-logical-enumeration.html
+ FAIL => FAIL      [1/3]    +1  css/cssom/getComputedStyle-pseudo-picker-icon.html
- FAIL => FAIL     [1/28]    -1  css/cssom/getComputedStyle-pseudo.html
+ FAIL => FAIL  [223/497]    +2  css/cssom/idlharness.html
+ FAIL => FAIL      [1/2]    +1  css/cssom/serialize-all-longhands.html
+ FAIL => FAIL  [108/168]  +108  css/motion/animation/offset-path-interpolation-007.html
+ FAIL => PASS      [1/1]    +1  css/selectors/invalidation/any-link-pseudo.html
+ FAIL => FAIL      [2/4]    +1  svg/extensibility/foreignObject/properties.svg
+ FAIL => FAIL    [15/34]    +8  svg/geometry/parsing/height-computed.svg
+ FAIL => FAIL    [10/14]    +6  svg/geometry/parsing/sizing-properties-computed.svg
+ FAIL => FAIL    [15/34]    +8  svg/geometry/parsing/width-computed.svg
+ FAIL => FAIL  [66/1705]   +10  svg/idlharness.window.html
+ FAIL => PASS      [3/3]    +3  svg/linking/scripted/a.hyperlink-getter-01.svg
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34724315134).</sub>
<!-- wpt-results-end -->
