### PR TITLE
Resolve `line-height: normal` from font metrics instead of 1.2 × font-size

### DIFF
--- a/packages/blitz-dom/src/font_metrics.rs
+++ b/packages/blitz-dom/src/font_metrics.rs
@@ -12,6 +12,80 @@ use style::{
     values::computed::{CSSPixelLength, font::QueryFontMetricsFlags},
 };
 
+/// Query fontique for the fonts matching `font_styles` (family list and attributes).
+fn query_for_font_styles<'a>(
+    font_ctx: &'a mut FontContext,
+    font_styles: &'a FontStyles,
+) -> parley::fontique::Query<'a> {
+    use parley::fontique::Attributes;
+
+    let mut query = font_ctx.collection.query(&mut font_ctx.source_cache);
+    let families = font_styles
+        .font_family
+        .families
+        .iter()
+        .map(stylo_to_parley::query_font_family);
+    query.set_families(families);
+    query.set_attributes(Attributes {
+        width: stylo_to_parley::font_width(font_styles.font_stretch),
+        weight: stylo_to_parley::font_weight(font_styles.font_weight),
+        style: stylo_to_parley::font_style(font_styles.font_style),
+    });
+    query
+}
+
+/// The used value of `line-height: normal` for the first available font matching
+/// `font_styles`: ascent + descent + line gap, at `font_size` (in CSS px).
+///
+/// Each metric is rounded to a whole device pixel (at `scale` device px per CSS px)
+/// before summing, matching Chromium and Parley's pixel-quantized line metrics.
+pub(crate) fn normal_line_height(
+    font_ctx: &mut FontContext,
+    font_styles: &FontStyles,
+    font_size: f32,
+    scale: f32,
+) -> Option<f32> {
+    use parley::fontique::{QueryFont, QueryStatus};
+    use skrifa::instance::{LocationRef, Size};
+    use skrifa::metrics::Metrics;
+
+    let variations = stylo_to_parley::font_variations(&font_styles.font_variation_settings);
+
+    // The "first available font" is the first font in the family list that contains
+    // U+0020 (space). See https://drafts.csswg.org/css-fonts/#first-available-font
+    let mut query = query_for_font_styles(font_ctx, font_styles);
+    let mut first_font: Option<QueryFont> = None;
+    let mut font: Option<QueryFont> = None;
+    query.matches_with(|q_font| {
+        if first_font.is_none() {
+            first_font = Some(q_font.clone());
+        }
+        let has_space = skrifa::FontRef::from_index(q_font.blob.as_ref(), q_font.index)
+            .is_ok_and(|font_ref| Charmap::new(&font_ref).map(' ').is_some());
+        if has_space {
+            font = Some(q_font.clone());
+            QueryStatus::Stop
+        } else {
+            QueryStatus::Continue
+        }
+    });
+    let font = font.or(first_font)?;
+
+    let font_ref = skrifa::FontRef::from_index(font.blob.as_ref(), font.index).ok()?;
+    let location = font_ref.axes().location(
+        variations
+            .iter()
+            .map(|v| (skrifa::Tag::from_be_bytes(v.tag.to_bytes()), v.value)),
+    );
+    let metrics = Metrics::new(
+        &font_ref,
+        Size::new(font_size * scale),
+        LocationRef::from(&location),
+    );
+    let line_height = metrics.ascent.round() + (-metrics.descent).round() + metrics.leading.round();
+    Some(line_height / scale)
+}
+
 #[derive(Clone)]
 pub(crate) struct BlitzFontMetricsProvider {
     pub(crate) font_ctx: Arc<Mutex<FontContext>>,
@@ -31,7 +105,7 @@ impl FontMetricsProvider for BlitzFontMetricsProvider {
         font_size: CSSPixelLength,
         _flags: QueryFontMetricsFlags,
     ) -> FontMetrics {
-        use parley::fontique::{Attributes, Query, QueryFont, QueryStatus};
+        use parley::fontique::{Query, QueryFont, QueryStatus};
         use skrifa::instance::{LocationRef, Size};
         use skrifa::metrics::{GlyphMetrics, Metrics};
 
@@ -40,18 +114,7 @@ impl FontMetricsProvider for BlitzFontMetricsProvider {
         let font_ctx = &mut *font_ctx;
 
         // Query fontique for the font that matches the font styles
-        let mut query = font_ctx.collection.query(&mut font_ctx.source_cache);
-        let families = font_styles
-            .font_family
-            .families
-            .iter()
-            .map(stylo_to_parley::query_font_family);
-        query.set_families(families);
-        query.set_attributes(Attributes {
-            width: stylo_to_parley::font_width(font_styles.font_stretch),
-            weight: stylo_to_parley::font_weight(font_styles.font_weight),
-            style: stylo_to_parley::font_style(font_styles.font_style),
-        });
+        let mut query = query_for_font_styles(font_ctx, font_styles);
         // let fb_script = crate::swash_convert::script_to_fontique(script);
         // let fb_language = locale.and_then(crate::swash_convert::locale_to_fontique);
         // query.set_fallbacks(fontique::FallbackKey::new(fb_script, fb_language.as_ref()));

--- a/packages/blitz-dom/src/layout/construct.rs
+++ b/packages/blitz-dom/src/layout/construct.rs
@@ -1,5 +1,6 @@
 use blitz_traits::node_id::NodeId;
 use core::str;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use markup5ever::{QualName, local_name, ns};
@@ -10,9 +11,10 @@ use parley::{
 use style::{
     computed_values::position::T as PositionProperty,
     data::ElementData as StyloElementData,
+    properties::ComputedValues,
     shared_lock::StylesheetGuards,
     values::{
-        computed::{Content, ContentItem, Display, Float, TextTransform},
+        computed::{Content, ContentItem, Display, Float, TextTransform, font::LineHeight},
         specified::box_::{DisplayInside, DisplayOutside},
     },
 };
@@ -20,6 +22,7 @@ use thin_vec::ThinVec;
 
 use crate::{
     BaseDocument, ElementData, Node, NodeData,
+    font_metrics::normal_line_height,
     layout::damage::{CONSTRUCT_BOX, CONSTRUCT_DESCENDENT, CONSTRUCT_FC},
     node::{
         ListItemLayout, ListItemLayoutPosition, Marker, NodeFlags, NodeKind, SpecialElementData,
@@ -286,12 +289,77 @@ fn push_non_whitespace_children_and_pseudos(layout_children: &mut ThinVec<NodeId
     }
 }
 
-/// Convert a relative line height to an absolute one
-fn resolve_line_height(line_height: parley::LineHeight, font_size: f32) -> f32 {
-    match line_height {
-        parley::LineHeight::FontSizeRelative(relative) => relative * font_size,
-        parley::LineHeight::Absolute(absolute) => absolute,
-        parley::LineHeight::MetricsRelative(relative) => relative * font_size, //unreachable!(),
+/// Resolve the used `line-height` (in CSS px) of an element. `normal` is resolved
+/// from the metrics of the element's first available font.
+fn resolve_line_height(font_ctx: &mut FontContext, style: &ComputedValues, scale: f32) -> f32 {
+    let font = style.get_font();
+    let font_size = font.font_size.used_size.0.px();
+    match font.line_height {
+        LineHeight::Normal => {
+            normal_line_height(font_ctx, font, font_size, scale).unwrap_or(font_size * 1.2)
+        }
+        LineHeight::Number(num) => font_size * num.0,
+        LineHeight::Length(value) => value.0.px(),
+    }
+}
+
+/// Whether an inline-level element is laid out as a Parley style span (as opposed
+/// to an atomic inline box) within an inline formatting context.
+fn is_inline_style_span(element_data: &ElementData) -> bool {
+    let tag_name = &element_data.name.local;
+    !(is_replaced_element(tag_name)
+        || *tag_name == local_name!("input")
+        || *tag_name == local_name!("textarea")
+        || *tag_name == local_name!("button")
+        || *tag_name == local_name!("br"))
+}
+
+/// Iterate a node's `::before` pseudo, children and `::after` pseudo, in tree order.
+fn children_and_pseudos(node: &Node) -> impl Iterator<Item = NodeId> + '_ {
+    node.before()
+        .into_iter()
+        .chain(node.children.iter().copied())
+        .chain(node.after())
+}
+
+/// Pre-compute the used line-height of every inline style span within an inline
+/// formatting context, floored by the line-height of the inline context's root.
+/// See https://www.w3.org/TR/CSS21/visudet.html#line-height
+///
+/// This has to happen before the Parley `TreeBuilder` is created as the builder
+/// holds a mutable borrow of the `FontContext`.
+fn collect_span_line_heights(
+    nodes: &crate::NodeTree,
+    font_ctx: &mut FontContext,
+    node_id: NodeId,
+    root_line_height: f32,
+    scale: f32,
+    out: &mut HashMap<NodeId, f32>,
+) {
+    let node = &nodes[node_id];
+    let (NodeData::Element(element_data) | NodeData::AnonymousBlock(element_data)) = &node.data
+    else {
+        return;
+    };
+
+    let display = node.display_style().unwrap_or(Display::inline());
+    match (display.outside(), display.inside()) {
+        (DisplayOutside::None, DisplayInside::Contents) => {
+            for child_id in node.children.iter().copied() {
+                collect_span_line_heights(nodes, font_ctx, child_id, root_line_height, scale, out);
+            }
+        }
+        (DisplayOutside::Inline, DisplayInside::Flow) if is_inline_style_span(element_data) => {
+            if let Some(style) = node.primary_styles() {
+                let line_height =
+                    resolve_line_height(font_ctx, &style, scale).max(root_line_height);
+                out.insert(node_id, line_height);
+            }
+            for child_id in children_and_pseudos(node) {
+                collect_span_line_heights(nodes, font_ctx, child_id, root_line_height, scale, out);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -1034,12 +1102,31 @@ pub(crate) fn build_inline_layout_into(
             .and_then(|parent_id| nodes[parent_id].primary_styles())
     });
 
-    let parley_style = root_node_style
+    let mut parley_style = root_node_style
         .as_ref()
         .map(|s| stylo_to_parley::style(inline_context_root_node_id, s))
         .unwrap_or_default();
 
-    let root_line_height = resolve_line_height(parley_style.line_height, parley_style.font_size);
+    // The line-height of the inline context's root (the "strut"). `normal` is resolved
+    // against the root's first available font rather than per-run by Parley, so that
+    // fallback fonts don't change the line height.
+    let root_line_height = root_node_style
+        .as_deref()
+        .map(|s| resolve_line_height(font_ctx, s, scale))
+        .unwrap_or(parley_style.font_size * 1.2);
+    parley_style.line_height = parley::LineHeight::Absolute(root_line_height);
+
+    let mut span_line_heights = HashMap::new();
+    for child_id in children_and_pseudos(root_node) {
+        collect_span_line_heights(
+            nodes,
+            font_ctx,
+            child_id,
+            root_line_height,
+            scale,
+            &mut span_line_heights,
+        );
+    }
 
     // Create a parley tree builder
     let mut builder = layout_ctx.tree_builder(font_ctx, scale, true, &parley_style);
@@ -1089,7 +1176,7 @@ pub(crate) fn build_inline_layout_into(
             before_id,
             collapse_mode,
             text_transform,
-            root_line_height,
+            &span_line_heights,
         );
     }
     for child_id in root_node.children.iter().copied() {
@@ -1100,7 +1187,7 @@ pub(crate) fn build_inline_layout_into(
             child_id,
             collapse_mode,
             text_transform,
-            root_line_height,
+            &span_line_heights,
         );
     }
     if let Some(after_id) = root_node.after() {
@@ -1111,7 +1198,7 @@ pub(crate) fn build_inline_layout_into(
             after_id,
             collapse_mode,
             text_transform,
-            root_line_height,
+            &span_line_heights,
         );
     }
 
@@ -1125,7 +1212,7 @@ pub(crate) fn build_inline_layout_into(
         node_id: NodeId,
         collapse_mode: WhiteSpaceCollapse,
         parent_text_transform: TextTransform,
-        root_line_height: f32,
+        span_line_heights: &HashMap<NodeId, f32>,
     ) {
         let node = &nodes[node_id];
 
@@ -1182,7 +1269,7 @@ pub(crate) fn build_inline_layout_into(
                                 child_id,
                                 collapse_mode,
                                 text_transform,
-                                root_line_height,
+                                span_line_heights,
                             );
                         }
                     }
@@ -1218,16 +1305,11 @@ pub(crate) fn build_inline_layout_into(
                                 .map(|s| stylo_to_parley::style(node.id, &s))
                                 .unwrap_or_default();
 
-                            // dbg!(&style);
-
-                            let font_size = style.font_size;
-
                             // Floor the line-height of the span by the line-height of the inline context
                             // See https://www.w3.org/TR/CSS21/visudet.html#line-height
-                            style.line_height = parley::LineHeight::Absolute(
-                                resolve_line_height(style.line_height, font_size)
-                                    .max(root_line_height),
-                            );
+                            if let Some(line_height) = span_line_heights.get(&node_id) {
+                                style.line_height = parley::LineHeight::Absolute(*line_height);
+                            }
 
                             // dbg!(node_id);
                             // dbg!(&style);
@@ -1242,7 +1324,7 @@ pub(crate) fn build_inline_layout_into(
                                     before_id,
                                     collapse_mode,
                                     text_transform,
-                                    root_line_height,
+                                    span_line_heights,
                                 );
                             }
 
@@ -1254,7 +1336,7 @@ pub(crate) fn build_inline_layout_into(
                                     child_id,
                                     collapse_mode,
                                     text_transform,
-                                    root_line_height,
+                                    span_line_heights,
                                 );
                             }
                             if let Some(after_id) = node.after() {
@@ -1265,7 +1347,7 @@ pub(crate) fn build_inline_layout_into(
                                     after_id,
                                     collapse_mode,
                                     text_transform,
-                                    root_line_height,
+                                    span_line_heights,
                                 );
                             }
 

--- a/packages/blitz-dom/src/stylo_to_parley.rs
+++ b/packages/blitz-dom/src/stylo_to_parley.rs
@@ -299,7 +299,7 @@ pub(crate) fn style(
     // Convert font size and line height
     let font_size = font_styles.font_size.used_size.0.px();
     let line_height = match font_styles.line_height {
-        stylo::LineHeight::Normal => parley::LineHeight::FontSizeRelative(1.2),
+        stylo::LineHeight::Normal => parley::LineHeight::MetricsRelative(1.0),
         stylo::LineHeight::Number(num) => parley::LineHeight::FontSizeRelative(num.0),
         stylo::LineHeight::Length(value) => parley::LineHeight::Absolute(value.0.px()),
     };


### PR DESCRIPTION
## Summary

`line-height: normal` was hard-coded to `1.2 * font-size` in both `stylo_to_parley::style` and the inline-context strut/span floor in `layout/construct.rs`. Per CSS it is the first available font's `ascent + descent + lineGap` (for Ahem: exactly `1.0em`, so every CSS2 test mixing `normal` with `line-height: 1em` was off by 0.2em).

**How it's resolved now** (`font_metrics::normal_line_height`):
- Query fontique with the element's family list + attributes (shared with the `ex`/`ch` metrics provider via a new `query_for_font_styles` helper) and take the *first available font* — the first match whose cmap contains U+0020 — honouring `font-variation-settings` when reading metrics.
- Round `ascent`, `descent` and `lineGap` to whole device pixels *individually* before summing (Chromium's `SimpleFontData` formula). This matters because Parley quantizes line metrics: an unrounded sum like `18.625` for DejaVu Sans 16px yields a negative `leading` after Parley rounds ascent/descent, which shifted every line by a pixel. With rounding it's `15 + 4 + 0 = 19`.
- Falls back to `1.2 * font-size` if no font matches.

**Wiring in `layout/construct.rs`:** the strut and all inline span line-heights are resolved to `Absolute` *before* the Parley `TreeBuilder` is created (it holds `&mut FontContext`), via a `collect_span_line_heights` pre-pass mirroring the span-vs-inline-box classification of the main recursion. The root style is also forced to `Absolute(root_line_height)` so Parley doesn't compute `normal` per run from fallback fonts. `stylo_to_parley::style` now emits `MetricsRelative(1.0)` for `Normal`; that only reaches Parley for text inputs and list markers.

Not changed: the `1.2` in `layout/mod.rs` (only used for `<textarea rows>` / `<input>` intrinsic height).

**WPT** (`css/CSS2 css/css-fonts css/css-text css/css-inline`, local): **+44 / −7** reftests (5525 vs 5482 passing).
- Fixed: the 26 `css/CSS2/fonts` line-height failures (`font-011…043`, `font-family-applies-to-*`), `white-space-processing-002/003/008/009/010`, `numbers-units-007/009/010/021`, `pre-wrap-008/009`, `rcap-in-monospace`, `block-in-inline-first-line-001`, `line-breaking-atomic-009`, `font-size-122`.
- Regressed: `first-available-font-003/004` (need `unicode-range` support, which Blitz lacks — they only passed because `normal` was constant), and 5 tests (`floats-141`, `content-white-space-003/004`, `overflow-applies-to-001`, `white-space-zero-fontsize-001`) that differ by 1px from sub-pixel rounding of padding/inline-box offsets now that the line height is 19 rather than 19.2; Chrome snaps these via LayoutUnit. The inline-block cases trace to Parley folding inline-box height into `line_height` (negative leading), which is a separate Parley issue.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/43288fe5b6334c1da0f5ef2952bfde53
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/43288fe5b6334c1da0f5ef2952bfde53?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **69** newly passing, **15** newly failing (net +54).

<details>
<summary>Full diff (77 changed tests)</summary>

```diff
+ FAIL => PASS   [1/1]  +1  css/CSS2/box-display/block-in-inline-001.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/css1/c32-cascading-000.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/css1/c414-flt-fit-004.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/css1/c563-list-type-000.xht
- PASS => FAIL   [0/1]  -1  css/CSS2/floats-clear/floats-141.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/floats/float-table-align-left-quirk.html
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-011.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-012.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-013.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-014.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-015.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-016.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-029.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-030.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-031.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-032.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-042.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-043.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-family-applies-to-002.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-family-applies-to-006.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-family-applies-to-007.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-family-applies-to-008.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-family-applies-to-009.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-family-applies-to-010.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-family-applies-to-011.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-family-applies-to-014.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/fonts/font-size-122.xht
- PASS => FAIL   [0/1]  -1  css/CSS2/generated-content/content-white-space-003.xht
- PASS => FAIL   [0/1]  -1  css/CSS2/generated-content/content-white-space-004.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/normal-flow/block-in-inline-first-line-001.html
+ FAIL => PASS   [1/1]  +1  css/CSS2/tables/caption-side-applies-to-002.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/text/white-space-processing-002.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/text/white-space-processing-003.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/text/white-space-processing-008.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/text/white-space-processing-009.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/text/white-space-processing-010.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/values/numbers-units-007.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/values/numbers-units-009.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/values/numbers-units-010.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/values/numbers-units-021.xht
+ FAIL => PASS   [1/1]  +1  css/CSS2/values/units-005.xht
- PASS => FAIL   [0/1]  -1  css/CSS2/visufx/overflow-applies-to-001.xht
+ FAIL => PASS   [1/1]  +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-081a-print.html
+ FAIL => PASS   [1/1]  +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-081b-print.html
+ FAIL => PASS   [1/1]  +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-081c-print.html
+ FAIL => PASS   [1/1]  +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-081d-print.html
+ FAIL => PASS   [1/1]  +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-082a-print.html
+ FAIL => PASS   [1/1]  +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-082b-print.html
+ FAIL => PASS   [1/1]  +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-082c-print.html
+ FAIL => PASS   [1/1]  +1  css/css-break/flexbox/multi-line-row-flex-fragmentation-082d-print.html
+ FAIL => PASS   [1/1]  +1  css/css-break/widows-orphans-001.html
+ FAIL => PASS   [1/1]  +1  css/css-break/widows-orphans-002.html
+ FAIL => PASS   [1/1]  +1  css/css-break/widows-orphans-003.html
+ FAIL => PASS   [1/1]  +1  css/css-break/widows-orphans-004.html
+ FAIL => PASS   [2/2]  +2  css/css-display/empty-text-baseline-002.html
+ FAIL => PASS   [1/1]  +1  css/css-flexbox/flex-direction-row-reverse.html
+ FAIL => PASS   [1/1]  +1  css/css-flexbox/flexbox-align-self-vert-003.xhtml
- PASS => FAIL   [0/1]  -1  css/css-fonts/first-available-font-003.html
- PASS => FAIL   [0/1]  -1  css/css-fonts/first-available-font-004.html
+ FAIL => PASS   [1/1]  +1  css/css-fonts/rcap-in-monospace.html
+ FAIL => PASS   [1/1]  +1  css/css-gaps/grid/subgrid/subgrid-gap-decorations-001.html
+ FAIL => PASS   [1/1]  +1  css/css-grid/grid-model/grid-floats-no-intrude-002.html
- PASS => FAIL   [0/1]  -1  css/css-lists/change-list-descendant-display.html
- PASS => FAIL   [0/1]  -1  css/css-lists/li-list-item-counter-002.html
- PASS => FAIL   [0/1]  -1  css/css-lists/li-list-item-counter-004.html
- PASS => FAIL   [0/1]  -1  css/css-lists/li-list-item-counter-005.html
- PASS => FAIL   [0/1]  -1  css/css-lists/li-value-reversed-016.html
- PASS => FAIL   [0/1]  -1  css/css-lists/li-value-reversed-018.html
- PASS => FAIL   [0/1]  -1  css/css-lists/li-value-reversed-019.html
- PASS => FAIL   [0/1]  -1  css/css-overflow/line-clamp/line-clamp-balance-009.html
+ FAIL => PASS   [1/1]  +1  css/css-text/line-breaking/line-breaking-atomic-009.html
+ FAIL => PASS   [1/1]  +1  css/css-text/white-space/pre-wrap-008.html
+ FAIL => PASS   [1/1]  +1  css/css-text/white-space/pre-wrap-009.html
+ FAIL => PASS   [3/3]  +2  css/css-text/white-space/text-wrap-balance-001.html
+ FAIL => PASS   [3/3]  +2  css/css-text/white-space/text-wrap-balance-right-to-left.html
- PASS => FAIL   [0/1]  -1  css/css-text/white-space/white-space-zero-fontsize-001.html
+ FAIL => FAIL  [7/33]  +5  css/css-values/calc-size/calc-size-flex-basis-on-column.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34728256685).</sub>
<!-- wpt-results-end -->
