### PR TITLE
Paint `visibility: visible` descendants of `visibility: hidden` elements

### DIFF
--- a/packages/blitz-paint/src/render.rs
+++ b/packages/blitz-paint/src/render.rs
@@ -309,10 +309,9 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
             return;
         }
 
-        // Hide elements with a visibility style other than visible
-        if styles.get_inherited_box().visibility != StyloVisibility::Visible {
-            return;
-        }
+        // Elements with a visibility style other than visible paint none of their own boxes,
+        // but their descendants may still be painted if they set `visibility: visible`.
+        let is_visible = styles.get_inherited_box().visibility == StyloVisibility::Visible;
 
         let effects = styles.get_effects();
         let opacity = effects.opacity;
@@ -440,8 +439,10 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
         let mut clip_path_for_layer = clip_path_shape.unwrap_or(default_clip);
         clip_path_for_layer.apply_affine(Affine::scale(self.scale));
 
-        cx.draw_outline(scene);
-        cx.draw_outset_box_shadow(scene);
+        if is_visible {
+            cx.draw_outline(scene);
+            cx.draw_outset_box_shadow(scene);
+        }
 
         // clip-path clip ayer
         self.layer_manager.maybe_with_layer(
@@ -493,11 +494,13 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                     filter,
                     backdrop_filter,
                     |scene| {
-                        cx.draw_background(scene);
-                        cx.draw_inset_box_shadow(scene);
-                        cx.draw_table_row_backgrounds(scene);
-                        cx.draw_table_borders(scene);
-                        cx.draw_border(scene);
+                        if is_visible {
+                            cx.draw_background(scene);
+                            cx.draw_inset_box_shadow(scene);
+                            cx.draw_table_row_backgrounds(scene);
+                            cx.draw_table_borders(scene);
+                            cx.draw_border(scene);
+                        }
                         cx.stroke_devtools(scene);
 
                         // TODO: allow layers with opacity to be unclipped (overflow: visible)
@@ -527,16 +530,22 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                                     x: -node.scroll_offset().x * self.scale,
                                     y: -node.scroll_offset().y * self.scale,
                                 });
-                                cx.draw_image(scene);
-                                #[cfg(feature = "svg")]
-                                cx.draw_svg(scene);
-                                #[cfg(feature = "custom-widget")]
-                                cx.draw_custom_widget(scene);
-                                cx.draw_sub_document(scene);
-                                cx.draw_input(scene);
-                                cx.draw_text_input_text(scene, content_position);
+                                if is_visible {
+                                    cx.draw_image(scene);
+                                    #[cfg(feature = "svg")]
+                                    cx.draw_svg(scene);
+                                    #[cfg(feature = "custom-widget")]
+                                    cx.draw_custom_widget(scene);
+                                    cx.draw_sub_document(scene);
+                                    cx.draw_input(scene);
+                                    cx.draw_text_input_text(scene, content_position);
+                                }
+                                // Inline text checks visibility per run, as inline
+                                // descendants may override the root's visibility.
                                 cx.draw_inline_layout(scene, content_position);
-                                cx.draw_marker(scene, content_position);
+                                if is_visible {
+                                    cx.draw_marker(scene, content_position);
+                                }
                                 cx.draw_children(scene, cx.transform, child_clip_rect);
                             },
                         );
@@ -544,7 +553,7 @@ impl<'dom, 'a> BlitzDomPainter<'dom, 'a> {
                         // Overlay scrollbars, drawn unscrolled above the
                         // clipped content.
                         #[cfg(feature = "scrollbars")]
-                        {
+                        if is_visible {
                             cx.transform = unscrolled_transform;
                             cx.draw_scrollbars(scene);
                         }

--- a/packages/blitz-paint/src/text.rs
+++ b/packages/blitz-paint/src/text.rs
@@ -5,6 +5,7 @@ use parley::{Affinity, Cursor, Layout, Line, PositionedLayoutItem, Selection};
 use peniko::Fill;
 use std::collections::HashMap;
 use style::properties::generated::longhands::text_decoration_style::computed_value::T as TextDecorationStyle;
+use style::properties::generated::longhands::visibility::computed_value::T as Visibility;
 use style::values::computed::{
     Length, LengthPercentage, TextDecorationLength, TextDecorationLine, TextUnderlinePosition,
 };
@@ -43,6 +44,9 @@ pub(crate) fn draw_inline_backgrounds<'a>(
             let Some(styles) = doc.get_node(node_id).and_then(|node| node.primary_styles()) else {
                 continue;
             };
+            if styles.get_inherited_box().visibility != Visibility::Visible {
+                continue;
+            }
 
             let current_color = styles.clone_color();
             let bg_color = styles
@@ -143,6 +147,9 @@ struct ResolvedDecoration {
 /// consecutive runs doesn't re-resolve them.
 struct DecorationStackEntry {
     node_id: NodeId,
+    /// Whether this node's `visibility` is `visible`. Glyphs of runs whose innermost node
+    /// is hidden are not painted, and a hidden node does not paint its decorations.
+    visible: bool,
     /// This node's (inherited) text colour, used for the glyphs of runs whose
     /// innermost node is this one.
     text_color: Color,
@@ -155,11 +162,13 @@ fn resolve_decoration_entry(doc: &BaseDocument, node_id: NodeId) -> DecorationSt
     let Some(styles) = doc.get_node(node_id).and_then(|node| node.primary_styles()) else {
         return DecorationStackEntry {
             node_id,
+            visible: true,
             text_color: Color::BLACK,
             decoration: None,
         };
     };
 
+    let visible = styles.get_inherited_box().visibility == Visibility::Visible;
     let itext = styles.get_inherited_text();
     let text = styles.get_text();
     let text_color = itext.color.as_color_color();
@@ -171,7 +180,7 @@ fn resolve_decoration_entry(doc: &BaseDocument, node_id: NodeId) -> DecorationSt
     // Decorations propagate through the box tree, and a `display: contents` element
     // generates no box, so its decorations have no effect on descendants.
     let is_contents = styles.clone_display().is_contents();
-    let decoration = (!is_contents && line.intersects(drawn_lines)).then(|| {
+    let decoration = (visible && !is_contents && line.intersects(drawn_lines)).then(|| {
         // `text-decoration-color: currentColor` (the initial value) resolves against
         // the decorating box's own colour, not the descendant run's.
         let color = text
@@ -195,6 +204,7 @@ fn resolve_decoration_entry(doc: &BaseDocument, node_id: NodeId) -> DecorationSt
 
     DecorationStackEntry {
         node_id,
+        visible,
         text_color,
         decoration,
     }
@@ -609,6 +619,11 @@ pub(crate) fn stroke_text<'a>(
                     stack.push(resolve_decoration_entry(doc, node_id));
                 }
 
+                // `visibility` inherits, so the innermost node determines whether the run's
+                // glyphs are painted. Hidden runs still take part in decoration bookkeeping
+                // below so that visible ancestors' decorations span them.
+                let run_visible = stack.last().is_none_or(|e| e.visible);
+
                 // The glyph colour comes from the run's own node (the stack top): `color`
                 // inherits, so the innermost inline element already carries the right value.
                 let text_color = stack.last().map(|e| e.text_color).unwrap_or(Color::BLACK);
@@ -620,23 +635,25 @@ pub(crate) fn stroke_text<'a>(
                     kurbo::Vec2::default()
                 };
 
-                scene.draw_glyphs(
-                    font,
-                    font_size,
-                    !FONT_EMBOLDEN_ENABLED, // hint
-                    run.normalized_coords(),
-                    embolden,
-                    Fill::NonZero,
-                    &anyrender::Paint::from(text_color),
-                    1.0, // alpha
-                    transform,
-                    glyph_xform,
-                    glyph_run.positioned_glyphs().map(|glyph| anyrender::Glyph {
-                        id: glyph.id as _,
-                        x: glyph.x,
-                        y: glyph.y,
-                    }),
-                );
+                if run_visible {
+                    scene.draw_glyphs(
+                        font,
+                        font_size,
+                        !FONT_EMBOLDEN_ENABLED, // hint
+                        run.normalized_coords(),
+                        embolden,
+                        Fill::NonZero,
+                        &anyrender::Paint::from(text_color),
+                        1.0, // alpha
+                        transform,
+                        glyph_xform,
+                        glyph_run.positioned_glyphs().map(|glyph| anyrender::Glyph {
+                            id: glyph.id as _,
+                            x: glyph.x,
+                            y: glyph.y,
+                        }),
+                    );
+                }
 
                 // Accumulate this run's contribution to each decorating box on its ancestor
                 // path. The decoration is drawn once per box after the whole line has been


### PR DESCRIPTION
## Summary

Split out of #877.

`render_element` returned early for any element whose computed `visibility` wasn't `visible`, so a `visibility: visible` descendant of a hidden element was never painted (`css/CSS2/visufx/visibility-005`, `visibility-descendants-*`; `css/css-overflow/overflow-scroll-resize-visibility-hidden`).

- `render.rs`: a hidden element now skips only its *own* painting (outline, shadows, background, borders, table backgrounds/borders, images/svg/widgets/sub-documents/inputs, markers, scrollbars) but still recurses into `draw_children` and `draw_inline_layout`.
- `text.rs`: since `visibility` inherits, inline content is filtered per node: `draw_inline_backgrounds` skips hidden nodes, and the decoration stack gains a `visible` flag so glyph runs whose innermost node is hidden are not drawn and hidden nodes contribute no decorations (hidden runs still take part in decoration bookkeeping so a visible ancestor's underline spans them).

## WPT (local)
- `css/css-overflow`: +1 (`overflow-scroll-resize-visibility-hidden`)
- `css/CSS2/visufx`: `visibility-005` now renders the green square but **still fails** for an unrelated inline-layout reason — the line box of `<div><span style="font:100px/1 Ahem">X</span> <span>X</span></div>` is ~10px too tall (reproduces on `main` without any `visibility`).
- `visibility-descendants-002/003` flip PASS → FAIL: they passed vacuously before (nothing painted on either side). The content is now correct, but the test's `#div3` has `overflow: hidden` and the ref doesn't, and text rasterised inside a vello_cpu clip layer is anti-aliased slightly differently from text outside one. Pre-existing renderer issue, repro on `main`: `<div style="overflow:hidden">Filler Text</div>` vs `<div>Filler Text</div>` as a reftest pair fails.
- css-text, css-ui: unchanged


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/355437a9e8fd4bebbf536cf039421df2
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/355437a9e8fd4bebbf536cf039421df2?variant=devin-insiders
Requested by: @nicoburns