### PR TITLE
Repin Taffy to latest main (c17b313)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.14.0"
-source = "git+https://github.com/DioxusLabs/taffy?rev=63b273733cb913cbe32548329524f51e45dbd438#63b273733cb913cbe32548329524f51e45dbd438"
+source = "git+https://github.com/DioxusLabs/taffy?rev=c17b313cd1be5a4def91522cf3ea5995e664ebf7#c17b313cd1be5a4def91522cf3ea5995e664ebf7"
 dependencies = [
  "arrayvec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ dioxus-cli-config = { version = "0.7.3" }
 dioxus-core-macro = { version = "0.7.3" }
 
 # Taffy + Parley + Fontations
-taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "63b273733cb913cbe32548329524f51e45dbd438", default-features = false, features = [
+taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "c17b313cd1be5a4def91522cf3ea5995e664ebf7", default-features = false, features = [
     "std",
     "flexbox",
     "grid",


### PR DESCRIPTION
## Summary
Bumps the `taffy` git pin `63b2737` → `c17b313` (current `main`). Picks up:

- DioxusLabs/taffy#1187 — block: resolve child percentage padding/border against container width
- DioxusLabs/taffy#1188 — block: decide margin collapse-through by used height

Local `css/CSS2/normal-flow`: 672 → 674 subtests (the remaining collapse-through gains land together with #874, which fixes `getBoundingClientRect` rounding on the Blitz side).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0b908d48e0094e5aa841ae2e538f5d53
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/0b908d48e0094e5aa841ae2e538f5d53?variant=devin-insiders
Requested by: @nicoburns