### PR TITLE
Enable stylo's `layout.variable_fonts.enabled` pref

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -401,6 +401,7 @@ impl BaseDocument {
         style_config::set_pref!("layout.css.attr.enabled", true);
         style_config::set_pref!("layout.css.tree-counting-functions.enabled", true);
         style_config::set_pref!("layout.css.progress-function.enabled", true);
+        style_config::set_pref!("layout.variable_fonts.enabled", true);
         style_config::set_pref!("layout.threads", -1);
 
         let viewport = config.viewport.unwrap_or_default();


### PR DESCRIPTION
## Summary

In stylo 0.21 both `font-variation-settings` and `font-optical-sizing` are gated behind `servo_pref = "layout.variable_fonts.enabled"`. Blitz never set it, so both properties were rejected at parse time (stylesheets *and* CSSOM `element.style`), even though `stylo_to_parley::font_variations` already maps `font-variation-settings` into Parley for shaping and font metrics.

```rust
style_config::set_pref!("layout.variable_fonts.enabled", true);
```

Effect:
- `font-variation-settings` now parses, computes, and is rendered end to end.
- `font-optical-sizing` parses/computes (`auto`/`none`) but has no rendering effect yet — automatic `opsz` application is intentionally deferred to a follow-up alongside other related font properties.

WPT (`css/css-fonts/parsing`): 1254 → 1273 subtests passing; `font-variation-settings-{computed,valid}` and `font-optical-sizing-{computed,valid}` now fully pass.

WPT (`css/css-fonts/variations`): `variable-avar2-rvrn`, `variable-avar2-warp`, `variable-box-font`, `variable-gpos-m2b`, `variable-gsub` reftests newly pass. `variable-opsz.html` flips PASS → FAIL: it previously passed only because both test and ref ignored `font-variation-settings`; now the ref's explicit `'opsz'` values are honoured while the test's automatic optical sizing is not implemented, so the failure is the honest status until `font-optical-sizing: auto` is implemented.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/43288fe5b6334c1da0f5ef2952bfde53
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/43288fe5b6334c1da0f5ef2952bfde53?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **431** newly passing, **9** newly failing (net +422).

<details>
<summary>Full diff (41 changed tests)</summary>

```diff
+ PASS => PASS  [270/270]    +2  css/css-cascade/all-prop-revert-layer.html
+ FAIL => FAIL    [30/60]   +30  css/css-fonts/animations/font-variation-settings-composition.html
+ FAIL => FAIL  [277/358]  +277  css/css-fonts/animations/font-variation-settings-interpolation.html
+ FAIL => FAIL      [1/2]    +1  css/css-fonts/calc-in-font-variation-settings.html
+ FAIL => FAIL  [385/546]   +35  css/css-fonts/discrete-no-interpolation.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/font-face-stretch-auto-variable.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/font-face-stretch-default-variable.html
- PASS => FAIL      [0/1]    -1  css/css-fonts/font-face-style-auto-variable.html
- PASS => FAIL      [0/1]    -1  css/css-fonts/font-face-style-default-variable.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/font-face-weight-auto-variable.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/font-face-weight-default-variable.html
+ FAIL => FAIL  [191/202]   +28  css/css-fonts/font-shorthand-serialization-prevention.html
+ FAIL => FAIL    [10/11]    +2  css/css-fonts/font-shorthand-subproperties-reset.html
+ FAIL => PASS      [8/8]    +8  css/css-fonts/font-variation-settings-calc.html
- PASS => FAIL      [0/1]    -1  css/css-fonts/font-variation-settings-descriptor-01.html
- PASS => FAIL      [0/1]    -1  css/css-fonts/font-variation-settings-descriptor-03.html
- PASS => FAIL      [0/1]    -1  css/css-fonts/font-variation-settings-descriptor-04.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/font-variation-settings-serialization-001.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/font-variation-settings-serialization-002.html
+ FAIL => FAIL    [35/39]    +4  css/css-fonts/inheritance.html
+ FAIL => PASS      [2/2]    +2  css/css-fonts/parsing/font-optical-sizing-computed.html
+ FAIL => PASS      [2/2]    +2  css/css-fonts/parsing/font-optical-sizing-valid.html
+ FAIL => PASS      [8/8]    +8  css/css-fonts/parsing/font-variation-settings-computed.html
+ FAIL => PASS      [7/7]    +7  css/css-fonts/parsing/font-variation-settings-valid.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/variable-in-font-variation-settings.html
- PASS => FAIL      [0/1]    -1  css/css-fonts/variations/font-slant-1.html
+ FAIL => PASS      [3/3]    +3  css/css-fonts/variations/font-variation-settings-inherit.html
- PASS => FAIL      [0/1]    -1  css/css-fonts/variations/slnt-backslant-variable.html
- PASS => FAIL      [0/1]    -1  css/css-fonts/variations/slnt-variable.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/variations/variable-avar2-rvrn.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/variations/variable-avar2-warp.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/variations/variable-box-font.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/variations/variable-gpos-m2b.html
+ FAIL => PASS      [1/1]    +1  css/css-fonts/variations/variable-gsub.html
- PASS => FAIL      [0/1]    -1  css/css-fonts/variations/variable-opsz.html
+ FAIL => FAIL    [40/95]    +5  css/css-properties-values-api/font-property-unit-cycles.tentative.html
+ FAIL => PASS      [1/1]    +1  css/css-text-decor/text-decoration-thickness-from-font-variable.html
+ FAIL => PASS      [1/1]    +1  css/css-text-decor/text-underline-offset-variable.html
+ FAIL => PASS      [1/1]    +1  css/css-text-decor/text-underline-position-from-font-variable.html
+ FAIL => FAIL    [30/32]    +1  css/css-transitions/all-interpolates-same-as-explicit-property.html
+ FAIL => FAIL      [1/2]    +1  css/css-values/tree-counting/sibling-index-keyframe-font-variation-settings-dynamic.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34726815319).</sub>
<!-- wpt-results-end -->
