### PR TITLE
Fix CSS2/visufx failures: CSS2 `clip`, body overflow propagation, visible descendants of hidden elements

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -842,6 +842,45 @@ impl BaseDocument {
             .unwrap()
     }
 
+    /// The element whose `overflow` is propagated to the viewport, per the CSS overflow
+    /// propagation rules (css-overflow-3 §3.3). This is the root element, unless it is an
+    /// `<html>` element with `overflow: visible` in both axes and it has a `<body>` child
+    /// with a box, in which case the body's overflow is propagated instead. The used
+    /// overflow of the element returned is `visible`: it must not clip its own overflow.
+    pub fn viewport_overflow_element(&self) -> Option<NodeId> {
+        use style::values::computed::Overflow;
+
+        let root = self.try_root_element()?;
+        if !root.data.is_element_with_tag_name(&local_name!("html")) {
+            return Some(root.id);
+        }
+        let root_styles = root.primary_styles()?;
+        let root_overflow_visible = root_styles.clone_overflow_x() == Overflow::Visible
+            && root_styles.clone_overflow_y() == Overflow::Visible;
+        if !root_overflow_visible {
+            return Some(root.id);
+        }
+
+        // Only the first `<body>` child is a candidate; if it doesn't generate a box then
+        // nothing is propagated from the body.
+        let body = root
+            .children
+            .iter()
+            .copied()
+            .find(|&child_id| {
+                self.nodes[child_id]
+                    .data
+                    .is_element_with_tag_name(&local_name!("body"))
+            })
+            .filter(|&body_id| {
+                self.nodes[body_id].primary_styles().is_some_and(|styles| {
+                    let display = styles.clone_display();
+                    !display.is_none() && !display.is_contents()
+                })
+            });
+        Some(body.unwrap_or(root.id))
+    }
+
     pub fn create_node(&mut self, node_data: NodeData) -> NodeId {
         let tree_ptr = self.nodes.as_mut() as *mut NodeTree;
         let guard = self.guard.clone();

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -113,6 +113,9 @@ pub struct BlitzDomPainter<'dom, 'a> {
     pub(crate) initial_y: f64,
     /// The id of the document's root element (cached to avoid re-resolving it for every element)
     pub(crate) root_element_id: Option<NodeId>,
+    /// The id of the element whose overflow is propagated to the viewport (the root element
+    /// or the `<body>`), which must therefore not clip its own overflow.
+    pub(crate) viewport_overflow_element_id: Option<NodeId>,
     /// Scrollbar hover/drag state, resolved once per scene like the root element
     #[cfg(feature = "scrollbars")]
     pub(crate) hovered_scrollbar: Option<blitz_dom::node::ScrollbarRef>,
@@ -147,6 +150,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
 
         let layer_manager = LayerManager::default();
         let root_element_id = dom.try_root_element().map(|el| el.id);
+        let viewport_overflow_element_id = dom.viewport_overflow_element();
 
         Self {
             dom,
@@ -156,6 +160,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             initial_x,
             initial_y,
             root_element_id,
+            viewport_overflow_element_id,
             #[cfg(feature = "scrollbars")]
             hovered_scrollbar: dom.hovered_scrollbar(),
             #[cfg(feature = "scrollbars")]
@@ -309,10 +314,9 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             return;
         }
 
-        // Hide elements with a visibility style other than visible
-        if styles.get_inherited_box().visibility != StyloVisibility::Visible {
-            return;
-        }
+        // Elements with a visibility style other than visible paint none of their own boxes,
+        // but their descendants may still be painted if they set `visibility: visible`.
+        let is_visible = styles.get_inherited_box().visibility == StyloVisibility::Visible;
 
         let effects = styles.get_effects();
         let opacity = effects.opacity;
@@ -346,16 +350,18 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             .element_data()
             .and_then(|el| el.text_input_data())
             .is_some();
-        // The root element's overflow is propagated to the viewport (which is clipped by the
-        // window/surface bounds), so the root element must not clip its own overflow.
+        // The root element's (or, when the root's overflow is visible, the body's) overflow
+        // is propagated to the viewport (which is clipped by the window/surface bounds), so
+        // that element's used overflow is `visible`. Other clipping reasons (e.g. `contain: paint`)
+        // still apply to it.
         let is_root_element = self.root_element_id == Some(node_id);
-        let should_clip = !is_root_element
-            && (is_image
-                || is_sub_doc
-                || is_text_input
-                || contain_paint
-                || !matches!(overflow_x, Overflow::Visible)
+        let propagates_overflow_to_viewport =
+            is_root_element || self.viewport_overflow_element_id == Some(node_id);
+        let clips_overflow = !propagates_overflow_to_viewport
+            && (!matches!(overflow_x, Overflow::Visible)
                 || !matches!(overflow_y, Overflow::Visible));
+        let should_clip =
+            is_image || is_sub_doc || is_text_input || contain_paint || clips_overflow;
 
         // Apply padding/border offset to inline root
         let taffy::Layout {
@@ -433,6 +439,13 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             clip_rect
         };
 
+        // CSS 2 `clip` property (absolutely positioned elements only). Applies to the whole of
+        // the element's rendering (including outlines and shadows), so it is the outermost layer.
+        let css_clip_rect = cx.css_clip_rect();
+        if css_clip_rect.is_some_and(|rect| rect.is_zero_area()) {
+            return;
+        }
+
         // Compute clip-path (if any) and wrap all rendering in a clip layer
         let clip_path_shape = cx.clip_path_shape();
         let has_clip_path = clip_path_shape.is_some();
@@ -440,120 +453,142 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         let mut clip_path_for_layer = clip_path_shape.unwrap_or(default_clip);
         clip_path_for_layer.apply_affine(Affine::scale(self.scale));
 
-        cx.draw_outline(scene);
-        cx.draw_outset_box_shadow(scene);
-
-        // clip-path clip ayer
         self.layer_manager.maybe_with_layer(
             scene,
-            has_clip_path,
+            css_clip_rect.is_some(),
             1.0,
             cx.transform,
-            &clip_path_for_layer,
+            &css_clip_rect.unwrap_or(Rect::ZERO),
             None,
             None,
             |scene| {
-                // If the element has a CSS `mask`, then push an isolation layer for the
-                // masked content. The mask is applied when the layer is popped below.
-                let mask_layer_pushed = cx.maybe_push_css_mask_layer(scene);
-                // `cx.transform` is mutated to apply scroll offsets while drawing content.
-                // Save it so that the mask can be drawn untransformed by scroll offsets.
-                let unscrolled_transform = cx.transform;
+                if is_visible {
+                    cx.draw_outline(scene);
+                    cx.draw_outset_box_shadow(scene);
+                }
 
-                let filter = convert_filters(&effects.filter.0).map(Arc::new);
-                let backdrop_filter = convert_filters(&effects.backdrop_filter.0).map(Arc::new);
-
-                // Adjust effect layer clip by filter expansion area
-                //
-                // Returns a rectangle centered at the origin representing how much the filter
-                // expands the processing region in each direction. The rect coordinates are:
-                // - x0: negative left expansion
-                // - y0: negative top expansion
-                // - x1: positive right expansion
-                // - y1: positive bottom expansion
-                let filter_expansion_area = filter
-                    .as_ref()
-                    .map(|f| f.expansion_rect())
-                    .unwrap_or(Rect::ZERO);
-
-                let mut effect_layer_clip = cx.frame.border_box_path().bounding_box();
-                effect_layer_clip.x0 += filter_expansion_area.x0;
-                effect_layer_clip.y0 += filter_expansion_area.y0;
-                effect_layer_clip.x1 += filter_expansion_area.x1;
-                effect_layer_clip.y1 += filter_expansion_area.y1;
-
-                // Opacity/Filter layer if box has opacity or a filter.
-                // Clipped to border-box as it needs to include the background and borders.
+                // clip-path clip ayer
                 self.layer_manager.maybe_with_layer(
                     scene,
-                    has_opacity || filter.is_some() || backdrop_filter.is_some(),
-                    opacity,
+                    has_clip_path,
+                    1.0,
                     cx.transform,
-                    &effect_layer_clip,
-                    filter,
-                    backdrop_filter,
+                    &clip_path_for_layer,
+                    None,
+                    None,
                     |scene| {
-                        cx.draw_background(scene);
-                        cx.draw_inset_box_shadow(scene);
-                        cx.draw_table_row_backgrounds(scene);
-                        cx.draw_table_borders(scene);
-                        cx.draw_border(scene);
-                        cx.stroke_devtools(scene);
+                        // If the element has a CSS `mask`, then push an isolation layer for the
+                        // masked content. The mask is applied when the layer is popped below.
+                        let mask_layer_pushed = cx.maybe_push_css_mask_layer(scene);
+                        // `cx.transform` is mutated to apply scroll offsets while drawing content.
+                        // Save it so that the mask can be drawn untransformed by scroll offsets.
+                        let unscrolled_transform = cx.transform;
 
-                        // TODO: allow layers with opacity to be unclipped (overflow: visible)
-                        let clip = if is_text_input {
-                            &cx.frame.content_box_path()
-                        } else {
-                            &cx.frame.padding_box_path()
-                        };
+                        let filter = convert_filters(&effects.filter.0).map(Arc::new);
+                        let backdrop_filter =
+                            convert_filters(&effects.backdrop_filter.0).map(Arc::new);
 
-                        // Clip layer if box requires clipping. Opacity set to 1.0
+                        // Adjust effect layer clip by filter expansion area
+                        //
+                        // Returns a rectangle centered at the origin representing how much the filter
+                        // expands the processing region in each direction. The rect coordinates are:
+                        // - x0: negative left expansion
+                        // - y0: negative top expansion
+                        // - x1: positive right expansion
+                        // - y1: positive bottom expansion
+                        let filter_expansion_area = filter
+                            .as_ref()
+                            .map(|f| f.expansion_rect())
+                            .unwrap_or(Rect::ZERO);
+
+                        let mut effect_layer_clip = cx.frame.border_box_path().bounding_box();
+                        effect_layer_clip.x0 += filter_expansion_area.x0;
+                        effect_layer_clip.y0 += filter_expansion_area.y0;
+                        effect_layer_clip.x1 += filter_expansion_area.x1;
+                        effect_layer_clip.y1 += filter_expansion_area.y1;
+
+                        // Opacity/Filter layer if box has opacity or a filter.
+                        // Clipped to border-box as it needs to include the background and borders.
                         self.layer_manager.maybe_with_layer(
                             scene,
-                            should_clip,
-                            1.0, // opacity
+                            has_opacity || filter.is_some() || backdrop_filter.is_some(),
+                            opacity,
                             cx.transform,
-                            clip,
-                            None,
-                            None,
+                            &effect_layer_clip,
+                            filter,
+                            backdrop_filter,
                             |scene| {
-                                // Now that background has been drawn, offset pos and cx in order to draw our contents scrolled
-                                let content_position = Point {
-                                    x: content_position.x - node.scroll_offset().x,
-                                    y: content_position.y - node.scroll_offset().y,
+                                if is_visible {
+                                    cx.draw_background(scene);
+                                    cx.draw_inset_box_shadow(scene);
+                                    cx.draw_table_row_backgrounds(scene);
+                                    cx.draw_table_borders(scene);
+                                    cx.draw_border(scene);
+                                }
+                                cx.stroke_devtools(scene);
+
+                                // TODO: allow layers with opacity to be unclipped (overflow: visible)
+                                let clip = if is_text_input {
+                                    &cx.frame.content_box_path()
+                                } else {
+                                    &cx.frame.padding_box_path()
                                 };
 
-                                cx.transform = cx.transform.then_translate(Vec2 {
-                                    x: -node.scroll_offset().x * self.scale,
-                                    y: -node.scroll_offset().y * self.scale,
-                                });
-                                cx.draw_image(scene);
-                                #[cfg(feature = "svg")]
-                                cx.draw_svg(scene);
-                                #[cfg(feature = "custom-widget")]
-                                cx.draw_custom_widget(scene);
-                                cx.draw_sub_document(scene);
-                                cx.draw_input(scene);
-                                cx.draw_text_input_text(scene, content_position);
-                                cx.draw_inline_layout(scene, content_position);
-                                cx.draw_marker(scene, content_position);
-                                cx.draw_children(scene, cx.transform, child_clip_rect);
+                                // Clip layer if box requires clipping. Opacity set to 1.0
+                                self.layer_manager.maybe_with_layer(
+                                    scene,
+                                    should_clip,
+                                    1.0, // opacity
+                                    cx.transform,
+                                    clip,
+                                    None,
+                                    None,
+                                    |scene| {
+                                        // Now that background has been drawn, offset pos and cx in order to draw our contents scrolled
+                                        let content_position = Point {
+                                            x: content_position.x - node.scroll_offset().x,
+                                            y: content_position.y - node.scroll_offset().y,
+                                        };
+
+                                        cx.transform = cx.transform.then_translate(Vec2 {
+                                            x: -node.scroll_offset().x * self.scale,
+                                            y: -node.scroll_offset().y * self.scale,
+                                        });
+                                        if is_visible {
+                                            cx.draw_image(scene);
+                                            #[cfg(feature = "svg")]
+                                            cx.draw_svg(scene);
+                                            #[cfg(feature = "custom-widget")]
+                                            cx.draw_custom_widget(scene);
+                                            cx.draw_sub_document(scene);
+                                            cx.draw_input(scene);
+                                            cx.draw_text_input_text(scene, content_position);
+                                        }
+                                        // Inline text checks visibility per run, as inline
+                                        // descendants may override the root's visibility.
+                                        cx.draw_inline_layout(scene, content_position);
+                                        if is_visible {
+                                            cx.draw_marker(scene, content_position);
+                                        }
+                                        cx.draw_children(scene, cx.transform, child_clip_rect);
+                                    },
+                                );
+
+                                // Overlay scrollbars, drawn unscrolled above the
+                                // clipped content.
+                                #[cfg(feature = "scrollbars")]
+                                if is_visible {
+                                    cx.transform = unscrolled_transform;
+                                    cx.draw_scrollbars(scene);
+                                }
                             },
                         );
 
-                        // Overlay scrollbars, drawn unscrolled above the
-                        // clipped content.
-                        #[cfg(feature = "scrollbars")]
-                        {
-                            cx.transform = unscrolled_transform;
-                            cx.draw_scrollbars(scene);
-                        }
+                        // Apply the CSS `mask` (if any) to the content drawn above
+                        cx.transform = unscrolled_transform;
+                        cx.maybe_pop_css_mask_layer(scene, mask_layer_pushed);
                     },
                 );
-
-                // Apply the CSS `mask` (if any) to the content drawn above
-                cx.transform = unscrolled_transform;
-                cx.maybe_pop_css_mask_layer(scene, mask_layer_pushed);
             },
         );
     }

--- a/packages/blitz-paint/src/render/clip_path.rs
+++ b/packages/blitz-paint/src/render/clip_path.rs
@@ -10,6 +10,37 @@ use style::values::generics::basic_shape::{
 use style::values::generics::position::{GenericPosition, GenericPositionOrAuto};
 
 impl ElementCx<'_, '_> {
+    /// Compute the rectangle (in scaled pixels, relative to the border box origin) described by
+    /// the CSS 2 `clip` property, if it applies. `clip` only applies to absolutely positioned
+    /// elements; `auto` components resolve to the corresponding border box edge.
+    pub(super) fn css_clip_rect(&self) -> Option<Rect> {
+        use style::computed_values::position::T as Position;
+        use style::values::computed::LengthOrAuto;
+        use style::values::generics::ClipRectOrAuto;
+
+        if !matches!(
+            self.style.get_box().position,
+            Position::Absolute | Position::Fixed
+        ) {
+            return None;
+        }
+        let ClipRectOrAuto::Rect(rect) = &self.style.get_effects().clip else {
+            return None;
+        };
+
+        let border_box = self.frame.border_box;
+        let resolve = |component: &LengthOrAuto, auto: f64| match component {
+            LengthOrAuto::Auto => auto,
+            LengthOrAuto::LengthPercentage(length) => length.px() as f64 * self.scale,
+        };
+        let x0 = resolve(&rect.left, 0.0);
+        let y0 = resolve(&rect.top, 0.0);
+        let x1 = resolve(&rect.right, border_box.width());
+        let y1 = resolve(&rect.bottom, border_box.height());
+
+        Some(Rect::new(x0, y0, x1.max(x0), y1.max(y0)))
+    }
+
     /// Compute the clip-path BezPath (if any) for this element.
     /// Returns `None` if clip-path is `none` or unsupported.
     pub(super) fn clip_path_shape(&self) -> Option<BezPath> {

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -5,6 +5,7 @@ use parley::{Affinity, Cursor, Layout, Line, PositionedLayoutItem, Selection};
 use peniko::Fill;
 use std::collections::HashMap;
 use style::properties::generated::longhands::text_decoration_style::computed_value::T as TextDecorationStyle;
+use style::properties::generated::longhands::visibility::computed_value::T as Visibility;
 use style::values::computed::{
     Length, LengthPercentage, TextDecorationLength, TextDecorationLine, TextUnderlinePosition,
 };
@@ -43,6 +44,9 @@ pub(crate) fn draw_inline_backgrounds<'a>(
             let Some(styles) = doc.get_node(node_id).and_then(|node| node.primary_styles()) else {
                 continue;
             };
+            if styles.get_inherited_box().visibility != Visibility::Visible {
+                continue;
+            }
 
             let current_color = styles.clone_color();
             let bg_color = styles
@@ -143,6 +147,9 @@ struct ResolvedDecoration {
 /// consecutive runs doesn't re-resolve them.
 struct DecorationStackEntry {
     node_id: NodeId,
+    /// Whether this node's `visibility` is `visible`. Glyphs of runs whose innermost node
+    /// is hidden are not painted, and a hidden node does not paint its decorations.
+    visible: bool,
     /// This node's (inherited) text colour, used for the glyphs of runs whose
     /// innermost node is this one.
     text_color: Color,
@@ -155,11 +162,13 @@ fn resolve_decoration_entry(doc: &BaseDocument, node_id: NodeId) -> DecorationSt
     let Some(styles) = doc.get_node(node_id).and_then(|node| node.primary_styles()) else {
         return DecorationStackEntry {
             node_id,
+            visible: true,
             text_color: Color::BLACK,
             decoration: None,
         };
     };
 
+    let visible = styles.get_inherited_box().visibility == Visibility::Visible;
     let itext = styles.get_inherited_text();
     let text = styles.get_text();
     let text_color = itext.color.as_color_color();
@@ -171,7 +180,7 @@ fn resolve_decoration_entry(doc: &BaseDocument, node_id: NodeId) -> DecorationSt
     // Decorations propagate through the box tree, and a `display: contents` element
     // generates no box, so its decorations have no effect on descendants.
     let is_contents = styles.clone_display().is_contents();
-    let decoration = (!is_contents && line.intersects(drawn_lines)).then(|| {
+    let decoration = (visible && !is_contents && line.intersects(drawn_lines)).then(|| {
         // `text-decoration-color: currentColor` (the initial value) resolves against
         // the decorating box's own colour, not the descendant run's.
         let color = text
@@ -195,6 +204,7 @@ fn resolve_decoration_entry(doc: &BaseDocument, node_id: NodeId) -> DecorationSt
 
     DecorationStackEntry {
         node_id,
+        visible,
         text_color,
         decoration,
     }
@@ -609,6 +619,11 @@ pub(crate) fn stroke_text<'a>(
                     stack.push(resolve_decoration_entry(doc, node_id));
                 }
 
+                // `visibility` inherits, so the innermost node determines whether the run's
+                // glyphs are painted. Hidden runs still take part in decoration bookkeeping
+                // below so that visible ancestors' decorations span them.
+                let run_visible = stack.last().is_none_or(|e| e.visible);
+
                 // The glyph colour comes from the run's own node (the stack top): `color`
                 // inherits, so the innermost inline element already carries the right value.
                 let text_color = stack.last().map(|e| e.text_color).unwrap_or(Color::BLACK);
@@ -620,23 +635,25 @@ pub(crate) fn stroke_text<'a>(
                     kurbo::Vec2::default()
                 };
 
-                scene.draw_glyphs(
-                    font,
-                    font_size,
-                    !FONT_EMBOLDEN_ENABLED, // hint
-                    run.normalized_coords(),
-                    embolden,
-                    Fill::NonZero,
-                    &anyrender::Paint::from(text_color),
-                    1.0, // alpha
-                    transform,
-                    glyph_xform,
-                    glyph_run.positioned_glyphs().map(|glyph| anyrender::Glyph {
-                        id: glyph.id as _,
-                        x: glyph.x,
-                        y: glyph.y,
-                    }),
-                );
+                if run_visible {
+                    scene.draw_glyphs(
+                        font,
+                        font_size,
+                        !FONT_EMBOLDEN_ENABLED, // hint
+                        run.normalized_coords(),
+                        embolden,
+                        Fill::NonZero,
+                        &anyrender::Paint::from(text_color),
+                        1.0, // alpha
+                        transform,
+                        glyph_xform,
+                        glyph_run.positioned_glyphs().map(|glyph| anyrender::Glyph {
+                            id: glyph.id as _,
+                            x: glyph.x,
+                            y: glyph.y,
+                        }),
+                    );
+                }
 
                 // Accumulate this run's contribution to each decorating box on its ancestor
                 // path. The decoration is drawn once per box after the whole line has been


### PR DESCRIPTION
## Summary

Root causes of the (non-animation) failures in `css/CSS2/visufx`, and fixes:

**1. CSS 2 `clip` was not implemented (44 `clip-*` tests, plus 17 in `css/css-masking/clip`).**
The painter only looked at `clip-path`/overflow/`contain: paint`; `styles.get_effects().clip` was never read. Added `ElementCx::css_clip_rect()`:
```rust
// only for position: absolute | fixed; `auto` edges resolve to the border-box edges
clip: rect(top, right, bottom, left) -> Rect::new(left, top, max(right,left), max(bottom,top)) * scale
```
and wrap the element's *entire* rendering (outline/shadows included, per CSS2) in an outermost clip layer. A zero-area rect skips painting the subtree entirely.

**2. Overflow propagation only exempted the root element (`overflow-propagation-001a/b/c`).**
Per css-overflow-3 §3.3, when `<html>` has `overflow: visible` in both axes the *first* `<body>` child that generates a box propagates its overflow to the viewport instead, and its own used overflow becomes `visible`. Added `BaseDocument::viewport_overflow_element()` and cache it in `BlitzDomPainter::viewport_overflow_element_id`; that element no longer clips for *overflow* reasons. Other clip reasons (`contain: paint`, images, iframes, text inputs) still apply to it (`overflow-body-propagation-010`), and a `display: none` first body propagates nothing (`overflow-body-propagation-016`).

**3. `visibility: hidden` returned early from `render_element`, so `visibility: visible` descendants were never painted (`visibility-005`, `visibility-descendants-*`).**
Now a hidden element skips its own backgrounds/borders/shadows/outline/images/markers/scrollbars but still recurses into children. In `text.rs`, inline backgrounds, decorations and glyph runs are filtered per node via the (inherited) computed `visibility`, so `<span style="visibility: visible">` inside a hidden block paints while sibling runs don't.

## WPT results (local, vs `main`)

| suite | before → after | notes |
|---|---|---|
| `css/CSS2` | 4151 → 4196 | +44 `clip-*`, +3 `overflow-propagation-001*` |
| `css/css-masking` | 201 → 218 | `clip/*` |
| `css/css-overflow` | 227 → 233 | `overflow-body-propagation-007/8/9/14/15`, `overflow-scroll-resize-visibility-hidden` |
| `css/css-backgrounds` | 561 → 564 | `background-origin/origin-border-box*` (used `clip`) |
| `css/css-transforms` | 457 → 461 | |
| `css/css-flexbox` | 1046 → 1047 | |
| position / grid / text / display / ui / tables | unchanged | |

**Two tests flip PASS → FAIL: `visibility-descendants-002/003`.** They were passing vacuously (test and ref both rendered nothing). Now they render the right content, but the test's `#div3` has `overflow: hidden` and the reference doesn't, and text drawn inside a vello_cpu clip layer is anti-aliased slightly differently from text drawn outside one. This is a pre-existing renderer issue reproducible on `main` with:
```html
<div style="overflow:hidden">Filler Text</div>   vs   <div>Filler Text</div>
```
`visibility-005` also still fails, for an unrelated inline-layout reason: the line box of `<div><span style="font:100px/1 Ahem">X</span> <span>X</span></div>` is ~10px too tall in Blitz (reproducible on `main` without any `visibility`).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/355437a9e8fd4bebbf536cf039421df2
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/355437a9e8fd4bebbf536cf039421df2?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **87** newly passing, **13** newly failing (net +74).

<details>
<summary>Full diff (100 changed tests)</summary>

```diff
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-004.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-005.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-006.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-007.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-008.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-016.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-017.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-018.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-019.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-020.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-028.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-029.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-030.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-031.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-032.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-040.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-041.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-042.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-043.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-044.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-052.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-053.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-054.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-055.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-056.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-064.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-065.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-066.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-067.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-068.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-076.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-077.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-078.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-079.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-080.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-088.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-089.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-090.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-091.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-092.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-097.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-098.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-099.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-102.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/overflow-propagation-001a.html
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/overflow-propagation-001b.html
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/overflow-propagation-001c.html
- PASS => FAIL  [0/1]  -1  css/CSS2/visufx/visibility-descendants-002.html
- PASS => FAIL  [0/1]  -1  css/CSS2/visufx/visibility-descendants-003.html
+ FAIL => PASS  [1/1]  +1  css/css-backgrounds/background-origin/origin-border-box.html
+ FAIL => PASS  [1/1]  +1  css/css-backgrounds/background-origin/origin-border-box_with_radius.html
+ FAIL => PASS  [1/1]  +1  css/css-backgrounds/background-origin/origin-border-box_with_size.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-body-overflow-001.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-body-overflow-003.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-body-overflow-004.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-html-overflow-001.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-html-overflow-002.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-html-overflow-003.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-html-overflow-004.html
+ FAIL => PASS  [1/1]  +1  css/css-flexbox/flexbox-align-self-vert-001.xhtml
- PASS => FAIL  [0/1]  -1  css/css-images/image-orientation/image-orientation-img-object-fit.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-absolute-positioned-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-absolute-positioned-002.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-filter-order.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-fixed-pos-transform-descendant-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-negative-values-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-negative-values-002.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-negative-values-003.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-negative-values-004.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-002.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-003.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-004.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-005.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-006.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-comma-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-transform-order-2.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-transform-order.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-007.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-008.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-009.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-014.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-015.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-scroll-resize-visibility-hidden.html
- PASS => FAIL  [0/1]  -1  css/css-scroll-snap/snap-after-initial-layout/scroll-snap-initial-layout-000.html
+ FAIL => PASS  [1/1]  +1  css/css-sizing/fit-content-block-size-abspos.html
+ FAIL => PASS  [1/1]  +1  css/css-transforms/transform-fixed-bg-006.html
+ FAIL => PASS  [1/1]  +1  css/css-transforms/transform-inherit-001.html
+ FAIL => PASS  [1/1]  +1  css/css-transforms/transform-transformed-td-contains-fixed-position.html
+ FAIL => PASS  [1/1]  +1  css/css-transforms/transform-transformed-th-contains-fixed-position.html
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vlr-003.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vlr-005.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vlr-007.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vlr-009.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vrl-002.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vrl-004.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vrl-006.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vrl-008.xht
- PASS => FAIL  [0/1]  -1  css/cssom-view/cssom-getBoundingClientRect-vertical-rl.html
- PASS => FAIL  [0/1]  -1  css/filter-effects/backdrop-filter-plus-mask-large.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34728058989).</sub>
<!-- wpt-results-end -->
