### PR TITLE
wpt: report uncaught JS errors through testharness instead of discarding subtests

### DIFF
--- a/packages/blitz-vibey-script/src/runtime.rs
+++ b/packages/blitz-vibey-script/src/runtime.rs
@@ -24,7 +24,7 @@ use web_time::{Duration, Instant};
 
 use crate::dom::event::{EventRef, create_event, create_event_for_dom_event};
 use crate::dom::{
-    NodeRef, dom_ctx, node_id_of_value, node_wrapper, to_rust_string, wrap_style_object,
+    NodeRef, dom_ctx, js_str, node_id_of_value, node_wrapper, to_rust_string, wrap_style_object,
 };
 use crate::fetch::ScriptFetcher;
 use crate::state::{DomCtx, Listener, ReadyState};
@@ -1081,14 +1081,90 @@ const BOOTSTRAP_JS: &str = r#"
 })();
 "#;
 
-/// Record an unhandled JavaScript error in the runtime state, for the embedder
-/// to collect via [`ScriptDocument::take_js_errors`](crate::ScriptDocument::take_js_errors)
-fn report_js_error(ctx: &DomCtx, what: &str, error: &boa_engine::JsError) {
+/// Report an unhandled JavaScript error: record it in the runtime state for the
+/// embedder to collect via
+/// [`ScriptDocument::take_js_errors`](crate::ScriptDocument::take_js_errors),
+/// then fire an `error` event at the window (the HTML "report an exception"
+/// steps) so that `window.onerror` / `addEventListener("error")` handlers
+/// observe it.
+fn report_js_error(ctx: &DomCtx, context: &mut Context, what: &str, error: &JsError) {
     #[cfg(feature = "tracing")]
     tracing::error!("Uncaught JS error in {what}: {error}");
-    ctx.state
-        .borrow_mut()
-        .record_error(format!("Uncaught JS error in {what}: {error}"));
+    let already_dispatching = {
+        let mut state = ctx.state.borrow_mut();
+        state.record_error(format!("Uncaught JS error in {what}: {error}"));
+        std::mem::replace(&mut state.dispatching_error_event, true)
+    };
+    if already_dispatching {
+        return;
+    }
+    dispatch_error_event(ctx, context, error);
+    ctx.state.borrow_mut().dispatching_error_event = false;
+}
+
+/// Fire an `ErrorEvent`-shaped `error` event at the window for an uncaught
+/// exception. Exceptions thrown by the handlers themselves are recorded (via
+/// [`report_js_error`]) but do not fire further `error` events.
+fn dispatch_error_event(ctx: &DomCtx, context: &mut Context, error: &JsError) {
+    let listeners: Vec<Listener> = {
+        let mut state = ctx.state.borrow_mut();
+        match state.window_listeners.get_mut("error") {
+            Some(listeners) => {
+                let cloned = listeners.clone();
+                listeners.retain(|l| !l.once);
+                cloned
+            }
+            None => Vec::new(),
+        }
+    };
+    let onerror = context
+        .global_object()
+        .get(js_string!("onerror"), context)
+        .ok()
+        .and_then(|handler| handler.as_object().filter(|h| h.is_callable()));
+    if listeners.is_empty() && onerror.is_none() {
+        return;
+    }
+
+    let global: JsValue = context.global_object().into();
+    let event_obj = create_event(ctx, "error", false, true, &global, context);
+    crate::dom::define_value(&event_obj, "currentTarget", global.clone(), context);
+    let error_value = error
+        .clone()
+        .into_opaque(context)
+        .unwrap_or_else(|_| js_str(&error.to_string()));
+    let message = error_value
+        .as_object()
+        .and_then(|obj| obj.get(js_string!("message"), context).ok())
+        .filter(|message| message.is_string())
+        .unwrap_or_else(|| js_str(&error.to_string()));
+    crate::dom::define_value(&event_obj, "message", message.clone(), context);
+    crate::dom::define_value(&event_obj, "filename", js_str(""), context);
+    crate::dom::define_value(&event_obj, "lineno", JsValue::from(0), context);
+    crate::dom::define_value(&event_obj, "colno", JsValue::from(0), context);
+    crate::dom::define_value(&event_obj, "error", error_value.clone(), context);
+
+    for listener in listeners {
+        if let Err(error) = listener
+            .callback
+            .call(&global, &[event_obj.clone().into()], context)
+        {
+            report_js_error(ctx, context, "error event listener", &error);
+        }
+    }
+    // `window.onerror(message, source, lineno, colno, error)`
+    if let Some(handler) = onerror {
+        let args = [
+            message,
+            js_str(""),
+            JsValue::from(0),
+            JsValue::from(0),
+            error_value,
+        ];
+        if let Err(error) = handler.call(&global, &args, context) {
+            report_js_error(ctx, context, "error event listener", &error);
+        }
+    }
 }
 
 /// A [`ModuleLoader`] which fetches ES module imports synchronously via the
@@ -1369,14 +1445,14 @@ impl ScriptRuntime {
 
     fn eval_internal(&mut self, code: &str, description: &str) {
         if let Err(error) = self.context.eval(Source::from_bytes(code)) {
-            report_js_error(&self.ctx, description, &error);
+            report_js_error(&self.ctx, &mut self.context, description, &error);
         }
     }
 
     /// Run pending promise jobs (microtasks)
     pub fn run_jobs(&mut self, description: &str) {
         if let Err(error) = self.context.run_jobs() {
-            report_js_error(&self.ctx, description, &error);
+            report_js_error(&self.ctx, &mut self.context, description, &error);
         }
     }
 
@@ -1394,7 +1470,7 @@ impl ScriptRuntime {
         let module = match Module::parse(source, None, &mut self.context) {
             Ok(module) => module,
             Err(error) => {
-                report_js_error(&self.ctx, &description, &error);
+                report_js_error(&self.ctx, &mut self.context, &description, &error);
                 return;
             }
         };
@@ -1409,7 +1485,12 @@ impl ScriptRuntime {
         let promise = module.load_link_evaluate(&mut self.context);
         self.run_jobs(&description);
         if let PromiseState::Rejected(reason) = promise.state() {
-            report_js_error(&self.ctx, &description, &JsError::from_opaque(reason));
+            report_js_error(
+                &self.ctx,
+                &mut self.context,
+                &description,
+                &JsError::from_opaque(reason),
+            );
         }
     }
 
@@ -1533,7 +1614,7 @@ impl ScriptRuntime {
                     .callback
                     .call(&JsValue::undefined(), &timer.args, &mut self.context)
             {
-                report_js_error(&self.ctx, "timer callback", &error);
+                report_js_error(&self.ctx, &mut self.context, "timer callback", &error);
             }
         }
         self.run_jobs("timer microtasks");
@@ -1698,7 +1779,7 @@ impl ScriptRuntime {
                 if let Err(error) =
                     callback.call(&current_target, &[event_obj.clone().into()], context)
                 {
-                    report_js_error(&ctx, "event listener", &error);
+                    report_js_error(&ctx, context, "event listener", &error);
                 }
                 if event_ref(&event_obj, &|event| event.stopped_immediate.get()) {
                     break 'chain;
@@ -1733,7 +1814,7 @@ impl ScriptRuntime {
                             .callback
                             .call(&global, &[event_obj.clone().into()], context)
                     {
-                        report_js_error(&ctx, "event listener", &error);
+                        report_js_error(&ctx, context, "event listener", &error);
                     }
                     if event_ref(&event_obj, &|event| event.stopped_immediate.get()) {
                         break;
@@ -1804,7 +1885,7 @@ impl ScriptRuntime {
                     .callback
                     .call(&global, &[event_obj.clone().into()], context)
             {
-                report_js_error(&ctx, "event listener", &error);
+                report_js_error(&ctx, context, "event listener", &error);
             }
         }
 
@@ -1815,7 +1896,7 @@ impl ScriptRuntime {
                 if handler.is_callable() {
                     any_called = true;
                     if let Err(error) = handler.call(&global, &[event_obj.into()], context) {
-                        report_js_error(&ctx, "event listener", &error);
+                        report_js_error(&ctx, context, "event listener", &error);
                     }
                 }
             }

--- a/packages/blitz-vibey-script/src/state.rs
+++ b/packages/blitz-vibey-script/src/state.rs
@@ -88,6 +88,10 @@ pub(crate) struct RuntimeState {
     /// listeners, timer callbacks and promise jobs). Drained with
     /// [`ScriptDocument::take_js_errors`](crate::ScriptDocument::take_js_errors).
     pub uncaught_errors: Vec<String>,
+    /// Set while a window `error` event is being dispatched for an uncaught
+    /// exception, so that exceptions thrown by `error` handlers themselves are
+    /// only recorded and not re-dispatched
+    pub dispatching_error_event: bool,
     /// The document base URL, against which `fetch()` URLs are resolved
     pub base_url: Option<Url>,
     /// Fetcher backing `fetch()` (shared with `<script src>` and module loading)

--- a/packages/blitz-vibey-script/tests/dom.rs
+++ b/packages/blitz-vibey-script/tests/dom.rs
@@ -751,3 +751,36 @@ fn fetch_via_script_fetcher() {
         "404 false http://example.test/dir/missing.txt"
     );
 }
+
+#[test]
+fn uncaught_errors_fire_window_error_event() {
+    let mut doc = doc_from_html(
+        r#"
+        <html><body>
+            <div id="out"></div>
+            <script>
+                window.addEventListener("error", (e) => {
+                    document.getElementById("out").textContent +=
+                        "[" + e.type + ":" + e.message + ":" + (e.error instanceof TypeError) + "]";
+                });
+                window.onerror = (message) => {
+                    document.getElementById("out").textContent += "[onerror:" + message + "]";
+                    throw new Error("from handler");
+                };
+            </script>
+            <script>null.foo;</script>
+            <script>document.getElementById("out").textContent += "[after]";</script>
+        </body></html>
+        "#,
+    );
+    doc.execute_scripts();
+    let errors = doc.take_js_errors();
+    assert_eq!(errors.len(), 2, "{errors:?}");
+    assert!(errors[0].contains("TypeError"), "{errors:?}");
+    assert!(errors[1].contains("from handler"), "{errors:?}");
+    let out = text_of_selector(&doc, "#out");
+    assert!(
+        out.starts_with("[error:") && out.contains(":true][onerror:") && out.ends_with("[after]"),
+        "{out}"
+    );
+}

--- a/wpt/runner/src/test_runners/harness_test.rs
+++ b/wpt/runner/src/test_runners/harness_test.rs
@@ -113,7 +113,6 @@ impl ScriptFetcher for WptScriptFetcher {
 
 enum HarnessPumpOutcome {
     Results(i64, Vec<SubtestResult>),
-    JsErrors(Vec<String>),
     UnsupportedFeature(String, String),
 }
 
@@ -129,9 +128,11 @@ pub fn process_harness_test(
     // Synchronous tests complete during `execute_scripts` (testharness completes
     // on the `load` event); async tests may schedule timers.
     //
-    // Uncaught JS errors fail the test immediately: in a real browser they would
-    // reach testharness's window `error` handler and produce a harness ERROR, but
-    // here they typically mean the harness will never complete.
+    // Uncaught JS errors are dispatched to testharness's window `error` handler
+    // (as in a browser), which records a harness ERROR alongside the subtests
+    // completed so far and completes the harness. So they don't end the run on
+    // their own; they only decide the outcome if the harness never reports.
+    let mut js_errors = Vec::new();
     let outcome = pump_timers(&mut document, HARNESS_TIMEOUT, |document| {
         let messages = document.take_messages();
         if let Some((feature, command)) = messages
@@ -143,21 +144,25 @@ pub fn process_harness_test(
         if let Some((status, results)) = messages.iter().find_map(|msg| parse_results(msg)) {
             return Some(HarnessPumpOutcome::Results(status, results));
         }
-        let js_errors = document.take_js_errors();
-        if !js_errors.is_empty() {
-            return Some(HarnessPumpOutcome::JsErrors(js_errors));
-        }
+        js_errors.extend(document.take_js_errors());
         None
     });
+    js_errors.extend(document.take_js_errors());
+    for error in &js_errors {
+        warn!("{relative_path}: {error}");
+    }
 
     match outcome {
         Some(HarnessPumpOutcome::Results(harness_status, subtest_results)) => {
             harness_outcome(harness_status, subtest_results)
         }
-        Some(HarnessPumpOutcome::JsErrors(js_errors)) => {
-            for error in &js_errors {
-                warn!("{relative_path}: {error}");
-            }
+        Some(HarnessPumpOutcome::UnsupportedFeature(feature, command)) => {
+            debug!("Skipping {relative_path}: unsupported {feature} command {command}");
+            (TestStatus::Skip, SubtestCounts::ZERO_OF_ZERO, Vec::new())
+        }
+        // The harness never reported, and an uncaught error is the likely cause
+        // (e.g. it threw before testharness.js was even loaded)
+        None if !js_errors.is_empty() => {
             let subtest_results = vec![SubtestResult {
                 name: "Uncaught JS error".to_string(),
                 status: TestStatus::Fail,
@@ -168,10 +173,6 @@ pub fn process_harness_test(
                 SubtestCounts::ZERO_OF_ONE,
                 subtest_results,
             )
-        }
-        Some(HarnessPumpOutcome::UnsupportedFeature(feature, command)) => {
-            debug!("Skipping {relative_path}: unsupported {feature} command {command}");
-            (TestStatus::Skip, SubtestCounts::ZERO_OF_ZERO, Vec::new())
         }
         // Timeout, or no pending timers: the harness will never complete
         None => {


### PR DESCRIPTION
## Summary

When a testharness test threw an uncaught exception, the WPT runner bailed out and replaced *all* results with a single synthetic "Uncaught JS error" FAIL subtest — even if testharness had already recorded passing subtests. Browsers instead route the exception to testharness's `window.addEventListener("error")` handler, which sets harness status ERROR and completes with the subtests collected so far (e.g. `css/css-syntax/non-ascii-codepoints.html`, which has an upstream typo after its 15 subtests: Chrome/Servo report 15/15 + ERROR, Blitz reported 0/1).

Two parts:

**`blitz-vibey-script`** — `report_js_error` now takes the Boa `Context` and, after recording the error, fires an `error` event at the window (HTML "report an exception"): an `ErrorEvent`-shaped object (`message`, `error`, `filename`/`lineno`/`colno` placeholders) to `window` `error` listeners, then `window.onerror(message, source, lineno, colno, error)`. A `dispatching_error_event` flag on `RuntimeState` makes exceptions thrown *by* error handlers get recorded only, not re-dispatched. Applies to all uncaught-error sources (script eval, modules, microtasks, timers, event listeners). Test added in `tests/dom.rs`.

**`wpt` runner** — `process_harness_test` no longer stops on the first JS error; it keeps pumping so testharness can complete (status ERROR ⇒ test still FAILs via `harness_outcome`, but subtest counts are real). The synthetic "Uncaught JS error" subtest is kept only as a fallback when errors occurred and the harness never reported (e.g. threw before testharness.js loaded).

Diff vs main over `css/css-syntax` + `css/cssom` (same wpt checkout):
- `non-ascii-codepoints.html`: FAIL 0/1 → FAIL 15/15
- 8 cssom tests that throw early (`MutationObserver`/`CSSStyleSheet` constructor missing, ...): FAIL 0/1 → FAIL 0/1 (now via harness ERROR with 0 subtests instead of the synthetic subtest); everything else unchanged.

Companion to #885 (the `selectorText` setter); independent of it.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/31227ea7475248ecaba2e44856b9722a
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/31227ea7475248ecaba2e44856b9722a?variant=devin-insiders
Requested by: @nicoburns

<!-- wpt-results-start -->
## WPT results

Subtests: **495** newly passing, **1** newly failing (net +494).

<details>
<summary>Full diff (30 changed tests)</summary>

```diff
! FAIL => FAIL      [0/2]    +0  css/css-anchor-position/at-position-try-invalidation-shadow-dom.html
+ FAIL => FAIL      [2/3]    +2  css/css-anchor-position/position-try-tree-scoped.html
+ FAIL => PASS      [1/1]    +1  css/css-contain/content-visibility/content-visibility-081.html
- PASS => FAIL      [0/1]    -1  css/css-contain/content-visibility/content-visibility-resize-observer-no-error.html
! FAIL => FAIL      [0/5]    +0  css/css-easing/linear-timing-functions-output.html
+ FAIL => FAIL    [13/13]   +13  css/css-properties-values-api/registered-property-initial.html
! FAIL => FAIL      [0/3]    +0  css/css-scroll-snap/snap-events/scrollsnapchange/scrollsnapchange-on-programmatic-root-scroll.tentative.html
! FAIL => FAIL      [0/2]    +0  css/css-sizing/contain-intrinsic-size/auto-008.html
+ FAIL => FAIL    [15/15]   +15  css/css-syntax/non-ascii-codepoints.html
+ FAIL => FAIL    [15/30]   +15  css/css-text/animations/letter-spacing-composition.html
+ FAIL => FAIL   [56/112]   +56  css/css-transforms/animation/transform-translate-composition.html
! FAIL => FAIL      [0/2]    +0  css/css-typed-om/stylevalue-normalization/transformvalue-normalization.tentative.html
! FAIL => FAIL     [0/10]    +0  css/css-typed-om/stylevalue-subclasses/cssMatrixComponent.tentative.html
! FAIL => FAIL      [0/8]    +0  css/css-typed-om/stylevalue-subclasses/cssTransformValue.tentative.html
! FAIL => FAIL      [0/7]    +0  css/css-ui/accent-color-computed.html
+ FAIL => FAIL    [10/20]   +10  css/css-ui/animation/caret-color-composition.html
! FAIL => FAIL      [0/4]    +0  css/css-ui/input-security-computed.html
! FAIL => FAIL      [0/8]    +0  css/css-values/attr-pseudo-elem-invalidation-2.html
! FAIL => FAIL      [0/3]    +0  css/css-values/ch-empty-pseudo-recalc-on-font-load.html
! FAIL => FAIL      [0/5]    +0  css/css-values/ch-pseudo-recalc-on-font-load.html
! FAIL => FAIL      [0/3]    +0  css/css-values/ch-recalc-on-font-load.html
+ FAIL => FAIL  [108/321]  +108  css/selectors/attribute-selectors/attribute-case/semantics.html
+ FAIL => FAIL  [176/176]  +176  css/selectors/attribute-selectors/attribute-case/syntax.html
+ FAIL => FAIL     [9/14]    +9  css/selectors/invalidation/attribute-or-elemental-selectors-in-has.html
+ FAIL => FAIL      [2/4]    +2  css/selectors/invalidation/has-invalidation-for-wiping-an-element.html
! FAIL => FAIL      [0/3]    +0  css/selectors/invalidation/has-with-pseudo-class.html
+ FAIL => FAIL    [29/42]   +29  css/selectors/invalidation/heading-pseudo-class-in-has.html
+ FAIL => FAIL      [1/1]    +1  css/selectors/invalidation/host-has-shadow-tree-element-at-subject-position.html
! FAIL => FAIL      [0/7]    +0  svg/animations/animateMotion-rotate-angle.html
+ FAIL => FAIL    [58/66]   +58  svg/types/SameObject-identity.html
```

</details>

<sub>Generated by the [WPT workflow](https://github.com/DioxusLabs/blitz/actions/runs/34732361977).</sub>
<!-- wpt-results-end -->
