### PR TITLE
cssom: implement the CSSStyleRule.selectorText setter

### DIFF
--- a/packages/blitz-dom/src/cssom.rs
+++ b/packages/blitz-dom/src/cssom.rs
@@ -9,6 +9,7 @@
 
 use cssparser::{Parser, ParserInput};
 use selectors::matching::QuirksMode;
+use selectors::parser::{ParseRelative, SelectorList};
 use style::font_face::FontFaceRule;
 use style::invalidation::stylesheets::RuleChangeKind;
 use style::parser::ParserContext;
@@ -17,6 +18,7 @@ use style::properties::{
     Importance, PropertyDeclarationBlock, PropertyId, SourcePropertyDeclaration,
     parse_one_declaration_into,
 };
+use style::selector_parser::SelectorParser;
 use style::servo_arc::Arc as ServoArc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::keyframes_rule::{Keyframe, KeyframesRule};
@@ -827,6 +829,84 @@ impl BaseDocument {
         self.stylist
             .rule_changed(&sheet, &rule, &guard, change_kind, &ancestor_refs);
         Ok(removed_value)
+    }
+
+    /// Replace the selectors of the style rule at `path` with those parsed
+    /// from `selectors` (`CSSStyleRule.selectorText` setter). Per CSSOM, an
+    /// invalid selector list leaves the rule unchanged (without throwing).
+    pub fn stylesheet_rule_set_selector_text(
+        &mut self,
+        node_id: NodeId,
+        path: &[usize],
+        selectors: &str,
+    ) -> Result<(), CssomError> {
+        let sheet = self
+            .nodes_to_stylesheet
+            .get(&node_id)
+            .ok_or(CssomError::NotFound)?
+            .clone();
+        let lock = &self.guard;
+
+        let (ancestors, style_rule) = {
+            let guard = lock.read();
+            let mut ancestors = Vec::with_capacity(path.len());
+            let handle =
+                Self::resolve_rule(&sheet, &guard, path, |rule| ancestors.push(rule.clone()))
+                    .ok_or(CssomError::NotFound)?;
+            let RuleHandle::Rule(CssRule::Style(style_rule)) = handle else {
+                return Err(CssomError::NotSupported);
+            };
+            (ancestors, style_rule)
+        };
+
+        // Nested style rules take relative selectors (`> .a`), resolved
+        // against the innermost enclosing style rule or `@scope`, mirroring
+        // stylo's `NestingContext`.
+        let parse_relative = ancestors
+            .iter()
+            .rev()
+            .find_map(|rule| match rule.rule_type() {
+                CssRuleType::Style => Some(ParseRelative::ForNesting),
+                CssRuleType::Scope => Some(ParseRelative::ForScope),
+                _ => None,
+            })
+            .unwrap_or(ParseRelative::No);
+
+        let new_selectors = {
+            let guard = lock.read();
+            let contents = sheet.contents(&guard);
+            let selector_parser = SelectorParser {
+                stylesheet_origin: contents.origin,
+                namespaces: &contents.namespaces,
+                url_data: &contents.url_data,
+                for_supports_rule: false,
+            };
+            let mut input = ParserInput::new(selectors);
+            let mut parser = Parser::new(&mut input);
+            let Ok(new_selectors) =
+                SelectorList::parse(&selector_parser, &mut parser, parse_relative)
+            else {
+                return Ok(());
+            };
+            new_selectors
+        };
+
+        {
+            let mut guard = lock.write();
+            style_rule.write_with(&mut guard).selectors = new_selectors;
+        }
+
+        let guard = lock.read();
+        let rule = CssRule::Style(style_rule);
+        let ancestor_refs: Vec<CssRuleRef> = ancestors.iter().map(CssRuleRef::from).collect();
+        self.stylist.rule_changed(
+            &sheet,
+            &rule,
+            &guard,
+            RuleChangeKind::Generic,
+            &ancestor_refs,
+        );
+        Ok(())
     }
 
     /// Replace the declarations of the rule at `path` with those parsed from

--- a/packages/blitz-vibey-script/src/dom/stylesheet.rs
+++ b/packages/blitz-vibey-script/src/dom/stylesheet.rs
@@ -24,6 +24,7 @@ pub(crate) fn register(context: &mut Context) {
         ("__blitz_sheet_rule_info", 2, rule_info),
         ("__blitz_sheet_insert_rule", 4, insert_rule),
         ("__blitz_sheet_delete_rule", 3, delete_rule),
+        ("__blitz_sheet_set_selector_text", 3, set_selector_text),
         ("__blitz_sheet_style_css_text", 2, style_css_text),
         ("__blitz_sheet_style_set_css_text", 3, style_set_css_text),
         (
@@ -222,6 +223,20 @@ fn style_css_text(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsRes
         .stylesheet_rule_style_css_text(node_id, &path)
         .unwrap_or_default();
     Ok(js_str(&css))
+}
+
+fn set_selector_text(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let ctx = dom_ctx(context)?;
+    let node_id = node_arg(args, 0)?;
+    let path = path_arg(args, 1, context)?;
+    let selectors = string_arg(args, 2, context)?;
+    // `selectorText` assignment never throws per CSSOM: invalid selectors (and
+    // rules without selectors) leave the rule unchanged
+    let _ = ctx
+        .doc
+        .borrow_mut()
+        .stylesheet_rule_set_selector_text(node_id, &path, &selectors);
+    Ok(JsValue::undefined())
 }
 
 fn style_set_css_text(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {

--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -817,6 +817,16 @@ const BOOTSTRAP_JS: &str = r#"
             conditionText: str,
         });
         defineRuleClass("CSSStyleRule", CSSGroupingRule, [styleGetter], { selectorText: str });
+        Object.defineProperty(ruleClasses.CSSStyleRule.prototype, "selectorText", {
+            get: attrGetter("selectorText", str),
+            set(value) {
+                const d = data(this);
+                __blitz_sheet_set_selector_text(d.owner, d.path, String(value));
+                touchSheet(d.sheet);
+            },
+            configurable: true,
+            enumerable: true,
+        });
         defineRuleClass("CSSNestedDeclarations", CSSRule, [styleGetter]);
         defineRuleClass("CSSMediaRule", CSSConditionRule, [
             {


### PR DESCRIPTION
## Summary

`CSSStyleRule.selectorText` was getter-only, so every WPT that round-trips a selector through it (`css/css-syntax/anb-parsing`, `anb-serialization`, `input-preprocessing`, `inclusive-ranges`, ...) saw the assignment silently ignored and failed.

New `BaseDocument::stylesheet_rule_set_selector_text(node_id, path, selectors)` in `blitz-dom`:
- resolves the rule at `path`, requires it to be a `CssRule::Style` (`NotSupported` otherwise)
- parses with stylo's `SelectorParser` (sheet's `origin`/`namespaces`/`url_data`), using `ParseRelative::ForNesting` / `ForScope` when the innermost enclosing ancestor is a style rule / `@scope` (mirrors stylo's `NestingContext`), else `ParseRelative::No`
- on parse failure leaves the rule unchanged (per CSSOM, no throw); on success swaps `StyleRule::selectors` and calls `stylist.rule_changed(.., RuleChangeKind::Generic, ancestors)` so the change restyles

Exposed as `__blitz_sheet_set_selector_text` and wired to a `selectorText` setter on `CSSStyleRule.prototype` (bumps the sheet generation so cached rule info refreshes).

WPT (`css/css-syntax`): `anb-parsing` 32→67/67, `anb-serialization` 0→20/20, `input-preprocessing` 0→10/10, `inclusive-ranges` 10→38/38. `css/cssom/CSSStyleRule-selectorText-setter`, `CSSStyleRule-set-selectorText-namespace`, `selectorText-modification-restyle-001` pass; `CSSStyleRule-set-selectorText` 78/82 (remaining are `:lang` matching and `::first-line`, unrelated to the setter).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/31227ea7475248ecaba2e44856b9722a
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/31227ea7475248ecaba2e44856b9722a?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **186** newly passing, **0** newly failing (net +186).

<details>
<summary>Full diff (15 changed tests)</summary>

```diff
+ FAIL => FAIL  [10/14]   +1  css/css-nesting/cssom.html
+ FAIL => PASS    [1/1]   +1  css/css-nesting/invalidation-004.html
+ FAIL => FAIL  [10/11]   +1  css/css-nesting/nested-declarations-matching.html
+ FAIL => PASS    [1/1]   +1  css/css-nesting/nested-rule-cssom-invalidation.html
+ FAIL => FAIL    [5/7]   +5  css/css-nesting/set-selector-text.html
+ FAIL => PASS  [67/67]  +35  css/css-syntax/anb-parsing.html
+ FAIL => PASS  [20/20]  +20  css/css-syntax/anb-serialization.html
+ FAIL => PASS  [38/38]  +28  css/css-syntax/inclusive-ranges.html
+ FAIL => PASS  [10/10]  +10  css/css-syntax/input-preprocessing.html
+ FAIL => FAIL  [89/95]   +1  css/css-syntax/urange-parsing.html
+ FAIL => PASS    [5/5]   +5  css/cssom/CSSStyleRule-set-selectorText-namespace.html
+ FAIL => FAIL  [78/82]  +58  css/cssom/CSSStyleRule-set-selectorText.html
+ FAIL => PASS    [1/1]   +1  css/cssom/selectorText-modification-restyle-001.html
+ FAIL => PASS  [72/72]  +18  css/selectors/attribute-selectors/attribute-case/cssom.html
+ FAIL => PASS    [1/1]   +1  css/selectors/is-where-error-recovery.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34732088421).</sub>
<!-- wpt-results-end -->
