### PR TITLE
dom: use unrounded layout positions for getBoundingClientRect/getClientRects

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -2241,7 +2241,7 @@ impl BaseDocument {
         }
 
         let node = self.get_node(node_id)?;
-        let pos = node.absolute_position(0.0, 0.0);
+        let pos = node.unrounded_absolute_position(0.0, 0.0);
 
         Some(BoundingRect {
             x: pos.x as f64 - self.viewport_scroll.x,
@@ -2304,8 +2304,8 @@ impl BaseDocument {
         };
 
         // Fragment rects are relative to the inline root's content box.
-        let root_layout = inline_root.final_layout();
-        let root_pos = inline_root.absolute_position(0.0, 0.0);
+        let root_layout = inline_root.unrounded_layout();
+        let root_pos = inline_root.unrounded_absolute_position(0.0, 0.0);
         let origin_x = root_pos.x as f64
             + (root_layout.padding.left + root_layout.border.left) as f64
             - self.viewport_scroll.x;

--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -2244,10 +2244,10 @@ impl BaseDocument {
         let pos = node.unrounded_absolute_position(0.0, 0.0);
 
         Some(BoundingRect {
-            x: pos.x as f64 - self.viewport_scroll.x,
-            y: pos.y as f64 - self.viewport_scroll.y,
-            width: node.unrounded_layout().size.width as f64,
-            height: node.unrounded_layout().size.height as f64,
+            x: snap_to_layout_unit(pos.x as f64 - self.viewport_scroll.x),
+            y: snap_to_layout_unit(pos.y as f64 - self.viewport_scroll.y),
+            width: snap_to_layout_unit(node.unrounded_layout().size.width as f64),
+            height: snap_to_layout_unit(node.unrounded_layout().size.height as f64),
         })
     }
 
@@ -2362,10 +2362,10 @@ impl BaseDocument {
 
             if let Some((x0, y0, x1, y1)) = line_rect {
                 rects.push(BoundingRect {
-                    x: origin_x + x0 / scale,
-                    y: origin_y + y0 / scale,
-                    width: (x1 - x0) / scale,
-                    height: (y1 - y0) / scale,
+                    x: snap_to_layout_unit(origin_x + x0 / scale),
+                    y: snap_to_layout_unit(origin_y + y0 / scale),
+                    width: snap_to_layout_unit((x1 - x0) / scale),
+                    height: snap_to_layout_unit((y1 - y0) / scale),
                 });
             }
         }
@@ -2739,6 +2739,13 @@ pub struct BoundingRect {
     pub y: f64,
     pub width: f64,
     pub height: f64,
+}
+
+/// Snap a CSSOM geometry value to a 1/64px grid (the precision of Blink's `LayoutUnit`).
+/// Layout values are accumulated in `f32`, so e.g. seven `55/7`-wide flex items would
+/// otherwise end at `55.0000005` and appear to overflow their 55px container.
+fn snap_to_layout_unit(value: f64) -> f64 {
+    (value * 64.0).round() / 64.0
 }
 
 impl AsRef<BaseDocument> for BaseDocument {

--- a/packages/blitz-dom/src/node/node.rs
+++ b/packages/blitz-dom/src/node/node.rs
@@ -1529,6 +1529,18 @@ impl Node {
             .unwrap_or(crate::util::Point { x, y })
     }
 
+    /// Computes the Document-relative coordinates of the `Node` from the unrounded
+    /// (sub-pixel) layout, for CSSOM geometry APIs such as `getBoundingClientRect`
+    pub fn unrounded_absolute_position(&self, x: f32, y: f32) -> crate::util::Point<f32> {
+        let x = x + self.unrounded_layout().location.x - self.scroll_offset().x as f32;
+        let y = y + self.unrounded_layout().location.y - self.scroll_offset().y as f32;
+
+        self.layout_parent
+            .get()
+            .map(|i| self.with(i).unrounded_absolute_position(x, y))
+            .unwrap_or(crate::util::Point { x, y })
+    }
+
     /// Whether this node can act as an [`offset_parent`](Self::offset_parent): a positioned
     /// element, or one of the elements that always qualify (`body`, `td`, `th`).
     fn is_offset_parent(&self) -> bool {


### PR DESCRIPTION
## Summary

`get_client_bounding_rect` returned a rect whose *size* came from `unrounded_layout()` but whose *position* came from `absolute_position()`, which sums `final_layout().location` (the pixel-rounded layout). Mixing the two makes adjacent boxes inconsistent: e.g. a text box reports `top=9, height=19.2` (bottom 28.2) while the next box reports `top=78`, so `after.top - before.bottom` comes out as 49.8 instead of 50. This single issue failed 65/72 subtests of WPT `css/CSS2/normal-flow/margin-collapse-through-for-various-height-values.tentative.html`.

- `Node::unrounded_absolute_position()` — same as `absolute_position()` but accumulates `unrounded_layout().location` up the `layout_parent` chain
- `get_client_bounding_rect` and `inline_fragment_rects` (getClientRects / inline fragments) now use it, and the inline-root padding/border offset is read from the unrounded layout too

Hit-testing, painting and `offsetTop`-style APIs still use `absolute_position()`.

WPT (local): `css/CSS2/normal-flow` 672 → 737 / 908 (the remaining 7 subtests of that test need DioxusLabs/taffy#1188, with which it is 72/72 and normal-flow reaches 746). `css/cssom-view` 781 → 783; `css/CSS2/box-display`, `css/css-position` unchanged.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0b908d48e0094e5aa841ae2e538f5d53
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/0b908d48e0094e5aa841ae2e538f5d53?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **70** newly passing, **0** newly failing (net +70).

<details>
<summary>Full diff (6 changed tests)</summary>

```diff
+ FAIL => FAIL  [65/72]  +65  css/CSS2/normal-flow/margin-collapse-through-for-various-height-values.tentative.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/align-content-rounding.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/justify-content-rounding.html
+ FAIL => PASS    [1/1]   +1  css/css-flexbox/main-axis-margin-rounding.html
+ FAIL => PASS    [1/1]   +1  css/css-grid/subgrid/sibling-nested-subgrids-overflow-hidden-contribution.html
+ FAIL => FAIL    [2/4]   +1  css/cssom-view/elementFromPoint-subpixel.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34726107298).</sub>
<!-- wpt-results-end -->
