### PR TITLE
Don't clip the `<body>` when its overflow propagates to the viewport

### DIFF
--- a/packages/blitz-dom/src/document.rs
+++ b/packages/blitz-dom/src/document.rs
@@ -842,6 +842,45 @@ impl BaseDocument {
             .unwrap()
     }
 
+    /// The element whose `overflow` is propagated to the viewport, per the CSS overflow
+    /// propagation rules (css-overflow-3 §3.3). This is the root element, unless it is an
+    /// `<html>` element with `overflow: visible` in both axes and it has a `<body>` child
+    /// with a box, in which case the body's overflow is propagated instead. The used
+    /// overflow of the element returned is `visible`: it must not clip its own overflow.
+    pub fn viewport_overflow_element(&self) -> Option<NodeId> {
+        use style::values::computed::Overflow;
+
+        let root = self.try_root_element()?;
+        if !root.data.is_element_with_tag_name(&local_name!("html")) {
+            return Some(root.id);
+        }
+        let root_styles = root.primary_styles()?;
+        let root_overflow_visible = root_styles.clone_overflow_x() == Overflow::Visible
+            && root_styles.clone_overflow_y() == Overflow::Visible;
+        if !root_overflow_visible {
+            return Some(root.id);
+        }
+
+        // Only the first `<body>` child is a candidate; if it doesn't generate a box then
+        // nothing is propagated from the body.
+        let body = root
+            .children
+            .iter()
+            .copied()
+            .find(|&child_id| {
+                self.nodes[child_id]
+                    .data
+                    .is_element_with_tag_name(&local_name!("body"))
+            })
+            .filter(|&body_id| {
+                self.nodes[body_id].primary_styles().is_some_and(|styles| {
+                    let display = styles.clone_display();
+                    !display.is_none() && !display.is_contents()
+                })
+            });
+        Some(body.unwrap_or(root.id))
+    }
+
     pub fn create_node(&mut self, node_data: NodeData) -> NodeId {
         let tree_ptr = self.nodes.as_mut() as *mut NodeTree;
         let guard = self.guard.clone();

--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -113,6 +113,9 @@ pub struct BlitzDomPainter<'dom, 'a> {
     pub(crate) initial_y: f64,
     /// The id of the document's root element (cached to avoid re-resolving it for every element)
     pub(crate) root_element_id: Option<NodeId>,
+    /// The id of the element whose overflow is propagated to the viewport (the root element
+    /// or the `<body>`), which must therefore not clip its own overflow.
+    pub(crate) viewport_overflow_element_id: Option<NodeId>,
     /// Scrollbar hover/drag state, resolved once per scene like the root element
     #[cfg(feature = "scrollbars")]
     pub(crate) hovered_scrollbar: Option<blitz_dom::node::ScrollbarRef>,
@@ -147,6 +150,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
 
         let layer_manager = LayerManager::default();
         let root_element_id = dom.try_root_element().map(|el| el.id);
+        let viewport_overflow_element_id = dom.viewport_overflow_element();
 
         Self {
             dom,
@@ -156,6 +160,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             initial_x,
             initial_y,
             root_element_id,
+            viewport_overflow_element_id,
             #[cfg(feature = "scrollbars")]
             hovered_scrollbar: dom.hovered_scrollbar(),
             #[cfg(feature = "scrollbars")]
@@ -346,16 +351,18 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             .element_data()
             .and_then(|el| el.text_input_data())
             .is_some();
-        // The root element's overflow is propagated to the viewport (which is clipped by the
-        // window/surface bounds), so the root element must not clip its own overflow.
+        // The root element's (or, when the root's overflow is visible, the body's) overflow
+        // is propagated to the viewport (which is clipped by the window/surface bounds), so
+        // that element's used overflow is `visible`. Other clipping reasons (e.g. `contain: paint`)
+        // still apply to it.
         let is_root_element = self.root_element_id == Some(node_id);
-        let should_clip = !is_root_element
-            && (is_image
-                || is_sub_doc
-                || is_text_input
-                || contain_paint
-                || !matches!(overflow_x, Overflow::Visible)
+        let propagates_overflow_to_viewport =
+            is_root_element || self.viewport_overflow_element_id == Some(node_id);
+        let clips_overflow = !propagates_overflow_to_viewport
+            && (!matches!(overflow_x, Overflow::Visible)
                 || !matches!(overflow_y, Overflow::Visible));
+        let should_clip =
+            is_image || is_sub_doc || is_text_input || contain_paint || clips_overflow;
 
         // Apply padding/border offset to inline root
         let taffy::Layout {


### PR DESCRIPTION
## Summary

Split out of #877.

The painter exempted only the root element from overflow clipping. Per [css-overflow-3 §3.3](https://drafts.csswg.org/css-overflow-3/#overflow-propagation), when `<html>` has `overflow: visible` in both axes, the overflow of the first `<body>` child that generates a box is propagated to the viewport instead, and the body's own used overflow becomes `visible` — so `body { overflow: hidden }` must not clip the body's content (`css/CSS2/visufx/overflow-propagation-001a/b/c`).

- New `BaseDocument::viewport_overflow_element()` returns the element whose overflow is propagated: the root, unless it's an `<html>` with visible overflow and its first `<body>` child has a box (a `display: none` body propagates nothing → `overflow-body-propagation-016`).
- `BlitzDomPainter` caches it as `viewport_overflow_element_id`; in `render_element` that element skips clipping for *overflow* reasons only:
  ```rust
  let clips_overflow = !propagates_overflow_to_viewport && (overflow_x != Visible || overflow_y != Visible);
  let should_clip = is_image || is_sub_doc || is_text_input || contain_paint || clips_overflow;
  ```
  Previously the root also skipped `contain: paint` / image / iframe / text-input clipping; now those still apply (`overflow-body-propagation-010`).

Scrolling already followed these rules (`scrolling.rs`); this brings paint clipping in line.

## WPT (local)
- `css/CSS2/visufx`: +3 (`overflow-propagation-001*`)
- `css/css-overflow`: 227 → 232 (`overflow-body-propagation-007/008/009/014/015`), no regressions
- `css/css-position`, flexbox, grid, text: unchanged


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/355437a9e8fd4bebbf536cf039421df2
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/355437a9e8fd4bebbf536cf039421df2?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **16** newly passing, **12** newly failing (net +4).

<details>
<summary>Full diff (28 changed tests)</summary>

```diff
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/overflow-propagation-001a.html
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/overflow-propagation-001b.html
+ FAIL => PASS  [1/1]  +1  css/CSS2/visufx/overflow-propagation-001c.html
+ FAIL => PASS  [1/1]  +1  css/css-backgrounds/background-origin/origin-border-box.html
- PASS => FAIL  [0/1]  -1  css/css-backgrounds/background-origin/origin-border-box_with_position.html
+ FAIL => PASS  [1/1]  +1  css/css-backgrounds/background-origin/origin-border-box_with_radius.html
+ FAIL => PASS  [1/1]  +1  css/css-backgrounds/background-origin/origin-border-box_with_size.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-body-overflow-001.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-body-overflow-003.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-body-overflow-004.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-html-overflow-001.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-html-overflow-002.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-html-overflow-003.html
- PASS => FAIL  [0/1]  -1  css/css-contain/contain-html-overflow-004.html
- PASS => FAIL  [0/1]  -1  css/css-images/image-orientation/image-orientation-img-object-fit.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-007.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-008.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-009.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-014.html
+ FAIL => PASS  [1/1]  +1  css/css-overflow/overflow-body-propagation-015.html
- PASS => FAIL  [0/1]  -1  css/css-scroll-snap/snap-after-initial-layout/scroll-snap-initial-layout-000.html
+ FAIL => PASS  [1/1]  +1  css/css-sizing/fit-content-block-size-abspos.html
+ FAIL => PASS  [1/1]  +1  css/css-transforms/transform-fixed-bg-006.html
+ FAIL => PASS  [1/1]  +1  css/css-transforms/transform-inherit-001.html
+ FAIL => PASS  [1/1]  +1  css/css-transforms/transform-transformed-td-contains-fixed-position.html
+ FAIL => PASS  [1/1]  +1  css/css-transforms/transform-transformed-th-contains-fixed-position.html
- PASS => FAIL  [0/1]  -1  css/cssom-view/cssom-getBoundingClientRect-vertical-rl.html
- PASS => FAIL  [0/1]  -1  css/filter-effects/backdrop-filter-plus-mask-large.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34728648716).</sub>
<!-- wpt-results-end -->
