### PR TITLE
Implement the CSS 2 `clip` property

### DIFF
--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -440,6 +440,22 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         let mut clip_path_for_layer = clip_path_shape.unwrap_or(default_clip);
         clip_path_for_layer.apply_affine(Affine::scale(self.scale));
 
+        // CSS 2 `clip` property (absolutely positioned elements only). Applies to the whole of
+        // the element's rendering (including outlines and shadows), so it is the outermost layer.
+        let css_clip_rect = cx.css_clip_rect();
+        if css_clip_rect.is_some_and(|rect| rect.is_zero_area()) {
+            return;
+        }
+        let css_clip_layer_pushed = self.layer_manager.maybe_push_layer(
+            scene,
+            css_clip_rect.is_some(),
+            1.0,
+            cx.transform,
+            &css_clip_rect.unwrap_or(Rect::ZERO),
+            None,
+            None,
+        );
+
         cx.draw_outline(scene);
         cx.draw_outset_box_shadow(scene);
 
@@ -556,6 +572,9 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                 cx.maybe_pop_css_mask_layer(scene, mask_layer_pushed);
             },
         );
+
+        self.layer_manager
+            .maybe_pop_layer(scene, css_clip_layer_pushed);
     }
 
     fn render_node(

--- a/packages/blitz-paint/src/render/clip_path.rs
+++ b/packages/blitz-paint/src/render/clip_path.rs
@@ -10,6 +10,37 @@ use style::values::generics::basic_shape::{
 use style::values::generics::position::{GenericPosition, GenericPositionOrAuto};
 
 impl ElementCx<'_, '_> {
+    /// Compute the rectangle (in scaled pixels, relative to the border box origin) described by
+    /// the CSS 2 `clip` property, if it applies. `clip` only applies to absolutely positioned
+    /// elements; `auto` components resolve to the corresponding border box edge.
+    pub(super) fn css_clip_rect(&self) -> Option<Rect> {
+        use style::computed_values::position::T as Position;
+        use style::values::computed::LengthOrAuto;
+        use style::values::generics::ClipRectOrAuto;
+
+        if !matches!(
+            self.style.get_box().position,
+            Position::Absolute | Position::Fixed
+        ) {
+            return None;
+        }
+        let ClipRectOrAuto::Rect(rect) = &self.style.get_effects().clip else {
+            return None;
+        };
+
+        let border_box = self.frame.border_box;
+        let resolve = |component: &LengthOrAuto, auto: f64| match component {
+            LengthOrAuto::Auto => auto,
+            LengthOrAuto::LengthPercentage(length) => length.px() as f64 * self.scale,
+        };
+        let x0 = resolve(&rect.left, 0.0);
+        let y0 = resolve(&rect.top, 0.0);
+        let x1 = resolve(&rect.right, border_box.width());
+        let y1 = resolve(&rect.bottom, border_box.height());
+
+        Some(Rect::new(x0, y0, x1.max(x0), y1.max(y0)))
+    }
+
     /// Compute the clip-path BezPath (if any) for this element.
     /// Returns `None` if clip-path is `none` or unsupported.
     pub(super) fn clip_path_shape(&self) -> Option<BezPath> {


### PR DESCRIPTION
## Summary

Split out of #877.

The painter only handled `clip-path`, overflow and `contain: paint`; the legacy CSS 2 `clip` property (`styles.get_effects().clip`) was never read, which is why all 44 `css/CSS2/visufx/clip-*` tests failed.

New `ElementCx::css_clip_rect()` in `render/clip_path.rs`:
```rust
// only for position: absolute | fixed; `auto` edges resolve to the border-box edges
clip: rect(top, right, bottom, left)
  -> Rect::new(left, top, max(right, left), max(bottom, top)) * scale   // relative to border-box origin
```
In `render_element` the whole of the element's rendering (outline and outset shadows included, per CSS 2) is wrapped in an outermost clip layer via `LayerManager::maybe_push_layer`/`maybe_pop_layer`. A zero-area rect (e.g. `rect(0,0,0,0)`) returns early without painting the subtree.

## WPT (local)
- `css/CSS2/visufx`: +44 (`clip-*`)
- `css/css-masking`: 201 → 218 (`clip/*`)
- no changes in css-position / flexbox / grid / text / overflow


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/355437a9e8fd4bebbf536cf039421df2
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/355437a9e8fd4bebbf536cf039421df2?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **69** newly passing, **0** newly failing (net +69).

<details>
<summary>Full diff (69 changed tests)</summary>

```diff
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-004.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-005.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-006.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-007.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-008.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-016.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-017.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-018.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-019.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-020.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-028.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-029.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-030.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-031.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-032.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-040.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-041.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-042.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-043.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-044.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-052.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-053.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-054.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-055.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-056.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-064.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-065.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-066.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-067.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-068.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-076.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-077.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-078.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-079.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-080.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-088.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-089.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-090.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-091.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-092.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-097.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-098.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-099.xht
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/clip-102.xht
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-absolute-positioned-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-absolute-positioned-002.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-filter-order.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-fixed-pos-transform-descendant-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-negative-values-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-negative-values-002.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-negative-values-003.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-negative-values-004.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-002.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-003.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-004.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-005.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-auto-006.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-rect-comma-001.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-transform-order-2.html
+ FAIL => PASS  [1/1]  +1  css/css-masking/clip/clip-transform-order.html
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vlr-003.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vlr-005.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vlr-007.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vlr-009.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vrl-002.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vrl-004.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vrl-006.xht
+ FAIL => PASS  [1/1]  +1  css/css-writing-modes/clip-rect-vrl-008.xht
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34728601504).</sub>
<!-- wpt-results-end -->
